### PR TITLE
Make dimension deltas and sparklines as-of aware

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -2,7 +2,7 @@ import React, { useMemo, lazy, Suspense } from 'react';
 import TrendBadge from '../../../components/TrendBadge.jsx';
 import DimensionCardsGrid from './DimensionCardsGrid.jsx';
 import { formatRunId, gradeLetter, complianceRatio, extDisplayName } from '../../../utils/formatters.js';
-import { collapseByPeriod, collectPeriodDimensions, bucketKey, extractDimensionPeriodSeries } from '../../../utils/dailyGrouping.js';
+import { collapseByPeriod, collectPeriodDimensions, bucketKey, extractDimensionPeriodSeries, sliceTrendAtRun } from '../../../utils/dailyGrouping.js';
 const RunHistoryPanel = lazy(() => import('./RunHistoryPanel.jsx'));
 import DimensionScorePanel from './DimensionScorePanel.jsx';
 import TopOffendingFilesTable from './TopOffendingFilesTable.jsx';
@@ -157,7 +157,7 @@ function AccumulatedDimensionsSection({ sortedDimensions, onDimensionClick, sele
 // Accumulated overview panel
 // ---------------------------------------------------------------------------
 
-function useAccumulatedComputations(data) {
+export function useAccumulatedComputations(data) {
   const { accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, trend, selectedRunId, granularity = 'day' } = data;
   const dayRuns = dailyRuns || availableRuns;
   const dayTrend = useMemo(() => collapseByPeriod(trend, 'day'), [trend]);
@@ -195,17 +195,26 @@ function useAccumulatedComputations(data) {
   // { delta, scores }, bucketed by the selected granularity from the raw
   // (visible-filtered, per-run) trend. Feeds both the dimension cards and
   // the DIMENSIONS panel so their deltas/sparklines match the Overview chart.
+  // The trend is sliced at the selected overview run first, so navigating to
+  // a previous period truncates the series at that point in time — arrows
+  // and sparklines then agree with the as-of scores on the cards. The delta
+  // compares the last two buckets in which the dimension has data (carry-over
+  // semantics, same as the dimmed cards).
+  const asOfTrend = useMemo(
+    () => sliceTrendAtRun(filteredTrend, currentOverviewRun),
+    [filteredTrend, currentOverviewRun]
+  );
   const dimTrends = useMemo(() => {
     const map = {};
     for (const dim of filteredDimensions) {
       const name = dim.dimension || '';
-      const series = extractDimensionPeriodSeries(filteredTrend, name, granularity, DIM_SPARKLINE_LIMIT);
+      const series = extractDimensionPeriodSeries(asOfTrend, name, granularity, DIM_SPARKLINE_LIMIT);
       const scores = series.map((s) => s.score);
       const delta = scores.length >= 2 ? scores[scores.length - 1] - scores[scores.length - 2] : null;
       map[name.toLowerCase()] = { delta, scores };
     }
     return map;
-  }, [filteredDimensions, filteredTrend, granularity]);
+  }, [filteredDimensions, asOfTrend, granularity]);
   const filteredAccumulated = useMemo(() => filterAccumulatedByVisibleStandards(accumulated, visibleSet, filteredPeriodTrend, currentOverviewRun), [accumulated, visibleSet, filteredPeriodTrend, currentOverviewRun]);
   const filteredStats = useMemo(() => computeAccumulatedStats(filteredDimensions, filteredPeriodTrend, currentOverviewRun), [filteredDimensions, filteredPeriodTrend, currentOverviewRun]);
 

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.test.jsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useAccumulatedComputations } from './AccumulatedOverviewPanel.jsx';
+
+// Newest-first, one run per day, maintainability scored in every run.
+const TREND = [
+  { runId: 't1', dateISO: '2026-07-03T10:00:00', dateLabel: 'Jul 3', numericAverage: 9, overallGrade: 'A', dimensions: ['maintainability'], dimensionDetails: [{ dimension: 'maintainability', score: 9 }] },
+  { runId: 't2', dateISO: '2026-06-15T10:00:00', dateLabel: 'Jun 15', numericAverage: 7, overallGrade: 'B', dimensions: ['maintainability'], dimensionDetails: [{ dimension: 'maintainability', score: 7 }] },
+  { runId: 't3', dateISO: '2026-05-10T10:00:00', dateLabel: 'May 10', numericAverage: 4, overallGrade: 'D', dimensions: ['maintainability'], dimensionDetails: [{ dimension: 'maintainability', score: 4 }] },
+];
+
+const DIMS = [{ dimension: 'maintainability', overallScore: '7.0/10' }];
+
+function runHook(selectedRunId) {
+  return renderHook(() => useAccumulatedComputations({
+    accumulated: { summary: { numericAverage: 7 }, dimensions: DIMS },
+    accumulatedDimensions: DIMS,
+    availableRuns: [],
+    dailyRuns: null,
+    overviewRunIndex: 0,
+    trend: TREND,
+    selectedRunId,
+    granularity: 'day',
+  })).result.current;
+}
+
+describe('useAccumulatedComputations dimTrends (as-of)', () => {
+  it('uses the full series at the latest run', () => {
+    const { dimTrends } = runHook('t1');
+    expect(dimTrends.maintainability.scores).toEqual([4, 7, 9]);
+    expect(dimTrends.maintainability.delta).toBe(2);
+  });
+
+  it('truncates the series at the selected previous run so arrows match as-of scores', () => {
+    const { dimTrends } = runHook('t2');
+    // Entries newer than t2 are gone: the sparkline ends at the selected
+    // period and the delta compares t2 vs t3 (7 - 4), not t1 vs t2.
+    expect(dimTrends.maintainability.scores).toEqual([4, 7]);
+    expect(dimTrends.maintainability.delta).toBe(3);
+  });
+});

--- a/src/quodeq/ui/src/utils/dailyGrouping.js
+++ b/src/quodeq/ui/src/utils/dailyGrouping.js
@@ -146,6 +146,26 @@ export function extractDimensionPeriodSeries(trend, dimensionName, granularity =
   return out.reverse();
 }
 
+/**
+ * Slice a newest-first trend so it ends at the selected run: entries newer
+ * than `runId` are dropped; the selected entry and everything older stay.
+ *
+ * Feeds the as-of view of per-dimension deltas and sparklines: when the user
+ * selects a previous period, the series must stop at that point in time so
+ * arrows and bars agree with the as-of scores shown on the cards. Fails open
+ * to the full trend for an absent/unknown runId (the default "latest" view).
+ *
+ * @param {Array} trend    Trend entries, newest-first.
+ * @param {string} runId   Selected run id.
+ * @returns {Array}
+ */
+export function sliceTrendAtRun(trend, runId) {
+  if (!Array.isArray(trend)) return [];
+  if (!trend.length || !runId) return trend;
+  const idx = trend.findIndex((t) => t.runId === runId);
+  return idx <= 0 ? trend : trend.slice(idx);
+}
+
 // ── Day-named wrappers (preserve existing call sites and tests) ─────────────
 /**
  * Collapse trend entries (newest-first) into one entry per calendar day.

--- a/src/quodeq/ui/src/utils/dailyGrouping.test.js
+++ b/src/quodeq/ui/src/utils/dailyGrouping.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import {
   collapseByDay, collectDayDimensions, buildDailyRuns,
   bucketKey, isoWeekKey, collapseByPeriod, collectPeriodDimensions, buildPeriodRuns,
-  extractDimensionPeriodSeries,
+  extractDimensionPeriodSeries, sliceTrendAtRun,
 } from './dailyGrouping.js';
 
 // ---------------------------------------------------------------------------
@@ -335,4 +335,28 @@ test('extractDimensionPeriodSeries: empty/invalid inputs return []', () => {
   assert.deepEqual(extractDimensionPeriodSeries([], 'maintainability', 'day'), []);
   assert.deepEqual(extractDimensionPeriodSeries(null, 'maintainability', 'day'), []);
   assert.deepEqual(extractDimensionPeriodSeries(DIM_TREND, '', 'day'), []);
+});
+
+// ---------------------------------------------------------------------------
+// sliceTrendAtRun
+// ---------------------------------------------------------------------------
+
+test('sliceTrendAtRun: drops entries newer than the selected run, keeps it and older', () => {
+  const sliced = sliceTrendAtRun(TREND, 'r3');
+  assert.deepEqual(sliced.map((t) => t.runId), ['r3', 'r4', 'r5']);
+});
+
+test('sliceTrendAtRun: selecting the newest run returns the full trend', () => {
+  assert.deepEqual(sliceTrendAtRun(TREND, 'r1').map((t) => t.runId), ['r1', 'r2', 'r3', 'r4', 'r5']);
+});
+
+test('sliceTrendAtRun: unknown or absent runId fails open to the full trend', () => {
+  assert.equal(sliceTrendAtRun(TREND, 'nope').length, TREND.length);
+  assert.equal(sliceTrendAtRun(TREND, null).length, TREND.length);
+  assert.equal(sliceTrendAtRun(TREND, 'latest').length, TREND.length);
+});
+
+test('sliceTrendAtRun: empty/invalid trend returns []', () => {
+  assert.deepEqual(sliceTrendAtRun([], 'r1'), []);
+  assert.deepEqual(sliceTrendAtRun(null, 'r1'), []);
 });


### PR DESCRIPTION
## What

Selecting a previous day/week/month in the overview re-fetches the dimension scores as-of that point in time, but the trend arrows and the DIMENSIONS-panel sparklines were still computed from the full history ending at the newest run — so the score changed while the arrow and bars stayed frozen at "now" and didn't represent reality at the selected point.

The trend is now sliced at the selected overview run before the per-dimension period bucketing, so:

- The arrow updates together with the score when navigating periods.
- Sparklines truncate at the selected period instead of always showing the latest measures.
- At the default (latest) view nothing changes.

Delta semantics are unchanged and now consistent everywhere: the arrow compares the **last two period buckets in which that dimension has data** (carry-over semantics, same philosophy as the dimmed cards), bucketed by the selected day/week/month.

## Changes

- `dailyGrouping.js`: new `sliceTrendAtRun(trend, runId)` helper (fail-open for unknown/absent run ids) + node:test coverage.
- `AccumulatedOverviewPanel.jsx`: compute `dimTrends` from the sliced trend; hook exported for testing.
- `AccumulatedOverviewPanel.test.jsx`: regression tests — full series at the latest run, truncated series + recomputed delta at a previous run.

## Verification

- vitest 805/805 (139 files), node:test 264/264.
- Browser check on real data (selectives-android): selecting a May period changed maintainability from 7.9/arrow 0.0 to 5.7/arrow +0.1, performance from +1.7 to −0.2, usability from 0.0 to −0.4 — scores, arrows, dates, and lit/dimmed all consistent; a dimension whose last two valid buckets are identical at both points (reliability) correctly keeps its arrow.