### PR TITLE
perf(cache): per-run scoped score-cache version (surgical dismiss/delete invalidation)

### DIFF
--- a/src/quodeq/services/_fs_metadata.py
+++ b/src/quodeq/services/_fs_metadata.py
@@ -77,10 +77,12 @@ def _read_accumulated_summary(
         from quodeq.services import grade_formula  # noqa: PLC0415
         params = grade_formula.load_params()
 
-    from quodeq.services.score_cache import accumulated_cache_version, cached_project_summary  # noqa: PLC0415
+    from quodeq.services.score_cache import (  # noqa: PLC0415
+        accumulated_cache_version, cached_project_summary, per_run_versions,
+    )
     project_dir = reports_root / entry_name
-    run_fingerprint = [(r.run_id, r.status) for r in runs]
-    version = accumulated_cache_version(project_dir, params, run_fingerprint, as_of=None)
+    run_versions = per_run_versions(project_dir, entry_name, params, [r.run_id for r in runs])
+    version = accumulated_cache_version(project_dir, params, run_versions, as_of=None)
 
     def _compute() -> dict:
         try:

--- a/src/quodeq/services/_fs_metadata.py
+++ b/src/quodeq/services/_fs_metadata.py
@@ -81,7 +81,8 @@ def _read_accumulated_summary(
         accumulated_cache_version, cached_project_summary, per_run_versions,
     )
     project_dir = reports_root / entry_name
-    run_versions = per_run_versions(project_dir, entry_name, params, [r.run_id for r in runs])
+    run_versions = per_run_versions(
+        project_dir, entry_name, params, [(r.run_id, r.status) for r in runs])
     version = accumulated_cache_version(project_dir, params, run_versions, as_of=None)
 
     def _compute() -> dict:

--- a/src/quodeq/services/_trend_fetcher.py
+++ b/src/quodeq/services/_trend_fetcher.py
@@ -29,7 +29,7 @@ from quodeq.services.deleted import deleted_keys as _default_deleted_keys
 from quodeq.services.dismissed import dismissed_keys as _default_dismissed_keys
 from quodeq.services.ports import read_run_scalars as _default_read_run_scalars
 from quodeq.services.rescore import _rescore_dimension
-from quodeq.services.score_cache import make_cache_backed_fetcher, score_cache_version
+from quodeq.services.score_cache import make_cache_backed_fetcher
 
 _Fetcher = Callable[[str], list[DimensionResult]]
 
@@ -105,13 +105,36 @@ def make_trend_fetcher(
             base_fetcher=base_fetcher_factory(reports_root, project),
             dismissed_keys=dismissed_keys, deleted_keys=deleted_keys,
         )
-        version = score_cache_version(project_dir, params)
+        from quodeq.services.run_keys import read_run_key_sets  # noqa: PLC0415
+        from quodeq.services.score_cache import (  # noqa: PLC0415
+            load_run_keys, open_score_cache, run_scoped_version, store_run_keys,
+        )
+        dismissed = dismissed_keys(project_dir)
+        deleted = deleted_keys(project_dir)
+        try:
+            with open_score_cache() as _conn:
+                _keys = load_run_keys(_conn, project)
+        except Exception:
+            _keys = {}
+
+        def version_for(run_id: str) -> str:
+            keys = _keys.get(run_id)
+            if keys is None:
+                keys = read_run_key_sets(project_dir / run_id)
+                _keys[run_id] = keys
+                if cacheable_run_ids is None or run_id in cacheable_run_ids:
+                    try:
+                        with open_score_cache() as _c:
+                            store_run_keys(_c, project, run_id, keys[0], keys[1])
+                    except Exception:
+                        pass
+            return run_scoped_version(params, keys[0], keys[1], dismissed, deleted)
+
         is_cacheable = (
             None if cacheable_run_ids is None
             else (lambda rid: rid in cacheable_run_ids)
         )
-        return make_cache_backed_fetcher(
-            project, lambda _rid: version, base, is_cacheable=is_cacheable)
+        return make_cache_backed_fetcher(project, version_for, base, is_cacheable=is_cacheable)
 
     cache: OrderedDict = OrderedDict()
     return make_lru_dimension_fetcher(

--- a/src/quodeq/services/_trend_fetcher.py
+++ b/src/quodeq/services/_trend_fetcher.py
@@ -110,7 +110,8 @@ def make_trend_fetcher(
             None if cacheable_run_ids is None
             else (lambda rid: rid in cacheable_run_ids)
         )
-        return make_cache_backed_fetcher(project, version, base, is_cacheable=is_cacheable)
+        return make_cache_backed_fetcher(
+            project, lambda _rid: version, base, is_cacheable=is_cacheable)
 
     cache: OrderedDict = OrderedDict()
     return make_lru_dimension_fetcher(

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -482,7 +482,11 @@ def _compute_dashboard_payload(
     # Key the in-memory dimension cache by the project's suppression state so a
     # dismiss/delete (or a formula change) invalidates warmed entries and no
     # read path can serve a pre-dismiss score. ``score_cache_version`` already
-    # hashes dismissed + deleted keys + params.
+    # hashes dismissed + deleted keys + params. This fetcher is SHARED across the
+    # whole history window (previous-scores, stale-dimensions, and the trend all
+    # iterate many runs through it), so we keep the global project-scoped version
+    # here rather than a per-run scoped one -- per-run scoping only makes sense
+    # when a single run is in play, which this path is not.
     from quodeq.services.score_cache import score_cache_version  # noqa: PLC0415
     dim_cache_version = score_cache_version(reports_root / project, params)
     get_run_dimensions = make_trend_fetcher(

--- a/src/quodeq/services/run_keys.py
+++ b/src/quodeq/services/run_keys.py
@@ -1,0 +1,36 @@
+"""Read a run's finding identity keys (for per-run cache-version scoping).
+
+A run's score depends only on the suppressions whose keys are present in that
+run, so the score cache versions each run by (dismissed ∩ these) + (deleted ∩
+these). Keys come from ALL findings regardless of verdict, so a dismiss (which
+only flips a verdict) never changes a run's key set. Best-effort: an
+unreadable/absent db yields empty sets.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+def read_run_key_sets(run_dir: Path) -> tuple[set[tuple], set[tuple]]:
+    """Return ``(dismiss_keys, class_keys)`` present in *run_dir*'s findings.
+
+    ``dismiss_keys``: ``{(requirement, file, line)}`` (matches ``dismissed_keys``).
+    ``class_keys``: ``{(dimension, practice_id, file)}`` (matches ``deleted_keys``).
+    """
+    db_path = run_dir / "evaluation.db"
+    if not db_path.is_file():
+        return set(), set()
+    dismiss: set[tuple] = set()
+    cls: set[tuple] = set()
+    try:
+        from quodeq.data.sqlite.connection import open_evaluation_db  # noqa: PLC0415
+        with open_evaluation_db(run_dir) as conn:
+            for req, file, line, dim, pid in conn.execute(
+                "SELECT requirement, file, line, dimension, practice_id FROM findings"
+            ):
+                dismiss.add((str(req or ""), str(file or ""), int(line or 0)))
+                cls.add((str(dim or ""), str(pid or ""), str(file or "")))
+    except sqlite3.DatabaseError:
+        return set(), set()
+    return dismiss, cls

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -46,6 +46,10 @@ _SCHEMA = (
     " PRIMARY KEY (project, version));"
     "CREATE TABLE IF NOT EXISTS project_summary_cache ("
     " project TEXT PRIMARY KEY, version TEXT NOT NULL, payload TEXT NOT NULL);"
+    "CREATE TABLE IF NOT EXISTS run_keys ("
+    " project TEXT NOT NULL, run_id TEXT NOT NULL,"
+    " dismiss_keys TEXT NOT NULL, class_keys TEXT NOT NULL,"
+    " PRIMARY KEY (project, run_id));"
 )
 
 
@@ -218,6 +222,45 @@ def run_scoped_version(
         "params": _params_fingerprint(params),
     }, sort_keys=True)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def store_run_keys(
+    conn: sqlite3.Connection, project: str, run_id: str,
+    dismiss_keys: set[tuple], class_keys: set[tuple],
+) -> None:
+    """Persist a run's key sets (best-effort)."""
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO run_keys (project, run_id, dismiss_keys, class_keys) "
+            "VALUES (?, ?, ?, ?)",
+            (project, run_id,
+             json.dumps(sorted(list(k) for k in dismiss_keys)),
+             json.dumps(sorted(list(k) for k in class_keys))),
+        )
+        conn.commit()
+    except sqlite3.Error:
+        _logger.warning("run_keys write failed for %s/%s", project, run_id, exc_info=True)
+
+
+def load_run_keys(
+    conn: sqlite3.Connection, project: str,
+) -> dict[str, tuple[set[tuple], set[tuple]]]:
+    """Return ``{run_id: (dismiss_keys, class_keys)}`` for *project* (empty on error)."""
+    out: dict[str, tuple[set[tuple], set[tuple]]] = {}
+    try:
+        rows = conn.execute(
+            "SELECT run_id, dismiss_keys, class_keys FROM run_keys WHERE project=?",
+            (project,),
+        ).fetchall()
+    except sqlite3.Error:
+        return {}
+    for run_id, dj, cj in rows:
+        try:
+            out[run_id] = ({tuple(k) for k in json.loads(dj)},
+                           {tuple(k) for k in json.loads(cj)})
+        except (ValueError, TypeError):
+            continue
+    return out
 
 
 def accumulated_cache_version(

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -32,7 +32,11 @@ _BUSY_TIMEOUT_MS = 5000
 # scoping carried stale dimensions (e.g. clean-architecture) that the project
 # no longer evaluates; the run-fingerprint could never invalidate them, so this
 # bump rebuilds them once against the latest run's configured-dimension set.
-_CACHE_WRITER_EPOCH = "3"
+# "4": earlier writers persisted in-progress runs' PARTIAL run_keys sets (the
+# per-run version path had no completeness gate), which load_run_keys froze
+# forever; the gate now persists only terminal runs, and this bump purges the
+# non-version-keyed run_keys table once so stranded partial snapshots rebuild.
+_CACHE_WRITER_EPOCH = "4"
 _SCHEMA = (
     "CREATE TABLE IF NOT EXISTS run_scalars ("
     " project TEXT NOT NULL, run_id TEXT NOT NULL, version TEXT NOT NULL,"
@@ -50,7 +54,32 @@ _SCHEMA = (
     " project TEXT NOT NULL, run_id TEXT NOT NULL,"
     " dismiss_keys TEXT NOT NULL, class_keys TEXT NOT NULL,"
     " PRIMARY KEY (project, run_id));"
+    "CREATE TABLE IF NOT EXISTS cache_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
 )
+
+
+def _purge_run_keys_on_epoch_change(conn: sqlite3.Connection) -> None:
+    """One-time purge of the non-version-keyed run_keys table on epoch bump.
+
+    ``run_scalars`` / ``accumulated_cache`` / ``project_summary_cache`` embed the
+    epoch in their version hash and self-invalidate, but ``run_keys`` rows are not
+    version-keyed, so a partial snapshot persisted by a prior writer would survive
+    a bump and stay frozen. Clearing the table once forces a fresh read.
+    """
+    try:
+        row = conn.execute(
+            "SELECT value FROM cache_meta WHERE key='writer_epoch'"
+        ).fetchone()
+        if row is not None and row[0] == _CACHE_WRITER_EPOCH:
+            return
+        conn.execute("DELETE FROM run_keys")
+        conn.execute(
+            "INSERT OR REPLACE INTO cache_meta (key, value) VALUES ('writer_epoch', ?)",
+            (_CACHE_WRITER_EPOCH,),
+        )
+        conn.commit()
+    except sqlite3.Error:
+        _logger.warning("run_keys epoch purge failed", exc_info=True)
 
 
 def _init(path: Path) -> sqlite3.Connection:
@@ -60,6 +89,7 @@ def _init(path: Path) -> sqlite3.Connection:
         conn.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
         conn.executescript(_SCHEMA)
         conn.commit()
+        _purge_run_keys_on_epoch_change(conn)
     except sqlite3.DatabaseError:
         # Close before re-raising so the caller's rebuild path can unlink the
         # file with no open handle (Windows raises PermissionError otherwise).
@@ -265,20 +295,28 @@ def load_run_keys(
 
 def accumulated_cache_version(
     project_dir: Path, params: ScoringParams,
-    run_versions: list[tuple[str, str]], as_of: str | None,
+    run_versions: list[tuple], as_of: str | None,
 ) -> str:
-    """Version for the accumulated cache: params + the per-run scoped versions +
-    *as_of*. Composing per-run versions means a dismiss/delete on one run
+    """Version for the accumulated cache: params + the per-run fingerprints +
+    *as_of*. Composing per-run fingerprints means a dismiss/delete on one run
     invalidates the accumulated payload only when that run's contribution
     actually changed (its scoped version changed).
+
+    Each fingerprint tuple carries the run's *status* alongside its scoped
+    version (see :func:`per_run_versions`) so a status transition (e.g.
+    ``in_progress -> complete``, ``complete -> cancelled``) changes the hash and
+    invalidates the cache. The scoped version is status-independent — it hashes
+    params + intersecting suppressions — so without status folded in, a run
+    completing mid-poll would recompute the same version and serve a stale
+    payload that omitted the just-finished (now eligible) run.
     """
     payload = json.dumps({
         # Bump when the accumulated / project-card computation changes, so
         # existing cache entries recompute on deploy instead of serving a stale
-        # value until the next scan/dismiss/delete. v3: composed from per-run
-        # scoped versions (was base-hash + raw (run_id, status) fingerprint), so
-        # a suppression change only invalidates the runs it actually touched.
-        "algo": 3,
+        # value until the next scan/dismiss/delete. v4: fold each run's status
+        # back into its fingerprint so a status flip re-invalidates (v3 composed
+        # only status-independent scoped versions and lost that guard).
+        "algo": 4,
         "params": _params_fingerprint(params),
         "runs": sorted(list(t) for t in run_versions),
         "as_of": as_of or "",
@@ -287,9 +325,24 @@ def accumulated_cache_version(
 
 
 def per_run_versions(
-    project_dir: Path, project: str, params: ScoringParams, run_ids: list[str],
-) -> list[tuple[str, str]]:
-    """(run_id, scoped_version) for each run, using persisted/lazy run_keys."""
+    project_dir: Path, project: str, params: ScoringParams,
+    runs: list[tuple[str, str]],
+) -> list[tuple[str, str, str]]:
+    """``(run_id, status, scoped_version)`` per run, from persisted/lazy run_keys.
+
+    *runs* is a list of ``(run_id, status)`` pairs. The returned ``status`` is
+    folded into the accumulated version so a status transition invalidates the
+    cache (see :func:`accumulated_cache_version`).
+
+    Only TERMINAL runs persist their key sets: an in-progress run's findings
+    table is still being written as dimensions finish, so its key set is partial.
+    Persisting that partial snapshot would freeze it (``load_run_keys`` short-
+    circuits any re-read), so a suppression targeting a key that appears only
+    after the run is first observed mid-scan would not intersect the frozen set
+    and would silently under-invalidate. Non-terminal runs therefore compute
+    their scoped version from a fresh ``read_run_key_sets`` each call and never
+    write it back, mirroring ``_trend_fetcher.version_for``.
+    """
     from quodeq.services.deleted import deleted_keys  # noqa: PLC0415
     from quodeq.services.dismissed import dismissed_keys  # noqa: PLC0415
     from quodeq.services.run_keys import read_run_key_sets  # noqa: PLC0415
@@ -299,17 +352,20 @@ def per_run_versions(
             cached = load_run_keys(conn, project)
     except sqlite3.Error:
         cached = {}
-    out: list[tuple[str, str]] = []
-    for rid in run_ids:
-        keys = cached.get(rid)
+    out: list[tuple[str, str, str]] = []
+    for rid, status in runs:
+        terminal = status == "complete"
+        keys = cached.get(rid) if terminal else None
         if keys is None:
             keys = read_run_key_sets(project_dir / rid)
-            try:
-                with open_score_cache() as conn:
-                    store_run_keys(conn, project, rid, keys[0], keys[1])
-            except sqlite3.Error:
-                pass
-        out.append((rid, run_scoped_version(params, keys[0], keys[1], dismissed, deleted)))
+            if terminal:
+                try:
+                    with open_score_cache() as conn:
+                        store_run_keys(conn, project, rid, keys[0], keys[1])
+                except sqlite3.Error:
+                    pass
+        out.append(
+            (rid, status, run_scoped_version(params, keys[0], keys[1], dismissed, deleted)))
     return out
 
 

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -198,6 +198,28 @@ def score_cache_version(project_dir: Path, params: ScoringParams) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+def run_scoped_version(
+    params: ScoringParams,
+    run_dismiss_keys: set[tuple],
+    run_class_keys: set[tuple],
+    dismissed_all: set[tuple],
+    deleted_all: set[tuple],
+) -> str:
+    """Version hash for a single run: params + only the suppressions that touch it.
+
+    A run's rescored score depends solely on dismissals whose (req,file,line) is
+    in *run_dismiss_keys* and deletions whose (dim,principle,file) is in
+    *run_class_keys*, so intersecting keeps unaffected runs' versions stable.
+    """
+    payload = json.dumps({
+        "epoch": _CACHE_WRITER_EPOCH,
+        "dismissed": sorted(str(k) for k in (dismissed_all & run_dismiss_keys)),
+        "deleted": sorted(str(k) for k in (deleted_all & run_class_keys)),
+        "params": _params_fingerprint(params),
+    }, sort_keys=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
 def accumulated_cache_version(
     project_dir: Path, params: ScoringParams,
     run_fingerprint: list[tuple[str, str]], as_of: str | None,

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -373,53 +373,53 @@ def cached_project_summary(
 
 
 def make_cache_backed_fetcher(
-    project: str, version: str,
+    project: str, version_for: Callable[[str], str],
     base_fetcher: Callable[[str], list[DimensionResult]],
     is_cacheable: Callable[[str], bool] | None = None,
 ) -> Callable[[str], list[DimensionResult]]:
-    """Wrap *base_fetcher* (returns rescored dims) with the read-through cache.
+    """Wrap *base_fetcher* with the read-through cache, versioned PER RUN.
 
-    Bulk-loads all cached runs for (project, version) once, serves hits from
-    memory, and on a miss computes via *base_fetcher*, extracts scalars, writes
-    them back, and returns the scalars. Returns scalar-only DimensionResults
-    (dimension/overall_score/overall_grade). If the kill switch is set, returns
-    *base_fetcher* unchanged.
+    *version_for(run_id)* returns that run's scoped version (params + the
+    suppressions touching it). Bulk-loads every cached row for *project* keyed by
+    (run_id, version); a hit requires the row's version to equal the run's
+    current version, so a dismiss/delete only misses the runs it touches. Misses
+    compute via *base_fetcher*, cache scalars at the run's version (only when
+    ``is_cacheable``), and return them. Kill switch -> *base_fetcher* unchanged.
 
-    ``is_cacheable`` gates *persistence* per run. The version hash covers only
-    dismissals/deletions/params, so it can't tell that an in-progress run's
-    scalar set grows as dimensions finish. Without a guard, opening History
-    mid-scan persists the run's partial set (e.g. only ``security`` of six) and
-    the run completing never invalidates it -- so the trend shows one dimension
-    forever while run-detail shows all six. Callers pass a predicate that is
-    True only for terminal (complete) runs; non-cacheable runs compute-through
-    and are served for the current build but never written to disk. Defaults to
-    "always cacheable" for backward compatibility.
+    ``is_cacheable`` gates *persistence* per run: only terminal (complete) runs
+    are safe. An in-progress run's scalar set grows as dimensions finish, and the
+    version hash can't see that, so persisting its partial set would strand a
+    stale row -- so opening History mid-scan would leave the trend showing one
+    dimension forever while run-detail shows all six. Non-cacheable runs
+    compute-through and are served for the current build but never written to
+    disk. Defaults to "always cacheable" for backward compatibility.
     """
     if score_cache_disabled():
         return base_fetcher
 
-    by_run: dict[str, list[DimensionResult]] = {}
+    by_run_version: dict[tuple[str, str], list[DimensionResult]] = {}
     try:
         with open_score_cache() as conn:
-            for rid, dim, score, grade in conn.execute(
-                "SELECT run_id, dimension, overall_score, overall_grade FROM run_scalars "
-                "WHERE project=? AND version=? ORDER BY run_id, dimension",
-                (project, version),
+            for rid, ver, dim, score, grade in conn.execute(
+                "SELECT run_id, version, dimension, overall_score, overall_grade "
+                "FROM run_scalars WHERE project=? ORDER BY run_id, dimension",
+                (project,),
             ):
-                by_run.setdefault(rid, []).append(
+                by_run_version.setdefault((rid, ver), []).append(
                     DimensionResult(dimension=dim, overall_score=score, overall_grade=grade))
     except sqlite3.Error:
-        by_run = {}
+        by_run_version = {}
 
     def fetch(run_id: str) -> list[DimensionResult]:
-        hit = by_run.get(run_id)
+        version = version_for(run_id)
+        hit = by_run_version.get((run_id, version))
         if hit is not None:
             return hit
         dims = base_fetcher(run_id)
         scalars = [DimensionResult(dimension=d.dimension, overall_score=d.overall_score,
                                    overall_grade=d.overall_grade)
                    for d in dims if d.dimension]
-        by_run[run_id] = scalars
+        by_run_version[(run_id, version)] = scalars
         if is_cacheable is None or is_cacheable(run_id):
             try:
                 with open_score_cache() as conn:

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -265,25 +265,52 @@ def load_run_keys(
 
 def accumulated_cache_version(
     project_dir: Path, params: ScoringParams,
-    run_fingerprint: list[tuple[str, str]], as_of: str | None,
+    run_versions: list[tuple[str, str]], as_of: str | None,
 ) -> str:
-    """Version for the accumulated cache: the base dismissals/deletions/params
-    hash plus the run-set (run_id, status) and *as_of*, so a new scan, a status
-    change, or a historical view all invalidate. Run-set is sorted for order
-    independence.
+    """Version for the accumulated cache: params + the per-run scoped versions +
+    *as_of*. Composing per-run versions means a dismiss/delete on one run
+    invalidates the accumulated payload only when that run's contribution
+    actually changed (its scoped version changed).
     """
     payload = json.dumps({
         # Bump when the accumulated / project-card computation changes, so
         # existing cache entries recompute on deploy instead of serving a stale
-        # value until the next scan/dismiss/delete. v2: the project-card summary
-        # now applies the dismiss/delete rescore (was raw read_run_data, which
-        # ignored deletions).
-        "algo": 2,
-        "base": score_cache_version(project_dir, params),
-        "runs": sorted(list(t) for t in run_fingerprint),
+        # value until the next scan/dismiss/delete. v3: composed from per-run
+        # scoped versions (was base-hash + raw (run_id, status) fingerprint), so
+        # a suppression change only invalidates the runs it actually touched.
+        "algo": 3,
+        "params": _params_fingerprint(params),
+        "runs": sorted(list(t) for t in run_versions),
         "as_of": as_of or "",
     }, sort_keys=True)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def per_run_versions(
+    project_dir: Path, project: str, params: ScoringParams, run_ids: list[str],
+) -> list[tuple[str, str]]:
+    """(run_id, scoped_version) for each run, using persisted/lazy run_keys."""
+    from quodeq.services.deleted import deleted_keys  # noqa: PLC0415
+    from quodeq.services.dismissed import dismissed_keys  # noqa: PLC0415
+    from quodeq.services.run_keys import read_run_key_sets  # noqa: PLC0415
+    dismissed, deleted = dismissed_keys(project_dir), deleted_keys(project_dir)
+    try:
+        with open_score_cache() as conn:
+            cached = load_run_keys(conn, project)
+    except sqlite3.Error:
+        cached = {}
+    out: list[tuple[str, str]] = []
+    for rid in run_ids:
+        keys = cached.get(rid)
+        if keys is None:
+            keys = read_run_key_sets(project_dir / rid)
+            try:
+                with open_score_cache() as conn:
+                    store_run_keys(conn, project, rid, keys[0], keys[1])
+            except sqlite3.Error:
+                pass
+        out.append((rid, run_scoped_version(params, keys[0], keys[1], dismissed, deleted)))
+    return out
 
 
 def cached_accumulated(

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -43,6 +43,7 @@ from quodeq.services._fs_projects import find_children
 from quodeq.services.score_cache import (
     accumulated_cache_version,
     cached_accumulated,
+    per_run_versions,
 )
 from quodeq.services.ports import RunInfo, list_runs, read_run_data, read_run_scalars
 from quodeq.services.rescore import _rescore_dimension, rescore_dimensions
@@ -555,7 +556,9 @@ def get_project_scores(
     else:
         acc_version = accumulated_cache_version(
             reports_root / project, params,
-            [(r.run_id, r.status) for r in all_runs], as_of,
+            per_run_versions(reports_root / project, project, params,
+                             [r.run_id for r in all_runs]),
+            as_of,
         )
         accumulated = cached_accumulated(project, acc_version, _compute_accumulated_payload)
 

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -557,7 +557,7 @@ def get_project_scores(
         acc_version = accumulated_cache_version(
             reports_root / project, params,
             per_run_versions(reports_root / project, project, params,
-                             [r.run_id for r in all_runs]),
+                             [(r.run_id, r.status) for r in all_runs]),
             as_of,
         )
         accumulated = cached_accumulated(project, acc_version, _compute_accumulated_payload)

--- a/tests/services/test_run_keys.py
+++ b/tests/services/test_run_keys.py
@@ -1,0 +1,25 @@
+from quodeq.data.sqlite.connection import open_evaluation_db
+from quodeq.services.run_keys import read_run_key_sets
+
+
+def test_reads_dismiss_and_class_keys(tmp_path):
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    with open_evaluation_db(run_dir) as conn:
+        conn.execute(
+            "INSERT INTO findings (practice_id, dimension, requirement, verdict, "
+            "severity, file, line, dedup_key) VALUES "
+            "('P1','security','R1','violation','major','a.py',1,'k1'),"
+            "('P2','security','R2','dismissed','minor','b.py',2,'k2')"
+        )
+        conn.commit()
+
+    dismiss, cls = read_run_key_sets(run_dir)
+    assert ("R1", "a.py", 1) in dismiss
+    assert ("R2", "b.py", 2) in dismiss          # dismissed rows still contribute keys
+    assert ("security", "P1", "a.py") in cls
+    assert ("security", "P2", "b.py") in cls
+
+
+def test_missing_db_is_empty(tmp_path):
+    assert read_run_key_sets(tmp_path / "nope") == (set(), set())

--- a/tests/services/test_run_keys_store.py
+++ b/tests/services/test_run_keys_store.py
@@ -1,0 +1,18 @@
+import pytest
+
+from quodeq.services.score_cache import load_run_keys, open_score_cache, store_run_keys
+
+
+@pytest.fixture(autouse=True)
+def _iso(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+
+
+def test_store_then_load_roundtrip():
+    with open_score_cache() as conn:
+        store_run_keys(conn, "proj", "r1", {("R1", "a.py", 1)}, {("security", "P1", "a.py")})
+    with open_score_cache() as conn:
+        keys = load_run_keys(conn, "proj")
+    assert keys["r1"] == ({("R1", "a.py", 1)}, {("security", "P1", "a.py")})
+    with open_score_cache() as conn:
+        assert load_run_keys(conn, "other") == {}  # unknown project -> empty

--- a/tests/services/test_run_scoped_version.py
+++ b/tests/services/test_run_scoped_version.py
@@ -1,0 +1,21 @@
+from quodeq.core.scoring.params import DEFAULT_PARAMS
+from quodeq.services.score_cache import run_scoped_version
+
+
+def test_version_changes_only_for_intersecting_suppression():
+    run_dismiss = {("R1", "a.py", 1)}
+    run_class = {("security", "P1", "a.py")}
+
+    base = run_scoped_version(DEFAULT_PARAMS, run_dismiss, run_class, set(), set())
+    # A dismissal NOT present in this run's keys must not change its version.
+    unrelated = run_scoped_version(
+        DEFAULT_PARAMS, run_dismiss, run_class, {("OTHER", "z.py", 9)}, set())
+    assert unrelated == base
+    # A dismissal that IS present must change it.
+    related = run_scoped_version(
+        DEFAULT_PARAMS, run_dismiss, run_class, {("R1", "a.py", 1)}, set())
+    assert related != base
+    # A delete of this run's class must change it.
+    deleted = run_scoped_version(
+        DEFAULT_PARAMS, run_dismiss, run_class, set(), {("security", "P1", "a.py")})
+    assert deleted != base

--- a/tests/services/test_scoped_invalidation.py
+++ b/tests/services/test_scoped_invalidation.py
@@ -3,6 +3,7 @@ import pytest
 
 from quodeq.data.sqlite.connection import open_evaluation_db
 from quodeq.services.dashboard import clear_shared_dimension_cache
+from quodeq.services.deleted import delete_finding
 from quodeq.services.dismissed import dismiss_finding
 from quodeq.services.score_cache import open_score_cache
 from quodeq.services.scoring import get_project_scores
@@ -56,5 +57,35 @@ def test_dismiss_only_reversions_the_touched_run(tmp_path):
 
     changed_runs = {r for (r, v) in after - before}
     # The touched run (run 1) re-versions; the untouched run (run 2) keeps its version.
+    assert "20260101T000000" in changed_runs
+    assert "20260102T000000" not in changed_runs
+
+
+def test_delete_only_reversions_the_touched_run(tmp_path):
+    """A delete keyed (dimension, principle, file) must re-version exactly the runs
+    whose findings carry that class. Guards the delete-key identity
+    (read_run_key_sets uses practice_id == _principle_of) for delete-heavy projects.
+    """
+    reports = tmp_path / "evaluations"
+    r1 = build_projected_run(reports, "proj", "20260101T000000", {"security": (7.0, "Fair")})
+    build_projected_run(reports, "proj", "20260102T000000", {"security": (8.0, "Good")})
+    # Run 1 has a finding whose class key is (security, P1, a.py); run 2 has none.
+    _insert_finding(
+        r1, requirement="R1", file="a.py", line=1,
+        dimension="security", practice_id="P1", dedup_key="k1",
+    )
+
+    # Activate the heavy path + populate run_scalars for both runs (seed a
+    # non-intersecting dismissal so both runs' versions are recorded first).
+    dismiss_finding(reports / "proj", {"req": "SEED", "file": "seed.py", "line": 0})
+    get_project_scores(reports, "proj")
+    before = _versions("proj")
+
+    # Delete the (security, P1, a.py) class -> matches only run 1's key set.
+    delete_finding(reports / "proj", {"dimension": "security", "principle": "P1", "file": "a.py"})
+    get_project_scores(reports, "proj")
+    after = _versions("proj")
+
+    changed_runs = {r for (r, v) in after - before}
     assert "20260101T000000" in changed_runs
     assert "20260102T000000" not in changed_runs

--- a/tests/services/test_scoped_invalidation.py
+++ b/tests/services/test_scoped_invalidation.py
@@ -1,0 +1,60 @@
+"""Per-run scoped invalidation: a dismiss/delete re-versions only the runs it touches."""
+import pytest
+
+from quodeq.data.sqlite.connection import open_evaluation_db
+from quodeq.services.dashboard import clear_shared_dimension_cache
+from quodeq.services.dismissed import dismiss_finding
+from quodeq.services.score_cache import open_score_cache
+from quodeq.services.scoring import get_project_scores
+from tests.services._scalar_fixtures import build_projected_run
+
+
+@pytest.fixture(autouse=True)
+def _iso(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    clear_shared_dimension_cache()
+    yield
+    clear_shared_dimension_cache()
+
+
+def _insert_finding(run_dir, *, requirement, file, line, dimension, practice_id, dedup_key):
+    with open_evaluation_db(run_dir) as conn:
+        conn.execute(
+            "INSERT INTO findings (practice_id, dimension, requirement, verdict, "
+            "severity, file, line, dedup_key) VALUES (?,?,?,?,?,?,?,?)",
+            (practice_id, dimension, requirement, "violation", "major", file, line, dedup_key),
+        )
+        conn.commit()
+
+
+def _versions(project):
+    with open_score_cache() as conn:
+        return {(r, v) for r, v in conn.execute(
+            "SELECT DISTINCT run_id, version FROM run_scalars WHERE project=?", (project,))}
+
+
+def test_dismiss_only_reversions_the_touched_run(tmp_path):
+    reports = tmp_path / "evaluations"
+    r1 = build_projected_run(reports, "proj", "20260101T000000", {"security": (7.0, "Fair")})
+    build_projected_run(reports, "proj", "20260102T000000", {"security": (8.0, "Good")})
+    # Give run 1 a finding whose key is (R1, a.py, 1) so it (and only it) intersects
+    # the dismissal below. Run 2 has no findings -> its key set never intersects.
+    _insert_finding(
+        r1, requirement="R1", file="a.py", line=1,
+        dimension="security", practice_id="P1", dedup_key="k1",
+    )
+
+    # Activate the heavy path + populate run_scalars for both runs.
+    dismiss_finding(reports / "proj", {"req": "SEED", "file": "seed.py", "line": 0})
+    get_project_scores(reports, "proj")
+    before = _versions("proj")
+
+    # Dismiss a finding that exists only in the first run's key set.
+    dismiss_finding(reports / "proj", {"req": "R1", "file": "a.py", "line": 1})
+    get_project_scores(reports, "proj")
+    after = _versions("proj")
+
+    changed_runs = {r for (r, v) in after - before}
+    # The touched run (run 1) re-versions; the untouched run (run 2) keeps its version.
+    assert "20260101T000000" in changed_runs
+    assert "20260102T000000" not in changed_runs

--- a/tests/services/test_score_cache_accumulated_helper.py
+++ b/tests/services/test_score_cache_accumulated_helper.py
@@ -1,7 +1,13 @@
 from pathlib import Path
 
 from quodeq.core.scoring.params import DEFAULT_PARAMS
-from quodeq.services.score_cache import accumulated_cache_version, cached_accumulated
+from quodeq.services.score_cache import (
+    accumulated_cache_version,
+    cached_accumulated,
+    load_run_keys,
+    open_score_cache,
+    per_run_versions,
+)
 
 
 def _patch_keys(monkeypatch, dismissed=frozenset(), deleted=frozenset()):
@@ -43,6 +49,48 @@ def test_cached_accumulated_miss_then_hit(tmp_path, monkeypatch):
     r2 = cached_accumulated("proj", "v1", lambda: (_ for _ in ()).throw(AssertionError("recomputed on hit")))
     assert r1 == r2 == {"dimensions": [], "summary": {"x": 1}}
     assert calls == [1]
+
+
+def test_per_run_versions_status_flip_reinvalidates(tmp_path, monkeypatch):
+    """A run flipping in_progress -> complete must change the accumulated version.
+
+    Regression: the scoped version hashes only params + intersecting suppressions
+    (status-independent) and run_keys are frozen on first read, so without status
+    folded into the accumulated fingerprint a run completing mid-poll would
+    recompute the SAME version and serve a stale payload omitting that run.
+    """
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    _patch_keys(monkeypatch)
+    pd = tmp_path / "proj"; pd.mkdir()
+
+    in_progress = per_run_versions(pd, "proj", DEFAULT_PARAMS, [("r1", "in_progress")])
+    complete = per_run_versions(pd, "proj", DEFAULT_PARAMS, [("r1", "complete")])
+    assert in_progress != complete  # status carried in the tuple
+
+    v_ip = accumulated_cache_version(pd, DEFAULT_PARAMS, in_progress, None)
+    v_c = accumulated_cache_version(pd, DEFAULT_PARAMS, complete, None)
+    assert v_ip != v_c
+
+
+def test_per_run_versions_does_not_persist_in_progress_keys(tmp_path, monkeypatch):
+    """Non-terminal runs must not freeze a partial run_keys snapshot.
+
+    Persisting an in-progress run's partial findings set would freeze it
+    (load_run_keys short-circuits any re-read), so a suppression targeting a key
+    that appears only after the run is observed mid-scan would silently
+    under-invalidate.
+    """
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    _patch_keys(monkeypatch)
+    pd = tmp_path / "proj"; pd.mkdir()
+
+    per_run_versions(pd, "proj", DEFAULT_PARAMS, [("r1", "in_progress")])
+    with open_score_cache() as conn:
+        assert load_run_keys(conn, "proj") == {}  # nothing persisted
+
+    per_run_versions(pd, "proj", DEFAULT_PARAMS, [("r2", "complete")])
+    with open_score_cache() as conn:
+        assert "r2" in load_run_keys(conn, "proj")  # terminal run persisted
 
 
 def test_cached_accumulated_kill_switch(tmp_path, monkeypatch):

--- a/tests/services/test_score_cache_fetcher.py
+++ b/tests/services/test_score_cache_fetcher.py
@@ -14,7 +14,7 @@ def test_miss_computes_and_caches_then_hit_skips_base(tmp_path, monkeypatch):
         calls.append(rid)
         return _rescored(rid)
 
-    f1 = make_cache_backed_fetcher("proj", "v1", base)
+    f1 = make_cache_backed_fetcher("proj", lambda _rid: "v1", base)
     out1 = f1("r1")                    # miss -> base called, cached
     assert [d.overall_score for d in out1] == ["8.0/10"]
     assert calls == ["r1"]
@@ -22,19 +22,19 @@ def test_miss_computes_and_caches_then_hit_skips_base(tmp_path, monkeypatch):
     # New fetcher instance (fresh bulk-load) sees the cached row -> base NOT called.
     def boom(rid):
         raise AssertionError("base fetcher called on a cache hit")
-    f2 = make_cache_backed_fetcher("proj", "v1", boom)
+    f2 = make_cache_backed_fetcher("proj", lambda _rid: "v1", boom)
     out2 = f2("r1")
     assert [(d.dimension, d.overall_score, d.overall_grade) for d in out2] == [("security", "8.0/10", "Good")]
 
 
 def test_version_change_is_a_miss(tmp_path, monkeypatch):
     monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
-    make_cache_backed_fetcher("proj", "v1", _rescored)("r1")  # cache under v1
+    make_cache_backed_fetcher("proj", lambda _rid: "v1", _rescored)("r1")  # cache under v1
     calls = []
     def base(rid):
         calls.append(rid)
         return _rescored(rid)
-    make_cache_backed_fetcher("proj", "v2", base)("r1")       # different version -> miss
+    make_cache_backed_fetcher("proj", lambda _rid: "v2", base)("r1")       # different version -> miss
     assert calls == ["r1"]
 
 
@@ -42,7 +42,7 @@ def test_kill_switch_returns_base_fetcher(tmp_path, monkeypatch):
     monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
     monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
     base = _rescored
-    assert make_cache_backed_fetcher("proj", "v1", base) is base
+    assert make_cache_backed_fetcher("proj", lambda _rid: "v1", base) is base
 
 
 def _dims(*names):
@@ -66,7 +66,7 @@ def test_in_progress_run_is_not_persisted(tmp_path, monkeypatch):
         partial_calls.append(rid)
         return _dims("security")
 
-    f1 = make_cache_backed_fetcher("proj", "v1", base_partial, is_cacheable=lambda rid: False)
+    f1 = make_cache_backed_fetcher("proj", lambda _rid: "v1", base_partial, is_cacheable=lambda rid: False)
     out1 = f1("r1")
     assert [d.dimension for d in out1] == ["security"]   # still served this build
     assert partial_calls == ["r1"]
@@ -79,7 +79,7 @@ def test_in_progress_run_is_not_persisted(tmp_path, monkeypatch):
         return _dims("security", "reliability", "maintainability",
                      "performance", "usability", "flexibility")
 
-    f2 = make_cache_backed_fetcher("proj", "v1", base_full, is_cacheable=lambda rid: True)
+    f2 = make_cache_backed_fetcher("proj", lambda _rid: "v1", base_full, is_cacheable=lambda rid: True)
     out2 = f2("r1")
     assert [d.dimension for d in out2] == sorted(
         ["flexibility", "maintainability", "performance", "reliability", "security", "usability"]
@@ -89,5 +89,5 @@ def test_in_progress_run_is_not_persisted(tmp_path, monkeypatch):
     # Build 3: now the completed run IS persisted -> hit, base not called.
     def boom(rid):
         raise AssertionError("base fetcher called on a cache hit for a completed run")
-    f3 = make_cache_backed_fetcher("proj", "v1", boom, is_cacheable=lambda rid: True)
+    f3 = make_cache_backed_fetcher("proj", lambda _rid: "v1", boom, is_cacheable=lambda rid: True)
     assert len(f3("r1")) == 6

--- a/tests/services/test_score_cache_scoped_parity.py
+++ b/tests/services/test_score_cache_scoped_parity.py
@@ -1,0 +1,81 @@
+"""Parity gate: cached (cold + warm) == kill-switch direct across suppression scenarios.
+
+This is the safety contract for the per-run scoped score-cache refactor. Because
+``build_projected_run`` bakes the SQL grades directly (a dismiss only flips a
+verdict; the numbers do not move), the full ``get_project_scores`` payload must
+be byte-identical between the cache-on path (cold compute+populate, then warm
+hits) and the cache-off (kill-switch) direct path for every scenario below.
+
+Every later task in the refactor must keep this test green. If it goes red, the
+refactor changed scoring output -- stop and fix before proceeding.
+"""
+import json
+
+import pytest
+
+from quodeq.services.dashboard import clear_shared_dimension_cache
+from quodeq.services.deleted import delete_finding
+from quodeq.services.dismissed import dismiss_finding
+from quodeq.services.scoring import get_project_scores
+from tests.services._scalar_fixtures import build_projected_run
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    clear_shared_dimension_cache()
+    yield
+    clear_shared_dimension_cache()
+
+
+def _two_runs(reports):
+    build_projected_run(reports, "proj", "20260101T000000", {"security": (7.0, "Fair")})
+    build_projected_run(reports, "proj", "20260102T000000", {"security": (8.0, "Good")})
+
+
+def _cached_equals_direct(reports, monkeypatch):
+    """Cold (compute+populate) and warm (hits) must equal the kill-switch direct path."""
+    monkeypatch.delenv("QUODEQ_DISABLE_SCORE_CACHE", raising=False)
+    clear_shared_dimension_cache()
+    cold = get_project_scores(reports, "proj")
+    warm = get_project_scores(reports, "proj")
+    monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
+    clear_shared_dimension_cache()
+    direct = get_project_scores(reports, "proj")
+    monkeypatch.delenv("QUODEQ_DISABLE_SCORE_CACHE", raising=False)
+    assert json.dumps(cold, sort_keys=True) == json.dumps(direct, sort_keys=True)
+    assert json.dumps(warm, sort_keys=True) == json.dumps(direct, sort_keys=True)
+
+
+def test_parity_no_suppression(tmp_path, monkeypatch):
+    reports = tmp_path / "evaluations"
+    _two_runs(reports)
+    _cached_equals_direct(reports, monkeypatch)
+
+
+def test_parity_with_dismissal(tmp_path, monkeypatch):
+    reports = tmp_path / "evaluations"
+    _two_runs(reports)
+    dismiss_finding(reports / "proj", {"req": "R1", "file": "a.py", "line": 1})
+    _cached_equals_direct(reports, monkeypatch)
+
+
+def test_parity_with_deletion(tmp_path, monkeypatch):
+    reports = tmp_path / "evaluations"
+    _two_runs(reports)
+    delete_finding(
+        reports / "proj",
+        {"dimension": "security", "principle": "P1", "file": "a.py"},
+    )
+    _cached_equals_direct(reports, monkeypatch)
+
+
+def test_parity_with_mixed_suppression(tmp_path, monkeypatch):
+    reports = tmp_path / "evaluations"
+    _two_runs(reports)
+    dismiss_finding(reports / "proj", {"req": "R1", "file": "a.py", "line": 1})
+    delete_finding(
+        reports / "proj",
+        {"dimension": "security", "principle": "P2", "file": "b.py"},
+    )
+    _cached_equals_direct(reports, monkeypatch)


### PR DESCRIPTION
## What

Replaces the **global** score-cache version with a **per-run scoped** one. A dismiss/delete now re-versions only the runs whose findings it actually touches, instead of invalidating every run's cached scalars and the accumulated payload.

- `run_keys.py`: reads a run's `(req,file,line)` + `(dimension,practice_id,file)` key sets from `evaluation.db`.
- `run_scoped_version(params, run_keys, dismissed_all, deleted_all)`: hashes params + only the suppressions whose keys intersect the run.
- `run_keys` table (persisted for complete runs) so the version is cheap to recompute.
- `make_cache_backed_fetcher` reworked from a single version to a per-run `version_for`, bulk-loading by `(run_id, version)`.
- `accumulated_cache_version` composes the per-run versions (still folds in run status).

## Why

On a delete-heavy project, every dismiss/delete bumped the one global version and forced a full historic re-fold (2.5–4.9 s) on the next load. Scoping the version per run keeps unaffected runs warm, so a mutation only recomputes the 1–3 runs it touches.

Correctness is guaranteed by construction: a run's rescore depends only on suppressions whose keys are present in that run, and the version hashes exactly that intersection (`read_run_key_sets` mirrors `_finding_key` and `_principle_of`).

## Review-caught + fixed

- **Blocker:** the accumulated version had dropped run status, so a run finishing mid-poll wouldn't refresh the Overview. Re-added status; gated `run_keys` persistence to complete runs; epoch bump to purge stranded partial snapshots.
- **Major:** in-progress runs were persisting partial key sets — now compute-through.

## Tests

- Parity gate (`test_score_cache_scoped_parity.py`): cached == direct across no-suppression / dismiss / delete / mixed — green through every step.
- Scoping (`test_scoped_invalidation.py`): a dismiss, and a delete, each re-version only the touched run.
- Full non-integration suite: 4217 passed, 1 skipped.

Follow-up: PR3 (frontend `<2`-run delta fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)