### PR TITLE
fix(analysis): pass MCP allow-list args for cli-register providers

### DIFF
--- a/src/quodeq/analysis/_command.py
+++ b/src/quodeq/analysis/_command.py
@@ -17,6 +17,7 @@ from quodeq.analysis._config import (
 )
 from quodeq.analysis._mcp_config import _codex_mcp_config_arg, _create_mcp_config
 from quodeq.analysis._provider_cache import get_provider_configs as _get_provider_configs
+from quodeq.shared._models import normalize_model_id
 from quodeq.shared.utils import get_ai_cmd, get_ai_model
 
 _log = logging.getLogger(__name__)
@@ -75,6 +76,12 @@ def _build_mcp_args(
     if config.jsonl_file is None:
         return [], None
     mcp_style = provider_cfg.get("mcp_style", "config-file")
+    if mcp_style == "cli-register":
+        # The findings server is registered out-of-band (`<cmd> mcp add` in
+        # subprocess._run_cli_analysis), so no config file/arg is needed —
+        # but the CLI must still receive its allow-list args (e.g. gemini's
+        # --allowed-mcp-server-names) or the registered server stays blocked.
+        return list(provider_cfg.get("mcp_permission_args", [])), None
     if mcp_style not in {"config-file", "config-arg"}:
         return [], None
 
@@ -130,7 +137,7 @@ def _build_model_budget_prompt_args(
     """Build model, budget, turns, and prompt args."""
     args: list[str] = []
     if model:
-        args.extend(["--model", model])
+        args.extend(["--model", normalize_model_id(provider_cfg.get("cmd", ""), model)])
     if provider_cfg.get("supports_budget", True) and config.analysis_budget:
         args.extend(["--max-budget-usd", str(config.analysis_budget)])
     if provider_cfg.get("supports_turns", True) and config.max_turns is not None:

--- a/src/quodeq/assistant/adapters/_cli_command.py
+++ b/src/quodeq/assistant/adapters/_cli_command.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import re
 
 from quodeq.assistant.adapters._cli_config import CliChatConfig
+from quodeq.shared._models import normalize_model_id
 
 _NATIVE_WEB_TOOLS = ("WebSearch", "WebFetch")
 
@@ -55,10 +55,7 @@ def _resume_args(cfg: CliChatConfig, prior: str | None, new_id: str) -> tuple[li
 def _model_arg(cfg: CliChatConfig, model: str | None) -> str | None:
     if not model:
         return None
-    value = model.strip()
-    if cfg.cmd == "codex" and re.fullmatch(r"\d+(?:\.\d+)*(?:-[A-Za-z0-9_.-]+)?", value):
-        return f"gpt-{value}"
-    return value
+    return normalize_model_id(cfg.cmd, model)
 
 
 def build_turn_argv(cfg: CliChatConfig, *, prompt: str, model: str | None,

--- a/src/quodeq/shared/_models.py
+++ b/src/quodeq/shared/_models.py
@@ -1,0 +1,15 @@
+"""Model-id normalization shared by assistant and analysis CLI builders."""
+from __future__ import annotations
+
+import re
+
+# Bare version shorthand like "5.4" or "5.3-codex" (no vendor prefix).
+_NUMERIC_SHORTHAND = re.compile(r"\d+(?:\.\d+)*(?:-[A-Za-z0-9_.-]+)?")
+
+
+def normalize_model_id(cmd: str, model: str) -> str:
+    """Expand provider-specific model shorthand (codex: "5.4" -> "gpt-5.4")."""
+    value = model.strip()
+    if cmd == "codex" and _NUMERIC_SHORTHAND.fullmatch(value):
+        return f"gpt-{value}"
+    return value

--- a/src/quodeq/shared/prereqs.py
+++ b/src/quodeq/shared/prereqs.py
@@ -31,7 +31,7 @@ _CLI_INSTALL_HINTS: dict[str, str] = {
     ),
     "gemini": (
         "Install Gemini CLI:\n"
-        "  npm install -g @anthropic-ai/gemini-cli\n"
+        "  npm install -g @google/gemini-cli\n"
         "  https://geminicli.com/docs/get-started/installation/"
     ),
 }

--- a/tests/analysis/test_command_builder.py
+++ b/tests/analysis/test_command_builder.py
@@ -47,6 +47,26 @@ _CODEX_CFG = {
 }
 
 
+_GEMINI_CFG = {
+    "gemini": {
+        "type": "cli",
+        "cmd": "gemini",
+        "cmd_subcommand": "",
+        "base_args": "--output-format stream-json --yolo",
+        "prompt_style": "flag",
+        "prompt_flag": "-p",
+        "mcp_style": "cli-register",
+        "mcp_add_separator": False,
+        "mcp_permission_args": ["--allowed-mcp-server-names", "quodeq-findings"],
+        "supports_tools": False,
+        "supports_budget": False,
+        "supports_turns": False,
+        "env_set_if_missing": {},
+        "env_remove": [],
+    }
+}
+
+
 def _patch_providers(cfg: dict):
     return patch("quodeq.analysis._command._get_provider_configs", return_value=cfg)
 
@@ -128,6 +148,13 @@ class TestBuildAiCmdCodex:
         idx = args.index("--model")
         assert args[idx + 1] == "gpt-5.4"
 
+    def test_normalizes_numeric_model_shorthand(self):
+        config = AnalysisConfig(ai_cmd="codex", ai_model="5.4")
+        with _patch_providers(_CODEX_CFG):
+            args, _ = _build_ai_cmd("Analyze", config)
+        idx = args.index("--model")
+        assert args[idx + 1] == "gpt-5.4"
+
     def test_inlines_codex_mcp_config_arg_with_jsonl(self, tmp_path):
         import sys
         import tomllib
@@ -155,3 +182,41 @@ class TestBuildAiCmdCodex:
         assert str(jsonl.resolve()) in server["args"]
         assert "--queue" in server["args"] and str(queue.resolve()) in server["args"]
         assert "--agent-id" in server["args"] and "agent-0" in server["args"]
+
+
+class TestBuildAiCmdGemini:
+    """Gemini provider command building (cli-register MCP style)."""
+
+    def test_cli_register_emits_permission_args_with_jsonl(self, tmp_path):
+        jsonl = tmp_path / "findings.jsonl"
+        jsonl.touch()
+        config = AnalysisConfig(
+            ai_cmd="gemini", ai_model="gemini-2.5-pro",
+            jsonl_file=jsonl, compiled_dir=tmp_path, dimension="security",
+        )
+        with _patch_providers(_GEMINI_CFG):
+            args, mcp_path = _build_ai_cmd("Analyze", config)
+        # Server registration happens out-of-band (`gemini mcp add`), so no
+        # config file or inline config — but the CLI must still be told the
+        # registered server is allowed, or every tool call is blocked.
+        assert mcp_path is None
+        assert "--mcp-config" not in args
+        assert "-c" not in args
+        idx = args.index("--allowed-mcp-server-names")
+        assert args[idx + 1] == "quodeq-findings"
+
+    def test_cli_register_no_mcp_args_without_jsonl(self):
+        config = AnalysisConfig(ai_cmd="gemini", ai_model="gemini-2.5-pro")
+        with _patch_providers(_GEMINI_CFG):
+            args, mcp_path = _build_ai_cmd("Analyze", config)
+        assert mcp_path is None
+        assert "--allowed-mcp-server-names" not in args
+
+    def test_prompt_via_flag_and_stream_json(self):
+        config = AnalysisConfig(ai_cmd="gemini", ai_model="gemini-2.5-pro")
+        with _patch_providers(_GEMINI_CFG):
+            args, _ = _build_ai_cmd("Analyze this", config)
+        assert args[0] == "gemini"
+        assert "--yolo" in args
+        pidx = args.index("-p")
+        assert args[pidx + 1] == "Analyze this"

--- a/tests/shared/test_prereqs.py
+++ b/tests/shared/test_prereqs.py
@@ -152,3 +152,11 @@ class TestProviderInjection:
         result = subprocess.CompletedProcess([], 0, stdout="1.0.0\n")
         with patch("subprocess.run", return_value=result):
             _check_cli_provider("claude")  # must not raise
+
+
+class TestInstallHints:
+    def test_gemini_hint_uses_google_npm_scope(self):
+        from quodeq.shared.prereqs import _CLI_INSTALL_HINTS
+
+        assert "@google/gemini-cli" in _CLI_INSTALL_HINTS["gemini"]
+        assert "@anthropic-ai/gemini-cli" not in _CLI_INSTALL_HINTS["gemini"]


### PR DESCRIPTION
## Problem
Gemini analysis runs registered the findings MCP server via `gemini mcp add` (in `_run_cli_analysis`), but `_build_mcp_args()` returned nothing for the `cli-register` style — so the CLI never received the configured `--allowed-mcp-server-names quodeq-findings` and the findings server stayed unusable for the entire evaluation. The assistant path already handled this correctly; analysis didn't.

Two smaller gaps in the same area:
- Codex numeric model shorthand (`5.4` → `gpt-5.4`) was normalized only in the assistant command builder; the analysis path passed the raw value to `--model`.
- The gemini install hint pointed at `@anthropic-ai/gemini-cli` instead of `@google/gemini-cli`.

## Changes
- `_build_mcp_args()` now emits the provider's `mcp_permission_args` for `mcp_style="cli-register"` (server registration still happens out-of-band). Side benefit: the allow-list also scopes gemini runs away from any user-registered MCP servers, matching what the assistant already does with `quodeq-assistant`.
- New `quodeq.shared._models.normalize_model_id(cmd, model)` shared by the assistant and analysis builders; removes the duplicated regex from `_cli_command.py`.
- Fixed the gemini npm scope in `_CLI_INSTALL_HINTS`.

## Verification
- All `ai_providers.json` CLI assumptions live-verified against the installed binaries — gemini 0.46.0 (`--yolo`, `--output-format stream-json`, `--session-id`, `-r`, `--allowed-mcp-server-names`, `mcp add`) and codex-cli 0.144.1 (`--json`, `-c`, `-m/--model`, `exec resume <id>`, `--disable shell_tool`).
- New tests written first and observed failing: gemini cli-register permission args, codex shorthand in the analysis path, install-hint scope. Full suite: 4215 passed, 1 skipped.