### PR TITLE
refactor(dashboard): share fallbackDelta helper and cover its edge paths

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
@@ -1,13 +1,6 @@
 import { useMemo } from 'react';
 import DimensionGaugeCard from './DimensionGaugeCard.jsx';
-
-// Fallback delta when the parent did not supply a period-aware entry for this
-// dimension (defensive; the accumulated overview always supplies dimTrends).
-function fallbackDelta(item) {
-  const curr = parseFloat(item.overallScore);
-  const prev = parseFloat(item.previousScore);
-  return !Number.isNaN(curr) && !Number.isNaN(prev) ? curr - prev : null;
-}
+import { fallbackDelta } from '../../../utils/dimensionUtils.js';
 
 export default function DimensionCardsGrid({ sortedDimensions, onDimensionClick, selectedDayDimNames, dimTrends }) {
   const dimNameSet = selectedDayDimNames instanceof Set ? selectedDayDimNames : new Set();

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionScorePanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionScorePanel.jsx
@@ -1,5 +1,6 @@
 import TrendBadge from '../../../components/TrendBadge.jsx';
 import DimensionSparkline from '../../../components/DimensionSparkline.jsx';
+import { fallbackDelta } from '../../../utils/dimensionUtils.js';
 
 function violationCount(dim) {
   if (typeof dim.totalViolations === 'number') return dim.totalViolations;
@@ -29,14 +30,6 @@ function DimensionRow({ dim, onBarClick, delta, scores }) {
       <span className="dim-score-viol">{violations}v</span>
     </div>
   );
-}
-
-// Fallback delta when the parent did not supply a period-aware entry for this
-// dimension (defensive; the accumulated overview always supplies dimTrends).
-function fallbackDelta(dim) {
-  const curr = parseFloat(dim.overallScore);
-  const prev = parseFloat(dim.previousScore);
-  return !Number.isNaN(curr) && !Number.isNaN(prev) ? curr - prev : null;
 }
 
 export default function DimensionScorePanel({ dimensions = [], onBarClick, dimTrends }) {

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionScorePanel.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionScorePanel.test.jsx
@@ -16,6 +16,11 @@ describe('DimensionScorePanel', () => {
     expect(screen.queryByText('+6.0')).not.toBeInTheDocument();
   });
 
+  it('falls back to overallScore - previousScore when dimTrends is absent', () => {
+    render(<DimensionScorePanel dimensions={DIMS} />);
+    expect(screen.getByText('+6.0')).toBeInTheDocument();
+  });
+
   it('renders one sparkline bar per period score', () => {
     const dimTrends = { maintainability: { delta: 0.5, scores: [7.0, 7.5, 8.0] } };
     const { container } = render(<DimensionScorePanel dimensions={DIMS} dimTrends={dimTrends} />);

--- a/src/quodeq/ui/src/utils/dailyGrouping.test.js
+++ b/src/quodeq/ui/src/utils/dailyGrouping.test.js
@@ -316,6 +316,21 @@ test('extractDimensionPeriodSeries: carries dateISO/dateLabel/grade/overallGrade
   assert.equal(last.overallGrade, 'Good');
 });
 
+test('extractDimensionPeriodSeries: runs with missing/invalid dateISO collapse into one bucket, newest scored kept', () => {
+  // All falsy dates bucket to the empty key "", so these three runs form a
+  // single bucket. e1 is newest but did not score maintainability (skipped
+  // without consuming the bucket); e2 is the newest run that did; e3 is older.
+  const trend = [
+    { runId: 'e1', dateISO: null,      dimensionDetails: [{ dimension: 'security', score: 9 }] },
+    { runId: 'e2', dateISO: '',        dimensionDetails: [{ dimension: 'maintainability', score: 8.0 }] },
+    { runId: 'e3', dateISO: undefined, dimensionDetails: [{ dimension: 'maintainability', score: 4.0 }] },
+  ];
+  const s = extractDimensionPeriodSeries(trend, 'maintainability', 'day');
+  assert.equal(s.length, 1);
+  assert.equal(s[0].runId, 'e2');
+  assert.equal(s[0].score, 8.0);
+});
+
 test('extractDimensionPeriodSeries: empty/invalid inputs return []', () => {
   assert.deepEqual(extractDimensionPeriodSeries([], 'maintainability', 'day'), []);
   assert.deepEqual(extractDimensionPeriodSeries(null, 'maintainability', 'day'), []);

--- a/src/quodeq/ui/src/utils/dimensionUtils.js
+++ b/src/quodeq/ui/src/utils/dimensionUtils.js
@@ -13,6 +13,17 @@ export function withDimensionsStr(files) {
 }
 
 /**
+ * Run-based delta fallback for a dimension when no period-aware trend entry is
+ * available (defensive; the accumulated overview always supplies dimTrends).
+ * Returns overallScore - previousScore, or null when either is not numeric.
+ */
+export function fallbackDelta(dim) {
+  const curr = parseFloat(dim.overallScore);
+  const prev = parseFloat(dim.previousScore);
+  return !Number.isNaN(curr) && !Number.isNaN(prev) ? curr - prev : null;
+}
+
+/**
  * Sort dimensions by violation severity (critical > major > minor),
  * keeping only dimensions that have at least one violation.
  */


### PR DESCRIPTION
Small quality follow-up to the per-dimension score-history grouping feature (PR #751).

## Changes

**1. Consolidated the duplicated `fallbackDelta` helper.** It appeared verbatim (only the param name differed) in `DimensionScorePanel.jsx` and `DimensionCardsGrid.jsx`. Extracted a single shared export into `src/utils/dimensionUtils.js` and imported it in both components. Behavior is unchanged.

**2. Added two cheap missing tests.**
- `dailyGrouping.test.js` — `extractDimensionPeriodSeries` empty-key bucket path: trend entries with missing/invalid `dateISO` (`null`/`''`/`undefined`) all collapse into the single `""` bucket, and the newest run that actually scored the dimension is kept (skipping a newer run that didn't score it and an older duplicate).
- `DimensionScorePanel.test.jsx` — fallback path: rendered with no `dimTrends` entry for the dimension, the run-based delta (`overallScore 8.0` / `previousScore 2.0`) renders `+6.0`.

## Verification

`npm run test:all` from `src/quodeq/ui`:
- node `--test`: 260 passed, 0 failed
- vitest: 802 passed, 0 failed