### PR TITLE
fix(portability): pin UTF-8 on subprocess/fdopen text I/O for Windows

### DIFF
--- a/src/quodeq/_cli_resolution.py
+++ b/src/quodeq/_cli_resolution.py
@@ -54,7 +54,7 @@ def _create_worktree(repo_dir: Path, branch: str) -> Path | None:
     try:
         subprocess.run(
             ["git", "-C", str(repo_dir), "worktree", "add", str(worktree_dir), branch],
-            capture_output=True, text=True, check=True, timeout=_WORKTREE_TIMEOUT_S,
+            capture_output=True, text=True, encoding="utf-8", check=True, timeout=_WORKTREE_TIMEOUT_S,
         )
         return worktree_dir
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
@@ -69,7 +69,7 @@ def _cleanup_worktree(repo_dir: Path, worktree_dir: Path) -> None:
     try:
         subprocess.run(
             ["git", "-C", str(repo_dir), "worktree", "remove", str(worktree_dir), "--force"],
-            capture_output=True, text=True, timeout=_WORKTREE_TIMEOUT_S,
+            capture_output=True, text=True, encoding="utf-8", timeout=_WORKTREE_TIMEOUT_S,
         )
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
         _logger.debug("Failed to clean up worktree %s: %s", worktree_dir, exc)

--- a/src/quodeq/analysis/_diff_resolver.py
+++ b/src/quodeq/analysis/_diff_resolver.py
@@ -20,7 +20,7 @@ class DiffResolveError(RuntimeError):
 def _git(args: list[str], cwd: Path) -> str:
     try:
         result = subprocess.run(
-            ["git", *args], cwd=str(cwd), capture_output=True, text=True,
+            ["git", *args], cwd=str(cwd), capture_output=True, text=True, encoding="utf-8",
             timeout=_GIT_TIMEOUT_S,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:

--- a/src/quodeq/analysis/subagents/_git_scoring.py
+++ b/src/quodeq/analysis/subagents/_git_scoring.py
@@ -43,7 +43,7 @@ def _run_git_log(src: Path, months: int = 3) -> str | None:
     try:
         result = subprocess.run(
             ["git", "log", f"--since={months} months ago", "--name-only", "--format=%H%n%ai"],
-            cwd=str(src), capture_output=True, text=True, timeout=_GIT_LOG_TIMEOUT_S,
+            cwd=str(src), capture_output=True, text=True, encoding="utf-8", timeout=_GIT_LOG_TIMEOUT_S,
         )
         return result.stdout if result.returncode == 0 else None
     except (OSError, subprocess.TimeoutExpired):
@@ -57,7 +57,7 @@ def _iter_git_log(src: Path, months: int = 3):
     try:
         proc = subprocess.Popen(
             ["git", "log", f"--since={months} months ago", "--name-only", "--format=%H%n%ai"],
-            cwd=str(src), stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True,
+            cwd=str(src), stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, encoding="utf-8",
         )
     except OSError:
         return

--- a/src/quodeq/analysis/subagents/_queue_state.py
+++ b/src/quodeq/analysis/subagents/_queue_state.py
@@ -122,7 +122,7 @@ def write_state(state: dict, path: Path) -> None:
     fd, tmp_path = tempfile.mkstemp(dir=str(parent), suffix=".tmp", prefix=".queue_")
     cleanup_tmp: str | None = tmp_path
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(state, f)
             f.flush()
             os.fsync(f.fileno())

--- a/src/quodeq/assistant/adapters/_cli_spawn.py
+++ b/src/quodeq/assistant/adapters/_cli_spawn.py
@@ -148,5 +148,5 @@ def spawn_turn(argv: list[str], *, cwd: Path, env: dict) -> subprocess.Popen:
     return subprocess.Popen(
         argv, cwd=str(cwd), env=env,
         stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-        text=True, start_new_session=True,
+        text=True, encoding="utf-8", start_new_session=True,
     )

--- a/src/quodeq/ci/review.py
+++ b/src/quodeq/ci/review.py
@@ -28,7 +28,7 @@ def detect_pr(pr_override: int | None = None) -> tuple[int, str]:
         try:
             result = subprocess.run(
                 ["gh", "pr", "view", str(pr_override), "--json", "number,baseRefName"],
-                capture_output=True, text=True, check=True,
+                capture_output=True, text=True, encoding="utf-8", check=True,
             )
         except FileNotFoundError:
             raise ReviewError("gh CLI not found. Install with 'brew install gh' and run 'gh auth login'.")
@@ -40,7 +40,7 @@ def detect_pr(pr_override: int | None = None) -> tuple[int, str]:
     try:
         result = subprocess.run(
             ["gh", "pr", "view", "--json", "number,baseRefName"],
-            capture_output=True, text=True, check=True,
+            capture_output=True, text=True, encoding="utf-8", check=True,
         )
     except FileNotFoundError:
         raise ReviewError("gh CLI not found. Install with 'brew install gh' and run 'gh auth login'.")
@@ -62,7 +62,7 @@ def get_github_token() -> str:
     try:
         result = subprocess.run(
             ["gh", "auth", "token"],
-            capture_output=True, text=True, check=True,
+            capture_output=True, text=True, encoding="utf-8", check=True,
         )
     except FileNotFoundError:
         raise ReviewError("gh CLI not found. Install with 'brew install gh' and run 'gh auth login'.")
@@ -81,7 +81,7 @@ def get_repo_info() -> tuple[str, str]:
     try:
         result = subprocess.run(
             ["gh", "repo", "view", "--json", "owner,name"],
-            capture_output=True, text=True, check=True,
+            capture_output=True, text=True, encoding="utf-8", check=True,
         )
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:
         raise ReviewError(

--- a/src/quodeq/dashboard/_frozen.py
+++ b/src/quodeq/dashboard/_frozen.py
@@ -57,7 +57,7 @@ def source_user_path() -> None:
         if shell not in _ALLOWED_SHELLS:
             shell = "/bin/zsh"
         result = subprocess.run(
-            [shell, "-c", cmd], capture_output=True, text=True,
+            [shell, "-c", cmd], capture_output=True, text=True, encoding="utf-8",
             timeout=_CMD_DISCOVERY_TIMEOUT_S,
         )
         if result.returncode == 0 and result.stdout.strip():

--- a/src/quodeq/data/fs/_index_io.py
+++ b/src/quodeq/data/fs/_index_io.py
@@ -50,7 +50,7 @@ def _save_index(reports_dir: Path, index: dict[str, str]) -> None:
     tmp = ""
     try:
         fd, tmp = tempfile.mkstemp(dir=reports_dir, suffix=".tmp")
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(index, f, indent=2)
         os.replace(tmp, index_path)
     except Exception as exc:

--- a/src/quodeq/services/_fs_scan.py
+++ b/src/quodeq/services/_fs_scan.py
@@ -101,7 +101,7 @@ def _list_branches(project_dir: Path) -> list[str]:
     try:
         result = subprocess.run(
             ["git", "-C", str(project_dir), "branch", "--format=%(refname:short)"],
-            capture_output=True, text=True, timeout=_GIT_TIMEOUT_S,
+            capture_output=True, text=True, encoding="utf-8", timeout=_GIT_TIMEOUT_S,
         )
         if result.returncode != 0:
             return []

--- a/src/quodeq/services/tooling_mixin.py
+++ b/src/quodeq/services/tooling_mixin.py
@@ -248,7 +248,7 @@ class FsToolingMixin:
             result = subprocess.run(
                 [client_id, "/models"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8",
                 timeout=_CLI_MODEL_TIMEOUT_S,
             )
             output = result.stdout if result.returncode == 0 else ""

--- a/src/quodeq/shared/_repo.py
+++ b/src/quodeq/shared/_repo.py
@@ -50,7 +50,7 @@ def git_remote_url(repo_path: str) -> str | None:
         result = subprocess.run(
             ["git", "-C", repo_path, "config", "--get", "remote.origin.url"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8",
             check=True,
         )
     except (FileNotFoundError, subprocess.CalledProcessError):

--- a/src/quodeq/shared/prereqs.py
+++ b/src/quodeq/shared/prereqs.py
@@ -67,7 +67,7 @@ def _run_version_cmd(cmd: list[str]) -> str:
         if not isinstance(token, str) or not _SAFE_CMD_TOKEN_RE.fullmatch(token):
             raise ValueError(f"unsafe command token: {token!r}")
     result = subprocess.run(
-        cmd, capture_output=True, text=True, check=True, shell=_IS_WIN32,
+        cmd, capture_output=True, text=True, encoding="utf-8", check=True, shell=_IS_WIN32,
         timeout=_VERSION_CMD_TIMEOUT_S,
     )
     return result.stdout.strip()

--- a/src/quodeq/shared/resource_sampler.py
+++ b/src/quodeq/shared/resource_sampler.py
@@ -38,7 +38,7 @@ def _ollama_rss_mb() -> int:
     """RSS of the first ``ollama`` process (if any) in MB. 0 if not running."""
     try:
         out = subprocess.run(
-            ["pgrep", "-x", "ollama"], capture_output=True, text=True,
+            ["pgrep", "-x", "ollama"], capture_output=True, text=True, encoding="utf-8",
             timeout=_PS_TIMEOUT_S, check=False,
         )
     except (OSError, subprocess.TimeoutExpired):
@@ -54,7 +54,7 @@ def _ollama_rss_mb() -> int:
 def _ps_rss_mb(pid: int) -> int:
     try:
         out = subprocess.run(
-            ["ps", "-o", "rss=", "-p", str(pid)], capture_output=True, text=True,
+            ["ps", "-o", "rss=", "-p", str(pid)], capture_output=True, text=True, encoding="utf-8",
             timeout=_PS_TIMEOUT_S, check=False,
         )
     except (OSError, subprocess.TimeoutExpired):

--- a/tests/test_no_bare_text_io.py
+++ b/tests/test_no_bare_text_io.py
@@ -14,6 +14,7 @@ via ``_NON_TEXT_OPEN``; binary-mode opens are exempted by ``_BINARY_MODE``.
 """
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -64,5 +65,84 @@ def test_no_bare_text_io() -> None:
     assert not offenders, (
         f"{len(offenders)} text-I/O call(s) without explicit encoding "
         "(breaks on Windows cp1252). Pass encoding='utf-8':\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+# --- subprocess text=True / os.fdopen coverage (AST-based) -----------------
+#
+# subprocess.run/Popen(..., text=True) decodes child output with the locale
+# code page on Windows, exactly like bare open(). The line-based scan above
+# cannot catch it because the encoding= kwarg may sit on a different line of
+# the same multi-line call, so this check parses the AST instead. os.fdopen
+# in text mode shares the same default and is missed by the open() regex.
+
+_SUBPROCESS_FUNCS = frozenset({"run", "Popen", "check_output", "check_call", "call"})
+
+# Sites that legitimately cannot pin encoding (document the reason).
+# Format: "src-relative/path.py:LINE"
+_SUBPROCESS_ALLOWLIST: set[str] = set()
+
+
+def _is_subprocess_call(node: ast.Call) -> bool:
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr in _SUBPROCESS_FUNCS
+        and isinstance(func.value, ast.Name)
+        and "subprocess" in func.value.id
+    )
+
+
+def _is_text_fdopen(node: ast.Call) -> bool:
+    func = node.func
+    if not (
+        isinstance(func, ast.Attribute)
+        and func.attr == "fdopen"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "os"
+    ):
+        return False
+    mode = "r"
+    if len(node.args) > 1 and isinstance(node.args[1], ast.Constant):
+        mode = node.args[1].value
+    for kw in node.keywords:
+        if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+            mode = kw.value.value
+    return isinstance(mode, str) and "b" not in mode
+
+
+def _subprocess_text_offenders() -> list[str]:
+    bad: list[str] = []
+    for py in sorted(SRC.rglob("*.py")):
+        rel = py.relative_to(SRC).as_posix()
+        tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if f"{rel}:{node.lineno}" in _SUBPROCESS_ALLOWLIST:
+                continue
+            kwargs = {kw.arg for kw in node.keywords if kw.arg}
+            if "encoding" in kwargs:
+                continue
+            if _is_subprocess_call(node):
+                wants_text = any(
+                    kw.arg in ("text", "universal_newlines")
+                    and isinstance(kw.value, ast.Constant)
+                    and kw.value.value is True
+                    for kw in node.keywords
+                )
+                if wants_text:
+                    bad.append(f"{rel}:{node.lineno}: subprocess {node.func.attr}(text=True)")
+            elif _is_text_fdopen(node):
+                bad.append(f"{rel}:{node.lineno}: os.fdopen() in text mode")
+    return bad
+
+
+def test_no_bare_subprocess_text() -> None:
+    offenders = _subprocess_text_offenders()
+    assert not offenders, (
+        f"{len(offenders)} subprocess/fdopen call(s) decode text without explicit "
+        "encoding (breaks on Windows cp1252). Pass encoding='utf-8':\n  "
         + "\n  ".join(offenders)
     )


### PR DESCRIPTION
## Problem
`subprocess(text=True)` and text-mode `os.fdopen` decode with the locale code page on Windows (usually cp1252), not UTF-8. Any non-ASCII byte in git/gh/AI-CLI output then mis-decodes or raises `UnicodeDecodeError`. The project has only ever run on macOS, where the locale default is UTF-8, so this bug class was invisible.

The existing `test_no_bare_text_io.py` guard is line-based and cannot catch it: multi-line subprocess calls may carry `encoding=` on a different line, and `os.fdopen` doesn't match the `open(` regex.

## Changes
- Pin `encoding="utf-8"` on all 17 `subprocess` `text=True` call sites and both text-mode `os.fdopen` sites (highest-impact: `assistant/adapters/_cli_spawn.py`, which decodes the AI CLI's stream output).
- Add `test_no_bare_subprocess_text`, an AST-based guard in `tests/test_no_bare_text_io.py` that flags any `subprocess.run/Popen/check_output/check_call/call` with `text=True`/`universal_newlines=True` and no `encoding=`, plus text-mode `os.fdopen`, with an allowlist for documented exceptions.

## Verification
- Guard test written first and observed failing with exactly the 19 offender sites, then green after the sweep.
- Full suite: 4211 passed, 1 skipped.
- No behavior change on macOS/Linux (locale default is already UTF-8 there).