### PR TITLE
fix(ui): align code-widget indentation for highlighted lines

### DIFF
--- a/src/quodeq/ui/src/components/ContextBlock.jsx
+++ b/src/quodeq/ui/src/components/ContextBlock.jsx
@@ -14,6 +14,7 @@
  */
 import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { measureWidth, cssFontFromElement } from '../utils/pretext.js';
+import { isHighlightedLine, stripHighlightMarker } from '../utils/codeMarker.js';
 
 const MAX_HIGHLIGHTED_COLLAPSED = 10;
 const CONTEXT_PADDING = 5;
@@ -22,7 +23,7 @@ const CODE_PRE_VPAD = 16;    // matches .term-code / .scope-bar-code vertical pa
 const DEFAULT_CODE_FONT = '12px "JetBrains Mono", ui-monospace, monospace';
 
 function renderLine(raw, lineNum, isHighlighted) {
-  const display = isHighlighted ? raw.slice(3) : raw;
+  const display = isHighlighted ? stripHighlightMarker(raw) : raw;
   return (
     <div key={lineNum} className={`ctx-line${isHighlighted ? ' ctx-line--hl' : ''}`}>
       <span className="ctx-gutter">{lineNum}</span>
@@ -44,8 +45,8 @@ function renderSnippetLine(text, lineNum) {
  * CodeBlockPre — the `<pre>` wrapper that pre-computes dimensions with pretext.
  *
  * `renderedLines` is an array of React children. `codeLines` is the raw string
- * array we use to measure natural widths (stripping the `>>>` highlight marker
- * so width reflects what the user actually sees).
+ * array we use to measure natural widths (stripping the highlight marker so
+ * width reflects what the user actually sees).
  */
 function CodeBlockPre({ renderedLines, codeLines }) {
   const preRef = useRef(null);
@@ -58,7 +59,7 @@ function CodeBlockPre({ renderedLines, codeLines }) {
     let max = 0;
     for (let i = 0; i < codeLines.length; i++) {
       const raw = codeLines[i] || '';
-      const text = raw.startsWith('>>>') ? raw.slice(3) : raw;
+      const text = stripHighlightMarker(raw);
       const w = measureWidth(text, font);
       if (w > max) max = w;
     }
@@ -106,7 +107,7 @@ function useCodeLayout(raw) {
     if (!raw) return { lines: [], highlightedIdx: -1 };
     const normalized = raw.replace(/\\n/g, '\n');
     const lines = normalized.split('\n');
-    const highlightedIdx = lines.findIndex((l) => l.startsWith('>>>'));
+    const highlightedIdx = lines.findIndex(isHighlightedLine);
     return { lines, highlightedIdx };
   }, [raw]);
 }
@@ -136,7 +137,7 @@ export default function ContextBlock({ context, snippet, scope, line, endLine })
     const after = [];
     let pastHighlighted = false;
     for (let i = 0; i < ctxLines.length; i++) {
-      const isHl = ctxLines[i].startsWith('>>>');
+      const isHl = isHighlightedLine(ctxLines[i]);
       const entry = { raw: ctxLines[i], lineNum: startLineNum + i };
       if (isHl) { pastHighlighted = true; highlighted.push(entry); }
       else if (!pastHighlighted) before.push(entry);

--- a/src/quodeq/ui/src/components/ContextBlock.test.jsx
+++ b/src/quodeq/ui/src/components/ContextBlock.test.jsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+
+// Pretext does off-DOM canvas measurement, which jsdom can't do and which is
+// irrelevant to the rendered text content we assert here.
+vi.mock('../utils/pretext.js', () => ({
+  measureWidth: () => 0,
+  cssFontFromElement: () => '12px monospace',
+}));
+
+import ContextBlock from './ContextBlock.jsx';
+
+// The backend marks the violation line with ">>> " (marker + separator space).
+// The highlighted line's real indentation is 4 spaces here.
+const context = [
+  'def hello():',
+  ">>>     print('hi')",
+  '    return 1',
+].join('\n');
+
+function textOf(el) {
+  // Mirror what the user sees; white-space: pre preserves leading spaces,
+  // and textContent is independent of CSS so it's a faithful check.
+  return el.textContent;
+}
+
+describe('ContextBlock highlighted-line indentation', () => {
+  it('strips the marker + separator so the highlighted line is not over-indented', () => {
+    const { container } = render(<ContextBlock context={context} line={42} />);
+    // Scope bar is collapsed by default — expand it to render the code.
+    fireEvent.click(screen.getByText(/See code/));
+
+    const hl = container.querySelector('.ctx-line--hl .ctx-code');
+    expect(hl).not.toBeNull();
+    // 4 spaces, NOT 5. The old slice(3) left the separator space behind.
+    expect(textOf(hl)).toBe("    print('hi')");
+  });
+
+  it('highlighted indentation matches an identical unmarked line', () => {
+    const { container } = render(<ContextBlock context={context} line={42} />);
+    fireEvent.click(screen.getByText(/See code/));
+
+    const codeCells = [...container.querySelectorAll('.ctx-code')].map(textOf);
+    const highlighted = textOf(container.querySelector('.ctx-line--hl .ctx-code'));
+    // The 'return 1' context line and the highlighted 'print' line share the
+    // same 4-space indentation depth.
+    const returnLine = codeCells.find((t) => t.includes('return 1'));
+    const hlIndent = highlighted.match(/^ */)[0].length;
+    const returnIndent = returnLine.match(/^ */)[0].length;
+    expect(hlIndent).toBe(returnIndent);
+  });
+});

--- a/src/quodeq/ui/src/utils/codeMarker.js
+++ b/src/quodeq/ui/src/utils/codeMarker.js
@@ -1,0 +1,31 @@
+/**
+ * Highlight marker used to flag the violation lines inside a code-context
+ * block.
+ *
+ * The analysis backend (src/quodeq/analysis/mcp/enrichment.py) prefixes every
+ * highlighted line with `">>> "` — three chevrons plus a single space. The
+ * space is a separator between the marker and the code, NOT part of the source
+ * line, so it must be stripped along with the chevrons. Stripping only the
+ * three chevrons leaves the highlighted line rendered one space too far to the
+ * right, misaligned from the surrounding context.
+ */
+export const HIGHLIGHT_MARKER = '>>> ';
+
+/** True when `line` carries the highlight marker. */
+export function isHighlightedLine(line) {
+  return typeof line === 'string' && line.startsWith('>>>');
+}
+
+/**
+ * Remove the highlight marker (and its single-space separator) from a line,
+ * recovering the original source text with its indentation intact. Lines
+ * without the marker are returned unchanged.
+ */
+export function stripHighlightMarker(line) {
+  if (typeof line !== 'string') return line;
+  if (line.startsWith(HIGHLIGHT_MARKER)) return line.slice(HIGHLIGHT_MARKER.length);
+  // Defensive: a bare ">>>" with no separator space — drop only the chevrons
+  // so no source character is lost.
+  if (line.startsWith('>>>')) return line.slice(3);
+  return line;
+}

--- a/src/quodeq/ui/src/utils/codeMarker.test.js
+++ b/src/quodeq/ui/src/utils/codeMarker.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { HIGHLIGHT_MARKER, isHighlightedLine, stripHighlightMarker } from './codeMarker.js';
+
+// The analysis backend (src/quodeq/analysis/mcp/enrichment.py) prefixes
+// highlighted context lines with ">>> " — the ">>>" marker plus a single
+// space separator. The separator is presentation, not source: stripping it
+// must recover the original line with its indentation byte-for-byte, or the
+// highlighted line renders one space too far to the right in the code widget.
+
+test('marker is ">>> " (three chevrons + one separator space)', () => {
+  assert.equal(HIGHLIGHT_MARKER, '>>> ');
+});
+
+test('strips the marker AND its separator space, preserving indentation', () => {
+  // Real line has 4 spaces of indentation; backend emits ">>>" + " " + line.
+  assert.equal(stripHighlightMarker('>>>     print("hello")'), '    print("hello")');
+});
+
+test('a highlighted line aligns with the same unmarked line', () => {
+  const source = '    print("hello")';
+  assert.equal(stripHighlightMarker(`${HIGHLIGHT_MARKER}${source}`), source);
+});
+
+test('zero-indent highlighted line has no leading space', () => {
+  assert.equal(stripHighlightMarker('>>> def hello():'), 'def hello():');
+});
+
+test('empty highlighted line (">>> ") becomes empty', () => {
+  assert.equal(stripHighlightMarker('>>> '), '');
+});
+
+test('unmarked lines are returned unchanged', () => {
+  assert.equal(stripHighlightMarker('    return x'), '    return x');
+  assert.equal(stripHighlightMarker('def hello():'), 'def hello():');
+});
+
+test('defensive: bare ">>>" with no separator drops only the marker', () => {
+  assert.equal(stripHighlightMarker('>>>x'), 'x');
+});
+
+test('isHighlightedLine detects the marker', () => {
+  assert.equal(isHighlightedLine('>>> foo'), true);
+  assert.equal(isHighlightedLine('    foo'), false);
+  assert.equal(isHighlightedLine(''), false);
+});


### PR DESCRIPTION
## Problem

In detail-page code widgets, the selected/highlighted code lines rendered **one space too far to the right** — their indentation was off by a single leading space compared to the surrounding context.

## Root cause

A backend/frontend contract mismatch on the highlight marker:

- The analysis backend (`analysis/mcp/enrichment.py`) marks each highlighted line as `f">>> {text}"` — the `>>>` marker **plus a one-space separator** (4 chars).
- `ContextBlock.jsx` stripped only `raw.slice(3)` (the three chevrons), leaving the separator space behind as spurious indentation.

So `">>>     print()"` (real indent = 4 spaces) rendered as `"     print()"` (5 spaces).

## Fix

- New pure util `utils/codeMarker.js` — single source of truth for the marker contract: `HIGHLIGHT_MARKER`, `isHighlightedLine()`, `stripHighlightMarker()`. Removes the magic `3` and documents the contract.
- `ContextBlock.jsx` routes its two strip sites and three detection sites through the helper.

**Why the frontend, not the backend:** the `>>> ` format is the intended contract (backend tests assert it), and `context` strings are **persisted** in SQLite. Fixing the frontend also repairs already-stored findings; a backend-only change would not.

## Tests

- 8 unit tests on `codeMarker` (indentation preserved byte-for-byte).
- 2 component tests rendering the real `ContextBlock`, asserting the highlighted line's on-screen text keeps its indentation.
- Verified as a genuine regression guard: reverting to `slice(3)` fails these tests.
- Full suites green: 272 node tests + 805 vitest tests.

## Out of scope (pre-existing)

If an analyzed source file contains Python doctest lines (`>>> ...`) inside a **non-highlighted** context region, the widget would misdetect them as highlighted. Not addressed here.