### PR TITLE
fix(clone): never remove the system temp root on cleanup

### DIFF
--- a/src/quodeq/data/fs/repo_clone.py
+++ b/src/quodeq/data/fs/repo_clone.py
@@ -42,7 +42,10 @@ def _legacy_tempdir_clone(repo_input: str) -> str:
     Used when the online cache is disabled or when the cache helper
     couldn't produce a working copy (e.g. the cache directory is read-only).
     """
-    repo_name = repo_input.split("/")[-1].replace(".git", "")
+    # rstrip("/") + fallback: a trailing-slash URL yields an empty basename,
+    # which would make dest the mkdtemp dir itself — and cleanup_cloned_repo
+    # removes dest's *parent*, i.e. the system temp root.
+    repo_name = repo_input.rstrip("/").split("/")[-1].removesuffix(".git") or "repo"
     tmp_dir = tempfile.mkdtemp()
     dest = Path(tmp_dir) / repo_name
     env = {**os.environ, "GIT_LFS_SKIP_SMUDGE": "1"}
@@ -89,10 +92,22 @@ def cleanup_cloned_repo(repo_path: str) -> None:
     """
     if is_inside_cache(repo_path):
         return
-    parent = str(Path(repo_path).resolve().parent)
+    temp_root = Path(tempfile.gettempdir()).resolve()
+    resolved = Path(repo_path).resolve()
+    target = resolved.parent
+    if target == temp_root or not target.is_relative_to(temp_root):
+        # Defense-in-depth: never remove the system temp root or anything
+        # outside it. When dest sits directly inside the temp root (e.g. an
+        # empty repo name made dest the mkdtemp dir itself), fall back to
+        # removing just the clone.
+        if resolved != temp_root and resolved.is_relative_to(temp_root):
+            target = resolved
+        else:
+            _logger.warning("Refusing to clean up %s: not inside the temp dir", repo_path)
+            return
     try:
         # No ignore_errors=True: it would swallow the OSError and make the
         # warning below unreachable. Let rmtree raise so the failure is logged.
-        shutil.rmtree(parent)
+        shutil.rmtree(str(target))
     except OSError as exc:
-        _logger.warning("Failed to clean up temp repo dir %s: %s", parent, exc)
+        _logger.warning("Failed to clean up temp repo dir %s: %s", target, exc)

--- a/tests/data/fs/test_repo_clone.py
+++ b/tests/data/fs/test_repo_clone.py
@@ -1,0 +1,79 @@
+"""Tests for repo_clone: clone-destination naming and cleanup blast radius.
+
+A trailing-slash URL used to produce an empty repo name, making the clone
+destination the mkdtemp dir itself; cleanup_cloned_repo removes the
+destination's *parent*, which in that case was the system temp root.
+"""
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from quodeq.data.fs.repo_clone import cleanup_cloned_repo, prepare_repository
+
+
+class TestPrepareRepositoryDestination:
+    def test_trailing_slash_url_clones_into_subdir_of_tempdir(self, monkeypatch):
+        # Trailing slash passes validate_remote_url but yields an empty
+        # basename; the clone dest must still be a subdir of the mkdtemp
+        # dir so cleanup's parent-removal can never reach the temp root.
+        monkeypatch.setenv("QUODEQ_DISABLE_ONLINE_CACHE", "1")
+        with patch("quodeq.data.fs.repo_clone.subprocess.run") as run:
+            dest = Path(prepare_repository("https://github.com/user/repo/"))
+        run.assert_called_once()
+        temp_root = Path(tempfile.gettempdir()).resolve()
+        assert dest.resolve().parent != temp_root, (
+            "clone dest is directly inside the system temp root; "
+            "cleanup_cloned_repo would rmtree the temp root itself"
+        )
+
+
+class TestCleanupClonedRepo:
+    def test_never_removes_temp_root_when_dest_is_directly_inside(self, tmp_path, monkeypatch):
+        # Disaster shape (pre-fix trailing-slash URLs): dest IS the mkdtemp
+        # dir, so parent-removal would rmtree the whole system temp root.
+        # Cleanup must remove only the clone and leave siblings untouched.
+        monkeypatch.setattr(
+            "quodeq.data.fs.repo_clone.tempfile.gettempdir", lambda: str(tmp_path)
+        )
+        clone = tmp_path / "clone"
+        clone.mkdir()
+        (clone / "file.py").write_text("x")
+        sibling = tmp_path / "unrelated.txt"
+        sibling.write_text("keep")
+
+        cleanup_cloned_repo(str(clone))
+
+        assert tmp_path.exists(), "system temp root was deleted"
+        assert sibling.exists(), "sibling of the clone was deleted"
+        assert not clone.exists(), "the clone itself should still be cleaned up"
+
+    def test_removes_mkdtemp_parent_for_legacy_clone_dest(self, tmp_path, monkeypatch):
+        # Normal legacy shape: dest = <mkdtemp>/<repo_name>. Cleanup removes
+        # the whole mkdtemp dir, not just the clone inside it.
+        monkeypatch.setattr(
+            "quodeq.data.fs.repo_clone.tempfile.gettempdir", lambda: str(tmp_path)
+        )
+        mkdtemp_dir = tmp_path / "tmpabc123"
+        dest = mkdtemp_dir / "repo"
+        dest.mkdir(parents=True)
+
+        cleanup_cloned_repo(str(dest))
+
+        assert not mkdtemp_dir.exists()
+        assert tmp_path.exists()
+
+    def test_refuses_paths_outside_temp_root(self, tmp_path, monkeypatch):
+        # A path outside the temp root (e.g. a local project dir passed by
+        # mistake) must never be deleted, nor its parent.
+        fake_temp = tmp_path / "temp"
+        fake_temp.mkdir()
+        monkeypatch.setattr(
+            "quodeq.data.fs.repo_clone.tempfile.gettempdir", lambda: str(fake_temp)
+        )
+        project = tmp_path / "home" / "project"
+        project.mkdir(parents=True)
+
+        cleanup_cloned_repo(str(project))
+
+        assert project.exists()
+        assert (tmp_path / "home").exists()


### PR DESCRIPTION
## Problem

A trailing-slash repo URL, e.g. `https://github.com/user/repo/`, passes `validate_remote_url` (its regex allows a trailing `/`) but yields an **empty** `repo_name` in `_legacy_tempdir_clone`:

```python
repo_name = repo_input.split("/")[-1].replace(".git", "")   # -> ""
dest = Path(tmp_dir) / repo_name                             # -> tmp_dir itself
```

`cleanup_cloned_repo` then removes `dest`'s **parent**, which in that shape is the entire system temp root (`/tmp` / `/var/folders/...`). Reachable on the legacy clone path (cache disabled via `QUODEQ_DISABLE_ONLINE_CACHE`, or cache-miss fallback). Low probability, severe and silent blast radius.

Surfaced by the 2026-07-09 nightly self-scan (major, path-traversal class); confirmed by tracing the code. The scanner's stated trigger (".git suffix") was wrong; the real trigger is the empty basename.

## Fix (two layers)

1. **Name derivation**: `repo_input.rstrip("/").split("/")[-1].removesuffix(".git") or "repo"`, so the clone dest is always a subdirectory of the mkdtemp dir. (`removesuffix` also stops mangling names containing `.git` mid-string, which `replace` did.)
2. **Cleanup guard** (defense-in-depth): `cleanup_cloned_repo` now only removes paths strictly inside `tempfile.gettempdir()`. If the dest sits directly in the temp root it removes just the clone; paths outside the temp root are refused with a warning.

## Tests

TDD, 4 new tests in `tests/data/fs/test_repo_clone.py`:
- trailing-slash URL clones into a subdir of the mkdtemp dir (red before fix 1)
- cleanup of a dest directly inside the temp root leaves the root and siblings intact (red before fix 2)
- normal legacy dest still removes the whole mkdtemp parent (regression pin)
- paths outside the temp root are never deleted

Full suite: 4210 passed, 1 skipped, 13 deselected.