### PR TITLE
fix(dashboard): drop apples-to-oranges 'vs previous' delta fallback

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -20,8 +20,12 @@ import { buildOverviewReport } from '../../../utils/reportBuilder.js';
 // Accumulated overview panel helpers
 // ---------------------------------------------------------------------------
 
-function computeAccumulatedStats(accumulated, accumulatedDimensions, dailyTrend, selectedRunId) {
-  const curr = parseFloat(accumulated?.summary?.numericAverage);
+// The "vs previous" delta compares two accumulated numericAverage points from the
+// trend (this run vs the prior run). With fewer than two trend entries there is no
+// comparable previous point, so the delta stays null rather than falling back to
+// summary.previousNumericAverage: that value is the prior run's own-dimension average,
+// not comparable to the accumulated numericAverage (an apples-to-oranges subtraction).
+export function computeAccumulatedStats(accumulatedDimensions, dailyTrend, selectedRunId) {
   let scoreDelta = null;
   if (dailyTrend && dailyTrend.length >= 2) {
     const selectedIdx = selectedRunId ? dailyTrend.findIndex((t) => t.runId === selectedRunId) : 0;
@@ -29,10 +33,6 @@ function computeAccumulatedStats(accumulated, accumulatedDimensions, dailyTrend,
     const current = parseFloat(dailyTrend[idx]?.numericAverage);
     const previous = idx + 1 < dailyTrend.length ? parseFloat(dailyTrend[idx + 1]?.numericAverage) : NaN;
     if (!Number.isNaN(current) && !Number.isNaN(previous)) scoreDelta = (current - previous).toFixed(1);
-  }
-  if (scoreDelta === null) {
-    const prev = parseFloat(accumulated?.summary?.previousNumericAverage);
-    scoreDelta = (Number.isNaN(curr) || Number.isNaN(prev)) ? null : (curr - prev).toFixed(1);
   }
 
   const withDates = accumulatedDimensions
@@ -186,7 +186,7 @@ function useAccumulatedComputations(data) {
   const filteredTrend = useMemo(() => filterTrendByVisibleStandards(trend, visibleSet), [trend, visibleSet]);
   const filteredDimensions = useMemo(() => accumulatedDimensions.filter((d) => visibleSet.has((d.dimension || '').toLowerCase())), [accumulatedDimensions, visibleIds]);
   const filteredAccumulated = useMemo(() => filterAccumulatedByVisibleStandards(accumulated, visibleSet, filteredPeriodTrend, currentOverviewRun), [accumulated, visibleSet, filteredPeriodTrend, currentOverviewRun]);
-  const filteredStats = useMemo(() => computeAccumulatedStats(filteredAccumulated, filteredDimensions, filteredPeriodTrend, currentOverviewRun), [filteredAccumulated, filteredDimensions, filteredPeriodTrend, currentOverviewRun]);
+  const filteredStats = useMemo(() => computeAccumulatedStats(filteredDimensions, filteredPeriodTrend, currentOverviewRun), [filteredDimensions, filteredPeriodTrend, currentOverviewRun]);
 
   // Preserve today's "panel appears iff ≥2 days of data" behavior, regardless
   // of the chosen grouping — so the selector never disappears on collapse.

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.stats.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.stats.test.jsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { computeAccumulatedStats } from './AccumulatedOverviewPanel.jsx';
+
+const dims = [
+  { dimension: 'security', fromRunId: 'r1', fromDateIso: '2026-01-02', fromDateLabel: 'Jan 2' },
+];
+
+describe('computeAccumulatedStats scoreDelta', () => {
+  it('is null with fewer than two trend entries (no apples-to-oranges fallback)', () => {
+    const { scoreDelta } = computeAccumulatedStats(
+      dims, [{ runId: 'r1', numericAverage: '7.0' }], 'r1',
+    );
+    expect(scoreDelta).toBeNull();
+  });
+
+  it('subtracts this run vs the previous run when two or more entries exist', () => {
+    const trend = [
+      { runId: 'r2', numericAverage: '8.0' },
+      { runId: 'r1', numericAverage: '7.0' },
+    ];
+    const { scoreDelta } = computeAccumulatedStats(dims, trend, 'r2');
+    expect(scoreDelta).toBe('1.0');
+  });
+
+  it('uses the selected run index for the delta', () => {
+    const trend = [
+      { runId: 'r3', numericAverage: '9.0' },
+      { runId: 'r2', numericAverage: '8.0' },
+      { runId: 'r1', numericAverage: '6.5' },
+    ];
+    // Selecting r2 compares r2 (8.0) against the older r1 (6.5) = 1.5.
+    const { scoreDelta } = computeAccumulatedStats(dims, trend, 'r2');
+    expect(scoreDelta).toBe('1.5');
+  });
+});


### PR DESCRIPTION
## What

Removes the `<2`-trend-entry fallback in the overview "vs previous" delta. When there aren't two comparable trend points, the delta now stays **null** instead of subtracting `summary.numericAverage` (an accumulated all-dimension average) from `summary.previousNumericAverage` (the prior run's *own-dimension* average) — two values computed over different dimension sets, i.e. apples-to-oranges.

Also exports `computeAccumulatedStats` and drops its now-unused `accumulated` argument so the delta logic is unit-testable.

## Why

Closes the last thread of the original "+1.x vs previous" report. The primary path (this run vs the prior run over accumulated `numericAverage`) is unchanged; the deferred question of switching to a strict per-run number (Q1) is left for later.

## Tests

- New `AccumulatedOverviewPanel.stats.test.jsx` (vitest): null with a single trend entry; correct subtraction with 2+ entries; selected-run index respected.
- All dashboard component tests green (9 files, 48 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)