### PR TITLE
fix(dashboard): don't strand the user in onboarding on a transient projects-fetch failure

### DIFF
--- a/src/quodeq/ui/src/hooks/useProjectState.js
+++ b/src/quodeq/ui/src/hooks/useProjectState.js
@@ -3,6 +3,8 @@ import { useApi } from '../api/ApiContext.jsx';
 
 const STORAGE_KEY = 'quodeq_selected_project';
 const DEFAULT_RUN = 'latest';
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_RETRY_DELAY_MS = 400;
 
 function persistProject(setter, name, storage = localStorage) {
   setter(name);
@@ -37,14 +39,26 @@ function resolveInitialProject(list, currentProject, onChangeProject, onNoProjec
  *   setSelectedRun: Function, loadProjects: Function, handleProjectChange: Function,
  *   handleRunChange: Function, selectProjectAndRun: Function }}
  */
-export function useProjectState({ onNoProjects, storage = localStorage }) {
+export function useProjectState({
+  onNoProjects,
+  storage = localStorage,
+  maxRetries = DEFAULT_MAX_RETRIES,
+  retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+}) {
   const { listProjects } = useApi();
   const [projects, setProjects] = useState([]);
   const [projectsLoaded, setProjectsLoaded] = useState(false);
   const [selectedProject, setSelectedProject] = useState(() => readStoredProject(storage));
   const [selectedRun, setSelectedRun] = useState(DEFAULT_RUN);
 
-  const loadProjects = useCallback(() => {
+  // Resilient loader. A *transient* fetch failure (e.g. an aborted request
+  // during a startup/reload race) must NOT be mistaken for "no projects" —
+  // that used to strand the user in the onboarding wizard even though their
+  // projects were fine. Retry a few times; on genuine exhaustion return null
+  // so the caller skips onboarding and the app keeps its loading state (which
+  // recovers on the next successful load / reconnect). A successful fetch that
+  // returns an empty array is still a real "fresh user" -> onboarding.
+  const loadProjects = useCallback(function load(attempt = 0) {
     return listProjects()
       .then((data) => {
         const list = Array.isArray(data) ? data : (data?.projects || []);
@@ -52,11 +66,22 @@ export function useProjectState({ onNoProjects, storage = localStorage }) {
         setProjectsLoaded(true);
         return list;
       })
-      .catch((err) => { console.warn('Failed to load projects:', err); setProjectsLoaded(true); return []; });
-  }, []);
+      .catch((err) => {
+        if (attempt < maxRetries) {
+          return new Promise((resolve) => setTimeout(resolve, retryDelayMs))
+            .then(() => load(attempt + 1));
+        }
+        console.warn('Failed to load projects after retries:', err);
+        return null;
+      });
+  }, [listProjects, maxRetries, retryDelayMs]);
 
   useEffect(() => {
-    loadProjects().then((list) => resolveInitialProject(list, selectedProject, handleProjectChange, onNoProjects, storage));
+    loadProjects().then((list) => {
+      // Array (possibly empty -> onboarding) on success; null when the load
+      // failed after retries -> do NOT force onboarding on a transient error.
+      if (list) resolveInitialProject(list, selectedProject, handleProjectChange, onNoProjects, storage);
+    });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleProjectChange(name) {

--- a/src/quodeq/ui/src/hooks/useProjectState.test.jsx
+++ b/src/quodeq/ui/src/hooks/useProjectState.test.jsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+vi.mock('../api/index.js', () => ({ listProjects: vi.fn() }));
+import { listProjects } from '../api/index.js';
+import { useProjectState } from './useProjectState.js';
+
+const noStorage = { getItem: () => '', setItem: () => {} };
+
+beforeEach(() => { listProjects.mockReset(); });
+
+describe('useProjectState — resilience to a transient projects-fetch failure', () => {
+  it('does NOT fall to onboarding when the fetch keeps failing (retries, then gives up without onboarding)', async () => {
+    listProjects.mockRejectedValue(new DOMException('aborted', 'AbortError'));
+    const onNoProjects = vi.fn();
+    const { result } = renderHook(() =>
+      useProjectState({ onNoProjects, storage: noStorage, retryDelayMs: 0, maxRetries: 2 }));
+
+    // initial attempt + 2 retries = 3 calls
+    await waitFor(() => expect(listProjects).toHaveBeenCalledTimes(3));
+    await new Promise((r) => setTimeout(r, 0)); // flush the final .catch/.then
+
+    expect(onNoProjects).not.toHaveBeenCalled();       // <-- the bug: today this IS called
+    expect(result.current.projectsLoaded).toBe(false); // stays in loading, not a false "loaded/empty"
+  });
+
+  it('recovers via retry: a transient failure then success loads projects without onboarding', async () => {
+    listProjects
+      .mockRejectedValueOnce(new DOMException('aborted', 'AbortError'))
+      .mockResolvedValueOnce([{ id: 'p1', name: 'proj1' }]);
+    const onNoProjects = vi.fn();
+    const { result } = renderHook(() =>
+      useProjectState({ onNoProjects, storage: noStorage, retryDelayMs: 0, maxRetries: 3 }));
+
+    await waitFor(() => expect(result.current.projects).toHaveLength(1));
+    expect(result.current.selectedProject).toBe('p1');
+    expect(onNoProjects).not.toHaveBeenCalled();
+  });
+
+  it('still calls onNoProjects (onboarding) for a genuinely empty, successful list', async () => {
+    listProjects.mockResolvedValue([]);
+    const onNoProjects = vi.fn();
+    renderHook(() =>
+      useProjectState({ onNoProjects, storage: noStorage, retryDelayMs: 0 }));
+
+    await waitFor(() => expect(onNoProjects).toHaveBeenCalledTimes(1));
+  });
+
+  it('selects the first project on a successful non-empty load', async () => {
+    listProjects.mockResolvedValue([{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }]);
+    const { result } = renderHook(() =>
+      useProjectState({ onNoProjects: vi.fn(), storage: noStorage, retryDelayMs: 0 }));
+
+    await waitFor(() => expect(result.current.selectedProject).toBe('a'));
+  });
+});


### PR DESCRIPTION
## What

`useProjectState.loadProjects` now **retries** a failed `/api/projects` fetch and, on genuine exhaustion, returns `null` (a distinct "load failed" signal) instead of `[]`. The initial effect only routes to onboarding when it gets a real list — an *empty array* from a **successful** fetch (a genuinely fresh user) still shows onboarding, but a **fetch error/abort** no longer does.

## Why

Live-debugging the "keeps loading / can't enter the app" report: the backend is healthy (`/api/projects` returns the real 11 projects in ~220 ms), but the app was **stuck on the onboarding wizard** anyway. Root cause: `loadProjects`'s `.catch` returned `[]` on *any* error, and `resolveInitialProject([])` calls `onNoProjects()` → onboarding. So a single transient abort on startup (e.g. a reload/navigation race) permanently stranded the user in onboarding even though their projects were fine.

Reproduced directly: the app showed onboarding while `fetch('/api/projects')` from the same page returned all 11 projects.

## Tests

New `useProjectState.test.jsx`:
- keeps failing → retries, then gives up **without** calling `onNoProjects` (was: onboarding);
- transient failure **then success** → projects load, first project selected, no onboarding;
- genuinely empty successful list → still onboarding (unchanged);
- successful non-empty load → selects the first project.

Full UI suite: **793 passed**.

## Scope

This hardens the frontend against the transient failure that manifested the bug. The *exact* pywebview reload trigger that produces the transient abort (the desktop app's About-panel re-registration loop in `webview.log`) is still unconfirmed and tracked as a follow-up — but this makes the app resilient to it regardless. A related follow-up: `useServerHealth` redirects/marks-disconnected on a single 2 s health miss (could require 2-3 consecutive misses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)