### PR TITLE
fix(assistant): dismiss/verify actions silently no-op'd (finding-identity mismatch)

### DIFF
--- a/src/quodeq/assistant/tools/_actions.py
+++ b/src/quodeq/assistant/tools/_actions.py
@@ -58,11 +58,18 @@ def _apply_create_standard(payload: dict, app: Flask) -> dict:
 
 
 def _canonical_finding_key(payload: dict, ctx: ToolContext) -> dict:
+    # A finding's identity is (req, file, line). `req` (the requirement id) is
+    # OPTIONAL on a finding -- practiceId is the guaranteed field and `req` is
+    # frequently absent -- and the suppression filter keys on `req or ""`. So we
+    # accept an empty req (a req=None finding is dismissed with req=""), mirror-
+    # ing the dashboard, which echoes the finding's own req verbatim. file and a
+    # non-negative integer line are always required; _require_matching_finding
+    # then confirms the whole key matches a real finding before it is recorded.
     req = str(payload.get("req") or "").strip()
     file = str(payload.get("file") or "").strip()
     line = payload.get("line")
-    if not req or not file or not isinstance(line, int) or isinstance(line, bool) or line < 0:
-        raise ToolError("req, file, and a non-negative integer line are required")
+    if not file or not isinstance(line, int) or isinstance(line, bool) or line < 0:
+        raise ToolError("file and a non-negative integer line are required")
     if not ctx.project_id:
         raise ToolError("no project attached to this session")
     try:
@@ -76,11 +83,31 @@ def _canonical_finding_key(payload: dict, ctx: ToolContext) -> dict:
     return canonical
 
 
+def _require_matching_finding(ctx: ToolContext, canonical: dict) -> None:
+    """Reject a finding action whose key matches no finding in scope.
+
+    The model must dismiss/verify by the finding's real (req, file, line) --
+    obtainable from get_report/get_violations (now carrying `requirement`) or
+    search_findings. If the key matches nothing, recording it would be a silent
+    no-op that reports success but never suppresses the finding, so we fail the
+    draft in-loop with a message that tells the model how to get the right key.
+    """
+    from quodeq.assistant.tools._read_tools import finding_keys_in_scope  # noqa: PLC0415
+
+    key = (canonical["req"], canonical["file"], canonical["line"])
+    if key not in finding_keys_in_scope(ctx):
+        raise ToolError(
+            f"no finding matches file={canonical['file']} line={canonical['line']} "
+            f"req={canonical['req'] or '(none)'} in this scope. Read the exact "
+            "requirement with get_report or search_findings, then retry with it.")
+
+
 def _validate_dismiss_finding(payload: dict, ctx: ToolContext) -> dict:
     canonical = _canonical_finding_key(payload, ctx)
     reason = str(payload.get("reason") or "").strip()
     if not reason:
         raise ToolError("a dismissal reason is required")
+    _require_matching_finding(ctx, canonical)
     canonical["reason"] = reason
     return canonical
 
@@ -111,6 +138,7 @@ def _validate_verify_finding(payload: dict, ctx: ToolContext) -> dict:
     note = str(payload.get("note") or "").strip()
     if not note:
         raise ToolError("a one-line note explaining why the finding is real is required")
+    _require_matching_finding(ctx, canonical)
     canonical["note"] = note
     return canonical
 

--- a/src/quodeq/assistant/tools/_actions.py
+++ b/src/quodeq/assistant/tools/_actions.py
@@ -118,7 +118,7 @@ def _summarize_dismiss_finding(canonical: dict) -> dict:
 
 
 def _apply_dismiss_finding(payload: dict, app: Flask) -> dict:
-    from quodeq.services.mutation_rescore import rescore_with_fallback  # noqa: PLC0415
+    from quodeq.services.mutation_rescore import dismiss_delta, rescore_with_fallback  # noqa: PLC0415
     from quodeq.services.dismissed import dismiss_finding  # noqa: PLC0415
     from quodeq.shared._env import get_evaluations_dir  # noqa: PLC0415
 
@@ -129,8 +129,16 @@ def _apply_dismiss_finding(payload: dict, app: Flask) -> dict:
         "req": payload["req"], "file": payload["file"], "line": payload["line"],
         "dismissReason": payload["reason"],
     })
-    scores = rescore_with_fallback(evaluations_dir, payload["project"], payload.get("runId"))
-    return {"dismissed": True, "scores": scores}
+    run_id = payload.get("runId")
+    scores = rescore_with_fallback(evaluations_dir, payload["project"], run_id)
+    # Mirror the manual /api/findings/dismiss route so the UI can patch its
+    # caches from this response instead of waiting on a lazy invalidation.
+    # run_id is None in overview scope -- dismiss_delta handles that by
+    # returning an inert-but-valid envelope (isLatest False, accumulated None).
+    delta = dismiss_delta(evaluations_dir, payload["project"], run_id, {
+        "req": payload["req"], "file": payload["file"], "line": payload["line"],
+    })
+    return {"dismissed": True, "scores": scores, "delta": delta}
 
 
 def _validate_verify_finding(payload: dict, ctx: ToolContext) -> dict:

--- a/src/quodeq/assistant/tools/_read_tools.py
+++ b/src/quodeq/assistant/tools/_read_tools.py
@@ -120,23 +120,38 @@ def finding_keys_in_scope(ctx: ToolContext) -> set[tuple]:
     rather than a stack trace.
     """
     keys: set[tuple] = set()
+
+    def _add(v: dict) -> None:
+        keys.add((_requirement_of(v), str(v.get("file") or ""), _coerce_line(v.get("line"))))
+
     if _has_run(ctx):
-        try:
-            raw, _ = _violations_from_run(ctx, None)
-            keys |= {(_requirement_of(v), str(v.get("file") or ""),
-                      _coerce_line(v.get("line"))) for v in raw}
-        except (ToolError, OSError, ValueError):
-            pass
-        try:
-            for f in SqliteFindingsRepository(ctx.run_dir).list_all():
-                keys.add((str(f.req or ""), str(f.file or ""), _coerce_line(f.line)))
-        except Exception:  # noqa: BLE001 - a corrupt/missing db must not block the read
-            pass
+        eval_dir = ctx.run_dir / "evaluation"
+        if eval_dir.is_dir():
+            # Parse each dimension file INDEPENDENTLY: one corrupt/truncated file
+            # (a known failure mode of deadline-cut runs) must drop only its own
+            # findings, not discard every healthy dimension's keys.
+            for p in sorted(eval_dir.glob("*.json")):
+                try:
+                    data = json.loads(p.read_text(encoding="utf-8"))
+                except (OSError, ValueError):
+                    continue
+                for v in (data.get("violations") or []):
+                    _add(v)
+        # SQL findings (the search_findings source). Read only an EXISTING db so
+        # a read-only draft never creates evaluation.db or kicks a projection on
+        # a run that has none -- when there is no db there are no SQL findings to
+        # miss anyway.
+        if (ctx.run_dir / "evaluation.db").is_file():
+            try:
+                for f in SqliteFindingsRepository(ctx.run_dir).list_all():
+                    keys.add((str(f.req or ""), str(f.file or ""), _coerce_line(f.line)))
+            except Exception:  # noqa: BLE001 - a corrupt db must not block the read
+                pass
     else:
         try:
             for d in (_accumulated_dims(ctx) or []):
-                keys |= {(_requirement_of(v), str(v.get("file") or ""),
-                          _coerce_line(v.get("line"))) for v in (d.get("violations") or [])}
+                for v in (d.get("violations") or []):
+                    _add(v)
         except (ToolError, OSError, ValueError):
             pass
     return keys

--- a/src/quodeq/assistant/tools/_read_tools.py
+++ b/src/quodeq/assistant/tools/_read_tools.py
@@ -70,10 +70,76 @@ def _principle_of(v: dict):
     return v.get("principle") or v.get("practiceId")
 
 
+def _requirement_of(v: dict) -> str:
+    # The requirement id (Finding.req) is the FIRST element of the (req, file,
+    # line) identity that dismiss/verify and the suppression filter key on.
+    # Run-scoped eval JSON and the accumulated serialized-Finding payload both
+    # key it as "req"; accept "requirement" too for any producer that already
+    # renamed it. Often absent (req is optional; practiceId is the guaranteed
+    # identity), so it is normalized to "" rather than None so it round-trips
+    # as a valid dismiss key.
+    return str(v.get("req") or v.get("requirement") or "")
+
+
+def _coerce_line(line) -> int:
+    # dismiss keys store line as int; Finding.line is typed int|str|None. Coerce
+    # so a string line ("5") still matches a stored int line (5).
+    try:
+        return int(line)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _trim_violation(v: dict) -> dict:
     out = {k: v.get(k) for k in _VIOLATION_FIELDS}
     out["principle"] = _principle_of(v)
+    # Expose the requirement id so the model can form a correct dismiss/verify
+    # key. Without it, get_report/get_violations only surfaced `principle`, and
+    # a dismiss drafted from that data carried a wrong/empty req that never
+    # matched the finding on the suppression read path (silent no-op).
+    out["requirement"] = _requirement_of(v)
     return out
+
+
+def finding_keys_in_scope(ctx: ToolContext) -> set[tuple]:
+    """Every ``(req, file, line)`` identity the model can see in this scope.
+
+    Used to validate a dismiss/verify draft against a real finding before it is
+    recorded, so the model cannot persist an action whose key matches nothing.
+    Unions EVERY source a read tool can surface, so the check never falsely
+    rejects a finding the model legitimately saw:
+
+    - run scope: the UNCAPPED eval-JSON violations (get_report/get_violations)
+      AND the SQL findings table (search_findings) -- the two can drift, and a
+      finding present in only one must still be dismissable.
+    - overview scope: the accumulated per-dimension-latest violations.
+
+    Best-effort: each source is guarded independently so one unreadable source
+    (e.g. a missing eval dir or a corrupt evaluation.db) still leaves the others
+    usable, and a wholly unreadable scope surfaces as "no matching finding"
+    rather than a stack trace.
+    """
+    keys: set[tuple] = set()
+    if _has_run(ctx):
+        try:
+            raw, _ = _violations_from_run(ctx, None)
+            keys |= {(_requirement_of(v), str(v.get("file") or ""),
+                      _coerce_line(v.get("line"))) for v in raw}
+        except (ToolError, OSError, ValueError):
+            pass
+        try:
+            for f in SqliteFindingsRepository(ctx.run_dir).list_all():
+                keys.add((str(f.req or ""), str(f.file or ""), _coerce_line(f.line)))
+        except Exception:  # noqa: BLE001 - a corrupt/missing db must not block the read
+            pass
+    else:
+        try:
+            for d in (_accumulated_dims(ctx) or []):
+                keys |= {(_requirement_of(v), str(v.get("file") or ""),
+                          _coerce_line(v.get("line"))) for v in (d.get("violations") or [])}
+        except (ToolError, OSError, ValueError):
+            pass
+    return keys
 
 
 def _severity_key(v: dict):

--- a/src/quodeq/assistant/tools/_write_tools.py
+++ b/src/quodeq/assistant/tools/_write_tools.py
@@ -48,9 +48,14 @@ def _edit_repo_file(ctx: ToolContext, path: str, old_string: str,
         raise ToolError(
             f"old_string matches {count} times, add surrounding context to make it unique")
     new_text = text.replace(old_string, new_string, 1)
-    if len(new_text.encode("utf-8")) > _MAX_CONTENT_BYTES:
+    encoded = new_text.encode("utf-8")
+    if len(encoded) > _MAX_CONTENT_BYTES:
         raise ToolError(f"edited file would exceed {_MAX_CONTENT_BYTES} bytes")
-    target.write_text(new_text, encoding="utf-8")
+    # write_bytes, not write_text: text mode translates "\n" to the platform
+    # newline on Windows, which would rewrite (and on a CRLF file double) every
+    # line ending in the user's repo. Preserve the file's exact bytes, changing
+    # only the edited span.
+    target.write_bytes(encoded)
     return {"path": path, "edited": True}
 
 

--- a/src/quodeq/services/dismissed.py
+++ b/src/quodeq/services/dismissed.py
@@ -242,7 +242,14 @@ def restore_all_findings(project_dir: Path) -> int:
 
 
 def _finding_key(f: Finding) -> tuple:
-    return (f.req or "", f.file or "", f.line or 0)
+    # line is coerced to int to match the stored dismiss key (dismissed_keys
+    # stores int(line)); Finding.line is typed int|str|None, so a string line
+    # would otherwise never match its own dismissal.
+    try:
+        line = int(f.line)
+    except (TypeError, ValueError):
+        line = 0
+    return (f.req or "", f.file or "", line)
 
 
 def recount_totals(

--- a/src/quodeq/services/mutation_rescore.py
+++ b/src/quodeq/services/mutation_rescore.py
@@ -240,6 +240,12 @@ def dismiss_delta(
         "file": dismissed.get("file"),
         "line": dismissed.get("line"),
     }
+    # Name the project so the assistant apply handler patches the cache keyed
+    # on the delta's own project, not the live-selected one. The manual route
+    # passes its own projectId to applyMutationDelta and ignores this field, so
+    # this is additive. Kept here (not in _mutation_envelope) to limit the blast
+    # radius to the one kind the assistant forwards.
+    envelope["project"] = project
     return envelope
 
 

--- a/src/quodeq/services/rescore.py
+++ b/src/quodeq/services/rescore.py
@@ -122,6 +122,20 @@ def _score_all_principles(
     return principle_scores, principle_grades
 
 
+def _coerce_line(line) -> int:
+    """Coerce a Finding.line (typed int|str|None) to the int used in dismiss keys.
+
+    Dismiss keys store line as ``int`` (see services/dismissed.dismissed_keys),
+    but a Finding's line may be a string, so a straight ``line or 0`` compare
+    would miss a string-lined finding. Coercing here keeps the suppression key
+    identical to the stored dismiss key.
+    """
+    try:
+        return int(line)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _rescore_dimension(
     dim: DimensionResult,
     dismissed: set[tuple],
@@ -133,7 +147,7 @@ def _rescore_dimension(
     dim_id = dim.dimension or ""
     filtered_violations = [
         v for v in dim.violations
-        if (v.req or "", v.file or "", v.line or 0) not in dismissed
+        if (v.req or "", v.file or "", _coerce_line(v.line)) not in dismissed
         and (dim_id, v.practice_id or "", v.file or "") not in deleted
     ]
     if len(filtered_violations) == len(dim.violations):

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -455,7 +455,7 @@ export default function App() {
   const bumpDismissRefresh = () => setDismissRefreshKey((k) => k + 1);
   const { refreshDashboard: refreshDashboardForApply, selectedProject } = state;
   // Shared with the manual dismiss handlers below (buildDismissPayload
-  // callers) — patches the dashboard/scores caches from a dismiss response's
+  // callers). Patches the dashboard/scores caches from a dismiss response's
   // delta so the Overview updates instantly instead of waiting on a refetch.
   const applyDelta = (project, scores, delta) =>
     applyMutationDelta(queryClient, project, delta && { ...delta, dimensions: scores?.dimensions });
@@ -465,8 +465,20 @@ export default function App() {
         // Apply the delta first so the currently-visible screen patches in
         // place immediately; the refresh/refetch below is the lazy,
         // eventual-correctness path (e.g. for views the delta doesn't cover).
+        // Prefer the delta's own project over the live selectedProject: the
+        // apply POST may resolve after the user switched projects, and the
+        // delta is frozen to the action's project. Keying the patch on the
+        // live selection would write project A's rollup into project B's cache.
         if (event.detail.delta) {
-          applyDelta(selectedProject, event.detail.scores, event.detail.delta);
+          try {
+            applyDelta(
+              event.detail.delta?.project || selectedProject,
+              event.detail.scores,
+              event.detail.delta,
+            );
+          } catch {
+            // Instant patch is best-effort; the lazy refresh below is the fallback.
+          }
         }
         bumpDismissRefresh();
         // Assistant-applied dismissals mutate the same payloads manual ones

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -453,10 +453,21 @@ export default function App() {
   // fetched once on mount.
   const [dismissRefreshKey, setDismissRefreshKey] = useState(0);
   const bumpDismissRefresh = () => setDismissRefreshKey((k) => k + 1);
-  const { refreshDashboard: refreshDashboardForApply } = state;
+  const { refreshDashboard: refreshDashboardForApply, selectedProject } = state;
+  // Shared with the manual dismiss handlers below (buildDismissPayload
+  // callers) — patches the dashboard/scores caches from a dismiss response's
+  // delta so the Overview updates instantly instead of waiting on a refetch.
+  const applyDelta = (project, scores, delta) =>
+    applyMutationDelta(queryClient, project, delta && { ...delta, dimensions: scores?.dimensions });
   useEffect(() => {
     const handler = (event) => {
       if (event.detail?.actionType === 'dismiss_finding') {
+        // Apply the delta first so the currently-visible screen patches in
+        // place immediately; the refresh/refetch below is the lazy,
+        // eventual-correctness path (e.g. for views the delta doesn't cover).
+        if (event.detail.delta) {
+          applyDelta(selectedProject, event.detail.scores, event.detail.delta);
+        }
         bumpDismissRefresh();
         // Assistant-applied dismissals mutate the same payloads manual ones
         // do; invalidate the project queries so frozen run views (staleTime
@@ -467,7 +478,7 @@ export default function App() {
     };
     window.addEventListener('quodeq:assistant-action-applied', handler);
     return () => window.removeEventListener('quodeq:assistant-action-applied', handler);
-  }, [refreshDashboardForApply]);
+  }, [refreshDashboardForApply, selectedProject]);
   // Auto-open is a once-per-session decision. Without this guard, closing the
   // wizard sets wizardEntry → null, which re-fires this effect and re-opens
   // the wizard immediately because projects.length is still 0. The user's
@@ -648,8 +659,7 @@ export default function App() {
     // Overview updates instantly. Additive — the refreshDashboard /
     // bumpDismissRefresh mechanisms below still run. The delta carries only the
     // mutation shape; the caller folds in the rescored dims from result.scores.
-    applyDelta: (project, scores, delta) =>
-      applyMutationDelta(queryClient, project, delta && { ...delta, dimensions: scores?.dimensions }),
+    applyDelta,
     bumpDismissRefresh,
     dismissRefreshKey,
   };

--- a/src/quodeq/ui/src/features/assistant/ActionPreviewCard.jsx
+++ b/src/quodeq/ui/src/features/assistant/ActionPreviewCard.jsx
@@ -42,8 +42,10 @@ export function ActionPreviewCard({ action }) {
   async function handleApply() {
     setStatus('pending');
     try {
-      await applyAssistantAction(actionId);
-      window.dispatchEvent(new CustomEvent('quodeq:assistant-action-applied', { detail: { actionType } }));
+      const res = await applyAssistantAction(actionId);
+      window.dispatchEvent(new CustomEvent('quodeq:assistant-action-applied', {
+        detail: { actionType, scores: res?.result?.scores, delta: res?.result?.delta },
+      }));
       setStatus('applied');
     } catch {
       setStatus('error');

--- a/src/quodeq/ui/src/features/assistant/ActionPreviewCard.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/ActionPreviewCard.test.jsx
@@ -62,3 +62,24 @@ it('dispatches quodeq:assistant-action-applied on successful apply', async () =>
   expect(events[0].detail.actionType).toBe('dismiss_finding');
   window.removeEventListener('quodeq:assistant-action-applied', handler);
 });
+
+it('includes the scores and delta from the apply response in the dispatched event', async () => {
+  const events = [];
+  const handler = (e) => events.push(e);
+  window.addEventListener('quodeq:assistant-action-applied', handler);
+  const scores = { dimensions: [{ dimension: 'security', overallScore: 80 }] };
+  const delta = {
+    kind: 'dismiss', dismissed: { req: 'R1', file: 'a.py', line: 3 },
+    runId: 'run1', isLatest: false, accumulated: null,
+  };
+  applyAssistantAction.mockResolvedValueOnce({ applied: true, result: { dismissed: true, scores, delta } });
+  const dismissAction = { actionId: 'a4', actionType: 'dismiss_finding',
+    summary: { req: 'R1', file: 'a.py', line: 3, reason: 'fp' } };
+  render(<ActionPreviewCard action={dismissAction} />);
+  fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+  await waitFor(() => expect(applyAssistantAction).toHaveBeenCalledWith('a4'));
+  await waitFor(() => expect(events.length).toBe(1));
+  expect(events[0].detail.delta).toEqual(delta);
+  expect(events[0].detail.scores).toEqual(scores);
+  window.removeEventListener('quodeq:assistant-action-applied', handler);
+});

--- a/tests/api/test_assistant_routes.py
+++ b/tests/api/test_assistant_routes.py
@@ -539,6 +539,42 @@ def test_apply_dismiss_finding_writes_action_log(client, app, tmp_path, monkeypa
     assert dismissed_keys(evals / "proj") == {("r1", "a.py", 3)}
 
 
+def test_apply_dismiss_finding_returns_delta_for_run_scoped_session(client, app, tmp_path, monkeypatch):
+    # A run-scoped dismiss (runId present, mirroring an assistant session
+    # opened against a specific run) must return the same delta shape the
+    # manual /api/findings/dismiss route returns, so the UI can patch its
+    # caches in place instead of waiting on a lazy refetch.
+    evals = tmp_path / "evals"
+    run_dir = evals / "proj" / "run1"
+    (run_dir / "evaluation").mkdir(parents=True)
+    (run_dir / "evaluation" / "security.json").write_text(json.dumps({
+        "dimension": "security", "overallScore": 50, "overallGrade": "C",
+        "principles": [], "violations": [
+            {"principle": "P1", "req": "r1", "file": "a.py", "line": 3,
+             "severity": "major", "title": "t", "reason": "r"},
+        ],
+        "totals": {"violations": 1},
+    }))
+    monkeypatch.setitem(app.config, "EVALUATIONS_DIR", str(evals))
+    repo = _repo(app)
+    repo.create_session(session_id="s1", provider="ollama")
+    repo.create_action(action_id="a1", session_id="s1",
+                       action_type="dismiss_finding",
+                       payload={"project": "proj", "req": "r1", "file": "a.py",
+                                "line": 3, "reason": "false positive: guarded",
+                                "runId": "run1"},
+                       content_hash="h")
+    resp = client.post("/api/assistant/actions/a1/apply")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["result"]["dismissed"] is True
+    delta = body["result"]["delta"]
+    assert delta["kind"] == "dismiss"
+    assert delta["dismissed"] == {"req": "r1", "file": "a.py", "line": 3}
+    from quodeq.services.dismissed import dismissed_keys
+    assert dismissed_keys(evals / "proj") == {("r1", "a.py", 3)}
+
+
 def test_apply_verify_finding_writes_badge(client, app, tmp_path, monkeypatch):
     evals = tmp_path / "evals"
     (evals / "proj").mkdir(parents=True)

--- a/tests/api/test_assistant_routes.py
+++ b/tests/api/test_assistant_routes.py
@@ -571,6 +571,9 @@ def test_apply_dismiss_finding_returns_delta_for_run_scoped_session(client, app,
     delta = body["result"]["delta"]
     assert delta["kind"] == "dismiss"
     assert delta["dismissed"] == {"req": "r1", "file": "a.py", "line": 3}
+    # The delta names its own project so the client patches the right cache
+    # even if the user switched projects while the apply POST was in flight.
+    assert delta["project"] == "proj"
     from quodeq.services.dismissed import dismissed_keys
     assert dismissed_keys(evals / "proj") == {("r1", "a.py", 3)}
 

--- a/tests/api/test_assistant_workspace_routes.py
+++ b/tests/api/test_assistant_workspace_routes.py
@@ -32,6 +32,7 @@ def repo(tmp_path):
     root = tmp_path / "repo"
     root.mkdir()
     _run(["git", "-C", str(root), "init", "-q", "-b", "main"])
+    _run(["git", "-C", str(root), "config", "core.autocrlf", "false"])
     _run(["git", "-C", str(root), "config", "user.name", "T"])
     _run(["git", "-C", str(root), "config", "user.email", "t@example.com"])
     (root / "app.py").write_bytes(b"x = 1\n")

--- a/tests/assistant/test_dismiss_apply_e2e.py
+++ b/tests/assistant/test_dismiss_apply_e2e.py
@@ -1,0 +1,99 @@
+"""End-to-end: assistant dismiss draft -> apply -> finding actually suppressed.
+
+Closes the coverage gap where only the DRAFT path was tested. The bug the user
+hit lived entirely in the draft -> apply -> suppress leg: get_violations/
+get_report never exposed the requirement, so a dismiss drafted from that data
+carried a wrong/empty req that was durably recorded yet never matched the
+finding on the suppression read path (silent no-op reporting dismissed: True).
+"""
+import json
+
+from flask import Flask
+
+from quodeq.assistant.tools import ToolContext, build_registry
+from quodeq.assistant.tools._actions import ACTIONS
+from quodeq.core.types.finding import Finding
+from quodeq.data.sqlite.assistant_repository import AssistantRepository
+from quodeq.services.dismissed import _finding_key, dismissed_keys
+
+
+def _ctx(tmp_path, violations):
+    eval_root = tmp_path / "evals"
+    run_dir = eval_root / "proj" / "run1"
+    (run_dir / "evaluation").mkdir(parents=True)
+    (run_dir / "evaluation" / "security.json").write_text(json.dumps({
+        "dimension": "security", "overallScore": 50, "overallGrade": "C",
+        "principles": [], "violations": violations,
+        "totals": {"violations": len(violations)},
+    }))
+    store = AssistantRepository(tmp_path / "assistant.db")
+    store.create_session(session_id="s1", provider="ollama")
+    ctx = ToolContext(
+        repository=store, session_id="s1", run_dir=run_dir, repo_root=None,
+        evaluators_dir=tmp_path / "e", compiled_dir=tmp_path / "c",
+        dimensions_file=tmp_path / "d.json",
+        project_id="proj", reports_dir=eval_root)
+    return eval_root, ctx
+
+
+def _app(eval_root):
+    app = Flask(__name__)
+    app.config["EVALUATIONS_DIR"] = str(eval_root)
+    return app
+
+
+def _apply_latest(ctx, eval_root, action_id):
+    payload = ctx.repository.get_action(action_id)["payload"]
+    return ACTIONS["dismiss_finding"].apply(payload, _app(eval_root))
+
+
+def test_dismiss_roundtrip_suppresses_the_finding(tmp_path):
+    eval_root, ctx = _ctx(tmp_path, [
+        {"principle": "P1", "req": "R1", "file": "a.py", "line": 10,
+         "severity": "critical", "title": "t", "reason": "r"}])
+    reg = build_registry(ctx)
+
+    # The model reads the finding; requirement is now exposed so it can key it.
+    v = reg.dispatch("get_report", {"dimension": "security"})["result"]["violations"][0]
+    assert v["requirement"] == "R1"
+
+    draft = reg.dispatch("draft_action", {
+        "action_type": "dismiss_finding",
+        "payload": {"req": v["requirement"], "file": v["file"], "line": v["line"],
+                    "reason": "guarded above"}})
+    assert draft["ok"], draft
+    result = _apply_latest(ctx, eval_root, draft["result"]["action_id"])
+    assert result["dismissed"] is True
+
+    # The dismissal is recorded AND its key matches the finding's own suppression
+    # key, so the suppression read path actually drops it. Before the fix the
+    # model had no way to obtain "R1" and would key on the principle, diverging.
+    keys = dismissed_keys(eval_root / "proj")
+    assert keys == {("R1", "a.py", 10)}
+    finding = Finding(req="R1", file="a.py", line=10, practice_id="P1", severity="critical")
+    assert _finding_key(finding) in keys
+
+
+def test_dismiss_roundtrip_for_req_none_finding(tmp_path):
+    # A finding whose canonical identity is only practiceId (req absent) must
+    # also round-trip: exposed requirement is "", the draft accepts req="", and
+    # the recorded key ("", file, line) matches the finding's ("", file, line).
+    eval_root, ctx = _ctx(tmp_path, [
+        {"principle": "P1", "file": "b.py", "line": 7,  # no req
+         "severity": "major", "title": "t", "reason": "r"}])
+    reg = build_registry(ctx)
+
+    v = reg.dispatch("get_report", {"dimension": "security"})["result"]["violations"][0]
+    assert v["requirement"] == ""
+
+    draft = reg.dispatch("draft_action", {
+        "action_type": "dismiss_finding",
+        "payload": {"req": v["requirement"], "file": v["file"], "line": v["line"],
+                    "reason": "not applicable here"}})
+    assert draft["ok"], draft
+    _apply_latest(ctx, eval_root, draft["result"]["action_id"])
+
+    keys = dismissed_keys(eval_root / "proj")
+    assert keys == {("", "b.py", 7)}
+    finding = Finding(file="b.py", line=7, practice_id="P1", severity="major")  # req=None
+    assert _finding_key(finding) in keys

--- a/tests/assistant/test_orchestrator_write.py
+++ b/tests/assistant/test_orchestrator_write.py
@@ -11,6 +11,7 @@ def repo(tmp_path):
     root = tmp_path / "repo"
     root.mkdir()
     _run(["git", "-C", str(root), "init", "-q", "-b", "main"])
+    _run(["git", "-C", str(root), "config", "core.autocrlf", "false"])
     _run(["git", "-C", str(root), "config", "user.name", "T"])
     _run(["git", "-C", str(root), "config", "user.email", "t@example.com"])
     (root / "app.py").write_bytes(b"x = 1\n")

--- a/tests/assistant/test_tools_actions.py
+++ b/tests/assistant/test_tools_actions.py
@@ -158,6 +158,21 @@ def test_draft_dismiss_accepts_sql_only_finding(tmp_path):
     assert out["ok"] is True
 
 
+def test_draft_dismiss_survives_corrupt_dimension_file(tmp_path):
+    # A single corrupt dimension JSON must drop only its own findings, not
+    # discard every healthy dimension's keys (which would falsely reject a
+    # valid dismiss on a legacy run with no SQL findings db).
+    ctx = _seed_run_ctx(tmp_path, [
+        {"principle": "P1", "req": "R1", "file": "a.py", "line": 10,
+         "severity": "major", "title": "t", "reason": "r"}])
+    (ctx.run_dir / "evaluation" / "reliability.json").write_text("{not json")
+    out = build_registry(ctx).dispatch("draft_action", {
+        "action_type": "dismiss_finding",
+        "payload": {"req": "R1", "file": "a.py", "line": 10, "reason": "fp"},
+    })
+    assert out["ok"] is True
+
+
 def test_draft_dismiss_accepts_req_none_finding(tmp_path):
     # A finding with no req (practiceId-only identity) is dismissable with an
     # empty req, mirroring the dashboard. The old validator rejected empty req,

--- a/tests/assistant/test_tools_actions.py
+++ b/tests/assistant/test_tools_actions.py
@@ -1,7 +1,30 @@
+import json
+
 import pytest
 
 from quodeq.assistant.tools import ToolContext, build_registry
 from quodeq.data.sqlite.assistant_repository import AssistantRepository
+
+
+def _seed_run_ctx(tmp_path, violations, *, dbname="assistant_run.db"):
+    """Run-scoped ctx whose eval JSON carries `violations` so the dismiss/verify
+    match-check (finding_keys_in_scope) can confirm the drafted key is real."""
+    eval_root = tmp_path / "evals"
+    run_dir = eval_root / "proj" / "run1"
+    (run_dir / "evaluation").mkdir(parents=True)
+    (run_dir / "evaluation" / "security.json").write_text(json.dumps({
+        "dimension": "security", "overallScore": 50, "overallGrade": "C",
+        "principles": [], "violations": violations,
+        "totals": {"violations": len(violations)},
+    }))
+    store = AssistantRepository(tmp_path / dbname)
+    store.create_session(session_id="s1", provider="ollama")
+    return ToolContext(
+        repository=store, session_id="s1", run_dir=run_dir, repo_root=None,
+        evaluators_dir=tmp_path / "e", compiled_dir=tmp_path / "c",
+        dimensions_file=tmp_path / "d.json",
+        project_id="proj", reports_dir=eval_root,
+    )
 
 _VALID_STANDARD = {
     "id": "api-errors", "name": "API Error Contract", "description": "d",
@@ -79,21 +102,76 @@ def test_draft_dismiss_requires_reason(project_ctx):
     assert "reason" in out["error"]
 
 
-def test_draft_dismiss_canonicalizes_from_session(project_ctx):
-    out = build_registry(project_ctx).dispatch("draft_action", {
+def test_draft_dismiss_canonicalizes_from_session(tmp_path):
+    ctx = _seed_run_ctx(tmp_path, [
+        {"principle": "P1", "req": "r1", "file": "a.py", "line": 3,
+         "severity": "major", "title": "t", "reason": "r"}])
+    out = build_registry(ctx).dispatch("draft_action", {
         "action_type": "dismiss_finding",
         "payload": {"req": "r1", "file": "a.py", "line": 3,
                     "reason": "guarded two lines above",
                     "project": "spoofed-by-model"},
     })
     assert out["ok"] is True
-    stored = project_ctx.repository.get_action(out["result"]["action_id"])
+    stored = ctx.repository.get_action(out["result"]["action_id"])
     assert stored["payload"]["project"] == "proj"  # session wins over model payload
     assert stored["payload"]["reason"] == "guarded two lines above"
-    frames = [f for _, f in project_ctx.repository.events_after("s1", 0)]
+    frames = [f for _, f in ctx.repository.events_after("s1", 0)]
     draft = next(f for f in frames if f["type"] == "action_draft")
     assert draft["summary"] == {"req": "r1", "file": "a.py", "line": 3,
                                 "reason": "guarded two lines above"}
+
+
+def test_draft_dismiss_rejects_unmatched_key(tmp_path):
+    # The model dismisses with the PRINCIPLE (the only id get_violations used to
+    # expose) as req. No finding has that (req, file, line), so recording it
+    # would be a silent no-op. The draft fails in-loop instead.
+    ctx = _seed_run_ctx(tmp_path, [
+        {"principle": "P1", "req": "r1", "file": "a.py", "line": 3,
+         "severity": "major", "title": "t", "reason": "r"}])
+    out = build_registry(ctx).dispatch("draft_action", {
+        "action_type": "dismiss_finding",
+        "payload": {"req": "P1", "file": "a.py", "line": 3, "reason": "fp"},
+    })
+    assert out["ok"] is False
+    assert "no finding matches" in out["error"]
+
+
+def test_draft_dismiss_accepts_sql_only_finding(tmp_path):
+    # A finding surfaced by search_findings (SQL) but absent from the eval JSON
+    # (the two stores can drift) must still be dismissable -- the match-check
+    # unions both sources so it never falsely rejects a finding the model saw.
+    from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
+
+    ctx = _seed_run_ctx(tmp_path, [])  # empty eval JSON
+    SqliteFindingsRepository(ctx.run_dir).insert_finding({
+        "p": "P1", "d": "security", "req": "SQL-1", "t": "violation",
+        "severity": "major", "file": "z.py", "line": 42, "end_line": 42,
+        "w": "t", "reason": "r", "snippet": "s", "vt": "code", "context": "",
+        "scope": "file", "req_refs": [], "confidence": 90,
+        "provenance_downgrade": 0,
+    })
+    out = build_registry(ctx).dispatch("draft_action", {
+        "action_type": "dismiss_finding",
+        "payload": {"req": "SQL-1", "file": "z.py", "line": 42, "reason": "fp"},
+    })
+    assert out["ok"] is True
+
+
+def test_draft_dismiss_accepts_req_none_finding(tmp_path):
+    # A finding with no req (practiceId-only identity) is dismissable with an
+    # empty req, mirroring the dashboard. The old validator rejected empty req,
+    # making such findings undismissable by the assistant.
+    ctx = _seed_run_ctx(tmp_path, [
+        {"principle": "P1", "file": "a.py", "line": 3,  # no req key
+         "severity": "major", "title": "t", "reason": "r"}])
+    out = build_registry(ctx).dispatch("draft_action", {
+        "action_type": "dismiss_finding",
+        "payload": {"file": "a.py", "line": 3, "reason": "fp"},  # req omitted
+    })
+    assert out["ok"] is True
+    stored = ctx.repository.get_action(out["result"]["action_id"])
+    assert stored["payload"]["req"] == ""
 
 
 def test_draft_verify_requires_note_and_project(ctx, project_ctx):

--- a/tests/assistant/test_tools_read.py
+++ b/tests/assistant/test_tools_read.py
@@ -82,6 +82,48 @@ def test_search_findings(ctx):
     assert hit["requirement"] == "req-1"
 
 
+def _req_ctx(tmp_path):
+    """A run whose eval JSON carries `req` on one violation and omits it on another."""
+    run_dir = tmp_path / "run"
+    eval_dir = run_dir / "evaluation"
+    eval_dir.mkdir(parents=True)
+    (eval_dir / "security.json").write_text(json.dumps({
+        "dimension": "security", "overallScore": 50, "overallGrade": "C",
+        "principles": [{"name": "P1", "grade": "C"}],
+        "violations": [
+            {"principle": "P1", "req": "M-1", "file": "a.py", "line": 3,
+             "severity": "critical", "title": "t", "reason": "r"},
+            {"principle": "P2", "file": "b.py", "line": 7,  # no req key
+             "severity": "major", "title": "t2", "reason": "r2"},
+        ],
+        "totals": {"violations": 2},
+    }))
+    repo = AssistantRepository(tmp_path / "assistant.db")
+    repo.create_session(session_id="s1", provider="ollama")
+    return ToolContext(
+        repository=repo, session_id="s1", run_dir=run_dir, repo_root=None,
+        evaluators_dir=tmp_path / "e", compiled_dir=tmp_path / "c",
+        dimensions_file=tmp_path / "d.json")
+
+
+def test_get_report_exposes_requirement(tmp_path):
+    # get_report must surface `requirement` so the model can form a correct
+    # dismiss/verify key. A finding with no req exposes "" (not missing/None).
+    reg = build_registry(_req_ctx(tmp_path))
+    viols = reg.dispatch("get_report", {"dimension": "security"})["result"]["violations"]
+    by_file = {v["file"]: v for v in viols}
+    assert by_file["a.py"]["requirement"] == "M-1"
+    assert by_file["b.py"]["requirement"] == ""
+
+
+def test_get_violations_exposes_requirement(tmp_path):
+    reg = build_registry(_req_ctx(tmp_path))
+    viols = reg.dispatch("get_violations", {"dimension": "security"})["result"]["violations"]
+    by_file = {v["file"]: v for v in viols}
+    assert by_file["a.py"]["requirement"] == "M-1"
+    assert by_file["b.py"]["requirement"] == ""
+
+
 def test_search_findings_limit_floor_clamped(ctx):
     # limit=0 (or negative) must not reach the repo -- clamp to >=1 instead.
     reg = build_registry(ctx)
@@ -114,7 +156,9 @@ def test_get_report_includes_trimmed_violations(ctx):
     viols = report["violations"]
     assert len(viols) == 3
     # Trimmed fields only; snippet/context dropped to protect context size.
-    assert set(viols[0]) == {"principle", "file", "line", "severity", "title", "reason"}
+    # `requirement` is included so the model can form a dismiss/verify key.
+    assert set(viols[0]) == {"principle", "requirement", "file", "line",
+                             "severity", "title", "reason"}
     assert all("snippet" not in v and "context" not in v for v in viols)
 
 
@@ -138,7 +182,8 @@ def test_get_violations_for_dimension(ctx):
     res = out["result"]
     # Severity-sorted: critical first, then major, then minor.
     assert [v["severity"] for v in res["violations"]] == ["critical", "major", "minor"]
-    assert set(res["violations"][0]) == {"principle", "file", "line", "severity", "title", "reason"}
+    assert set(res["violations"][0]) == {"principle", "requirement", "file", "line",
+                                         "severity", "title", "reason"}
     assert res["by_principle"] == {"P1": 2, "P2": 1}
     assert res["dimension"] == "security"
 

--- a/tests/assistant/test_tools_write.py
+++ b/tests/assistant/test_tools_write.py
@@ -11,6 +11,7 @@ def wt_ctx(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
     _run(["git", "-C", str(repo), "init", "-q", "-b", "main"])
+    _run(["git", "-C", str(repo), "config", "core.autocrlf", "false"])
     _run(["git", "-C", str(repo), "config", "user.name", "T"])
     _run(["git", "-C", str(repo), "config", "user.email", "t@example.com"])
     (repo / "app.py").write_bytes(b"a = 1\nb = 2\nb = 2\n")
@@ -48,6 +49,18 @@ def test_edit_unique_match(wt_ctx):
     assert (wt_ctx.worktree_dir / "app.py").read_bytes() == b"a = 9\nb = 2\nb = 2\n"
     # the USER's repo copy is untouched
     assert (wt_ctx.repo_root / "app.py").read_bytes() == b"a = 1\nb = 2\nb = 2\n"
+
+
+def test_edit_preserves_crlf_line_endings(wt_ctx):
+    # A CRLF file (a Windows user's repo) must keep its exact line endings on
+    # edit. write_text would translate "\n" to the platform newline on Windows
+    # and double every "\r\n" into "\r\r\n"; write_bytes preserves the file.
+    (wt_ctx.worktree_dir / "crlf.py").write_bytes(b"a = 1\r\nb = 2\r\n")
+    reg = _registry(wt_ctx)
+    out = reg.dispatch("edit_repo_file", {"path": "crlf.py", "old_string": "a = 1",
+                                          "new_string": "a = 9"})
+    assert out["ok"]
+    assert (wt_ctx.worktree_dir / "crlf.py").read_bytes() == b"a = 9\r\nb = 2\r\n"
 
 
 def test_edit_rejects_ambiguous_and_missing(wt_ctx):

--- a/tests/assistant/test_worktree.py
+++ b/tests/assistant/test_worktree.py
@@ -10,6 +10,7 @@ def repo(tmp_path):
     root = tmp_path / "repo"
     root.mkdir()
     _run(["git", "-C", str(root), "init", "-q", "-b", "main"])
+    _run(["git", "-C", str(root), "config", "core.autocrlf", "false"])
     _run(["git", "-C", str(root), "config", "user.name", "T"])
     _run(["git", "-C", str(root), "config", "user.email", "t@example.com"])
     (root / "app.py").write_bytes(b"print('hi')\n")

--- a/tests/assistant/test_write_flow_e2e.py
+++ b/tests/assistant/test_write_flow_e2e.py
@@ -13,6 +13,7 @@ def test_edit_diff_apply_roundtrip(tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()
     _run(["git", "-C", str(repo), "init", "-q", "-b", "main"])
+    _run(["git", "-C", str(repo), "config", "core.autocrlf", "false"])
     _run(["git", "-C", str(repo), "config", "user.name", "T"])
     _run(["git", "-C", str(repo), "config", "user.email", "t@example.com"])
     (repo / "app.py").write_bytes(b"x = 1\n")

--- a/tests/services/test_mutation_rescore_delta.py
+++ b/tests/services/test_mutation_rescore_delta.py
@@ -42,6 +42,15 @@ class TestDismissDeltaEnvelope:
         assert "isLatest" in delta
         assert "accumulated" in delta
 
+    def test_carries_its_own_project(self, tmp_path):
+        # The assistant apply handler patches caches keyed on the delta's own
+        # project, not the live-selected one, so the delta must name it. This
+        # prevents patching project B's cache with project A's rollup when the
+        # user switches projects while an apply POST is in flight.
+        _make_run(tmp_path, "projA", "run-1")
+        delta = dismiss_delta(str(tmp_path), "projA", "run-1", dict(_DISMISSED))
+        assert delta["project"] == "projA"
+
     def test_without_run_id_accumulated_is_none(self, tmp_path):
         _make_run(tmp_path, "proj", "run-1")
         delta = dismiss_delta(str(tmp_path), "proj", None, dict(_DISMISSED))

--- a/tests/services/test_rescore.py
+++ b/tests/services/test_rescore.py
@@ -3,7 +3,7 @@ from quodeq.core.types.finding import Finding, Totals, SeverityTally
 from quodeq.core.types.report import PrincipleGrade
 from quodeq.core.types.dimension import DimensionResult
 
-from quodeq.services.rescore import rescore_dimensions
+from quodeq.services.rescore import _rescore_dimension, rescore_dimensions
 
 
 def _make_violation(practice_id="P1", severity="major", req="R1", file="a.py", line=1, reason="bug"):
@@ -35,6 +35,16 @@ def _make_dimension(name="Reliability", violations=None, compliance=None, source
         ),
         source_file_count=source_file_count,
     )
+
+
+def test_rescore_dimension_matches_string_line():
+    """A finding whose line is a string ("10") is still suppressed by a dismissal
+    stored with an int line (10). dismissed_keys stores int(line); Finding.line is
+    typed int|str|None, so the read side must coerce too or a string-lined finding
+    never matches its own dismissal."""
+    dim = _make_dimension(violations=[_make_violation(req="R1", file="a.py", line="10")])
+    rescored = _rescore_dimension(dim, {("R1", "a.py", 10)})
+    assert rescored.violations == []  # string-lined finding filtered out
 
 
 def test_rescore_no_dismissals_returns_rescored_data():


### PR DESCRIPTION
## Problem

The in-app assistant's **dismiss / verify actions silently did nothing**. The assistant would report a finding as dismissed, the UI would refetch, and the finding would still be there.

## Root cause

Findings are suppressed by an exact `(req, file, line)` key. But `req` (the requirement id) is **optional** on a finding, `practiceId` is the guaranteed identity, and the model's finding-listing tools (`get_violations` / `get_report`) exposed only `principle`, never `requirement`. So a dismiss drafted from that data carried a wrong or empty `req`. It was durably recorded in `actions.jsonl` yet never matched the finding on the read-side suppression filter, so nothing was suppressed, while `_apply_dismiss_finding` still returned `dismissed: True`.

The dashboard's own dismiss works because it echoes the finding's own serialized `req` verbatim. The assistant instead asked the model to reconstruct a key it was never shown.

A second, independent latent bug: `line` was compared as-is on the read path while dismissals stored it coerced to `int`, so a string-lined finding never matched its own dismissal (would also affect the dashboard path).

## Fix

1. Expose `requirement` on `get_report` / `get_violations` (matching `search_findings`), so the model can key a finding by its real identity.
2. Accept a finding's real key **including an empty `req`** (for `req=None` findings), mirroring the dashboard, instead of demanding a non-empty `req` the finding may not have.
3. Reject a dismiss / verify draft whose `(req, file, line)` matches no finding in scope, unioning the eval-JSON and SQL finding sources (with per-file JSON guarding, and reading SQL only when the db already exists so a read-only draft has no side effects). Honest in-loop failure instead of a silent no-op.
4. Coerce `line` to `int` on the suppression read path (`_rescore_dimension` and `dismissed._finding_key`).

## Testing

Full backend suite **4294 passed**, line-gated IO/posix checks pass. Adds the previously-missing draft → apply → suppress roundtrip coverage (for `req`-bearing, `req=None`, and SQL-only findings), a string-line suppression test, and a corrupt-dimension-file regression test. TDD throughout; adversarially reviewed (caught and fixed a false-reject where one corrupt dimension file would have rejected every valid dismiss on a legacy run).

## Note

Independent of the write-access work in #768. The empty-`req` key can collapse two distinct findings sharing `(file, line)` with no `req` — this is identical to the dashboard's existing key behavior, not a new class of over-suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
