### PR TITLE
feat(ui): enable assistant and terminal by default in settings

### DIFF
--- a/src/quodeq/ui/src/components/AssistantLauncherButton.jsx
+++ b/src/quodeq/ui/src/components/AssistantLauncherButton.jsx
@@ -6,8 +6,8 @@ export function AssistantLauncherButton() {
   const { openPanels, toggleTopbar } = useAssistantDrawer();
   const { enabled } = useAssistantProvider();
 
-  // The assistant is off by default; the launcher only appears once enabled
-  // in Settings.
+  // The assistant is on by default; the launcher disappears only when the
+  // user disables it in Settings.
   if (!enabled) return null;
 
   // Highlighted whenever the assistant panel is open/selected (both launchers

--- a/src/quodeq/ui/src/components/AssistantLauncherButton.test.jsx
+++ b/src/quodeq/ui/src/components/AssistantLauncherButton.test.jsx
@@ -16,14 +16,14 @@ beforeEach(() => {
 });
 afterEach(() => localStorage.clear());
 
-it('is hidden when the assistant is disabled (the default)', () => {
+it('is hidden when the assistant is explicitly disabled in Settings', () => {
+  localStorage.setItem('cc-assistant-enabled', 'false');
   const { container } = render(<AssistantLauncherButton />);
   expect(container).toBeEmptyDOMElement();
   expect(screen.queryByRole('button', { name: /assistant/i })).toBeNull();
 });
 
-it('is an icon-only labelled toggle when enabled; click toggles the panel', () => {
-  localStorage.setItem('cc-assistant-enabled', 'true');
+it('is an icon-only labelled toggle by default (enabled); click toggles the panel', () => {
   render(<AssistantLauncherButton />);
   const btn = screen.getByRole('button', { name: /assistant/i });
   expect(btn).toHaveClass('topbar-btn', 'topbar-btn--icon');

--- a/src/quodeq/ui/src/components/TerminalLauncherButton.test.jsx
+++ b/src/quodeq/ui/src/components/TerminalLauncherButton.test.jsx
@@ -16,14 +16,14 @@ beforeEach(() => {
 });
 afterEach(() => localStorage.clear());
 
-it('is hidden when the terminal is disabled (the default)', () => {
+it('is hidden when the terminal is explicitly disabled in Settings', () => {
+  localStorage.setItem('cc-terminal-enabled', 'false');
   const { container } = render(<TerminalLauncherButton />);
   expect(container).toBeEmptyDOMElement();
   expect(screen.queryByRole('button', { name: /terminal/i })).toBeNull();
 });
 
-it('renders and toggles the terminal panel when enabled', () => {
-  localStorage.setItem('cc-terminal-enabled', 'true');
+it('renders and toggles the terminal panel by default (enabled)', () => {
   render(<TerminalLauncherButton />);
   const btn = screen.getByRole('button', { name: /terminal/i });
   expect(btn).toHaveClass('topbar-btn', 'topbar-btn--icon');

--- a/src/quodeq/ui/src/features/settings/components/AssistantProviderTabs.jsx
+++ b/src/quodeq/ui/src/features/settings/components/AssistantProviderTabs.jsx
@@ -43,7 +43,7 @@ export default function AssistantProviderTabs({ providerConfigs }) {
         <div className="settings-row-label">
           <span className="settings-label">Enable assistant</span>
           <span className="settings-description">
-            Shows the assistant button (✦) in the toolbar and enables the Ctrl+` panel. Off by default.
+            Shows the assistant button (✦) in the toolbar and enables the Ctrl+` panel. On by default.
           </span>
         </div>
         <div className="settings-pill-group" role="tablist">

--- a/src/quodeq/ui/src/features/settings/components/AssistantProviderTabs.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/AssistantProviderTabs.test.jsx
@@ -51,15 +51,15 @@ describe('AssistantProviderTabs', () => {
     localStorage.clear();
     localStorage.setItem('cc-active-provider', 'claude');
     localStorage.setItem('cc-claude-model', 'sonnet');
-    // Enabled by default in these tests so the model-source rows render; the
-    // off-by-default behaviour has its own test below.
+    // Pinned enabled so the model-source rows render regardless of the
+    // default; the explicit opt-out behaviour has its own test below.
     localStorage.setItem('cc-assistant-enabled', 'true');
     fakeApi.getAiClients.mockClear();
     fakeApi.getOllamaModels.mockClear();
   });
   afterEach(() => localStorage.clear());
 
-  it('when disabled (the default) only the Enable toggle shows, no model source', async () => {
+  it('when explicitly disabled only the Enable toggle shows, no model source', async () => {
     localStorage.setItem('cc-assistant-enabled', 'false');
     const { container, queryAllByRole, queryByText } = await renderPanel();
     // Only the On/Off enable toggle is present — no Default/Custom, no note.

--- a/src/quodeq/ui/src/features/settings/components/TerminalSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/TerminalSection.jsx
@@ -22,7 +22,7 @@ export default function TerminalSection() {
         <div className="settings-row-label">
           <span className="settings-label">Enable terminal</span>
           <span className="settings-description">
-            Shows a shell (❯_) in the toolbar drawer. Ctrl+Shift+` opens it. Localhost only; off by default.
+            Shows a shell (❯_) in the toolbar drawer. Ctrl+Shift+` opens it. Localhost only; on by default.
           </span>
         </div>
         <div className="settings-pill-group" role="tablist">

--- a/src/quodeq/ui/src/features/settings/hooks/useAssistantProvider.js
+++ b/src/quodeq/ui/src/features/settings/hooks/useAssistantProvider.js
@@ -3,8 +3,8 @@ import { ACTIVE_PROVIDER_KEY, providerKey, PROVIDER_SETTINGS_CHANGED_EVENT } fro
 
 export const ASSISTANT_ACTIVE_PROVIDER_KEY = 'cc-assistant-active-provider';
 export const ASSISTANT_MODE_KEY = 'cc-assistant-mode';
-// The assistant is OFF by default: the toolbar launcher only appears once the
-// user explicitly enables it in Settings.
+// The assistant is ON by default: the toolbar launcher shows until the user
+// explicitly disables it in Settings.
 export const ASSISTANT_ENABLED_KEY = 'cc-assistant-enabled';
 
 // Broadcast so every useAssistantProvider() instance (Settings tab, drawer, ...)
@@ -19,8 +19,8 @@ const CHANGE_EVENT = 'assistant-provider-changed';
 function loadState(storage) {
   const mode = storage.getItem(ASSISTANT_MODE_KEY) === 'custom' ? 'custom' : 'default';
   const analysisActive = storage.getItem(ACTIVE_PROVIDER_KEY) || '';
-  // Default OFF: only 'true' enables it.
-  const enabled = storage.getItem(ASSISTANT_ENABLED_KEY) === 'true';
+  // Default ON: only an explicit opt-out ('false') disables it.
+  const enabled = storage.getItem(ASSISTANT_ENABLED_KEY) !== 'false';
 
   if (mode === 'default') {
     const model = analysisActive

--- a/src/quodeq/ui/src/features/settings/hooks/useAssistantProvider.test.jsx
+++ b/src/quodeq/ui/src/features/settings/hooks/useAssistantProvider.test.jsx
@@ -92,21 +92,27 @@ it('default mode updates live when the analysis gate fires the shared event', ()
   expect(result.current.model).toBe('sonnet');
 });
 
-it('is disabled by default and setEnabled persists + syncs across instances', () => {
+it('is enabled by default and setEnabled persists + syncs across instances', () => {
   const a = renderHook(() => useAssistantProvider());
   const b = renderHook(() => useAssistantProvider());
-  // Off by default — the launcher stays hidden until the user opts in.
-  expect(a.result.current.enabled).toBe(false);
-
-  act(() => a.result.current.setEnabled(true));
+  // On by default — the launcher shows until the user opts out in Settings.
   expect(a.result.current.enabled).toBe(true);
-  expect(localStorage.getItem('cc-assistant-enabled')).toBe('true');
-  // Other instances (drawer provider, launcher) see it live.
-  expect(b.result.current.enabled).toBe(true);
 
   act(() => a.result.current.setEnabled(false));
   expect(a.result.current.enabled).toBe(false);
+  expect(localStorage.getItem('cc-assistant-enabled')).toBe('false');
+  // Other instances (drawer provider, launcher) see it live.
   expect(b.result.current.enabled).toBe(false);
+
+  act(() => a.result.current.setEnabled(true));
+  expect(a.result.current.enabled).toBe(true);
+  expect(b.result.current.enabled).toBe(true);
+});
+
+it('an explicit opt-out sticks across new instances', () => {
+  localStorage.setItem('cc-assistant-enabled', 'false');
+  const { result } = renderHook(() => useAssistantProvider());
+  expect(result.current.enabled).toBe(false);
 });
 
 it('syncs mode/provider changes across independent hook instances', () => {

--- a/src/quodeq/ui/src/features/settings/hooks/useTerminalSettings.js
+++ b/src/quodeq/ui/src/features/settings/hooks/useTerminalSettings.js
@@ -4,7 +4,8 @@ export const TERMINAL_ENABLED_KEY = 'cc-terminal-enabled';
 const CHANGE_EVENT = 'terminal-settings-changed';
 
 function loadEnabled(storage) {
-  return storage.getItem(TERMINAL_ENABLED_KEY) === 'true';
+  // Enabled by default: only an explicit opt-out ('false') disables it.
+  return storage.getItem(TERMINAL_ENABLED_KEY) !== 'false';
 }
 
 export default function useTerminalSettings({ storage = localStorage } = {}) {

--- a/src/quodeq/ui/src/features/settings/hooks/useTerminalSettings.test.jsx
+++ b/src/quodeq/ui/src/features/settings/hooks/useTerminalSettings.test.jsx
@@ -5,12 +5,18 @@ import useTerminalSettings from './useTerminalSettings.js';
 beforeEach(() => localStorage.clear());
 afterEach(() => localStorage.clear());
 
-it('is disabled by default and setEnabled persists + syncs across instances', () => {
+it('is enabled by default and setEnabled persists + syncs across instances', () => {
   const a = renderHook(() => useTerminalSettings());
   const b = renderHook(() => useTerminalSettings());
-  expect(a.result.current.enabled).toBe(false);
-  act(() => a.result.current.setEnabled(true));
   expect(a.result.current.enabled).toBe(true);
-  expect(localStorage.getItem('cc-terminal-enabled')).toBe('true');
-  expect(b.result.current.enabled).toBe(true);
+  act(() => a.result.current.setEnabled(false));
+  expect(a.result.current.enabled).toBe(false);
+  expect(localStorage.getItem('cc-terminal-enabled')).toBe('false');
+  expect(b.result.current.enabled).toBe(false);
+});
+
+it('an explicit opt-out sticks across new instances', () => {
+  localStorage.setItem('cc-terminal-enabled', 'false');
+  const { result } = renderHook(() => useTerminalSettings());
+  expect(result.current.enabled).toBe(false);
 });


### PR DESCRIPTION
## Summary
The assistant and terminal settings toggles read localStorage with `=== 'true'`, so on a fresh install both launchers were hidden until the user opted in via Settings. This flips the default to **on**: a missing key now means enabled, and only an explicit `'false'` (the Off pill in Settings) disables them.

- `useAssistantProvider` / `useTerminalSettings`: missing key resolves to enabled (`!== 'false'`)
- Existing opt-outs keep working: a stored `'false'` still hides the launcher and its Settings section
- Users who had already enabled either feature see no change (`'true'` stays enabled)
- Settings copy updated ("off by default" → "on by default")

The server-side terminal gate (`terminal/gate.py`: localhost binding, no remote API key, Origin check on the WS handshake) is unchanged and still applies regardless of the UI toggle.

## Testing
- Test-first: flipped the default-behavior tests (hooks + both launcher buttons), watched all 4 fail, then flipped the defaults
- Added explicit opt-out regression tests (`'false'` sticks across instances)
- Full UI suite green: 850 vitest + 272 node tests
- Verified live in the dev server: fresh localStorage shows both toolbar launchers; setting the Off pill hides them; console clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)