### PR TITLE
Keep dimension card positions fixed across period changes

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
@@ -1,21 +1,14 @@
-import { useMemo } from 'react';
 import DimensionGaugeCard from './DimensionGaugeCard.jsx';
 import { fallbackDelta } from '../../../utils/dimensionUtils.js';
 
+// Cards keep the incoming (alphabetical) order regardless of the selected
+// period: changing the day/week/month re-dims cards but never reorders them,
+// so each dimension has a fixed position on the board.
 export default function DimensionCardsGrid({ sortedDimensions, onDimensionClick, selectedDayDimNames, dimTrends }) {
   const dimNameSet = selectedDayDimNames instanceof Set ? selectedDayDimNames : new Set();
-  const sorted = useMemo(() => [...sortedDimensions].sort((a, b) => {
-    if (dimNameSet.size === 0) return a.dimension.localeCompare(b.dimension);
-    const aActive = dimNameSet.has((a.dimension || '').toLowerCase());
-    const bActive = dimNameSet.has((b.dimension || '').toLowerCase());
-    if (aActive && !bActive) return -1;
-    if (!aActive && bActive) return 1;
-    return a.dimension.localeCompare(b.dimension);
-  }), [sortedDimensions, dimNameSet]);
-
   return (
     <div className="dimensions-grid">
-      {sorted.map((item) => {
+      {sortedDimensions.map((item) => {
         const isActive = dimNameSet.size === 0 || dimNameSet.has((item.dimension || '').toLowerCase());
         const entry = dimTrends?.[(item.dimension || '').toLowerCase()];
         const delta = entry ? entry.delta : fallbackDelta(item);

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.test.jsx
@@ -20,4 +20,23 @@ describe('DimensionCardsGrid', () => {
     render(<DimensionCardsGrid sortedDimensions={DIMS} />);
     expect(screen.getByText('+6.0')).toBeInTheDocument();
   });
+
+  it('keeps card positions fixed (incoming order) regardless of the selected period', () => {
+    const dims = [
+      { dimension: 'flexibility', overallScore: '7.9', totals: { severity: {} } },
+      { dimension: 'reliability', overallScore: '9.7', totals: { severity: {} } },
+      { dimension: 'security', overallScore: '9.3', totals: { severity: {} } },
+    ];
+    // Only reliability was evaluated in the selected bucket. It must NOT jump
+    // to the front: changing the selected day/week/month should never reorder
+    // the cards, only re-dim them.
+    render(
+      <DimensionCardsGrid
+        sortedDimensions={dims}
+        selectedDayDimNames={new Set(['reliability'])}
+      />
+    );
+    const names = [...document.querySelectorAll('.dim-gauge-card__name')].map((el) => el.textContent);
+    expect(names).toEqual(['flexibility', 'reliability', 'security']);
+  });
 });


### PR DESCRIPTION
## What

The overview's dimension cards were sorted lit-first (dimensions evaluated in the selected day/week/month before the dimmed carry-overs), so changing the selected period reshuffled the whole grid — confusing when stepping through days.

Cards now render in the incoming alphabetical order unconditionally: a period change re-dims cards in place but never moves them, so every dimension keeps a fixed position on the board.

## Changes

- `DimensionCardsGrid.jsx`: drop the active-first sort (and the now-unneeded `useMemo`); the parent already supplies alphabetically sorted dimensions.
- `DimensionCardsGrid.test.jsx`: regression test — with only one dimension in the selected bucket, card order stays alphabetical.

## Verification

- vitest: 803 passed (138 files).
- Browser check on real data: cards render flexibility, maintainability, performance, reliability (lit), security, usability — reliability stays in its alphabetical slot instead of jumping to the front.

Pairs with #753 (which restores the older dimmed dimensions); independent and mergeable in any order.