### PR TITLE
fix(assistant): preserve file bytes exactly on Windows (CRLF)

### DIFF
--- a/src/quodeq/assistant/tools/_write_tools.py
+++ b/src/quodeq/assistant/tools/_write_tools.py
@@ -50,7 +50,9 @@ def _edit_repo_file(ctx: ToolContext, path: str, old_string: str,
     new_text = text.replace(old_string, new_string, 1)
     if len(new_text.encode("utf-8")) > _MAX_CONTENT_BYTES:
         raise ToolError(f"edited file would exceed {_MAX_CONTENT_BYTES} bytes")
-    target.write_text(new_text, encoding="utf-8")
+    # bytes, not text mode: Windows text-mode writes translate \n to \r\n,
+    # corrupting files that already use \r\n into \r\r\n
+    target.write_bytes(new_text.encode("utf-8"))
     return {"path": path, "edited": True}
 
 

--- a/src/quodeq/assistant/worktree.py
+++ b/src/quodeq/assistant/worktree.py
@@ -23,6 +23,10 @@ class WorktreeError(Exception):
 
 
 def _run_bytes(argv: list[str], *, cwd: Path | None = None) -> bytes:
+    if argv[0] == "git":
+        # never let core.autocrlf (Git-for-Windows default: true) rewrite line
+        # endings at checkout/diff/apply; the tool contract is byte-exact files
+        argv = ["git", "-c", "core.autocrlf=false", *argv[1:]]
     try:
         proc = subprocess.run(  # noqa: S603 - argv list, no shell
             argv, cwd=str(cwd) if cwd else None,

--- a/tests/assistant/test_tools_write.py
+++ b/tests/assistant/test_tools_write.py
@@ -50,6 +50,16 @@ def test_edit_unique_match(wt_ctx):
     assert (wt_ctx.repo_root / "app.py").read_bytes() == b"a = 1\nb = 2\nb = 2\n"
 
 
+def test_edit_preserves_crlf_bytes(wt_ctx):
+    # byte-exact contract: an edit must not rewrite line endings, even on
+    # Windows where text-mode writes would turn \r\n into \r\r\n
+    (wt_ctx.worktree_dir / "crlf.py").write_bytes(b"a = 1\r\nb = 2\r\n")
+    reg = _registry(wt_ctx)
+    assert reg.dispatch("edit_repo_file", {"path": "crlf.py", "old_string": "a = 1",
+                                           "new_string": "a = 9"})["ok"]
+    assert (wt_ctx.worktree_dir / "crlf.py").read_bytes() == b"a = 9\r\nb = 2\r\n"
+
+
 def test_edit_rejects_ambiguous_and_missing(wt_ctx):
     reg = _registry(wt_ctx)
     assert reg.dispatch("edit_repo_file", {"path": "app.py", "old_string": "b = 2",

--- a/tests/assistant/test_worktree.py
+++ b/tests/assistant/test_worktree.py
@@ -105,6 +105,19 @@ def test_apply_to_repo_leaves_uncommitted_changes(manager, repo):
     assert "app.py" in out
 
 
+def test_byte_exact_despite_autocrlf(repo, tmp_path):
+    # core.autocrlf=true is the Git-for-Windows default; checkout and apply
+    # must still preserve repo bytes exactly (LF stays LF)
+    _run(["git", "-C", str(repo), "config", "core.autocrlf", "true"])
+    manager = WorktreeManager.for_session(repo, "proj", "feedbeef12345678",
+                                          base=tmp_path / "wts")
+    manager.create()
+    assert (manager.path / "app.py").read_bytes() == b"print('hi')\n"
+    (manager.path / "app.py").write_bytes(b"print('bye')\n")
+    manager.apply_to_repo()
+    assert (repo / "app.py").read_bytes() == b"print('bye')\n"
+
+
 def test_apply_conflict_applies_nothing(manager, repo):
     (manager.path / "app.py").write_bytes(b"print('worktree')\n")
     (repo / "app.py").write_bytes(b"print('diverged')\n")  # user edited too


### PR DESCRIPTION
## Problem

develop's Windows CI leg is red since #768 (7 tests, CRLF-vs-LF byte assertions). This also blocks checks on every open PR, since PR checks run the merge ref against develop.

## Root cause (two compounding bugs)

1. **`worktree.py` inherited the host's `core.autocrlf`.** Git for Windows (and the GH `windows-latest` image) defaults to `autocrlf=true`, so `git worktree add` checked out CRLF and `git apply` wrote CRLF into the user's repo. This alone explains the 5 failures with single `\r\n` (`b'x = 2\r\n' == b'x = 2\n'`).
2. **`_edit_repo_file` wrote with text-mode `write_text`.** On Windows that translates every `\n` to `\r\n`; since the edit path reads raw bytes (preserving the CRLF from the autocrlf checkout), the result was `\r\r\n` — the fingerprint in `test_edit_unique_match` and `test_edit_diff_apply_roundtrip`.

Reproduced all 7 failures on macOS by forcing `autocrlf=true` via `GIT_CONFIG_GLOBAL` (autocrlf is config-driven, not platform-driven), byte-for-byte identical to the CI assertions.

## Fix

- Every git invocation in `worktree.py` now passes `-c core.autocrlf=false` (highest config precedence). A code-editing tool's contract is byte-exact files; letting git rewrite line endings at checkout/apply corrupts them.
- `_edit_repo_file` writes bytes (`write_bytes(new_text.encode("utf-8"))`) instead of text-mode `write_text`.

Tests are untouched except for two new regression tests:
- `test_byte_exact_despite_autocrlf` pins `autocrlf=true` in the repo config, so it fails pre-fix on **every** OS, not just Windows.
- `test_edit_preserves_crlf_bytes` edits a CRLF file through the tool and asserts endings survive.

## Behavior note

For a user whose repo genuinely runs `autocrlf=true` (CRLF working tree, LF blobs), `apply_to_repo` now fails cleanly at `git apply --check` (nothing applied — same as the existing conflict path) instead of succeeding with converted endings; commit/push/PR flow is unaffected. Repos using `.gitattributes` `* text=auto` still convert independently of autocrlf — pre-existing gap, out of scope here.

## Verification

- Full suite: 4293 passed, 8 skipped.
- The 4 affected test files: 46/46 pass both with default config and with `autocrlf=true` forced globally (Windows-runner simulation).
- `tools/check_imports.py`: no new violations.