### PR TITLE
feat(dashboard): per-dimension score-history grouping

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -346,6 +346,8 @@ const ROUTE_RENDERERS = {
       onNavigate={props.navigation.handleNavigate}
       refreshSignal={props.dashboardData.dashboard}
       trend={props.dashboardData.dashboard?.trend || []}
+      granularity={props.dashboardData.granularity}
+      onGranularityChange={props.dashboardData.onGranularityChange}
     />
   ),
   evaluate: (params, props) => <EvaluateCase serverHealth={props.serverHealth} evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} projects={props.navigation.projects} preselectDims={params.preselectDims} onGoToProjects={() => props.navigation.navTab('projects')} onGoToSettings={() => props.navigation.navTab('settings')} />,

--- a/src/quodeq/ui/src/components/DimensionSparkline.jsx
+++ b/src/quodeq/ui/src/components/DimensionSparkline.jsx
@@ -18,32 +18,6 @@ const MAX_SCORE = 10;
 const VISIBLE_MIN_SCORE = 4;
 
 /**
- * Extract the last `limit` scores for a dimension from a trend array.
- * Input `trend` is newest-first; output is oldest-first so the sparkline
- * reads left-to-right chronologically.
- *
- * @param {Array} trend - Trend entries (newest-first).
- * @param {string} dimensionName - Case-insensitive match.
- * @param {number} [limit=10]
- * @returns {number[]}
- */
-export function extractDimensionHistory(trend, dimensionName, limit = 10) {
-  if (!Array.isArray(trend) || !dimensionName) return [];
-  const want = String(dimensionName).toLowerCase();
-  const scores = [];
-  for (const entry of trend) {
-    const details = entry?.dimensionDetails;
-    if (!Array.isArray(details)) continue;
-    const match = details.find((d) => (d.dimension || '').toLowerCase() === want);
-    if (match && match.score != null && !Number.isNaN(parseFloat(match.score))) {
-      scores.push(parseFloat(match.score));
-      if (scores.length >= limit) break;
-    }
-  }
-  return scores.reverse();
-}
-
-/**
  * Responsive sparkline. The SVG fills 100% of its container width and uses
  * `preserveAspectRatio="none"` so the bars stretch horizontally — the caller
  * controls the final width via CSS on the wrapping element (`.dim-score-spark`).

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -2,7 +2,7 @@ import React, { useMemo, lazy, Suspense } from 'react';
 import TrendBadge from '../../../components/TrendBadge.jsx';
 import DimensionCardsGrid from './DimensionCardsGrid.jsx';
 import { formatRunId, gradeLetter, complianceRatio, extDisplayName } from '../../../utils/formatters.js';
-import { collapseByPeriod, collectPeriodDimensions, bucketKey } from '../../../utils/dailyGrouping.js';
+import { collapseByPeriod, collectPeriodDimensions, bucketKey, extractDimensionPeriodSeries } from '../../../utils/dailyGrouping.js';
 const RunHistoryPanel = lazy(() => import('./RunHistoryPanel.jsx'));
 import DimensionScorePanel from './DimensionScorePanel.jsx';
 import TopOffendingFilesTable from './TopOffendingFilesTable.jsx';
@@ -15,6 +15,10 @@ import { readVisibleStandardIds } from '../../../utils/visibleStandards.js';
 import { filterTrendByVisibleStandards, filterTrendByVisibleStandardsDaily, filterAccumulatedByVisibleStandards } from '../../../utils/scoreFiltering.js';
 import { useRegisterWindowSpec, ReportContent } from '../../side-pane/index.js';
 import { buildOverviewReport } from '../../../utils/reportBuilder.js';
+
+// Sparkline history length for the per-dimension period series (matches the
+// old DimensionScorePanel SPARKLINE_LIMIT).
+const DIM_SPARKLINE_LIMIT = 10;
 
 // ---------------------------------------------------------------------------
 // Accumulated overview panel helpers
@@ -131,7 +135,7 @@ function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, accumulated
   );
 }
 
-function AccumulatedDimensionsSection({ sortedDimensions, onDimensionClick, selectedDayDimNames }) {
+function AccumulatedDimensionsSection({ sortedDimensions, onDimensionClick, selectedDayDimNames, dimTrends }) {
   return (
     <section className="quality-dimensions" aria-label="Quality dimensions">
       <div className="quality-dimensions__head">
@@ -142,6 +146,7 @@ function AccumulatedDimensionsSection({ sortedDimensions, onDimensionClick, sele
           sortedDimensions={sortedDimensions}
           onDimensionClick={onDimensionClick}
           selectedDayDimNames={selectedDayDimNames}
+          dimTrends={dimTrends}
         />
       </div>
     </section>
@@ -185,6 +190,22 @@ function useAccumulatedComputations(data) {
   // period-collapsed representatives.
   const filteredTrend = useMemo(() => filterTrendByVisibleStandards(trend, visibleSet), [trend, visibleSet]);
   const filteredDimensions = useMemo(() => accumulatedDimensions.filter((d) => visibleSet.has((d.dimension || '').toLowerCase())), [accumulatedDimensions, visibleIds]);
+
+  // Period-aware per-dimension trends: one entry per visible dimension,
+  // { delta, scores }, bucketed by the selected granularity from the raw
+  // (visible-filtered, per-run) trend. Feeds both the dimension cards and
+  // the DIMENSIONS panel so their deltas/sparklines match the Overview chart.
+  const dimTrends = useMemo(() => {
+    const map = {};
+    for (const dim of filteredDimensions) {
+      const name = dim.dimension || '';
+      const series = extractDimensionPeriodSeries(filteredTrend, name, granularity, DIM_SPARKLINE_LIMIT);
+      const scores = series.map((s) => s.score);
+      const delta = scores.length >= 2 ? scores[scores.length - 1] - scores[scores.length - 2] : null;
+      map[name.toLowerCase()] = { delta, scores };
+    }
+    return map;
+  }, [filteredDimensions, filteredTrend, granularity]);
   const filteredAccumulated = useMemo(() => filterAccumulatedByVisibleStandards(accumulated, visibleSet, filteredPeriodTrend, currentOverviewRun), [accumulated, visibleSet, filteredPeriodTrend, currentOverviewRun]);
   const filteredStats = useMemo(() => computeAccumulatedStats(filteredDimensions, filteredPeriodTrend, currentOverviewRun), [filteredDimensions, filteredPeriodTrend, currentOverviewRun]);
 
@@ -192,12 +213,12 @@ function useAccumulatedComputations(data) {
   // of the chosen grouping — so the selector never disappears on collapse.
   const chartMountable = filteredDayTrend.length >= 2;
 
-  return { currentOverviewRun, selectedDayDimNames, filteredPeriodTrend, filteredTrend, filteredDimensions, filteredAccumulated, filteredStats, chartMountable };
+  return { currentOverviewRun, selectedDayDimNames, filteredPeriodTrend, filteredTrend, filteredDimensions, filteredAccumulated, filteredStats, chartMountable, dimTrends };
 }
 
 export default function AccumulatedOverviewPanel({ data, callbacks }) {
   const { onRunClick, onDimensionClick, onNavigate } = callbacks;
-  const { currentOverviewRun, selectedDayDimNames, filteredPeriodTrend, filteredTrend, filteredDimensions, filteredAccumulated, filteredStats, chartMountable } = useAccumulatedComputations(data);
+  const { currentOverviewRun, selectedDayDimNames, filteredPeriodTrend, filteredTrend, filteredDimensions, filteredAccumulated, filteredStats, chartMountable, dimTrends } = useAccumulatedComputations(data);
 
   const topFiles = useMemo(
     () => withDimensionsStr(buildTopOffendingFiles(filteredDimensions || [])),
@@ -262,13 +283,14 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
             />
           )}
         </Suspense>
-        <DimensionScorePanel dimensions={filteredDimensions} onBarClick={onDimensionClick} runDate={filteredStats.lastRun.date} runId={filteredStats.lastRun.runId} trend={filteredTrend} />
+        <DimensionScorePanel dimensions={filteredDimensions} onBarClick={onDimensionClick} dimTrends={dimTrends} />
       </div>
 
       <AccumulatedDimensionsSection
         sortedDimensions={filteredStats.sorted}
         onDimensionClick={onDimensionClick}
         selectedDayDimNames={selectedDayDimNames}
+        dimTrends={dimTrends}
       />
 
       {topFiles.length > 0 && (

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
@@ -1,13 +1,15 @@
 import { useMemo } from 'react';
 import DimensionGaugeCard from './DimensionGaugeCard.jsx';
 
-function computeDelta(item) {
+// Fallback delta when the parent did not supply a period-aware entry for this
+// dimension (defensive; the accumulated overview always supplies dimTrends).
+function fallbackDelta(item) {
   const curr = parseFloat(item.overallScore);
   const prev = parseFloat(item.previousScore);
   return !Number.isNaN(curr) && !Number.isNaN(prev) ? curr - prev : null;
 }
 
-export default function DimensionCardsGrid({ sortedDimensions, onDimensionClick, selectedDayDimNames }) {
+export default function DimensionCardsGrid({ sortedDimensions, onDimensionClick, selectedDayDimNames, dimTrends }) {
   const dimNameSet = selectedDayDimNames instanceof Set ? selectedDayDimNames : new Set();
   const sorted = useMemo(() => [...sortedDimensions].sort((a, b) => {
     if (dimNameSet.size === 0) return a.dimension.localeCompare(b.dimension);
@@ -22,11 +24,13 @@ export default function DimensionCardsGrid({ sortedDimensions, onDimensionClick,
     <div className="dimensions-grid">
       {sorted.map((item) => {
         const isActive = dimNameSet.size === 0 || dimNameSet.has((item.dimension || '').toLowerCase());
+        const entry = dimTrends?.[(item.dimension || '').toLowerCase()];
+        const delta = entry ? entry.delta : fallbackDelta(item);
         return (
           <DimensionGaugeCard
             key={item.dimension}
             item={item}
-            delta={computeDelta(item)}
+            delta={delta}
             onDimensionClick={onDimensionClick}
             evaluatedToday={isActive}
           />

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.test.jsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import DimensionCardsGrid from './DimensionCardsGrid.jsx';
+
+const DIMS = [
+  { dimension: 'maintainability', overallScore: '8.0', previousScore: '2.0', overallGrade: 'B', totals: { violationCount: 1, complianceCount: 4, severity: {} } },
+];
+
+describe('DimensionCardsGrid', () => {
+  it('uses the period-aware delta from dimTrends on the card badge', () => {
+    // run-based fallback would render +6.0 (8.0 - 2.0); the period delta is -0.5
+    const dimTrends = { maintainability: { delta: -0.5, scores: [8.5, 8.0] } };
+    render(<DimensionCardsGrid sortedDimensions={DIMS} dimTrends={dimTrends} />);
+    expect(screen.getByText('-0.5')).toBeInTheDocument();
+    expect(screen.queryByText('+6.0')).not.toBeInTheDocument();
+  });
+
+  it('falls back to overallScore - previousScore when dimTrends is absent', () => {
+    render(<DimensionCardsGrid sortedDimensions={DIMS} />);
+    expect(screen.getByText('+6.0')).toBeInTheDocument();
+  });
+});

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionScorePanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionScorePanel.jsx
@@ -1,7 +1,5 @@
 import TrendBadge from '../../../components/TrendBadge.jsx';
-import DimensionSparkline, { extractDimensionHistory } from '../../../components/DimensionSparkline.jsx';
-
-const SPARKLINE_LIMIT = 10;
+import DimensionSparkline from '../../../components/DimensionSparkline.jsx';
 
 function violationCount(dim) {
   if (typeof dim.totalViolations === 'number') return dim.totalViolations;
@@ -9,10 +7,8 @@ function violationCount(dim) {
   return 0;
 }
 
-function DimensionRow({ dim, onBarClick, history }) {
+function DimensionRow({ dim, onBarClick, delta, scores }) {
   const curr = parseFloat(dim.overallScore);
-  const prev = parseFloat(dim.previousScore);
-  const delta = !Number.isNaN(curr) && !Number.isNaN(prev) ? curr - prev : null;
   const score = Number.isNaN(curr) ? 0 : curr;
   const violations = violationCount(dim);
 
@@ -26,7 +22,7 @@ function DimensionRow({ dim, onBarClick, history }) {
     >
       <span className="dim-score-label">{String(dim.dimension || '').toLowerCase()}</span>
       <span className="dim-score-spark">
-        <DimensionSparkline scores={history} />
+        <DimensionSparkline scores={scores} />
       </span>
       <span className="dim-score-value">{score.toFixed(1)}</span>
       <span className="dim-score-trend"><TrendBadge delta={delta} /></span>
@@ -35,7 +31,15 @@ function DimensionRow({ dim, onBarClick, history }) {
   );
 }
 
-export default function DimensionScorePanel({ dimensions = [], onBarClick, trend = [] }) {
+// Fallback delta when the parent did not supply a period-aware entry for this
+// dimension (defensive; the accumulated overview always supplies dimTrends).
+function fallbackDelta(dim) {
+  const curr = parseFloat(dim.overallScore);
+  const prev = parseFloat(dim.previousScore);
+  return !Number.isNaN(curr) && !Number.isNaN(prev) ? curr - prev : null;
+}
+
+export default function DimensionScorePanel({ dimensions = [], onBarClick, dimTrends }) {
   if (!dimensions || dimensions.length === 0) return null;
 
   const sorted = [...dimensions].sort((a, b) => a.dimension.localeCompare(b.dimension));
@@ -44,14 +48,20 @@ export default function DimensionScorePanel({ dimensions = [], onBarClick, trend
     <section className="dim-score-panel dim-score-panel--terminal panel" aria-label="Dimension scores">
       <header className="dim-score-panel__header">DIMENSIONS</header>
       <div className="dim-score-rows">
-        {sorted.map((dim) => (
-          <DimensionRow
-            key={dim.dimension}
-            dim={dim}
-            onBarClick={onBarClick}
-            history={extractDimensionHistory(trend, dim.dimension, SPARKLINE_LIMIT)}
-          />
-        ))}
+        {sorted.map((dim) => {
+          const entry = dimTrends?.[(dim.dimension || '').toLowerCase()];
+          const delta = entry ? entry.delta : fallbackDelta(dim);
+          const scores = entry ? entry.scores : [];
+          return (
+            <DimensionRow
+              key={dim.dimension}
+              dim={dim}
+              onBarClick={onBarClick}
+              delta={delta}
+              scores={scores}
+            />
+          );
+        })}
       </div>
     </section>
   );

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionScorePanel.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionScorePanel.test.jsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import DimensionScorePanel from './DimensionScorePanel.jsx';
+
+const DIMS = [
+  { dimension: 'maintainability', overallScore: '8.0', previousScore: '2.0', totalViolations: 3 },
+];
+
+describe('DimensionScorePanel', () => {
+  it('shows the period-aware delta from dimTrends, not overallScore - previousScore', () => {
+    // run-based fallback would render +6.0 (8.0 - 2.0); the period delta is -0.5
+    const dimTrends = { maintainability: { delta: -0.5, scores: [8.5, 8.0] } };
+    render(<DimensionScorePanel dimensions={DIMS} dimTrends={dimTrends} />);
+    expect(screen.getByText('-0.5')).toBeInTheDocument();
+    expect(screen.queryByText('+6.0')).not.toBeInTheDocument();
+  });
+
+  it('renders one sparkline bar per period score', () => {
+    const dimTrends = { maintainability: { delta: 0.5, scores: [7.0, 7.5, 8.0] } };
+    const { container } = render(<DimensionScorePanel dimensions={DIMS} dimTrends={dimTrends} />);
+    expect(container.querySelectorAll('.dim-sparkline rect')).toHaveLength(3);
+  });
+
+  it('renders no trend badge when the period delta is null (single bucket)', () => {
+    const dimTrends = { maintainability: { delta: null, scores: [8.0] } };
+    const { container } = render(<DimensionScorePanel dimensions={DIMS} dimTrends={dimTrends} />);
+    expect(container.querySelector('.trend-badge')).toBeNull();
+  });
+});

--- a/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.a11y.test.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.a11y.test.jsx
@@ -4,8 +4,8 @@ import '@testing-library/jest-dom/vitest';
 import DimensionScoreHistoryPanel from './DimensionScoreHistoryPanel.jsx';
 
 const TREND = [
-  { runId: 'r2', dateLabel: 'Apr 5', dimensionDetails: [{ dimension: 'maintainability', score: 5.7 }] },
-  { runId: 'r1', dateLabel: 'Apr 3', dimensionDetails: [{ dimension: 'maintainability', score: 5.2 }] },
+  { runId: 'r2', dateISO: '2026-04-05T10:00:00', dateLabel: 'Apr 5', dimensionDetails: [{ dimension: 'maintainability', score: 5.7 }] },
+  { runId: 'r1', dateISO: '2026-04-03T10:00:00', dateLabel: 'Apr 3', dimensionDetails: [{ dimension: 'maintainability', score: 5.2 }] },
 ];
 
 // #1800: the old keyboard handler only ever activated the LAST data point, so

--- a/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
@@ -11,8 +11,9 @@ import {
   Cell,
   ReferenceLine,
 } from 'recharts';
-import { SectionLabel } from '../../../components/terminal/index.js';
-import { gradeLetter } from '../../../utils/formatters.js';
+import { SectionLabel, PeriodSelect } from '../../../components/terminal/index.js';
+import { gradeLetter, formatPeriodLabel } from '../../../utils/formatters.js';
+import { extractDimensionPeriodSeries } from '../../../utils/dailyGrouping.js';
 import ChartKeyboardControls from '../../../components/ChartKeyboardControls.jsx';
 import {
   cssVar,
@@ -27,31 +28,21 @@ import {
 
 const MAX = 16;
 const CHART_HEIGHT = 160;
+const GRANULARITY_SUFFIX = { day: 'd', week: 'w', month: 'mo' };
 
 /**
- * Build chart data points for a single dimension's history.
- * Walks the trend (newest-first) and emits one point per run that
- * scored this dimension, oldest-first to read left-to-right.
+ * Build chart points for a single dimension, collapsed to one point per
+ * period bucket (day/week/month) using the newest run in each bucket that
+ * scored the dimension. Oldest-first to read left-to-right.
  */
-function buildDimensionData(trend, dimensionName, limit) {
-  if (!Array.isArray(trend) || !dimensionName) return [];
-  const want = String(dimensionName).toLowerCase();
-  const points = [];
-  for (const entry of trend) {
-    const details = entry?.dimensionDetails;
-    if (!Array.isArray(details)) continue;
-    const match = details.find((d) => (d.dimension || '').toLowerCase() === want);
-    const score = match ? parseFloat(match.score) : NaN;
-    if (!Number.isFinite(score)) continue;
-    points.push({
-      runId: entry.runId,
-      dateLabel: entry.dateLabel,
-      numericAverage: score,
-      overallGrade: match.grade ?? entry.overallGrade,
-    });
-    if (points.length >= limit) break;
-  }
-  return points.reverse();
+function buildDimensionData(trend, dimensionName, granularity, limit) {
+  return extractDimensionPeriodSeries(trend, dimensionName, granularity, limit).map((entry) => ({
+    runId: entry.runId,
+    dateLabel: entry.dateLabel,
+    periodLabel: formatPeriodLabel(entry, granularity),
+    numericAverage: entry.score,
+    overallGrade: entry.grade ?? entry.overallGrade,
+  }));
 }
 
 function DimensionTooltip({ active, payload }) {
@@ -62,7 +53,7 @@ function DimensionTooltip({ active, payload }) {
   const grade = gradeLetter(entry.overallGrade);
   return (
     <div className="run-history-tooltip">
-      <span className="rht-date">{entry.dateLabel}</span>
+      <span className="rht-date">{entry.periodLabel || entry.dateLabel}</span>
       <span className="rht-score">{score} - {grade}</span>
     </div>
   );
@@ -131,9 +122,9 @@ function DimensionHistoryChart({ data, selectedRunId, hoveredIndex, setHoveredIn
   );
 }
 
-export default function DimensionScoreHistoryPanel({ trend = [], dimension, selectedRunId = null, onBarClick }) {
+export default function DimensionScoreHistoryPanel({ trend = [], dimension, selectedRunId = null, onBarClick, granularity = 'day', onGranularityChange }) {
   const [hoveredIndex, setHoveredIndex] = useState(null);
-  const data = useMemo(() => buildDimensionData(trend, dimension, MAX), [trend, dimension]);
+  const data = useMemo(() => buildDimensionData(trend, dimension, granularity, MAX), [trend, dimension, granularity]);
 
   const stats = useMemo(() => {
     const scores = data.map((d) => d.numericAverage).filter(Number.isFinite);
@@ -145,15 +136,20 @@ export default function DimensionScoreHistoryPanel({ trend = [], dimension, sele
     };
   }, [data]);
 
+  const suffix = GRANULARITY_SUFFIX[granularity] || 'd';
+
   return (
     <section className="run-history-panel run-history-panel--terminal panel" aria-label={`${dimension} score history`}>
       <div className="run-history-panel__header">
-        <SectionLabel>score_history · {data.length}d</SectionLabel>
-        {stats && (
-          <span className="run-history-panel__stats">
-            MIN {stats.min.toFixed(1)} / MAX {stats.max.toFixed(1)} / AVG {stats.avg.toFixed(1)}
-          </span>
-        )}
+        <SectionLabel>score_history · {data.length}{suffix}</SectionLabel>
+        <span className="run-history-panel__controls">
+          {onGranularityChange && <PeriodSelect value={granularity} onChange={onGranularityChange} />}
+          {stats && (
+            <span className="run-history-panel__stats">
+              MIN {stats.min.toFixed(1)} / MAX {stats.max.toFixed(1)} / AVG {stats.avg.toFixed(1)}
+            </span>
+          )}
+        </span>
       </div>
       {data.length === 0 ? (
         <div className="qd-history-empty">no history yet for this dimension</div>

--- a/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.test.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.test.jsx
@@ -1,11 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import DimensionScoreHistoryPanel from './DimensionScoreHistoryPanel.jsx';
 
 const TREND = [
-  { runId: 'r3', dateLabel: 'Apr 7', dimensionDetails: [{ dimension: 'maintainability', score: 6.1 }, { dimension: 'reliability', score: 5.9 }] },
-  { runId: 'r2', dateLabel: 'Apr 5', dimensionDetails: [{ dimension: 'maintainability', score: 5.7 }] },
-  { runId: 'r1', dateLabel: 'Apr 3', dimensionDetails: [{ dimension: 'maintainability', score: 5.2 }] },
+  { runId: 'r3', dateISO: '2026-04-07T10:00:00', dateLabel: 'Apr 7', dimensionDetails: [{ dimension: 'maintainability', score: 6.1 }, { dimension: 'reliability', score: 5.9 }] },
+  { runId: 'r2', dateISO: '2026-04-05T10:00:00', dateLabel: 'Apr 5', dimensionDetails: [{ dimension: 'maintainability', score: 5.7 }] },
+  { runId: 'r1', dateISO: '2026-04-03T10:00:00', dateLabel: 'Apr 3', dimensionDetails: [{ dimension: 'maintainability', score: 5.2 }] },
 ];
 
 describe('DimensionScoreHistoryPanel', () => {
@@ -26,5 +26,31 @@ describe('DimensionScoreHistoryPanel', () => {
     render(<DimensionScoreHistoryPanel trend={TREND} dimension="maintainability" />);
     expect(screen.getByText(/score_history/i)).toBeInTheDocument();
     expect(screen.getByText(/· 3d/)).toBeInTheDocument();
+  });
+
+  it('collapses runs into ISO-week buckets when granularity is week', () => {
+    // Apr 3 and Apr 5 are the same ISO week; Apr 7 is the next week.
+    render(<DimensionScoreHistoryPanel trend={TREND} dimension="maintainability" granularity="week" />);
+    expect(screen.getByText(/· 2w/)).toBeInTheDocument();
+  });
+
+  it('renders the PeriodSelect when onGranularityChange is provided and reports changes', () => {
+    const onGranularityChange = vi.fn();
+    render(
+      <DimensionScoreHistoryPanel
+        trend={TREND}
+        dimension="maintainability"
+        granularity="day"
+        onGranularityChange={onGranularityChange}
+      />,
+    );
+    const select = screen.getByLabelText(/Group score history by/i);
+    fireEvent.change(select, { target: { value: 'month' } });
+    expect(onGranularityChange).toHaveBeenCalledWith('month');
+  });
+
+  it('omits the PeriodSelect when onGranularityChange is absent', () => {
+    render(<DimensionScoreHistoryPanel trend={TREND} dimension="maintainability" />);
+    expect(screen.queryByLabelText(/Group score history by/i)).toBeNull();
   });
 });

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -65,6 +65,8 @@ export default function ExplorerPage({
   onNavigate,
   refreshSignal,
   trend = [],
+  granularity = 'day',
+  onGranularityChange,
 }) {
   // Local run/date state lets the score-history bar click swap which run
   // is shown without pushing a new entry onto the nav stack (avoids the
@@ -194,6 +196,8 @@ export default function ExplorerPage({
             trend={trend}
             dimension={d.evalData.dimension}
             selectedRunId={activeRunId}
+            granularity={granularity}
+            onGranularityChange={onGranularityChange}
             onBarClick={(point) => {
               setActiveRunId(point.runId);
               setActiveDateLabel(point.dateLabel);

--- a/src/quodeq/ui/src/utils/dailyGrouping.js
+++ b/src/quodeq/ui/src/utils/dailyGrouping.js
@@ -103,6 +103,49 @@ export function buildPeriodRuns(availableRuns, trend, granularity = 'day') {
   return byBucket;
 }
 
+/**
+ * Per-dimension score series collapsed to one entry per period bucket.
+ *
+ * Walks the trend newest-first; for each bucket keeps the newest run that
+ * actually scored `dimensionName` (so a bucket whose newest run skipped the
+ * dimension still surfaces the newest run in that bucket that did score it).
+ * Buckets are keyed by bucketKey(dateISO, granularity); entries without a
+ * usable date share the empty-key bucket. Returns oldest-first so callers read
+ * left-to-right chronologically.
+ *
+ * @param {Array} trend            Trend entries, newest-first.
+ * @param {string} dimensionName   Case-insensitive match.
+ * @param {'day'|'week'|'month'} [granularity='day']
+ * @param {number} [limit=Infinity] Max buckets to keep (newest buckets win).
+ * @returns {Array<{runId:string, dateISO:string, dateLabel:string, score:number, grade:*, overallGrade:*}>}
+ */
+export function extractDimensionPeriodSeries(trend, dimensionName, granularity = 'day', limit = Infinity) {
+  if (!Array.isArray(trend) || !dimensionName) return [];
+  const want = String(dimensionName).toLowerCase();
+  const seen = new Set();
+  const out = [];
+  for (const entry of trend) {
+    const key = bucketKey(entry?.dateISO, granularity);
+    if (seen.has(key)) continue;
+    const details = entry?.dimensionDetails;
+    if (!Array.isArray(details)) continue;
+    const match = details.find((d) => (d.dimension || '').toLowerCase() === want);
+    const score = match ? parseFloat(match.score) : NaN;
+    if (!Number.isFinite(score)) continue;
+    seen.add(key);
+    out.push({
+      runId: entry.runId,
+      dateISO: entry.dateISO,
+      dateLabel: entry.dateLabel,
+      score,
+      grade: match.grade,
+      overallGrade: entry.overallGrade,
+    });
+    if (out.length >= limit) break;
+  }
+  return out.reverse();
+}
+
 // ── Day-named wrappers (preserve existing call sites and tests) ─────────────
 /**
  * Collapse trend entries (newest-first) into one entry per calendar day.

--- a/src/quodeq/ui/src/utils/dailyGrouping.test.js
+++ b/src/quodeq/ui/src/utils/dailyGrouping.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   collapseByDay, collectDayDimensions, buildDailyRuns,
   bucketKey, isoWeekKey, collapseByPeriod, collectPeriodDimensions, buildPeriodRuns,
+  extractDimensionPeriodSeries,
 } from './dailyGrouping.js';
 
 // ---------------------------------------------------------------------------
@@ -253,4 +254,70 @@ test('buildPeriodRuns: month keeps newest run per month', () => {
 
 test('buildPeriodRuns: day matches buildDailyRuns', () => {
   assert.deepEqual(buildPeriodRuns(AVAILABLE_RUNS, TREND, 'day'), buildDailyRuns(AVAILABLE_RUNS, TREND));
+});
+
+// ---------------------------------------------------------------------------
+// extractDimensionPeriodSeries
+// ---------------------------------------------------------------------------
+
+// Newest-first, entries carry per-dimension scores.
+const DIM_TREND = [
+  { runId: 'd1', dateISO: '2026-05-02T12:00:00', dateLabel: '2 May',  overallGrade: 'Exemplary', dimensionDetails: [{ dimension: 'security', score: 9.0 }] },                                            // May, W18
+  { runId: 'd2', dateISO: '2026-04-14T18:00:00', dateLabel: '14 Apr', overallGrade: 'Good',      dimensionDetails: [{ dimension: 'maintainability', score: 8.0, grade: 'Good' }] },                       // Apr, W16 (newest in week)
+  { runId: 'd3', dateISO: '2026-04-13T09:00:00', dateLabel: '13 Apr', overallGrade: 'Good',      dimensionDetails: [{ dimension: 'maintainability', score: 7.0 }] },                                       // Apr, W16 (older same week)
+  { runId: 'd4', dateISO: '2026-03-25T14:00:00', dateLabel: '25 Mar', overallGrade: 'Good',      dimensionDetails: [{ dimension: 'security', score: 6.0 }, { dimension: 'maintainability', score: 6.5 }] },// Mar, W13
+  { runId: 'd5', dateISO: '2026-03-23T10:00:00', dateLabel: '23 Mar', overallGrade: 'Good',      dimensionDetails: [{ dimension: 'maintainability', score: 6.0 }] },                                       // Mar, W13 (older)
+];
+
+test('extractDimensionPeriodSeries: day keeps every run that scored the dim, oldest-first', () => {
+  const s = extractDimensionPeriodSeries(DIM_TREND, 'maintainability', 'day');
+  assert.deepEqual(s.map((x) => x.runId), ['d5', 'd4', 'd3', 'd2']);
+  assert.deepEqual(s.map((x) => x.score), [6.0, 6.5, 7.0, 8.0]);
+});
+
+test('extractDimensionPeriodSeries: week collapses to newest-scored run per ISO week', () => {
+  const s = extractDimensionPeriodSeries(DIM_TREND, 'maintainability', 'week');
+  assert.deepEqual(s.map((x) => x.runId), ['d4', 'd2']); // W13->d4(6.5), W16->d2(8.0)
+  assert.deepEqual(s.map((x) => x.score), [6.5, 8.0]);
+});
+
+test('extractDimensionPeriodSeries: month collapses to newest-scored run per month', () => {
+  const s = extractDimensionPeriodSeries(DIM_TREND, 'maintainability', 'month');
+  assert.deepEqual(s.map((x) => x.runId), ['d4', 'd2']); // Mar->d4, Apr->d2
+});
+
+test('extractDimensionPeriodSeries: within a bucket uses newest run that scored the dim, skipping runs that did not', () => {
+  const trend = [
+    { runId: 'a', dateISO: '2026-03-25T18:00:00', dimensionDetails: [{ dimension: 'security', score: 9 }] },        // newest in day, NO maintainability
+    { runId: 'b', dateISO: '2026-03-25T09:00:00', dimensionDetails: [{ dimension: 'maintainability', score: 7 }] }, // older same day, HAS it
+  ];
+  const s = extractDimensionPeriodSeries(trend, 'maintainability', 'day');
+  assert.equal(s.length, 1);
+  assert.equal(s[0].runId, 'b');
+  assert.equal(s[0].score, 7);
+});
+
+test('extractDimensionPeriodSeries: limit keeps the newest buckets', () => {
+  const s = extractDimensionPeriodSeries(DIM_TREND, 'maintainability', 'day', 2);
+  assert.deepEqual(s.map((x) => x.runId), ['d3', 'd2']); // newest two day-buckets, oldest-first
+});
+
+test('extractDimensionPeriodSeries: case-insensitive dimension match', () => {
+  const s = extractDimensionPeriodSeries(DIM_TREND, 'Maintainability', 'day');
+  assert.equal(s.length, 4);
+});
+
+test('extractDimensionPeriodSeries: carries dateISO/dateLabel/grade/overallGrade for the representative run', () => {
+  const s = extractDimensionPeriodSeries(DIM_TREND, 'maintainability', 'day');
+  const last = s[s.length - 1]; // d2
+  assert.equal(last.dateISO, '2026-04-14T18:00:00');
+  assert.equal(last.dateLabel, '14 Apr');
+  assert.equal(last.grade, 'Good');
+  assert.equal(last.overallGrade, 'Good');
+});
+
+test('extractDimensionPeriodSeries: empty/invalid inputs return []', () => {
+  assert.deepEqual(extractDimensionPeriodSeries([], 'maintainability', 'day'), []);
+  assert.deepEqual(extractDimensionPeriodSeries(null, 'maintainability', 'day'), []);
+  assert.deepEqual(extractDimensionPeriodSeries(DIM_TREND, '', 'day'), []);
 });


### PR DESCRIPTION
## Summary

Makes the dimension cards, the dashboard **DIMENSIONS** panel, and the explorer dimension-detail score history all respect the same global day/week/month grouping the Overview chart already uses, and adds the grouping selector to the dimension-detail panel. Pure frontend change; no backend, endpoint, or data-shape changes.

## What changed

- **New reusable helper** `extractDimensionPeriodSeries` (`utils/dailyGrouping.js`): collapses one dimension's per-run scores into one entry per period bucket (the newest run in each bucket that actually scored the dimension), keyed by the existing `bucketKey`, oldest-first. All per-dimension deltas and sparklines derive from it.
- **DIMENSIONS panel** (`DimensionScorePanel`) and **dimension cards** (`DimensionCardsGrid`) now consume a period-aware `dimTrends` map (`{ delta, scores }` per dimension) computed in `AccumulatedOverviewPanel`, instead of a run-based `overallScore - previousScore` delta. They fall back to the run-based delta only when no period entry exists.
- **Dimension-detail score history** (`DimensionScoreHistoryPanel`) collapses its series by `granularity`, gains a `PeriodSelect` (Day/Week/Month) and a `d`/`w`/`mo` suffix, and is wired to the same global preference (`state.granularity`) threaded through `ExplorerPage` and the `App` explorer route.
- Removed the now-dead `extractDimensionHistory` export from `DimensionSparkline.jsx`.

The single-run overview path and `HistoryDimensionPanel` are intentionally untouched.

## Delta semantics

`extractDimensionPeriodSeries` returns oldest-first, so the delta is `scores[last] - scores[last-1]` (newest bucket minus prior bucket), consistent across every per-dimension view and the Overview.

## Testing

- 8 new unit tests for `extractDimensionPeriodSeries` (day/week/month collapse, within-bucket newest-scored selection, limit, case-insensitivity, carried fields, empty/invalid inputs).
- New component tests for the panel and cards period-aware deltas/sparklines; 3 new grouping/selector tests + updated fixtures for the detail panel (incl. a11y).
- Full UI sweep green: **node:test 259/259**, **vitest 801/801** across 138 files.
- Manual verification: changing Day -> Month on the Overview updates the DIMENSIONS panel deltas and sparklines and persists the choice; the dimension detail shows the selector synced to the same grouping.