### PR TITLE
fix(providers): fail fast when a required cloud API key is missing

### DIFF
--- a/src/quodeq/analysis/subprocess.py
+++ b/src/quodeq/analysis/subprocess.py
@@ -269,6 +269,14 @@ def _resolve_provider_config(cfg: AnalysisConfig) -> tuple[str, str, str]:
             f"No API base URL configured for provider '{ai_cmd}'. "
             f"Go to Settings in the dashboard to configure it, or set the URL in ai_providers.json."
         )
+    if not api_key and provider_cfg.get("api_key_required"):
+        # Defense in depth for entry points that skip check_evaluate_prereqs:
+        # fail with a clear message instead of 401s on every request mid-run.
+        raise AnalysisError(
+            f"No API key found for provider '{ai_cmd}'. "
+            f"Set the {api_key_env or 'API key'} environment variable, "
+            f"or configure the key in the dashboard Settings."
+        )
     return model, api_base, api_key
 
 

--- a/src/quodeq/data/config/ai_providers.json
+++ b/src/quodeq/data/config/ai_providers.json
@@ -97,6 +97,7 @@
     "model": "baidu/cobuddy:free",
     "api_base": "https://openrouter.ai/api/v1",
     "api_key_env": "OPENROUTER_API_KEY",
+    "api_key_required": true,
     "browse_url": "https://openrouter.ai/models"
   },
   "custom": {

--- a/src/quodeq/shared/prereqs.py
+++ b/src/quodeq/shared/prereqs.py
@@ -135,8 +135,9 @@ def _check_cli_provider(provider: str) -> None:
 
 
 def _check_api_provider(provider: str, *, env: dict[str, str] | None = None) -> None:
-    """Check that an API provider has basic connectivity (Ollama: server running)."""
-    _env = env or os.environ
+    """Check that an API provider has basic connectivity (Ollama: server running)
+    and that cloud providers have their required API key set."""
+    _env = os.environ if env is None else env
     if provider == "ollama":
         try:
             _ollama_base = _env.get("OLLAMA_BASE_URL", "http://localhost:11434")
@@ -163,6 +164,21 @@ def _check_api_provider(provider: str, *, env: dict[str, str] | None = None) -> 
                 "  llama-server -m path/to/target.gguf -md path/to/drafter.gguf --port 8080\n\n"
                 "Install llama.cpp from https://github.com/ggml-org/llama.cpp"
             ) from exc
+    else:
+        # Cloud API providers (openrouter, ...): fail fast on a missing key
+        # instead of surfacing 401s mid-evaluation.
+        provider_cfg = get_provider_configs().get(provider, {})
+        key_env = provider_cfg.get("api_key_env", "")
+        if provider_cfg.get("api_key_required") and key_env and not _env.get(key_env):
+            browse_url = provider_cfg.get("browse_url", "")
+            url_hint = f"  {browse_url}\n\n" if browse_url else ""
+            raise RuntimeError(
+                f"'{provider}' is configured as your AI provider but the "
+                f"{key_env} environment variable is not set.\n\n"
+                f"Create an API key and export it:\n"
+                f"  export {key_env}=<your-key>\n\n"
+                f"{url_hint}{_SETTINGS_HINT}"
+            )
 
 
 def _collect_tool_issue(cmd: list[str], tool_name: str, min_major: int) -> str | None:

--- a/tests/analysis/test_command_builder.py
+++ b/tests/analysis/test_command_builder.py
@@ -220,3 +220,17 @@ class TestBuildAiCmdGemini:
         assert "--yolo" in args
         pidx = args.index("-p")
         assert args[pidx + 1] == "Analyze this"
+
+
+class TestBuildAnalysisEnv:
+    def test_provider_api_key_survives_env_filtering(self):
+        # API providers read their key from the environment at analysis time
+        # (see _resolve_provider_config); the sensitive-key filter must never
+        # grow to swallow provider api_key_env variables.
+        from quodeq.analysis._command import _build_analysis_env
+
+        env = {"OPENROUTER_API_KEY": "sk-or-x", "QUODEQ_API_KEY": "internal", "PATH": "/usr/bin"}
+        with _patch_providers({"openrouter": {"type": "api"}}):
+            out = _build_analysis_env("openrouter", env=env)
+        assert out.get("OPENROUTER_API_KEY") == "sk-or-x"
+        assert "QUODEQ_API_KEY" not in out

--- a/tests/analysis/test_subprocess_coverage.py
+++ b/tests/analysis/test_subprocess_coverage.py
@@ -297,6 +297,17 @@ class TestResolveProviderConfig:
             _, _, key = _resolve_provider_config(cfg)
         assert key == "secret"
 
+    def test_required_api_key_missing_raises(self, monkeypatch):
+        provider = {"openrouter": {
+            "type": "api", "model": "m", "api_base": "https://openrouter.ai/api/v1",
+            "api_key_env": "OPENROUTER_API_KEY", "api_key_required": True,
+        }}
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        cfg = AnalysisConfig(ai_cmd="openrouter", ai_model="m")
+        with patch("quodeq.analysis.subprocess.get_provider_configs", return_value=provider):
+            with pytest.raises(Exception, match="OPENROUTER_API_KEY"):
+                _resolve_provider_config(cfg)
+
     def test_omlx_falls_back_to_read_omlx_api_key(self):
         provider = {"omlx": {"type": "api", "model": "m", "api_base": "http://localhost:8000/v1"}}
         cfg = AnalysisConfig(ai_cmd="omlx", ai_model="m")

--- a/tests/shared/test_prereqs.py
+++ b/tests/shared/test_prereqs.py
@@ -74,9 +74,26 @@ class TestCheckApiProvider:
             with pytest.raises(RuntimeError, match="llama-server is not running"):
                 _check_api_provider("llamacpp")
 
-    def test_non_ollama_api_passes(self):
-        # Cloud API providers have no connectivity check
-        _check_api_provider("openrouter")
+    def test_keyless_api_provider_passes(self):
+        # API providers that don't require a key have no connectivity check
+        cfg = {"custom": {"type": "api", "api_key_env": "AI_API_KEY"}}
+        with patch("quodeq.shared.prereqs.get_provider_configs", return_value=cfg):
+            _check_api_provider("custom", env={"PATH": "/usr/bin"})
+
+    def test_openrouter_missing_key_raises(self):
+        cfg = {"openrouter": {
+            "type": "api", "api_key_env": "OPENROUTER_API_KEY", "api_key_required": True,
+        }}
+        with patch("quodeq.shared.prereqs.get_provider_configs", return_value=cfg):
+            with pytest.raises(RuntimeError, match="OPENROUTER_API_KEY"):
+                _check_api_provider("openrouter", env={"PATH": "/usr/bin"})
+
+    def test_openrouter_with_key_passes(self):
+        cfg = {"openrouter": {
+            "type": "api", "api_key_env": "OPENROUTER_API_KEY", "api_key_required": True,
+        }}
+        with patch("quodeq.shared.prereqs.get_provider_configs", return_value=cfg):
+            _check_api_provider("openrouter", env={"OPENROUTER_API_KEY": "sk-or-x"})
 
 
 class TestIsProviderExplicitlyConfigured:


### PR DESCRIPTION
## Problem
OpenRouter is implemented (`type=api`, OpenAI-compatible via `llm_bridge/_cloud.py`) but was never gated by prereq checks: `_check_api_provider` only knew ollama and llamacpp, and `_resolve_provider_config` validated model and api_base but happily returned an empty API key. Running an evaluation without `OPENROUTER_API_KEY` therefore started normally and then failed with a 401 on every request mid-run, instead of a clear upfront error.

## Changes
- New `api_key_required: true` field on the openrouter entry in `ai_providers.json`.
- `_check_api_provider` (used by `check_evaluate_prereqs`) now raises a clear RuntimeError — with the env var name, an export example, and the provider's browse URL — when a required key is missing from the environment.
- `_resolve_provider_config` enforces the same as defense in depth for entry points that skip prereqs (`AnalysisError` instead of mid-run 401s).
- Pinned via test that `_build_analysis_env` filtering never strips provider `api_key_env` variables (it only removes `QUODEQ_API_KEY`/`DATABASE_URL`/`SECRET_KEY` today, but nothing guarded that).

## Non-goals / safety
- Keyless OpenAI-compatible endpoints are unaffected: `custom` (local vLLM/LM Studio) doesn't declare `api_key_required`, so it keeps working without a key.
- The check reads the same source the consumers do — both the analysis path (`subprocess.py`) and the dashboard connection tester (`llm_bridge_routes.py`) read the key from `os.environ`, so there's no false blocking from an alternate key store.
- No network call in prereqs; the existing dashboard connection test remains the place for live verification.

## Verification
- New tests written first and observed failing (missing-key raise in prereqs and in `_resolve_provider_config`), then green.
- Full suite: 4214 passed, 1 skipped.