### PR TITLE
fix(analysis): wire Codex evaluation MCP via config-arg TOML override

### DIFF
--- a/src/quodeq/analysis/_command.py
+++ b/src/quodeq/analysis/_command.py
@@ -15,7 +15,7 @@ from quodeq.analysis._config import (
     _MCP_TOOL_MARK_FILE_DONE,
     _MCP_TOOL_REPORT_FINDING,
 )
-from quodeq.analysis._mcp_config import _create_mcp_config
+from quodeq.analysis._mcp_config import _codex_mcp_config_arg, _create_mcp_config
 from quodeq.analysis._provider_cache import get_provider_configs as _get_provider_configs
 from quodeq.shared.utils import get_ai_cmd, get_ai_model
 
@@ -75,7 +75,7 @@ def _build_mcp_args(
     if config.jsonl_file is None:
         return [], None
     mcp_style = provider_cfg.get("mcp_style", "config-file")
-    if mcp_style != "config-file":
+    if mcp_style not in {"config-file", "config-arg"}:
         return [], None
 
     agent_params = _AgentParams(
@@ -89,6 +89,14 @@ def _build_mcp_args(
         model_id=_resolve_model_id(config),
         language=_resolve_language(config),
     )
+    if mcp_style == "config-arg":
+        return [
+            "-c",
+            _codex_mcp_config_arg(
+                config.jsonl_file, config.compiled_dir, config.dimension, agent_params,
+            ),
+        ], None
+
     mcp_config_path = _create_mcp_config(
         config.jsonl_file, config.compiled_dir, config.dimension, agent_params,
     )

--- a/src/quodeq/analysis/_mcp_config.py
+++ b/src/quodeq/analysis/_mcp_config.py
@@ -8,6 +8,10 @@ import tempfile
 from pathlib import Path
 
 from quodeq.analysis._config import _AgentParams
+from quodeq.shared._mcp import codex_mcp_override
+
+_SERVER_NAME = "findings"
+_SERVER_MODULE = ["-m", "quodeq.analysis.mcp.findings_server"]
 
 
 def _default_cache_root():
@@ -65,3 +69,28 @@ def _create_mcp_config(
     finally:
         tmp.close()
     return Path(tmp.name)
+
+
+def _codex_mcp_config_arg(
+    jsonl_file: Path,
+    compiled_dir: Path | None = None,
+    dimension: str | None = None,
+    agent_params: _AgentParams | None = None,
+) -> str:
+    """Return a Codex ``-c`` TOML override for the findings MCP server."""
+    ap = agent_params or _AgentParams()
+    args = [*_SERVER_MODULE, str(jsonl_file.resolve())]
+    if compiled_dir and dimension:
+        args.extend(["--compiled-dir", str(compiled_dir.resolve()), "--dimension", dimension])
+    if ap.queue_path:
+        args.extend(["--queue", str(ap.queue_path.resolve())])
+    if ap.agent_id:
+        args.extend(["--agent-id", ap.agent_id])
+    if ap.work_dir:
+        args.extend(["--work-dir", str(ap.work_dir.resolve())])
+    args.extend([
+        "--cache-root", str(_default_cache_root()),
+        "--model-id", ap.model_id or "unknown",
+        "--language", ap.language or "",
+    ])
+    return codex_mcp_override(_SERVER_NAME, args)

--- a/src/quodeq/analysis/_provider_cache.py
+++ b/src/quodeq/analysis/_provider_cache.py
@@ -32,7 +32,7 @@ _PROVIDER_CONFIGS_FALLBACK: dict[str, dict] = {
         "cmd_subcommand": "exec",
         "base_args": "--json --dangerously-bypass-approvals-and-sandbox",
         "prompt_style": "positional",
-        "mcp_style": "cli-register",
+        "mcp_style": "config-arg",
         "supports_tools": False,
         "supports_budget": False,
         "supports_turns": False,

--- a/src/quodeq/analysis/subprocess.py
+++ b/src/quodeq/analysis/subprocess.py
@@ -74,7 +74,7 @@ def _run_cli_analysis(
     provider_cfg = configs.get(ai_cmd, {})
     mcp_style = provider_cfg.get("mcp_style", "config-file")
 
-    # For cli-register providers (e.g. Codex), register MCP server before the run.
+    # For cli-register providers (e.g. Gemini), register MCP server before the run.
     # Registration is shared across all parallel agents — the first agent registers,
     # and we never unregister during the run (cleanup happens at pool level).
     cli_mcp_registered = False

--- a/src/quodeq/assistant/mcp/_config.py
+++ b/src/quodeq/assistant/mcp/_config.py
@@ -8,6 +8,8 @@ import sys
 import threading
 from pathlib import Path
 
+from quodeq.shared._mcp import codex_mcp_override
+
 _SERVER_NAME = "quodeq-assistant"
 _SERVER_MODULE = ["-m", "quodeq.assistant.mcp.server"]
 _REGISTER_TIMEOUT_S = 10
@@ -33,13 +35,9 @@ def codex_mcp_config_arg(server_args: list[str]) -> str:
     This replaces `codex mcp add`, which mutates the user's global
     ~/.codex/config.toml under a name-only key: concurrent assistant sessions
     would clobber each other's per-session args and a finished turn would remove
-    the server out from under a still-running one. JSON string encoding is a
-    valid TOML basic string, so paths with spaces/backslashes round-trip.
+    the server out from under a still-running one.
     """
-    args = [*_SERVER_MODULE, *server_args]
-    command = json.dumps(sys.executable)
-    args_toml = "[" + ", ".join(json.dumps(a) for a in args) + "]"
-    return f"mcp_servers.{_SERVER_NAME}={{command = {command}, args = {args_toml}}}"
+    return codex_mcp_override(_SERVER_NAME, [*_SERVER_MODULE, *server_args])
 
 
 def register_cli_mcp(cmd: str, server_args: list[str], *, separator: bool = True) -> None:

--- a/src/quodeq/shared/_mcp.py
+++ b/src/quodeq/shared/_mcp.py
@@ -1,0 +1,19 @@
+"""Codex CLI MCP config helpers shared by the analysis and assistant pipelines."""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def codex_mcp_override(server_name: str, args: list[str]) -> str:
+    """Render a ``codex exec -c`` TOML override defining an MCP server inline.
+
+    Codex accepts single-invocation config overrides as TOML assignments,
+    scoping the server to one run instead of mutating the user's global
+    ``~/.codex/config.toml``. JSON string encoding is valid TOML basic-string
+    syntax, so paths with spaces or backslashes round-trip without custom
+    escaping. The server is launched via the current interpreter.
+    """
+    command = json.dumps(sys.executable)
+    args_toml = "[" + ", ".join(json.dumps(a) for a in args) + "]"
+    return f"mcp_servers.{server_name}={{command = {command}, args = {args_toml}}}"

--- a/tests/analysis/test_command_builder.py
+++ b/tests/analysis/test_command_builder.py
@@ -36,7 +36,7 @@ _CODEX_CFG = {
         "cmd_subcommand": "exec",
         "base_args": "--json --dangerously-bypass-approvals-and-sandbox",
         "prompt_style": "positional",
-        "mcp_style": "cli-register",
+        "mcp_style": "config-arg",
         "supports_tools": False,
         "supports_budget": False,
         "supports_turns": False,
@@ -128,14 +128,30 @@ class TestBuildAiCmdCodex:
         idx = args.index("--model")
         assert args[idx + 1] == "gpt-5.4"
 
-    def test_skips_mcp_even_with_jsonl(self, tmp_path):
+    def test_inlines_codex_mcp_config_arg_with_jsonl(self, tmp_path):
+        import sys
+        import tomllib
+
         jsonl = tmp_path / "findings.jsonl"
         jsonl.touch()
+        queue = tmp_path / "queue.json"
         config = AnalysisConfig(
             ai_cmd="codex", ai_model="gpt-5.4",
             jsonl_file=jsonl, compiled_dir=tmp_path, dimension="security",
+            queue_path=queue, agent_id="agent-0",
         )
         with _patch_providers(_CODEX_CFG):
             args, mcp_path = _build_ai_cmd("Analyze", config)
-        assert "--mcp-config" not in args
+
         assert mcp_path is None
+        assert "--mcp-config" not in args
+        assert args[-1] == "Analyze"
+
+        mcp_arg = next(a for a in args if str(a).startswith("mcp_servers.findings="))
+        assert args[args.index(mcp_arg) - 1] == "-c"
+        server = tomllib.loads(mcp_arg)["mcp_servers"]["findings"]
+        assert server["command"] == sys.executable
+        assert "quodeq.analysis.mcp.findings_server" in server["args"]
+        assert str(jsonl.resolve()) in server["args"]
+        assert "--queue" in server["args"] and str(queue.resolve()) in server["args"]
+        assert "--agent-id" in server["args"] and "agent-0" in server["args"]


### PR DESCRIPTION
## Problem

Since `ai_providers.json` switched Codex to `mcp_style: "config-arg"` (#741, assistant work), the analysis command builder only understood `config-file` and returned no MCP args for Codex. Codex evaluations ran without the findings MCP server, so findings were never reported.

## Fix

- `_build_mcp_args` now handles the `config-arg` style: the findings server is defined inline via a `codex exec -c mcp_servers.findings={...}` TOML override, scoped to the single invocation (no mutation of the user's global `~/.codex/config.toml`, safe for parallel agents).
- The hardcoded provider fallback in `_provider_cache.py` still said `cli-register` for Codex — aligned it with the shipped `config-arg` so a failed `ai_providers.json` load doesn't silently revert Codex to the legacy path.
- The TOML override renderer was byte-identical to the assistant's `codex_mcp_config_arg`; extracted it into `quodeq.shared._mcp.codex_mcp_override` and pointed both call sites at it.

## Testing

- `tests/analysis/test_command_builder.py`: new test parses the generated `-c` value with `tomllib` and asserts the server command/args (jsonl path, `--queue`, `--agent-id`) and that the positional prompt stays last.
- Full `tests/analysis` + `tests/assistant` suites: 1017 passed, 7 skipped. Ruff clean.