### PR TITLE
feat(ui): drawer close button becomes a Hide chevron

### DIFF
--- a/src/quodeq/ui/src/components/CopyButton.jsx
+++ b/src/quodeq/ui/src/components/CopyButton.jsx
@@ -43,20 +43,37 @@ export function TerminalIcon() {
   );
 }
 
-// Chevron up = maximize (the bottom drawer grows upward); chevron down =
-// restore (it collapses back down).
-export function ChevronUpIcon() {
-  return (
-    <svg width={ICON_SIZE} height={ICON_SIZE} viewBox={ICON_VIEWBOX} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <polyline points="6 15 12 9 18 15" />
-    </svg>
-  );
-}
-
+// The drawer's hide control: a chevron-down (the panel is hidden, nothing is
+// killed), so maximize/restore use the distinct expand/shrink glyphs below
+// instead of chevrons.
 export function ChevronDownIcon() {
   return (
     <svg width={ICON_SIZE} height={ICON_SIZE} viewBox={ICON_VIEWBOX} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
       <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+// Diagonal corner arrows pointing outward: maximize the drawer.
+export function MaximizeIcon() {
+  return (
+    <svg width={ICON_SIZE} height={ICON_SIZE} viewBox={ICON_VIEWBOX} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polyline points="15 3 21 3 21 9" />
+      <polyline points="9 21 3 21 3 15" />
+      <line x1="21" y1="3" x2="14" y2="10" />
+      <line x1="3" y1="21" x2="10" y2="14" />
+    </svg>
+  );
+}
+
+// Diagonal corner arrows pointing inward: restore the maximized drawer.
+export function MinimizeIcon() {
+  return (
+    <svg width={ICON_SIZE} height={ICON_SIZE} viewBox={ICON_VIEWBOX} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polyline points="4 14 10 14 10 20" />
+      <polyline points="20 10 14 10 14 4" />
+      <line x1="14" y1="10" x2="21" y2="3" />
+      <line x1="3" y1="21" x2="10" y2="14" />
     </svg>
   );
 }

--- a/src/quodeq/ui/src/features/drawer/BottomDrawer.jsx
+++ b/src/quodeq/ui/src/features/drawer/BottomDrawer.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useRef, lazy, Suspense } from 'react';
 import { useAssistantDrawer } from '../assistant/AssistantDrawerProvider.jsx';
 import { AssistantPane } from '../assistant/AssistantDrawer.jsx';
-import { ChevronUpIcon, ChevronDownIcon, GlobeIcon, PencilIcon, RotateCcwIcon } from '../../components/CopyButton.jsx';
+import { ChevronDownIcon, GlobeIcon, MaximizeIcon, MinimizeIcon, PencilIcon, RotateCcwIcon } from '../../components/CopyButton.jsx';
 import { useSidePane, workspaceDiffSpec } from '../side-pane/index.js';
 
 const TerminalPane = lazy(() => import('../terminal/TerminalPane.jsx'));
@@ -131,10 +131,15 @@ export function BottomDrawer({ uiState }) {
             aria-label={maximized ? 'Restore drawer' : 'Maximize drawer'}
             aria-pressed={maximized}
             title={maximized ? 'Restore' : 'Maximize'}>
-            {maximized ? <ChevronDownIcon /> : <ChevronUpIcon />}
+            {maximized ? <MinimizeIcon /> : <MaximizeIcon />}
           </button>
+          {/* Chevron-down, NOT an ×: neither panel is killed by this. The
+              terminal's PTY shell and an in-flight assistant turn keep running
+              server-side; reopening the tab reattaches to them. */}
           <button type="button" className="assistant-drawer-btn" onClick={closeActiveTab}
-            aria-label="Close tab" title="Close tab">&times;</button>
+            aria-label="Hide tab" title="Hide (keeps running in the background)">
+            <ChevronDownIcon />
+          </button>
         </div>
       </header>
       {openPanels.includes('assistant') && (

--- a/src/quodeq/ui/src/features/drawer/BottomDrawer.test.jsx
+++ b/src/quodeq/ui/src/features/drawer/BottomDrawer.test.jsx
@@ -50,11 +50,23 @@ it('the maximize control toggles the maximized state', () => {
   expect(drawer.toggleMaximized).toHaveBeenCalled();
 });
 
-it('the close (×) button closes only the active tab, not the whole drawer', () => {
+it('the hide button hides only the active tab, not the whole drawer', () => {
   render(<BottomDrawer uiState={{}} />);
-  fireEvent.click(screen.getByRole('button', { name: /close tab/i }));
+  fireEvent.click(screen.getByRole('button', { name: /hide tab/i }));
   expect(drawer.closeActiveTab).toHaveBeenCalled();
   expect(drawer.close).not.toHaveBeenCalled();
+});
+
+it('the maximized-restore glyph is distinct from the hide chevron', () => {
+  // Both panels hide (nothing is killed), so the hide button is a chevron-down.
+  // When maximized, the restore control must NOT render the same chevron-down
+  // next to it — it uses the shrink glyph instead.
+  drawer.maximized = true;
+  render(<BottomDrawer uiState={{}} />);
+  const restore = screen.getByRole('button', { name: /restore/i });
+  const hide = screen.getByRole('button', { name: /hide tab/i });
+  expect(restore.innerHTML).not.toBe(hide.innerHTML);
+  drawer.maximized = false;
 });
 
 it('the model chip sits with the tabs on the left, not in the right controls', () => {


### PR DESCRIPTION
## What

The bottom drawer's × button implied the terminal/assistant gets closed or killed. Neither is true: the terminal's PTY shell is a server-side singleton that keeps running (reopening reattaches and replays scrollback), and the assistant session plus any in-flight turn live in the provider and server, untouched by the tab. This PR makes the control honest:

- × → chevron-down, aria-label "Hide tab", tooltip "Hide (keeps running in the background)"
- Maximize/restore moves off the chevron pair to expand/shrink corner-arrow glyphs, so the restore icon can't render as a twin of the hide chevron when maximized
- Removes the now-unused ChevronUpIcon

## Testing

- TDD: renamed/added BottomDrawer tests first (hide button calls closeActiveTab only; restore glyph is distinct from the hide chevron), watched them fail, then implemented
- Full UI suite: 853/853 pass
- Verified live in the dev dashboard: correct glyphs/labels/tooltip in the DOM, Hide dismisses the tab, terminal status stays running server-side

Follow-up (separate PR): a Stop control for in-flight assistant turns, which currently cannot be cancelled at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)