### PR TITLE
perf(enum): read run date from the index in list_runs (kills the ~350ms parse_run_date floor)

### DIFF
--- a/src/quodeq/data/fs/report_parser/runs.py
+++ b/src/quodeq/data/fs/report_parser/runs.py
@@ -175,6 +175,8 @@ def list_runs(reports_root: Path, project: str, *, limit: int = _DEFAULT_RUN_LIM
     """
     validate_path_segment(project)
     project_dir = reports_root / project
+    from quodeq.services.run_dates import project_run_dates  # noqa: PLC0415
+    index_dates = project_run_dates(reports_root, project)
     run_infos: list[RunInfo] = []
     for entry in safe_read_dir(project_dir):
         if not entry.is_dir() or entry.name.startswith("."):
@@ -194,7 +196,11 @@ def list_runs(reports_root: Path, project: str, *, limit: int = _DEFAULT_RUN_LIM
         else:
             raw_state = _read_run_status(run_dir)
             status = raw_state if raw_state in ("cancelled", "failed") else "complete"
-        date_iso, date_label = parse_run_date(reports_root, project, entry.name)
+        cached = index_dates.get(entry.name)
+        if cached is not None:
+            date_iso, date_label = cached
+        else:
+            date_iso, date_label = parse_run_date(reports_root, project, entry.name)
         run_infos.append(RunInfo(run_id=entry.name, date_iso=date_iso, date_label=date_label, status=status))
     run_infos.sort(key=lambda r: (r.date_iso or "", r.run_id), reverse=True)
     if limit > 0:

--- a/src/quodeq/services/run_dates.py
+++ b/src/quodeq/services/run_dates.py
@@ -1,0 +1,44 @@
+# src/quodeq/services/run_dates.py
+"""Index-backed run-date resolution for fast enumeration.
+
+`list_runs` otherwise reads a JSON file per run just to get its date. The run
+index already stores each run's ``started_at`` (which equals the displayed
+date), so this returns a ``{run_id: (date_iso, date_label)}`` map from the index,
+refreshing it with a cheap mtime-gated per-project sync first. Best-effort: any
+index error yields ``{}`` and the caller falls back to ``parse_run_date``.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+
+def project_run_dates(reports_root: Path, project: str) -> dict[str, tuple[str, str]]:
+    """Return ``{run_id: (date_iso, date_label)}`` from the run index, or ``{}``."""
+    try:
+        from quodeq.data.fs.report_parser._date_utils import normalize_date  # noqa: PLC0415
+        from quodeq.services.run_index import (  # noqa: PLC0415
+            list_runs_for_project, open_index, sync_project_dates,
+        )
+        from quodeq.shared._env import get_index_db_path  # noqa: PLC0415
+
+        db = open_index(Path(get_index_db_path()))
+        try:
+            sync_project_dates(db, Path(reports_root) / project, project)
+            rows = list_runs_for_project(db, project)
+        finally:
+            db.close()
+    except Exception:
+        _logger.debug("project_run_dates: index unavailable for %s", project, exc_info=True)
+        return {}
+
+    out: dict[str, tuple[str, str]] = {}
+    for r in rows:
+        if not r.started_at:
+            continue
+        normalized = normalize_date(r.started_at)
+        if normalized:
+            out[r.run_id] = normalized
+    return out

--- a/src/quodeq/services/run_dates.py
+++ b/src/quodeq/services/run_dates.py
@@ -6,6 +6,14 @@ index already stores each run's ``started_at`` (which equals the displayed
 date), so this returns a ``{run_id: (date_iso, date_label)}`` map from the index,
 refreshing it with a cheap mtime-gated per-project sync first. Best-effort: any
 index error yields ``{}`` and the caller falls back to ``parse_run_date``.
+
+Precedence note: for a run that has a ``status.json``, this uses ``started_at``
+as the date, which intentionally supersedes ``parse_run_date``'s evidence/eval
+``date``-field-first ordering. In practice the two are captured seconds apart in
+the same run, so the displayed label is identical; ``started_at`` is the
+canonical run timestamp and does not drift if an evidence file is later
+rewritten. Runs without a usable ``started_at`` are omitted so the caller falls
+back to ``parse_run_date``.
 """
 from __future__ import annotations
 

--- a/src/quodeq/services/run_index.py
+++ b/src/quodeq/services/run_index.py
@@ -221,6 +221,36 @@ def sync_index_for_run(db: sqlite3.Connection, run_dir: Path) -> None:
         _sync_one_run(db, run_dir, project_uuid=project_uuid, run_id=run_id)
 
 
+def sync_project_dates(db: sqlite3.Connection, project_dir: Path, project_uuid: str) -> None:
+    """Mtime-gated upsert of one project's runs' ``started_at`` into the index.
+
+    Lighter than :func:`sync_index` / ``_sync_one_run``: refreshes only rows whose
+    ``status.json`` mtime changed, and skips stale-promotion (the run date needs
+    only the immutable ``started_at``). Runs without ``status.json`` are left to
+    the caller's ``parse_run_date`` fallback. The mtime cache is keyed by
+    ``(project_uuid, run_id)`` so it matches the row regardless of ``job_id``.
+    """
+    if not project_dir.is_dir():
+        return
+    with db:
+        for run_dir in project_dir.iterdir():
+            if not run_dir.is_dir() or run_dir.name.startswith("."):
+                continue
+            if not (run_dir / "status.json").exists():
+                continue
+            disk_mtime = _status_mtime_ns(run_dir)
+            cached = db.execute(
+                "SELECT status_mtime FROM runs WHERE project_uuid=? AND run_id=?",
+                (project_uuid, run_dir.name),
+            ).fetchone()
+            if cached is None or cached[0] != disk_mtime:
+                try:
+                    _upsert_from_status(
+                        db, run_dir, project_uuid=project_uuid, run_id=run_dir.name)
+                except Exception:
+                    _logger.warning("date-sync upsert failed for %s", run_dir, exc_info=True)
+
+
 # ---------------------------------------------------------------------------
 # Public query API
 # ---------------------------------------------------------------------------

--- a/tests/data/fs/report_parser/test_list_runs_index_date.py
+++ b/tests/data/fs/report_parser/test_list_runs_index_date.py
@@ -1,0 +1,55 @@
+import json
+from pathlib import Path
+
+from quodeq.data.fs.report_parser.runs import list_runs
+from quodeq.data.fs.report_parser._date_utils import normalize_date
+
+
+def _make_run(reports: Path, project: str, run_id: str, *, started_at, eval_date=None,
+              write_status=True):
+    rd = reports / project / run_id
+    (rd / "evidence").mkdir(parents=True, exist_ok=True)
+    (rd / "evidence" / "manifest.json").write_text(json.dumps({"language_stats": {}}), "utf-8")
+    (rd / "evaluation").mkdir(parents=True, exist_ok=True)
+    ev = {"schema_version": 1, "dimension": "security", "overallScore": "8.0/10",
+          "overallGrade": "Good", "principles": [], "violations": []}
+    if eval_date is not None:
+        ev["date"] = eval_date
+    (rd / "evaluation" / "security.json").write_text(json.dumps(ev), "utf-8")
+    if write_status:
+        (rd / "status.json").write_text(json.dumps({
+            "schema_version": 1, "job_id": f"job-{run_id}", "state": "done",
+            "started_at": started_at, "updated_at": started_at, "finalized_at": started_at,
+            "phase": None, "current_dimension": None, "dimensions": [], "pid": None,
+            "exit_reason": None, "deadline_at": None,
+        }), "utf-8")
+    return rd
+
+
+def test_index_date_equals_disk_date(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(tmp_path / "idx.db"))
+    reports = tmp_path / "evaluations"
+    # eval_date == started_at (the real-world invariant): index path must match.
+    _make_run(reports, "proj", "run-a", started_at="2026-05-25T22:19:50+00:00",
+              eval_date="2026-05-25T22:19:50+00:00")
+    runs = list_runs(reports, "proj")
+    assert len(runs) == 1
+    assert (runs[0].date_iso, runs[0].date_label) == normalize_date("2026-05-25T22:19:50+00:00")
+
+
+def test_missing_status_falls_back_to_parse_run_date(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(tmp_path / "idx.db"))
+    reports = tmp_path / "evaluations"
+    _make_run(reports, "proj", "run-b", started_at="x", eval_date="2026-06-01T10:00:00+00:00",
+              write_status=False)  # not in index -> fallback to evaluation date
+    runs = list_runs(reports, "proj")
+    assert runs[0].date_iso == normalize_date("2026-06-01T10:00:00+00:00")[0]
+
+
+def test_dateless_run_gains_started_at_from_index(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(tmp_path / "idx.db"))
+    reports = tmp_path / "evaluations"
+    # No eval date -> disk-only would fall back to run_id; index supplies started_at.
+    _make_run(reports, "proj", "run-c", started_at="2026-07-04T05:25:51+00:00", eval_date=None)
+    runs = list_runs(reports, "proj")
+    assert runs[0].date_iso == normalize_date("2026-07-04T05:25:51+00:00")[0]

--- a/tests/services/test_run_dates.py
+++ b/tests/services/test_run_dates.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+from quodeq.services.run_dates import project_run_dates
+
+
+def _write_status(run_dir: Path, started_at: str):
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "status.json").write_text(json.dumps({
+        "schema_version": 1, "job_id": f"job-{run_dir.name}", "state": "done",
+        "started_at": started_at, "updated_at": started_at, "finalized_at": started_at,
+        "phase": None, "current_dimension": None, "dimensions": [], "pid": None,
+        "exit_reason": None, "deadline_at": None,
+    }), encoding="utf-8")
+
+
+def test_returns_normalized_dates_from_index(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(tmp_path / "idx.db"))
+    reports = tmp_path / "evaluations"
+    _write_status(reports / "proj" / "run-a", "2026-05-25T22:19:50+00:00")
+
+    dates = project_run_dates(reports, "proj")
+    # normalize_date on an ISO datetime -> (utc iso + 'Z', "25 May 2026")
+    assert dates["run-a"] == ("2026-05-25T22:19:50Z", "25 May 2026")
+
+
+def test_bad_index_returns_empty(tmp_path, monkeypatch):
+    # Point the index at a path that is a directory -> sqlite/open error -> {}.
+    monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(tmp_path))
+    assert project_run_dates(tmp_path / "evaluations", "proj") == {}

--- a/tests/services/test_sync_project_dates.py
+++ b/tests/services/test_sync_project_dates.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+from quodeq.services.run_index import open_index, sync_project_dates, list_runs_for_project
+
+
+def _write_status(run_dir: Path, started_at: str):
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "status.json").write_text(json.dumps({
+        "schema_version": 1, "job_id": f"job-{run_dir.name}", "state": "done",
+        "started_at": started_at, "updated_at": started_at, "finalized_at": started_at,
+        "phase": None, "current_dimension": None, "dimensions": [], "pid": None,
+        "exit_reason": None, "deadline_at": None,
+    }), encoding="utf-8")
+
+
+def test_syncs_started_at_and_is_mtime_gated(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(tmp_path / "idx.db"))
+    proj = tmp_path / "evaluations" / "proj"
+    _write_status(proj / "run-a", "2026-05-25T22:19:50+00:00")
+    _write_status(proj / "run-b", "2026-05-26T09:00:00+00:00")
+
+    db = open_index(tmp_path / "idx.db")
+    try:
+        sync_project_dates(db, proj, "proj")
+        rows = {r.run_id: r.started_at for r in list_runs_for_project(db, "proj")}
+        assert rows == {
+            "run-a": "2026-05-25T22:19:50+00:00",
+            "run-b": "2026-05-26T09:00:00+00:00",
+        }
+        # Second call, nothing changed on disk -> no upserts (mtime gate).
+        calls = {"n": 0}
+        import quodeq.services.run_index as ri
+        real = ri._upsert_from_status
+        def counting(*a, **k):
+            calls["n"] += 1
+            return real(*a, **k)
+        monkeypatch.setattr(ri, "_upsert_from_status", counting)
+        sync_project_dates(db, proj, "proj")
+        assert calls["n"] == 0, "unchanged runs must not be re-read/upserted"
+    finally:
+        db.close()

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -18,7 +18,8 @@ src/quodeq/api/import_project.py:32:data
 src/quodeq/api/llm_bridge_routes.py:8:llm_bridge
 src/quodeq/data/fs/project_resolver.py:17:services
 src/quodeq/data/fs/repo_clone.py:19:context
-src/quodeq/data/fs/report_parser/runs.py:190:services
+src/quodeq/data/fs/report_parser/runs.py:178:services
+src/quodeq/data/fs/report_parser/runs.py:192:services
 src/quodeq/data/projection/grade_projector.py:132:services
 src/quodeq/data/projection/grade_projector.py:20:services
 src/quodeq/data/sqlite/state_store.py:246:services


### PR DESCRIPTION
## What

`list_runs` no longer reads a JSON file per run to get each run's date. It keeps its disk walk (manifest filter, live status, sort — all unchanged) and gets the date from the run index (`started_at`), falling back to `parse_run_date` for any run not in the index.

- `sync_project_dates` (new): mtime-gated per-project `started_at` upsert — 0 reads when nothing changed.
- `project_run_dates` (new): `{run_id: (date_iso, date_label)}` from the index; `{}` on any error.
- `list_runs`: uses the index date with a `parse_run_date` fallback.

## Why

Profiling the real 204-run project: `list_runs` is ~354 ms and 98% of that is `parse_run_date`, paid on every dashboard request. `started_at` equals today's displayed date (verified 106/106 dated runs, 0 mismatches — the resolved date comes from `evaluation/*.json`'s `date`, which is stamped with the run's start time), and it's immutable, so the cached date is never stale.

## Behaviour notes

- **Fail-soft:** `project_run_dates` returns `{}` on any index error, so this can never make enumeration *fail* — worst case it's as slow as today.
- **`started_at` supersedes the evidence-date** for runs with a `status.json` (deliberate; documented in the `project_run_dates` docstring). Seconds apart in practice, so labels are identical.
- **~94 date-less runs** that previously showed a UUID label now show their real `started_at` date — an improvement.
- **Known benign footgun** (not reachable in the current pipeline; noted in review): the mtime-gate keys on `(project_uuid, run_id)` while `_upsert_from_status` writes by `job_id`; a duplicate row could only occur if a non-`ext-<run_id>` `status.json` writer were added alongside a pre-existing legacy row. All current writers use `ext-<run_id>`.

## Import gate

Adds one grandfathered `data→services` baseline entry (`runs.py:178`) — the same edge `runs.py` already uses for `resolve_external_pid` in that function. DI would spread across ~11 callers incl. data-layer ones without cleanly avoiding the edge.

## Tests

- `test_sync_project_dates` (mtime gate: 0 upserts on unchanged), `test_run_dates` (map + `{}` on bad index), `test_list_runs_index_date` (parity, index-miss fallback, date-less run gains a date — the last genuinely exercises the index path).
- Full non-integration suite: 4223 passed, 1 skipped. Import-layer gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)