### PR TITLE
Fix UTF-8 artifacts in embedded terminal during TUI redraws

### DIFF
--- a/src/quodeq/api/terminal_routes.py
+++ b/src/quodeq/api/terminal_routes.py
@@ -97,9 +97,11 @@ def register_terminal_routes(app: Flask, manager: TerminalManager | None = None)
             try:
                 manager.ensure_session(cwd=os.path.expanduser("~"), cols=80, rows=24)
                 # Replay scrollback so a reattaching client sees recent history.
+                # Already text: the manager decodes incrementally, so the ring
+                # never holds a torn multi-byte character.
                 sb = manager.scrollback()
                 if sb:
-                    ws.send("0" + sb.decode("utf-8", "replace"))
+                    ws.send("0" + sb)
             except Exception:
                 # Spawn failure or early disconnect must not propagate past
                 # flask-sock (would surface as a 500); close cleanly instead.
@@ -119,7 +121,7 @@ def register_terminal_routes(app: Flask, manager: TerminalManager | None = None)
                             break
                         continue
                     try:
-                        ws.send("0" + data.decode("utf-8", "replace"))
+                        ws.send("0" + data)
                     except Exception:
                         break
                 stop.set()

--- a/src/quodeq/terminal/manager.py
+++ b/src/quodeq/terminal/manager.py
@@ -1,7 +1,18 @@
 # src/quodeq/terminal/manager.py
-"""Owns the single embedded-terminal PTY session and its scrollback ring."""
+"""Owns the single embedded-terminal PTY session and its scrollback ring.
+
+The manager is also the bytes->text boundary: PTY reads chunk at arbitrary
+byte offsets, so a multi-byte UTF-8 character can be split across two reads.
+Decoding per chunk turned every split into replacement-char artifacts on
+screen (TUIs like claude redraw ❯/─/● constantly, so splits are routine).
+One incremental decoder per PTY session carries partial sequences across
+reads — and across client reconnects, which a per-connection decoder in the
+WS handler could not do. ``read()``/``scrollback()`` therefore return ``str``;
+``write()`` stays bytes (input is encoded by the caller).
+"""
 from __future__ import annotations
 
+import codecs
 import threading
 from collections import deque
 
@@ -9,14 +20,15 @@ from quodeq.terminal.backend import PtyBackend
 
 
 class TerminalManager:
-    MAX_SCROLLBACK = 256 * 1024
+    MAX_SCROLLBACK = 256 * 1024  # characters
 
     def __init__(self, *, backend_factory=PtyBackend):
         self._factory = backend_factory
         self._backend = None
         self._lock = threading.Lock()
-        self._ring: deque[bytes] = deque()
+        self._ring: deque[str] = deque()
         self._ring_size = 0
+        self._decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
 
     def ensure_session(self, *, cwd: str, cols: int, rows: int) -> None:
         with self._lock:
@@ -26,14 +38,22 @@ class TerminalManager:
                 self._backend.kill()
             self._ring.clear()
             self._ring_size = 0
+            # Fresh PTY = fresh byte stream; a dangling partial character from
+            # the dead session must not bleed into the new one.
+            self._decoder.reset()
             self._backend = self._factory()
             self._backend.spawn(cwd=cwd, cols=cols, rows=rows)
 
-    def read(self, max_bytes: int = 65536) -> bytes:
+    def read(self, max_bytes: int = 65536) -> str:
+        """Return decoded output, holding back a trailing partial character.
+
+        May return "" even when bytes arrived (all of them belonged to a
+        still-incomplete character); the next read completes it.
+        """
         backend = self._backend
         if backend is None:
-            return b""
-        data = backend.read(max_bytes)
+            return ""
+        data = self._decoder.decode(backend.read(max_bytes))
         if data:
             self._append_scrollback(data)
         return data
@@ -48,8 +68,8 @@ class TerminalManager:
         if backend is not None:
             backend.resize(cols, rows)
 
-    def scrollback(self) -> bytes:
-        return b"".join(self._ring)
+    def scrollback(self) -> str:
+        return "".join(self._ring)
 
     def kill(self) -> None:
         with self._lock:
@@ -61,7 +81,7 @@ class TerminalManager:
     def alive(self) -> bool:
         return self._backend is not None and self._backend.alive
 
-    def _append_scrollback(self, data: bytes) -> None:
+    def _append_scrollback(self, data: str) -> None:
         self._ring.append(data)
         self._ring_size += len(data)
         while self._ring_size > self.MAX_SCROLLBACK and len(self._ring) > 1:

--- a/tests/api/test_terminal_routes.py
+++ b/tests/api/test_terminal_routes.py
@@ -21,8 +21,8 @@ class _FakeManager:
     def __init__(self):
         self.killed = False; self._alive = False; self.ensured = None
     def ensure_session(self, *, cwd, cols, rows): self._alive = True; self.ensured = (cwd, cols, rows)
-    def scrollback(self): return b"hi\n"
-    def read(self, max_bytes=65536): return b""
+    def scrollback(self): return "hi\n"
+    def read(self, max_bytes=65536): return ""
     def write(self, data): pass
     def resize(self, cols, rows): pass
     def kill(self): self.killed = True; self._alive = False
@@ -126,8 +126,8 @@ class _LiveManager:
     def __init__(self):
         self._alive = True
     def ensure_session(self, *, cwd, cols, rows): self._alive = True
-    def scrollback(self): return b"ready\n"
-    def read(self, max_bytes=65536): time.sleep(0.05); return b""
+    def scrollback(self): return "ready\n"
+    def read(self, max_bytes=65536): time.sleep(0.05); return ""
     def write(self, data): pass
     def resize(self, cols, rows): pass
     def kill(self): self._alive = False

--- a/tests/terminal/test_manager.py
+++ b/tests/terminal/test_manager.py
@@ -24,8 +24,8 @@ def test_manager_spawns_once_and_records_scrollback():
     b1 = m._backend
     m.ensure_session(cwd="/home/u", cols=80, rows=24)  # already alive -> no respawn
     assert m._backend is b1
-    assert m.read() == b"welcome\n"
-    assert m.scrollback() == b"welcome\n"
+    assert m.read() == "welcome\n"
+    assert m.scrollback() == "welcome\n"
     m.write(b"ls\n"); m.resize(120, 40); m.kill()
     assert b1.written == [b"ls\n"] and b1.resized == (120, 40) and not m.alive
 
@@ -44,7 +44,7 @@ def test_respawn_kills_stale_backend_and_replaces_it():
 def test_scrollback_is_bounded():
     m = TerminalManager(backend_factory=_FakeBackend)
     m.ensure_session(cwd="/", cols=80, rows=24)
-    m._append_scrollback(b"x" * (TerminalManager.MAX_SCROLLBACK + 5000))
+    m._append_scrollback("x" * (TerminalManager.MAX_SCROLLBACK + 5000))
     assert len(m.scrollback()) <= TerminalManager.MAX_SCROLLBACK
 
 
@@ -52,7 +52,7 @@ def test_read_after_kill_returns_empty_not_crash():
     m = TerminalManager(backend_factory=_FakeBackend)
     m.ensure_session(cwd="/home/u", cols=80, rows=24)
     m.kill()
-    assert m.read() == b""
+    assert m.read() == ""
     m.write(b"x")
     m.resize(80, 24)
 
@@ -63,10 +63,47 @@ def test_scrollback_evicts_oldest_small_chunks():
     chunk_size = 1024
     num_chunks = (TerminalManager.MAX_SCROLLBACK // chunk_size) + 5
     for i in range(num_chunks):
-        marker = f"chunk-{i:05d}-".encode()
-        padding = b"y" * (chunk_size - len(marker))
+        marker = f"chunk-{i:05d}-"
+        padding = "y" * (chunk_size - len(marker))
         m._append_scrollback(marker + padding)
     data = m.scrollback()
     assert len(data) <= TerminalManager.MAX_SCROLLBACK
-    assert b"chunk-00000-" not in data
-    assert f"chunk-{num_chunks - 1:05d}-".encode() in data
+    assert "chunk-00000-" not in data
+    assert f"chunk-{num_chunks - 1:05d}-" in data
+
+
+def test_read_reassembles_utf8_char_split_across_chunks():
+    # PTY reads chunk at arbitrary byte offsets; a multi-byte character
+    # ('❯' = e2 9d af, the glyph TUIs use for selection markers) split
+    # across two reads must NOT decode to replacement chars ('�') --
+    # that was the "artifacts during claude menus" bug. The partial tail is
+    # held back and completed by the next read.
+    m = TerminalManager(backend_factory=_FakeBackend)
+    m.ensure_session(cwd="/", cols=80, rows=24)
+    m._backend._queue = [b"ok \xe2\x9d", b"\xaf done"]
+    first = m.read()
+    second = m.read()
+    assert "�" not in first + second
+    assert first + second == "ok ❯ done"
+
+
+def test_scrollback_replays_clean_text_after_split_reads():
+    m = TerminalManager(backend_factory=_FakeBackend)
+    m.ensure_session(cwd="/", cols=80, rows=24)
+    m._backend._queue = [b"\xe2\x9d", b"\xaf", b"\xe2\x96", b"\x8c"]
+    for _ in range(4):  # a partial-char read returns "" — keep draining
+        m.read()
+    assert m.scrollback() == "❯▌"
+
+
+def test_decoder_state_resets_on_respawn():
+    # A dangling partial char from a dead session must not corrupt the first
+    # bytes of the next session's stream.
+    m = TerminalManager(backend_factory=_FakeBackend)
+    m.ensure_session(cwd="/", cols=80, rows=24)
+    m._backend._queue = [b"\xe2\x9d"]  # partial char, never completed
+    m.read()
+    m._backend._alive = False
+    m.ensure_session(cwd="/", cols=80, rows=24)  # respawn
+    m._backend._queue = [b"fresh"]
+    assert m.read() == "fresh"


### PR DESCRIPTION
## Problem

Interactive CLIs in the embedded terminal (e.g. `claude` option menus) showed `�` artifacts during redraws.

TUI frameworks stream multi-byte glyphs (`❯ ● ─ ▌`, box drawing) on every repaint. PTY reads chunk at arbitrary byte offsets, and the WS pump decoded each chunk independently with `errors="replace"` — any character split across a read boundary became replacement chars on screen. Measured on a multi-byte flood: **2335 `�` across 1480 WS frames**, with the tell-tale signature of one frame ending `…❯�` and the next starting `0��`.

## Fix

Move the bytes→text boundary into `TerminalManager`: one incremental UTF-8 decoder per PTY session, created on spawn and reset on respawn. Partial sequences carry across reads and across client reconnects (a per-connection decoder in the WS handler could not do the latter). The scrollback ring stores decoded text, so reattach replay is inherently free of torn characters. `read()`/`scrollback()` now return `str`; `write()` stays bytes.

## Verification

- New regression tests: split-char reassembly across reads, clean scrollback after split reads, decoder reset on respawn (fail on the old code).
- Full terminal + routes suite: 36 passed.
- Live re-run of the identical flood through the real PTY→WS→xterm stack: **0 replacement chars in 1466 frames**, screen renders every glyph intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)