### PR TITLE
Fold threshold overrides into cache fingerprint; parameterize more thresholds; reposition threshold fields

### DIFF
--- a/src/quodeq/analysis/cache/cache_writer.py
+++ b/src/quodeq/analysis/cache/cache_writer.py
@@ -70,8 +70,11 @@ def build_cache_writer(
     # Provenance context, captured once at construction (run-constant). These
     # left the cache key in schema 3 but are recorded on each entry so reuse
     # across a model/prompts/standards boundary is surfaceable, not silent.
+    # src_root doubles as the project root whose threshold overrides fold
+    # into the standards hash — must match classify's _current_provenance.
     standards_hash = (
-        (_hash_standards(standards_dir, dimension) if standards_dir else "") or ""
+        (_hash_standards(standards_dir, dimension, src_root) if standards_dir else "")
+        or ""
     )
     prompts_hash = _hash_prompts_combined()
     version = quodeq_version()

--- a/src/quodeq/analysis/cache/dimension_helpers.py
+++ b/src/quodeq/analysis/cache/dimension_helpers.py
@@ -84,7 +84,7 @@ _PROV_LABELS = {
 def _current_provenance(config: RunConfig, dimension: str) -> dict:
     """The provenance the current run would stamp on a fresh entry."""
     standards_hash = (
-        _hash_standards(config.standards_dir, dimension)
+        _hash_standards(config.standards_dir, dimension, config.src)
         if config.standards_dir else ""
     ) or ""
     return {
@@ -285,7 +285,7 @@ def persist_dispatch_results(
     # Provenance context — run-constant, computed once. These left the cache
     # key in schema 3; recording them keeps each entry self-describing.
     standards_hash = (
-        _hash_standards(config.standards_dir, dimension)
+        _hash_standards(config.standards_dir, dimension, config.src)
         if config.standards_dir else ""
     ) or ""
     prompts_hash = _hash_prompts_combined()

--- a/src/quodeq/analysis/fingerprint.py
+++ b/src/quodeq/analysis/fingerprint.py
@@ -13,9 +13,11 @@ from __future__ import annotations
 
 import functools
 import hashlib
+import json
 from pathlib import Path
 
 from quodeq.config.paths import default_paths
+from quodeq.core.standards.overrides import OVERRIDES_RELPATH, load_project_overrides
 
 _HASH_CHUNK_SIZE = 1 << 16  # 64 KiB
 
@@ -59,23 +61,71 @@ def _stat_key(path: Path) -> tuple[int, int] | None:
     return st.st_size, st.st_mtime_ns
 
 
-def _hash_standards(standards_dir: Path, dimension: str) -> str | None:
+@functools.lru_cache(maxsize=None)
+def _hash_overrides_by_stat(project_root: Path, size: int, mtime_ns: int) -> str:
+    """Memoized hash of a project's resolved threshold overrides.
+
+    Hashes the *parsed* mapping (canonical JSON) rather than raw file
+    bytes, so the fingerprint tracks exactly what analysis consumes via
+    ``load_project_overrides``: a formatting-only rewrite or a malformed
+    file (ignored by analysis) does not shift the hash. Empty overrides
+    hash to "" so callers can fall back to the plain standards hash.
+    """
+    _ = (size, mtime_ns)
+    overrides = load_project_overrides(project_root)
+    if not overrides:
+        return ""
+    canonical = json.dumps(overrides, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _hash_overrides(project_root: Path) -> str:
+    """Hash of ``<project_root>/.quodeq/standards-overrides.json``; "" when
+    the file is absent, empty, or malformed (analysis ignores all three)."""
+    key = _stat_key(Path(project_root) / OVERRIDES_RELPATH)
+    if key is None:
+        return ""
+    return _hash_overrides_by_stat(Path(project_root), *key)
+
+
+def _hash_standards(
+    standards_dir: Path, dimension: str, project_root: Path | None = None,
+) -> str | None:
     """SHA-256 of the compiled standards JSON for a dimension.
 
     Uses the same chunked hashing approach as ``_hash_file`` to avoid
     reading the entire file into memory at once.
 
-    Memoized via ``_hash_file_by_stat``: inside one ``quodeq evaluate``
-    process the compiled JSON is rewritten only if the user edits it
-    mid-run, in which case the new ``mtime_ns`` invalidates the cache
-    automatically. Without this cache a 3 K-file dim re-hashes the same
-    JSON 3 K times.
+    When *project_root* is given, the project's threshold overrides
+    (``.quodeq/standards-overrides.json``) are folded in, so tuning a
+    numeric threshold changes the effective-standards fingerprint even
+    though the shared compiled JSON is untouched. The overrides file is
+    not per-dimension, so an override on any requirement shifts every
+    dimension's hash — deliberately coarse: the hash only feeds entry
+    provenance/drift, never the cache key, so the cost is an extra drift
+    flag, not a re-evaluation. A project with no (effective) overrides
+    hashes byte-identically to the plain compiled JSON, keeping entries
+    written before overrides existed quiet.
+
+    Memoized via ``_hash_file_by_stat`` / ``_hash_overrides_by_stat``:
+    inside one ``quodeq evaluate`` process the inputs are rewritten only
+    if the user edits them mid-run, in which case the new ``mtime_ns``
+    invalidates the cache automatically. Without this cache a 3 K-file
+    dim re-hashes the same JSON 3 K times.
     """
     compiled = standards_dir / "compiled" / f"{dimension}.json"
     key = _stat_key(compiled)
     if key is None:
         return None
-    return _hash_file_by_stat(compiled, *key)
+    base = _hash_file_by_stat(compiled, *key)
+    if base is None or project_root is None:
+        return base
+    overrides_hash = _hash_overrides(project_root)
+    if not overrides_hash:
+        return base
+    return hashlib.sha256(
+        f"{base}\x00overrides\x00{overrides_hash}".encode()
+    ).hexdigest()
 
 
 # Prompts in this set carry the rules that classify a finding (what counts
@@ -112,5 +162,10 @@ def _hash_prompts_map(prompts_dir: Path | None = None) -> dict[str, str]:
 # Expose ``cache_clear`` on the public-ish surface so test fixtures and
 # any code that genuinely needs to drop the cache (e.g. after editing
 # a prompt mid-process) don't have to reach for the internal helper.
-_hash_standards.cache_clear = _hash_file_by_stat.cache_clear  # type: ignore[attr-defined]
-_hash_prompts_map.cache_clear = _hash_file_by_stat.cache_clear  # type: ignore[attr-defined]
+def _clear_hash_caches() -> None:
+    _hash_file_by_stat.cache_clear()
+    _hash_overrides_by_stat.cache_clear()
+
+
+_hash_standards.cache_clear = _clear_hash_caches  # type: ignore[attr-defined]
+_hash_prompts_map.cache_clear = _clear_hash_caches  # type: ignore[attr-defined]

--- a/src/quodeq/data/standards/compiled/maintainability.json
+++ b/src/quodeq/data/standards/compiled/maintainability.json
@@ -138,7 +138,7 @@
         {
           "id": "M-MOD-7",
           "source": "iso25010",
-          "text": "Inheritance depth MUST NOT exceed 4 levels",
+          "text": "Inheritance depth MUST NOT exceed {max_inheritance_depth} levels",
           "severity": null,
           "scope": null,
           "refs": [
@@ -154,7 +154,16 @@
               "name": "Inheritance depth MUST NOT exceed 4 levels",
               "url": "https://www.it-cisq.org/coding-rules/"
             }
-          ]
+          ],
+          "params": {
+            "max_inheritance_depth": {
+              "label": "Max inheritance depth",
+              "type": "int",
+              "default": 4,
+              "min": 1,
+              "max": 20
+            }
+          }
         },
         {
           "id": "M-MOD-8",
@@ -533,7 +542,7 @@
         {
           "id": "M-ANA-1",
           "source": "iso25010",
-          "text": "Source files MUST NOT exceed 300 lines",
+          "text": "Source files MUST NOT exceed {max_file_lines} lines",
           "severity": null,
           "scope": null,
           "refs": [
@@ -549,7 +558,16 @@
               "name": "Source files MUST NOT exceed language-appropriate line limits",
               "url": "https://www.it-cisq.org/coding-rules/"
             }
-          ]
+          ],
+          "params": {
+            "max_file_lines": {
+              "label": "Max source file lines",
+              "type": "int",
+              "default": 300,
+              "min": 50,
+              "max": 5000
+            }
+          }
         },
         {
           "id": "M-ANA-2",

--- a/src/quodeq/data/standards/iso25010/maintainability.json
+++ b/src/quodeq/data/standards/iso25010/maintainability.json
@@ -50,10 +50,12 @@
         },
         {
           "id": "M-MOD-7",
-          "text": "Inheritance depth MUST NOT exceed 4 levels",
+          "text": "Inheritance depth MUST NOT exceed {max_inheritance_depth} levels",
           "cwe": [
             1074
-          ]
+          ],
+          "params": {"max_inheritance_depth": {"label": "Max inheritance depth", "type": "int",
+                                               "default": 4, "min": 1, "max": 20}}
         },
         {
           "id": "M-MOD-8",
@@ -186,10 +188,12 @@
       "requirements": [
         {
           "id": "M-ANA-1",
-          "text": "Source files MUST NOT exceed 300 lines",
+          "text": "Source files MUST NOT exceed {max_file_lines} lines",
           "cwe": [
             1080
-          ]
+          ],
+          "params": {"max_file_lines": {"label": "Max source file lines", "type": "int",
+                                        "default": 300, "min": 50, "max": 5000}}
         },
         {
           "id": "M-ANA-2",

--- a/src/quodeq/ui/src/features/standards/components/RequirementForm.jsx
+++ b/src/quodeq/ui/src/features/standards/components/RequirementForm.jsx
@@ -48,12 +48,6 @@ export default function RequirementForm({ requirement, principleIndex, reqIndex,
         />
       </div>
 
-      <ReferenceEditor
-        refs={requirement.refs || []}
-        onChange={(updated) => onUpdateField([...basePath, 'refs'], updated)}
-        disabled={!editable}
-      />
-
       {hasParams && onChangeParam && (
         <ThresholdFields
           requirement={requirement}
@@ -61,6 +55,12 @@ export default function RequirementForm({ requirement, principleIndex, reqIndex,
           onChangeParam={onChangeParam}
         />
       )}
+
+      <ReferenceEditor
+        refs={requirement.refs || []}
+        onChange={(updated) => onUpdateField([...basePath, 'refs'], updated)}
+        disabled={!editable}
+      />
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/standards/components/RequirementForm.test.jsx
+++ b/src/quodeq/ui/src/features/standards/components/RequirementForm.test.jsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import RequirementForm from './RequirementForm.jsx';
+
+const REQ = {
+  id: 'M-ANA-2',
+  text: 'Functions MUST NOT exceed {max_lines} lines',
+  description: 'Long functions are hard to reason about.',
+  refs: [],
+  params: { max_lines: { label: 'Max function lines', type: 'int', default: 50, min: 10, max: 500 } },
+};
+
+function renderForm(overrides = {}) {
+  return render(
+    <RequirementForm
+      requirement={REQ}
+      principleIndex={0}
+      reqIndex={0}
+      onUpdateField={() => {}}
+      editable={false}
+      reqOverrides={{}}
+      onChangeParam={() => {}}
+      {...overrides}
+    />,
+  );
+}
+
+describe('RequirementForm section order', () => {
+  it('renders Thresholds after Description and before References', () => {
+    renderForm();
+    const description = screen.getByLabelText('Description');
+    const thresholds = screen.getByText('Thresholds');
+    const references = screen.getByText('References');
+
+    // compareDocumentPosition: FOLLOWING (4) means the argument comes later
+    // in document order than the node the method is called on.
+    expect(
+      description.compareDocumentPosition(thresholds) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      thresholds.compareDocumentPosition(references) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('omits the Thresholds section when the requirement declares no params', () => {
+    renderForm({ requirement: { ...REQ, params: undefined } });
+    expect(screen.queryByText('Thresholds')).not.toBeInTheDocument();
+  });
+});

--- a/tests/analysis/cache/test_cache_writer.py
+++ b/tests/analysis/cache/test_cache_writer.py
@@ -124,6 +124,48 @@ def test_cache_writer_records_provenance_and_content_hash(tmp_path):
     assert prov["quodeq_version"] == (quodeq.__version__ or "")
 
 
+def test_cache_writer_provenance_folds_project_overrides(tmp_path):
+    """The written standards_hash is the override-aware value (folding
+    .quodeq/standards-overrides.json under src_root), matching what
+    classify-time provenance computes — otherwise every later run would
+    report phantom standards drift on entries this writer produced."""
+    from quodeq.analysis.cache.cache_writer import build_cache_writer
+    from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
+    from quodeq.analysis.cache.local import LocalFileBackend
+    from quodeq.analysis.fingerprint import _hash_standards
+
+    src_root = tmp_path / "src"
+    (src_root / ".quodeq").mkdir(parents=True)
+    (src_root / "Foo.kt").write_text("class Foo")
+    (src_root / ".quodeq" / "standards-overrides.json").write_text(
+        '{"version": 1, "overrides": {"F-ADP-1": {"max_lines": 60}}}'
+    )
+    standards_dir = tmp_path / "standards"
+    (standards_dir / "compiled").mkdir(parents=True)
+    (standards_dir / "compiled" / "flexibility.json").write_text('{"rule": "v1"}')
+
+    cache_root = tmp_path / "cache"
+    write = build_cache_writer(
+        cache_root=cache_root,
+        src_root=src_root,
+        standards_dir=standards_dir,
+        dimension="flexibility",
+        model_id="sonnet",
+        language="kotlin",
+    )
+    write("Foo.kt", [])
+
+    config = _make_config(src_root, standards_dir=standards_dir, model="sonnet")
+    key = build_cache_key_for_file(config, "Foo.kt", "flexibility")
+    entry = LocalFileBackend(root=cache_root).get(key)
+    assert entry is not None
+    expected = _hash_standards(standards_dir, "flexibility", src_root)
+    assert entry.provenance["standards_hash"] == expected
+    assert entry.provenance["standards_hash"] != _hash_standards(
+        standards_dir, "flexibility",
+    )
+
+
 def test_entry_is_self_describing_for_future_key_migration(tmp_path):
     """The schema-3 self-describing guarantee: an entry stores EVERY field its
     key was computed from (content hash, path, dimension, language), so a

--- a/tests/analysis/cache/test_dimension_helpers.py
+++ b/tests/analysis/cache/test_dimension_helpers.py
@@ -57,6 +57,12 @@ def _write_compiled_standards(standards_dir: Path, dim: str, payload: str) -> No
     (compiled / f"{dim}.json").write_text(payload)
 
 
+def _write_project_overrides(src: Path, payload: str) -> None:
+    path = src / ".quodeq" / "standards-overrides.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(payload)
+
+
 @pytest.fixture
 def cache(tmp_path: Path) -> LocalFileBackend:
     return LocalFileBackend(root=tmp_path / "cache")
@@ -258,6 +264,34 @@ class TestProvenanceDrift:
         assert result.misses == []
         assert result.provenance_drift == {}
 
+    def test_reports_standards_drift_when_overrides_change(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        # Threshold overrides fold into the standards hash: entries produced
+        # before a project tuned .quodeq/standards-overrides.json must show
+        # standards drift on reuse — the compiled JSON alone is unchanged.
+        from quodeq.analysis.fingerprint import _hash_standards
+
+        src = tmp_path / "src"
+        files = _write_files(src, {"a.py": "x"})
+        standards_dir = tmp_path / "standards"
+        _write_compiled_standards(standards_dir, "security", '{"rule": "v1"}')
+        config = _make_config(src, standards_dir=standards_dir)
+        pre_override = _hash_standards(standards_dir, "security") or ""
+        self._seed(cache, config, files, provenance={
+            "model_id": "test-model", "standards_hash": pre_override,
+            "prompts_hash": "", "quodeq_version": "",
+        })
+
+        _write_project_overrides(
+            src, '{"version": 1, "overrides": {"S-INJ-1": {"max_lines": 60}}}',
+        )
+        result = classify_files_via_cache(config, "security", files, cache)
+
+        # Reuse still happens (permissive key) but is flagged, not silent.
+        assert result.misses == []
+        assert result.provenance_drift["standards_hash"]["count"] == 1
+
     def test_no_drift_when_provenance_matches(self, tmp_path: Path, cache: LocalFileBackend):
         files = _write_files(tmp_path / "src", {"a.py": "x"})
         config = _make_config(tmp_path / "src", model="same-model")
@@ -424,6 +458,42 @@ class TestPersist:
         assert "prompts_hash" in entry.provenance
         assert "standards_hash" in entry.provenance
         assert "quodeq_version" in entry.provenance
+
+    def test_persisted_provenance_folds_project_overrides(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        # The persisted standards_hash must be the override-aware value —
+        # identical to what classify computes for the same run — or the very
+        # next classify would report phantom standards drift.
+        from quodeq.analysis.fingerprint import _hash_standards
+
+        src = tmp_path / "src"
+        files = _write_files(src, {"a.py": "x"})
+        standards_dir = tmp_path / "standards"
+        _write_compiled_standards(standards_dir, "security", '{"rule": "v1"}')
+        _write_project_overrides(
+            src, '{"version": 1, "overrides": {"S-INJ-1": {"max_lines": 60}}}',
+        )
+        config = _make_config(src, standards_dir=standards_dir, work_dir=tmp_path / "work")
+        miss_keys = {f: build_cache_key_for_file(config, f, "security") for f in files}
+
+        jsonl = tmp_path / "work" / "security_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        jsonl.write_text(
+            json.dumps({"_marker": "file_done", "file": "a.py", "status": "ok"}) + "\n"
+        )
+        persist_dispatch_results(
+            config, "security", miss_files=files,
+            jsonl_path=jsonl, miss_keys=miss_keys, cache=cache,
+        )
+
+        entry = cache.get(miss_keys["a.py"])
+        assert entry is not None
+        expected = _hash_standards(standards_dir, "security", src)
+        assert entry.provenance["standards_hash"] == expected
+        assert entry.provenance["standards_hash"] != _hash_standards(
+            standards_dir, "security",
+        )
 
     def test_handles_missing_jsonl(self, tmp_path: Path, cache: LocalFileBackend):
         files = _write_files(tmp_path / "src", {"a.py": "x"})

--- a/tests/analysis/test_fingerprint_overrides.py
+++ b/tests/analysis/test_fingerprint_overrides.py
@@ -1,0 +1,146 @@
+"""Project threshold overrides fold into the standards fingerprint.
+
+``_hash_standards`` hashes the compiled standards JSON, which is shared
+across projects and does NOT change when a project tunes a numeric
+threshold via ``.quodeq/standards-overrides.json``. Without folding the
+overrides in, tuning ``max_lines`` 50 -> 60 and re-running reuses cached
+findings classified under the 50-line rule with no drift signal.
+
+The contract:
+
+1. **Override change changes the fingerprint** — cached findings produced
+   under the old threshold become detectable as drifted.
+2. **Absent overrides leave the fingerprint byte-identical** to the
+   pre-override-aware hash, so existing cache entries written before this
+   feature (or by projects that never override) stay quiet — no phantom
+   "standards changed" drift.
+3. **Only the resolved content matters** — a formatting-only rewrite or a
+   malformed file (which analysis ignores) must not shift the hash.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis import fingerprint
+from quodeq.core.standards.overrides import OVERRIDES_RELPATH
+
+DIM = "maintainability"
+
+
+def _write_compiled_standard(standards_dir: Path, dimension: str, body: str) -> None:
+    compiled = standards_dir / "compiled"
+    compiled.mkdir(parents=True, exist_ok=True)
+    (compiled / f"{dimension}.json").write_text(body)
+
+
+def _write_overrides(project_root: Path, text: str) -> None:
+    path = project_root / OVERRIDES_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+@pytest.fixture(autouse=True)
+def _clear_fingerprint_caches():
+    fingerprint._hash_standards.cache_clear()
+    yield
+    fingerprint._hash_standards.cache_clear()
+
+
+@pytest.fixture
+def standards_dir(tmp_path: Path) -> Path:
+    std = tmp_path / "standards"
+    _write_compiled_standard(std, DIM, '{"rule": "v1"}')
+    return std
+
+
+@pytest.fixture
+def project_root(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    return root
+
+
+def test_changing_override_value_changes_fingerprint(standards_dir, project_root):
+    _write_overrides(
+        project_root,
+        '{"version": 1, "overrides": {"M-ANA-2": {"max_lines": 50}}}',
+    )
+    before = fingerprint._hash_standards(standards_dir, DIM, project_root)
+
+    _write_overrides(
+        project_root,
+        '{"version": 1, "overrides": {"M-ANA-2": {"max_lines": 600}}}',
+    )
+    after = fingerprint._hash_standards(standards_dir, DIM, project_root)
+
+    assert before is not None and after is not None
+    assert before != after
+
+
+def test_overrides_presence_changes_fingerprint_vs_baseline(standards_dir, project_root):
+    baseline = fingerprint._hash_standards(standards_dir, DIM)
+    _write_overrides(
+        project_root,
+        '{"version": 1, "overrides": {"M-ANA-2": {"max_lines": 60}}}',
+    )
+    overridden = fingerprint._hash_standards(standards_dir, DIM, project_root)
+
+    assert baseline is not None and overridden is not None
+    assert overridden != baseline
+
+
+def test_absent_overrides_file_leaves_fingerprint_unchanged(standards_dir, project_root):
+    # Load-bearing backward compatibility: entries written before the
+    # override-aware hash carry the plain compiled-JSON hash. A project
+    # with no overrides file must keep producing that exact value.
+    baseline = fingerprint._hash_standards(standards_dir, DIM)
+    with_root = fingerprint._hash_standards(standards_dir, DIM, project_root)
+    assert with_root == baseline
+
+
+def test_unchanged_overrides_file_keeps_fingerprint_stable(standards_dir, project_root):
+    _write_overrides(
+        project_root,
+        '{"version": 1, "overrides": {"M-ANA-2": {"max_lines": 60}}}',
+    )
+    first = fingerprint._hash_standards(standards_dir, DIM, project_root)
+    second = fingerprint._hash_standards(standards_dir, DIM, project_root)
+    assert first == second
+
+
+def test_formatting_only_rewrite_keeps_fingerprint(standards_dir, project_root):
+    # The hash covers the resolved override mapping, not raw bytes —
+    # re-saving the file with different whitespace/key order is not a
+    # threshold change and must not flag drift.
+    _write_overrides(
+        project_root,
+        '{"version": 1, "overrides": {"M-ANA-2": {"max_lines": 60}}}',
+    )
+    before = fingerprint._hash_standards(standards_dir, DIM, project_root)
+
+    reordered = json.dumps(
+        {"overrides": {"M-ANA-2": {"max_lines": 60}}, "version": 1}, indent=4,
+    )
+    _write_overrides(project_root, reordered)
+    after = fingerprint._hash_standards(standards_dir, DIM, project_root)
+
+    assert after == before
+
+
+def test_malformed_overrides_treated_as_absent(standards_dir, project_root):
+    # Analysis ignores a malformed file (load_project_overrides -> {});
+    # the fingerprint must agree with what analysis actually uses.
+    baseline = fingerprint._hash_standards(standards_dir, DIM)
+    _write_overrides(project_root, "{not json")
+    assert fingerprint._hash_standards(standards_dir, DIM, project_root) == baseline
+
+
+def test_missing_compiled_standard_still_none(tmp_path: Path, project_root):
+    _write_overrides(
+        project_root,
+        '{"version": 1, "overrides": {"M-ANA-2": {"max_lines": 60}}}',
+    )
+    assert fingerprint._hash_standards(tmp_path / "nostd", DIM, project_root) is None


### PR DESCRIPTION
## Summary

Follow-ups to the editable-thresholds feature (#770), in three parts:

### 1. Threshold overrides fold into the standards fingerprint (`fix(analysis)`)
`_hash_standards` hashed only the shared compiled standards JSON, so tuning a threshold in `.quodeq/standards-overrides.json` (e.g. max_lines 50→60) and re-running reused cached findings classified under the old value with **no drift signal**.

- `_hash_standards` now takes an optional project root and folds in a hash of the **parsed** overrides (via `load_project_overrides`), plumbed at the three provenance sites (`build_cache_writer`, classify-time `_current_provenance`, `persist_dispatch_results`) using the analyzed repo root.
- Absent / empty / malformed overrides hash **byte-identically** to the plain compiled JSON — existing cache entries and no-override projects show no phantom drift. Formatting-only rewrites of the overrides file don't shift the hash.
- The hash feeds entry **provenance only** (schema-3 permissive key untouched), so an override change surfaces as the existing "N across standards change" drift flag instead of forcing re-evaluation.
- Checked the accumulated score cache: no `algo`/epoch bump needed — it composes per-run scoped versions, and a threshold change only affects results through a new run, which already changes the runs list.

### 2. Two more thresholds parameterized (`feat(standards)`)
- **M-MOD-7** inheritance depth: `{max_inheritance_depth}`, default 4, range 1–20
- **M-ANA-1** source file lines: `{max_file_lines}`, default 300, range 50–5000

Compiled output regenerated with `tools/compile_standards.py`. Audit of the remaining hardcoded numbers: M-MOD-6 (7 callees), M-ANA-4 (3 conditions), M-TST-1 (80% coverage) are future candidates; M-MOD-3 (0 cycles) is a principle, not a tunable; the numeric-looking strings in performance/security ("N+1", "AES-256") are terms, not thresholds.

### 3. Thresholds section repositioned (`fix(ui)`)
Rendered after References; now sits directly below Description, above References. DOM-order pinned by a new `RequirementForm` test.

## Testing
- 10 new tests written first and watched fail (fingerprint contract incl. backward-compat + phantom-drift guards on both cache write paths; UI section order)
- Full suites green after rebase on develop: **4421 python passed** (8 skipped), **850 UI tests passed**, import-layer check clean
- Verified in the browser against a live backend: threshold field for M-ANA-1 renders between Description and References with "default 300 · 50 – 5000", tree labels resolve the new params, zero console errors