### PR TITLE
fix(dashboard): version in-memory dim cache by suppression state

### DIFF
--- a/src/quodeq/services/_cache.py
+++ b/src/quodeq/services/_cache.py
@@ -108,6 +108,7 @@ def make_lru_dimension_fetcher(
     lock: threading.Lock,
     max_size: int,
     reader: _Reader | None = None,
+    version: str = "",
 ) -> Callable[[str], list[DimensionResult]]:
     """Return a callable that fetches dimension data for a run.
 
@@ -122,7 +123,7 @@ def make_lru_dimension_fetcher(
     ctx = _CacheContext(cache=cache, lock=lock, max_size=max_size, reader=reader)
 
     def get_run_dimensions(run_id: str) -> list[DimensionResult]:
-        key = (reports_root, project, run_id)
+        key = (reports_root, project, run_id, version)
 
         cached = _cache_lookup(key, ctx)
         if cached is not None:

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -146,12 +146,14 @@ def _make_run_dimension_fetcher(
     cache: OrderedDict[tuple, list[DimensionResult]] | None = None,
     lock: threading.Lock | None = None,
     max_size: int | None = None,
+    version: str = "",
 ) -> Callable[[str], list[DimensionResult]]:
     """Return a cached fetcher for run dimension data (LRU, bounded).
 
     Defaults to the module-level shared cache so reads of the same run's
-    dimensions across requests reuse work. Tests pass explicit cache/lock to
-    isolate state.
+    dimensions across requests reuse work. *version* scopes the cache key to the
+    project's suppression state so a dismiss/delete invalidates it. Tests pass
+    explicit cache/lock to isolate state.
     """
     return make_lru_dimension_fetcher(
         reports_root,
@@ -159,6 +161,7 @@ def _make_run_dimension_fetcher(
         cache if cache is not None else _SHARED_RUN_DIM_CACHE,
         lock if lock is not None else _SHARED_RUN_DIM_LOCK,
         max_size if max_size is not None else _run_dim_cache_max(),
+        version=version,
     )
 
 
@@ -210,6 +213,7 @@ def _make_status_aware_fetcher(
     cache: OrderedDict[tuple, list[DimensionResult]] | None = None,
     lock: threading.Lock | None = None,
     max_size: int | None = None,
+    version: str = "",
 ) -> Callable[[str], list[DimensionResult]]:
     """Return a fetcher with two self-healing properties on top of the LRU cache.
 
@@ -230,7 +234,7 @@ def _make_status_aware_fetcher(
     resolved_lock = lock if lock is not None else _SHARED_RUN_DIM_LOCK
     cached = _make_run_dimension_fetcher(
         reports_root, project,
-        cache=resolved_cache, lock=resolved_lock, max_size=max_size,
+        cache=resolved_cache, lock=resolved_lock, max_size=max_size, version=version,
     )
     status_by_id = {r.run_id: r.status for r in runs}
 
@@ -243,7 +247,7 @@ def _make_status_aware_fetcher(
         # validate when an actual evaluation/ directory exists on disk:
         # without that anchor we'd evict every test stub that pre-seeds
         # the cache without creating disk state.
-        key = (reports_root, project, run_id)
+        key = (reports_root, project, run_id, version)
         if key in resolved_cache:
             eval_dir = reports_root / project / run_id / "evaluation"
             if eval_dir.is_dir():

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -77,8 +77,9 @@ def _run_dim_cache_max(override: int | None = None, env: dict[str, str] | None =
 # / _collect_previous_scores / build_accumulated_trend all walk) cost ~750ms
 # per request even on warm calls. The shared cache eliminates the cross-request
 # I/O without compromising the per-request consistency guarantees (the cache
-# is keyed by (reports_root, project, run_id) and runs are immutable once
-# finalized).
+# is keyed by (reports_root, project, run_id, suppression_version) so a
+# dismiss/delete produces a new key and never serves a pre-suppression score,
+# and runs are immutable once finalized).
 #
 # Tests that need isolation can pass an explicit DashboardCacheConfig.
 _SHARED_RUN_DIM_CACHE, _SHARED_RUN_DIM_LOCK = OrderedDict(), threading.Lock()

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -478,11 +478,18 @@ def _compute_dashboard_payload(
     # fetcher did via _count_eval_files. The dismiss-adjustment (Bug B) stays;
     # it is now cached rather than recomputed on every request.
     cacheable_run_ids = {r.run_id for r in history_runs if r.status == "complete"}
+    # Key the in-memory dimension cache by the project's suppression state so a
+    # dismiss/delete (or a formula change) invalidates warmed entries and no
+    # read path can serve a pre-dismiss score. ``score_cache_version`` already
+    # hashes dismissed + deleted keys + params.
+    from quodeq.services.score_cache import score_cache_version  # noqa: PLC0415
+    dim_cache_version = score_cache_version(reports_root / project, params)
     get_run_dimensions = make_trend_fetcher(
         reports_root, project, params=params, cacheable_run_ids=cacheable_run_ids,
         max_history=max_history,
         base_fetcher_factory=lambda rr, proj: _make_run_dimension_fetcher(
             rr, proj, cache=cc.cache, lock=cc.lock, max_size=cc.max_size,
+            version=dim_cache_version,
         ),
     )
     previous_by_dimension = _collect_previous_scores(

--- a/tests/services/test_cache_key_versioning.py
+++ b/tests/services/test_cache_key_versioning.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from collections import OrderedDict
+import threading
+
+from quodeq.core.types import DimensionResult
+from quodeq.services._cache import make_lru_dimension_fetcher
+
+
+def _reader_returning(score):
+    def read(_root, _proj, run_id):
+        return [DimensionResult(dimension="security", overall_score=score, overall_grade="Good")]
+    return read
+
+
+def test_different_version_is_a_separate_cache_entry():
+    cache, lock = OrderedDict(), threading.Lock()
+    root, proj, run = Path("/reports"), "proj", "run1"
+
+    v1 = make_lru_dimension_fetcher(root, proj, cache, lock, 256,
+                                    reader=_reader_returning("7.0/10"), version="v1")
+    v2 = make_lru_dimension_fetcher(root, proj, cache, lock, 256,
+                                    reader=_reader_returning("9.0/10"), version="v2")
+
+    assert v1(run)[0].overall_score == "7.0/10"   # populates key (..., "v1")
+    assert v2(run)[0].overall_score == "9.0/10"   # different version -> miss -> new read
+    assert len(cache) == 2  # both versions coexist; no cross-version contamination
+
+
+def test_default_version_is_backward_compatible():
+    cache, lock = OrderedDict(), threading.Lock()
+    fetch = make_lru_dimension_fetcher(Path("/reports"), "proj", cache, lock, 256,
+                                       reader=_reader_returning("5.0/10"))
+    assert fetch("run1")[0].overall_score == "5.0/10"
+    assert list(cache.keys()) == [(Path("/reports"), "proj", "run1", "")]

--- a/tests/services/test_dashboard.py
+++ b/tests/services/test_dashboard.py
@@ -490,7 +490,7 @@ class TestStaleCacheSelfHeal:
         # bug: cache was populated when only 1 dim was on disk, even though
         # disk now has 3).
         cache = OrderedDict()
-        cache[(tmp_path, "proj", "r-stale")] = [_dim("security", "F", "2.0")]
+        cache[(tmp_path, "proj", "r-stale", "")] = [_dim("security", "F", "2.0")]
 
         # Fresh disk read should return all 3 dims.
         read_calls = []
@@ -543,7 +543,7 @@ class TestStaleCacheSelfHeal:
         ]
 
         cache = OrderedDict()
-        cache[(tmp_path, "proj", "r-fresh")] = [_dim("security", "B", "7.0")]
+        cache[(tmp_path, "proj", "r-fresh", "")] = [_dim("security", "B", "7.0")]
 
         read_calls = []
         def fake_read(reports_root, project, run_id):

--- a/tests/services/test_dashboard_dismiss_consistency.py
+++ b/tests/services/test_dashboard_dismiss_consistency.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import pytest
+
+from quodeq.services.dashboard import (
+    build_dashboard, clear_shared_dimension_cache, _SHARED_RUN_DIM_CACHE,
+)
+from quodeq.services.dismissed import dismiss_finding, dismissed_keys
+from quodeq.services.score_cache import score_cache_version
+from quodeq.core.scoring.params import DEFAULT_PARAMS
+from tests.services._scalar_fixtures import build_projected_run
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    clear_shared_dimension_cache()
+    yield
+    clear_shared_dimension_cache()
+
+
+def _versions_in_shared_cache() -> set:
+    """Return the suppression-version component of every 4-tuple shared-cache key."""
+    return {k[3] for k in _SHARED_RUN_DIM_CACHE if len(k) == 4}
+
+
+def test_dismiss_produces_a_new_shared_cache_version(tmp_path):
+    """After a dismiss, the shared in-memory dim cache is keyed by the project's
+    suppression version, so no read path can serve a pre-dismiss entry.
+
+    A dismiss activates the trend fetcher's *heavy* (rescoring) path, which is
+    the one that populates ``_SHARED_RUN_DIM_CACHE``. Before the fix its keys
+    were 3-tuples with no version component, so ``_versions_in_shared_cache()``
+    was empty and this assertion failed. After the fix the key carries the
+    suppression hash from ``score_cache_version``.
+    """
+    reports = tmp_path / "evaluations"
+    project = "proj"
+    build_projected_run(reports, project, "20260101T000000", {"security": (7.0, "Fair")})
+
+    # Warm on a clean project so nothing but a dismiss can introduce a version.
+    build_dashboard(reports, project, run="latest")
+    versions_before = _versions_in_shared_cache()
+
+    # ``dismiss_finding(project_dir, finding: dict)`` -- confirmed against
+    # src/quodeq/services/dismissed.py; the dict keys are req/file/line.
+    dismiss_finding(reports / project, {"req": "R1", "file": "a.py", "line": 1})
+    assert dismissed_keys(reports / project), "dismiss did not register"
+
+    build_dashboard(reports, project, run="latest")
+    versions_after = _versions_in_shared_cache()
+
+    # A new suppression version key appeared -> the pre-dismiss entry is no longer
+    # the one served. Before the fix, keys were 3-tuples with no version, so
+    # `_versions_in_shared_cache()` would be empty and this assertion would fail.
+    new_versions = versions_after - versions_before
+    assert new_versions, "dismiss did not produce a new shared-cache version key"
+
+    # The new key is versioned by the project's actual suppression state.
+    expected = score_cache_version(reports / project, DEFAULT_PARAMS)
+    assert expected in new_versions, (
+        "shared-cache version does not match the project suppression hash"
+    )


### PR DESCRIPTION
## What

Versions the module-level in-memory run-dimension cache key with the project's suppression state, so a dismiss/delete produces a new key and the cache can no longer serve a **pre-dismiss** score for the "previous run" operand.

Key change: `(reports_root, project, run_id)` → `(reports_root, project, run_id, suppression_version)`, sourced from the existing `score_cache_version(project_dir, params)` (already hashes dismissed + deleted + grade params). `version=""` default keeps every existing caller identical.

## Why

The score-cache scalars already invalidate correctly on a dismiss, but the in-memory `_SHARED_RUN_DIM_CACHE` (full-data) did not — so history/overview could show a stale pre-dismiss grade for the previous run, which is the root of the "+1.x vs previous still considers the dismissed ones" report.

This is PR1 (consistency) of the dismiss/delete plan. It fixes cache **invalidation only**; the per-run *scoped* version (the historic-load speed win) and the frontend delta fallback are separate follow-ups.

## Tests

- New `test_cache_key_versioning.py` (version → separate cache entry; `""` default backward-compatible).
- New `test_dashboard_dismiss_consistency.py` (a dismiss yields a new 4-tuple cache-version key; verified failing pre-fix, passing post-fix).
- Full non-integration suite: 4205 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)