### PR TITLE
feat(analysis): wire detection.json skip_patterns into manifest walkers

### DIFF
--- a/src/quodeq/analysis/manifest_build.py
+++ b/src/quodeq/analysis/manifest_build.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 import os
 from collections import Counter
+from fnmatch import fnmatchcase
 from pathlib import Path
 
 from quodeq.analysis.manifest_models import AnalysisTarget, SourceManifest
@@ -36,6 +37,15 @@ def _deepest_scope(rel_path: str, scope_paths: list[str]) -> str | None:
             best = scope
             best_depth = depth
     return best
+
+
+def _matches_skip_pattern(rel_path: str, skip_patterns: list[str]) -> bool:
+    """Return True when *rel_path* (POSIX, relative to the scan root) matches a
+    skip_patterns glob from detection.json. fnmatch's ``*`` crosses directory
+    separators, so ``*.min.js`` excludes matching files at any depth — the same
+    semantics as .quodeqignore patterns.
+    """
+    return any(fnmatchcase(rel_path, pat) for pat in skip_patterns)
 
 
 def target_name(language: str, category: str | None) -> str:
@@ -102,6 +112,7 @@ def _build_targets_from_disciplines(
 
 def _walk_and_group(
     src: Path, ext_map: dict[str, str], skip_dirs: set[str],
+    skip_patterns: list[str],
     scope_path: str | None = None,
 ) -> tuple[dict[str, list[str]], Counter[str], dict[str, Counter]]:
     """Walk *src* (or a scoped subdirectory) once, grouping files by language.
@@ -129,6 +140,8 @@ def _walk_and_group(
                 # across platforms — downstream consumers and scope-prefix
                 # matching all assume "/".
                 rel = os.path.relpath(os.path.join(dirpath, fname), src).replace(os.sep, "/")
+                if _matches_skip_pattern(rel, skip_patterns):
+                    continue
                 lang = ext_map.get(suffix, _UNKNOWN_LANG)
                 files_by_lang.setdefault(lang, []).append(rel)
                 ext_counts[suffix] += 1
@@ -137,7 +150,8 @@ def _walk_and_group(
 
 
 def _walk_and_partition_by_scope(
-    src: Path, ext_map: dict[str, str], skip_dirs: set[str], scope_paths: list[str],
+    src: Path, ext_map: dict[str, str], skip_dirs: set[str],
+    skip_patterns: list[str], scope_paths: list[str],
 ) -> tuple[
     dict[str, dict[str, list[str]]],
     Counter[str],
@@ -162,6 +176,8 @@ def _walk_and_partition_by_scope(
             # Match the POSIX-style scope_paths from detect_matches_recursive
             # so prefix matching works on Windows.
             rel = os.path.relpath(os.path.join(dirpath, fname), src).replace(os.sep, "/")
+            if _matches_skip_pattern(rel, skip_patterns):
+                continue
             owner = _deepest_scope(rel, scope_paths)
             if owner is None:
                 continue
@@ -176,6 +192,7 @@ def _build_multi_scope_manifest(
     src: Path,
     ext_map: dict[str, str],
     skip_dirs: set[str],
+    skip_patterns: list[str],
     registry: DisciplineRegistry,
     sub_results: list[tuple[str, list[str]]],
 ) -> SourceManifest:
@@ -183,7 +200,7 @@ def _build_multi_scope_manifest(
     scope_paths = [rel for rel, _ in sub_results]
     matches_by_scope = {rel: matches for rel, matches in sub_results}
     files_by_scope, ext_counts_overall, ext_counts_by_scope_lang = _walk_and_partition_by_scope(
-        src, ext_map, skip_dirs, scope_paths,
+        src, ext_map, skip_dirs, skip_patterns, scope_paths,
     )
 
     targets: list[AnalysisTarget] = []
@@ -218,12 +235,13 @@ def _build_single_scope_manifest(
     src: Path,
     ext_map: dict[str, str],
     skip_dirs: set[str],
+    skip_patterns: list[str],
     disciplines_conf: Path | None,
     scope_path: str | None,
 ) -> SourceManifest:
     """Legacy single-scope path: walk once at the (optionally scoped) root."""
     files_by_lang, ext_counts, ext_counts_by_lang = _walk_and_group(
-        src, ext_map, skip_dirs, scope_path=scope_path,
+        src, ext_map, skip_dirs, skip_patterns, scope_path=scope_path,
     )
     all_source_files_count = sum(len(f) for f in files_by_lang.values())
 
@@ -279,10 +297,11 @@ def build_manifest(
     """
     ext_map: dict[str, str] = detection.get("extensions", {})
     skip_dirs = set(detection.get("skip_dirs", []))
+    skip_patterns: list[str] = detection.get("skip_patterns", [])
 
     if scope_path is not None:
         return _build_single_scope_manifest(
-            src, ext_map, skip_dirs, disciplines_conf, scope_path,
+            src, ext_map, skip_dirs, skip_patterns, disciplines_conf, scope_path,
         )
 
     registry: DisciplineRegistry | None = None
@@ -299,7 +318,9 @@ def build_manifest(
         )
         if not is_single_root:
             return _build_multi_scope_manifest(
-                src, ext_map, skip_dirs, registry, sub_results,
+                src, ext_map, skip_dirs, skip_patterns, registry, sub_results,
             )
 
-    return _build_single_scope_manifest(src, ext_map, skip_dirs, disciplines_conf, None)
+    return _build_single_scope_manifest(
+        src, ext_map, skip_dirs, skip_patterns, disciplines_conf, None,
+    )

--- a/tests/engine/test_manifest.py
+++ b/tests/engine/test_manifest.py
@@ -1,7 +1,6 @@
 """Tests for the source manifest builder."""
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import pytest
@@ -62,6 +61,42 @@ def test_skips_excluded_dirs(tmp_path: Path, detection: dict) -> None:
     manifest = build_manifest(tmp_path, detection)
     assert manifest.total_files == 3
     assert manifest.language == "javascript"
+
+
+def test_skip_patterns_exclude_matching_files(tmp_path: Path, detection: dict) -> None:
+    """Files matching a skip_patterns glob are excluded from the manifest."""
+    for i in range(3):
+        (tmp_path / f"app{i}.js").write_text(f"const x = {i};")
+    (tmp_path / "bundle.min.js").write_text("var a=1;var b=2;")
+
+    manifest = build_manifest(tmp_path, detection)
+    assert manifest.total_files == 3
+    assert "bundle.min.js" not in manifest.source_files
+
+
+def test_skip_patterns_match_at_any_depth(tmp_path: Path, detection: dict) -> None:
+    """skip_patterns apply to files in nested directories, not just the root."""
+    sub = tmp_path / "assets" / "js"
+    sub.mkdir(parents=True)
+    (sub / "lib.min.js").write_text("var a=1;")
+    for i in range(3):
+        (tmp_path / f"app{i}.js").write_text(f"const x = {i};")
+
+    manifest = build_manifest(tmp_path, detection)
+    assert manifest.total_files == 3
+    assert "assets/js/lib.min.js" not in manifest.source_files
+
+
+def test_missing_skip_patterns_key_includes_all_files(tmp_path: Path, detection: dict) -> None:
+    """Without a skip_patterns key, no file-level filtering happens."""
+    del detection["skip_patterns"]
+    for i in range(3):
+        (tmp_path / f"app{i}.js").write_text(f"const x = {i};")
+    (tmp_path / "bundle.min.js").write_text("var a=1;")
+
+    manifest = build_manifest(tmp_path, detection)
+    assert manifest.total_files == 4
+    assert "bundle.min.js" in manifest.source_files
 
 
 def test_multi_language_detection(tmp_path: Path, detection: dict) -> None:
@@ -245,6 +280,38 @@ def test_build_monorepo_partitions_files_by_subproject(
     assert web.language == "typescript"
     assert "React Best Practices" in web.frameworks
     assert all(f.startswith("apps/web/") for f in web.source_files)
+
+
+def test_monorepo_walk_applies_skip_patterns(tmp_path: Path, detection: dict) -> None:
+    """The multi-scope (monorepo) walk honours skip_patterns too."""
+    from quodeq.config.paths import default_paths
+
+    _write(
+        tmp_path / "apps/web/package.json",
+        '{"name":"web","dependencies":{"react":"^18.0.0","react-dom":"^18.0.0"}}',
+    )
+    _write(tmp_path / "apps/web/tsconfig.json", "{}")
+    _write(tmp_path / "apps/web/src/App.ts", "export const App = () => null;\n")
+    _write(tmp_path / "apps/web/src/index.ts", "import {App} from './App';\n")
+    _write(tmp_path / "apps/web/src/util.ts", "export const noop = () => {};\n")
+    _write(tmp_path / "apps/web/src/vendor.min.js", "var a=1;")
+
+    _write(
+        tmp_path / "services/api/pyproject.toml",
+        '[project]\nname = "api"\ndependencies = ["flask==3.1.3"]\n',
+    )
+    _write(tmp_path / "services/api/src/api/__init__.py", "")
+    _write(tmp_path / "services/api/src/api/main.py", "from flask import Flask\n")
+    _write(tmp_path / "services/api/src/api/routes.py", "from flask import Blueprint\n")
+
+    disciplines_conf = default_paths().disciplines_conf
+    if not disciplines_conf.exists():
+        pytest.skip("disciplines.conf not installed")
+
+    manifest = build_manifest(tmp_path, detection, disciplines_conf=disciplines_conf)
+
+    all_files = [f for t in manifest.targets for f in t.source_files]
+    assert "apps/web/src/vendor.min.js" not in all_files
 
 
 def test_build_single_root_project_uses_legacy_path(


### PR DESCRIPTION
## Summary
- `detection.json` has shipped a `skip_patterns` key (`*.min.js`, `*.generated.*`, `*.pb.go`, `*.d.ts`) that nothing ever read — this wires it into the manifest builder as built-in file-level exclusions.
- Both walk paths (single-scope `_walk_and_group` and monorepo `_walk_and_partition_by_scope`) now drop files whose POSIX relative path matches a pattern, via `fnmatchcase` — `*` crosses directory separators, so patterns exclude matching files at any depth. These are the same semantics documented for `.quodeqignore` patterns in #771, kept self-contained here since that PR is still open; the two predicates can be consolidated once it merges.
- A missing or empty `skip_patterns` key preserves today's behaviour exactly.

## Why wire it up rather than delete it
Minified bundles, generated protobuf/code, and `.d.ts` declarations are machine output — analyzing them wastes prompt budget and skews quality scores. The config intent was explicit; only the plumbing was missing.

## Behaviour change note
Manifests for repos containing minified/generated assets will shrink accordingly (intended), which can refresh analysis fingerprints once.

## Tests
- `test_skip_patterns_exclude_matching_files` — root-level exclusion
- `test_skip_patterns_match_at_any_depth` — nested-path exclusion
- `test_missing_skip_patterns_key_includes_all_files` — backward compat
- `test_monorepo_walk_applies_skip_patterns` — multi-scope walk
- Full `tests/engine` + `tests/analysis` suites pass (1193 passed, 7 skipped); also removed a pre-existing unused `json` import flagged by ruff in the touched test file.