### PR TITLE
fix(ui): default map viz to light in light app theme

### DIFF
--- a/src/quodeq/ui/src/features/map/components/useMapPageState.js
+++ b/src/quodeq/ui/src/features/map/components/useMapPageState.js
@@ -97,14 +97,14 @@ export default function useMapPageState({ data, callbacks, tabKey = 0 }) {
   const appIsDark = useThemeIsDark();
   const [darkMode, _setDarkMode] = useState(() => {
     if (appIsDark) return true;
-    try { const v = localStorage.getItem(MAP_DARK_KEY); return v === null ? true : v === '1'; } catch { return true; }
+    try { const v = localStorage.getItem(MAP_DARK_KEY); return v === null ? false : v === '1'; } catch { return false; }
   });
   const setDarkMode = (v) => { _setDarkMode(v); try { localStorage.setItem(MAP_DARK_KEY, v ? '1' : '0'); } catch {} };
   // A dark app theme always forces dark viz; back on light, restore the
-  // user's stored viz preference.
+  // user's stored viz preference (defaulting to light when none is stored).
   useEffect(() => {
     if (appIsDark) { _setDarkMode(true); }
-    else { try { const v = localStorage.getItem(MAP_DARK_KEY); _setDarkMode(v === null ? true : v === '1'); } catch { _setDarkMode(true); } }
+    else { try { const v = localStorage.getItem(MAP_DARK_KEY); _setDarkMode(v === null ? false : v === '1'); } catch { _setDarkMode(false); } }
   }, [appIsDark]);
   const [currentPath, _setCurrentPath] = useState(cached.currentPath);
   const setCurrentPath = (p) => { writeCachedState('map', selectedProject, { currentPath: p }); _setCurrentPath(p); };


### PR DESCRIPTION
## What

The map visualization now follows the app theme for its default: a **light** app shows a **light** map, a **dark** app shows a **dark** map.

## Why

Previously the map viz defaulted to **dark** even when the app was in **light** theme and no map preference was stored — so a fresh light-mode user saw a dark map.

## Change

In `useMapPageState.js`, the light-theme branch (both the state initializer and the `appIsDark` sync effect) defaulted `darkMode` to `true` when no `quodeq-map-dark` preference was stored. Flipped that default to `false` (light), including the `catch` fallbacks.

Unchanged:
- A **dark** app still forces the map dark.
- An **explicitly stored** user preference is still honored.

## Verification

- Live dev server against real project data:
  - Light app, no stored preference → map renders **light** (Light toggle on, no dark override on the container).
  - Dark app → map renders **dark** (Light toggle hidden, app forces dark).
- All 62 map unit tests pass; no console errors.