### PR TITLE
Show a reconnect overlay when the terminal socket drops

### DIFF
--- a/src/quodeq/api/terminal_routes.py
+++ b/src/quodeq/api/terminal_routes.py
@@ -39,6 +39,13 @@ def _gate_reason() -> str | None:
     )
 
 
+# App-specific WS close codes (4000-4999 range). The client's auto-reconnect
+# keys off these: a retry against a held lock or a closed gate can never
+# succeed, so it must not loop — only unexpected drops are retried.
+_WS_CLOSE_BUSY = 4002     # single-connection lock held by another window
+_WS_CLOSE_REFUSED = 4003  # terminal gate refused the handshake
+
+
 def _clamp_winsize(value: int) -> int:
     """Keep a terminal dimension within struct.pack('HH') range (1..65535)."""
     return max(1, min(int(value), 65535))
@@ -85,13 +92,13 @@ def register_terminal_routes(app: Flask, manager: TerminalManager | None = None)
     @sock.route("/api/terminal/ws")
     def terminal_ws(ws):
         if _gate_reason() is not None:
-            ws.close()
+            ws.close(_WS_CLOSE_REFUSED)
             return
         if not _conn_lock.acquire(blocking=False):
             try:
                 ws.send("0\r\n[terminal already open in another window]\r\n")
             finally:
-                ws.close()
+                ws.close(_WS_CLOSE_BUSY)
             return
         try:
             try:

--- a/src/quodeq/ui/src/features/terminal/TerminalPane.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.jsx
@@ -63,7 +63,7 @@ export default function TerminalPane({ active }) {
   // `active` is used ONLY to gate fitting (the fit effects below).
   const paneLive = checked && reason === null;
 
-  const { status, send, resize } = useTerminalSocket({
+  const { status, send, resize, reconnectNow } = useTerminalSocket({
     active: paneLive,
     restartKey,
     onData: (s) => termRef.current?.write(s),
@@ -177,5 +177,23 @@ export default function TerminalPane({ active }) {
   if (reason) {
     return <div className="tty-disabled" data-testid="tty-disabled">{reason}</div>;
   }
-  return <div ref={rootRef} className="tty-root" data-testid="tty-root" onKeyDown={containerKeyDown} />;
+  // A dead socket swallows keystrokes with no visual cue, so any not-connected
+  // state after mount gets an explicit banner. 'connecting' is excluded: the
+  // initial handshake resolves in milliseconds and a flash would be noise.
+  const overlay = {
+    reconnecting: { text: 'Terminal disconnected. Reconnecting…', btn: 'Retry now' },
+    busy: { text: 'Terminal is already open in another window.', btn: 'Use it here' },
+    refused: { text: 'Terminal connection refused by the server.', btn: 'Retry' },
+  }[status];
+  return (
+    <div className="tty-wrap" onKeyDown={containerKeyDown}>
+      <div ref={rootRef} className="tty-root" data-testid="tty-root" />
+      {overlay && (
+        <div className="tty-overlay" data-testid="tty-overlay" role="status">
+          <span>{overlay.text}</span>
+          <button type="button" className="tty-overlay-btn" onClick={reconnectNow}>{overlay.btn}</button>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
@@ -16,6 +16,10 @@ vi.mock('../../api/terminal.js', () => ({
   killTerminal: vi.fn(async () => ({ ok: true })),
   terminalSocketUrl: () => 'ws://localhost/api/terminal/ws',
 }));
+// Mock the socket hook: jsdom has no real terminal WS to reach, and the
+// overlay tests need to drive each connection status directly.
+const socketState = { status: 'open', send: vi.fn(), resize: vi.fn(), reconnectNow: vi.fn() };
+vi.mock('./useTerminalSocket.js', () => ({ useTerminalSocket: vi.fn(() => socketState) }));
 import TerminalPane from './TerminalPane.jsx';
 
 it('mounts an xterm terminal when active', async () => {
@@ -48,4 +52,32 @@ it('shows the gate reason and does not mount xterm when disabled', async () => {
   expect(disabled).toHaveTextContent('localhost only');
   expect(screen.queryByTestId('tty-root')).toBeNull();
   expect(Terminal).not.toHaveBeenCalled();
+});
+
+it('shows no overlay while the socket is open or on the initial connect', async () => {
+  socketState.status = 'open';
+  render(<TerminalPane active />);
+  await screen.findByTestId('tty-root');
+  expect(screen.queryByTestId('tty-overlay')).toBeNull();
+  socketState.status = 'connecting';
+  render(<TerminalPane active />);
+  expect(screen.queryByTestId('tty-overlay')).toBeNull();
+});
+
+it('shows a reconnecting banner when the socket drops, and Retry calls reconnectNow', async () => {
+  const { userEvent } = await import('@testing-library/user-event').then((m) => ({ userEvent: m.default }));
+  socketState.status = 'reconnecting';
+  socketState.reconnectNow = vi.fn();
+  render(<TerminalPane active />);
+  const overlay = await screen.findByTestId('tty-overlay');
+  expect(overlay).toHaveTextContent('Terminal disconnected. Reconnecting');
+  await userEvent.click(screen.getByRole('button', { name: 'Retry now' }));
+  expect(socketState.reconnectNow).toHaveBeenCalled();
+});
+
+it('shows a busy banner when another window owns the terminal', async () => {
+  socketState.status = 'busy';
+  render(<TerminalPane active />);
+  const overlay = await screen.findByTestId('tty-overlay');
+  expect(overlay).toHaveTextContent('already open in another window');
 });

--- a/src/quodeq/ui/src/features/terminal/useTerminalSocket.js
+++ b/src/quodeq/ui/src/features/terminal/useTerminalSocket.js
@@ -1,29 +1,65 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { terminalSocketUrl } from '../../api/terminal.js';
 
+// App-specific WS close codes sent by the server (api/terminal_routes.py).
+// They mean a reconnect cannot succeed right now, so the hook reports the
+// state instead of retrying — a busy loop here would ping-pong against the
+// server's single-connection lock and spam the other window's terminal.
+const CLOSE_BUSY = 4002;     // another window holds the single PTY connection
+const CLOSE_REFUSED = 4003;  // gate refused (non-loopback host / bad Origin)
+
+const RETRY_BASE_MS = 500;
+const RETRY_MAX_MS = 5000;
+
+// status: 'idle' | 'connecting' | 'open' | 'reconnecting' | 'busy' | 'refused'
 export function useTerminalSocket({ active, onData, restartKey = 0 }) {
   const [status, setStatus] = useState('idle');
+  // Bumped internally to open a fresh socket after an unexpected close.
+  const [gen, setGen] = useState(0);
   const wsRef = useRef(null);
+  const retryTimerRef = useRef(null);
+  const attemptsRef = useRef(0);
   const onDataRef = useRef(onData);
   onDataRef.current = onData;
 
-  // `restartKey` is a dependency so bumping it tears down the current socket
-  // and opens a fresh one (used to reconnect after the server session is killed
-  // → the reconnect spawns a brand-new PTY).
+  // An external restart (Settings kill -> fresh PTY) starts a fresh backoff
+  // history; only an internal retry keeps counting attempts.
+  useEffect(() => { attemptsRef.current = 0; }, [restartKey]);
+
+  // `restartKey`/`gen` are dependencies so bumping either tears down the
+  // current socket and opens a fresh one (restart from Settings / auto-retry).
   useEffect(() => {
     if (!active) return undefined;
     const ws = new WebSocket(terminalSocketUrl());
     wsRef.current = ws;
-    setStatus('connecting');
-    ws.onopen = () => setStatus('open');
-    ws.onclose = () => { setStatus('closed'); if (wsRef.current === ws) wsRef.current = null; };
+    setStatus(attemptsRef.current > 0 ? 'reconnecting' : 'connecting');
+    ws.onopen = () => { attemptsRef.current = 0; setStatus('open'); };
+    ws.onclose = (e) => {
+      if (wsRef.current === ws) wsRef.current = null;
+      if (e?.code === CLOSE_BUSY) { setStatus('busy'); return; }
+      if (e?.code === CLOSE_REFUSED) { setStatus('refused'); return; }
+      // Unexpected drop (server restart/crash/sleep). A dead socket swallows
+      // keystrokes silently, so surface it and retry with capped exponential
+      // backoff — the local server can come back at any moment.
+      setStatus('reconnecting');
+      const delay = Math.min(RETRY_BASE_MS * 2 ** attemptsRef.current, RETRY_MAX_MS);
+      attemptsRef.current += 1;
+      retryTimerRef.current = setTimeout(() => {
+        retryTimerRef.current = null;
+        setGen((g) => g + 1);
+      }, delay);
+    };
     ws.onmessage = (e) => {
       const s = typeof e.data === 'string' ? e.data : '';
       if (s[0] === '0') onDataRef.current?.(s.slice(1));
     };
-    return () => { ws.onopen = ws.onmessage = ws.onclose = null; try { ws.close(); } catch { /* noop */ }
-      if (wsRef.current === ws) wsRef.current = null; };
-  }, [active, restartKey]);
+    return () => {
+      if (retryTimerRef.current) { clearTimeout(retryTimerRef.current); retryTimerRef.current = null; }
+      ws.onopen = ws.onmessage = ws.onclose = null;
+      try { ws.close(); } catch { /* noop */ }
+      if (wsRef.current === ws) wsRef.current = null;
+    };
+  }, [active, restartKey, gen]);
 
   const send = useCallback((data) => {
     const ws = wsRef.current;
@@ -35,5 +71,12 @@ export function useTerminalSocket({ active, onData, restartKey = 0 }) {
     if (ws && ws.readyState === 1) ws.send('1' + JSON.stringify({ resize: { cols, rows } }));
   }, []);
 
-  return { status, send, resize };
+  // Manual retry (overlay click): skip any pending backoff and go now.
+  const reconnectNow = useCallback(() => {
+    if (retryTimerRef.current) { clearTimeout(retryTimerRef.current); retryTimerRef.current = null; }
+    attemptsRef.current = 0;
+    setGen((g) => g + 1);
+  }, []);
+
+  return { status, send, resize, reconnectNow };
 }

--- a/src/quodeq/ui/src/features/terminal/useTerminalSocket.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/useTerminalSocket.test.jsx
@@ -10,9 +10,10 @@ class MockWS {
   close() { this.readyState = 3; this.onclose && this.onclose(); }
   _open() { this.readyState = 1; this.onopen && this.onopen(); }
   _msg(data) { this.onmessage && this.onmessage({ data }); }
+  _drop(code) { this.readyState = 3; this.onclose && this.onclose({ code }); }
 }
 beforeEach(() => { MockWS.instances = []; globalThis.WebSocket = MockWS; });
-afterEach(() => vi.restoreAllMocks());
+afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks(); });
 
 it('reconnects (new socket) when restartKey changes', () => {
   const { rerender } = renderHook(
@@ -43,4 +44,63 @@ it('connects when active, forwards data, sends tagged frames', () => {
 it('does not connect when inactive', () => {
   renderHook(() => useTerminalSocket({ active: false, onData: () => {} }));
   expect(MockWS.instances.length).toBe(0);
+});
+
+it('auto-reconnects after an unexpected close, with growing backoff', () => {
+  vi.useFakeTimers();
+  const { result } = renderHook(() => useTerminalSocket({ active: true, onData: () => {} }));
+  act(() => MockWS.instances[0]._open());
+  // Server dies (e.g. restart): abnormal close, no app close code.
+  act(() => MockWS.instances[0]._drop(1006));
+  expect(result.current.status).toBe('reconnecting');
+  expect(MockWS.instances.length).toBe(1);      // waits out the backoff first
+  act(() => vi.advanceTimersByTime(500));
+  expect(MockWS.instances.length).toBe(2);      // first retry after 500ms
+  // Retry fails too (server still down): next delay doubles to 1000ms.
+  act(() => MockWS.instances[1]._drop(1006));
+  act(() => vi.advanceTimersByTime(500));
+  expect(MockWS.instances.length).toBe(2);      // not yet
+  act(() => vi.advanceTimersByTime(500));
+  expect(MockWS.instances.length).toBe(3);      // second retry after 1000ms
+  // Server is back: a successful open resets the backoff and the status.
+  act(() => MockWS.instances[2]._open());
+  expect(result.current.status).toBe('open');
+});
+
+it('reports busy and does not retry when another window owns the terminal', () => {
+  vi.useFakeTimers();
+  const { result } = renderHook(() => useTerminalSocket({ active: true, onData: () => {} }));
+  act(() => MockWS.instances[0]._drop(4002));   // server: single-connection lock held
+  expect(result.current.status).toBe('busy');
+  act(() => vi.advanceTimersByTime(60000));
+  expect(MockWS.instances.length).toBe(1);      // no auto-retry ping-pong
+});
+
+it('reports refused and does not retry when the gate rejects the connection', () => {
+  vi.useFakeTimers();
+  const { result } = renderHook(() => useTerminalSocket({ active: true, onData: () => {} }));
+  act(() => MockWS.instances[0]._drop(4003));
+  expect(result.current.status).toBe('refused');
+  act(() => vi.advanceTimersByTime(60000));
+  expect(MockWS.instances.length).toBe(1);
+});
+
+it('reconnectNow retries immediately, skipping the pending backoff', () => {
+  vi.useFakeTimers();
+  const { result } = renderHook(() => useTerminalSocket({ active: true, onData: () => {} }));
+  act(() => MockWS.instances[0]._open());
+  act(() => MockWS.instances[0]._drop(1006));
+  expect(MockWS.instances.length).toBe(1);
+  act(() => result.current.reconnectNow());
+  expect(MockWS.instances.length).toBe(2);      // immediate, no timer wait
+});
+
+it('unmount during a pending retry cancels the timer (no zombie sockets)', () => {
+  vi.useFakeTimers();
+  const { unmount } = renderHook(() => useTerminalSocket({ active: true, onData: () => {} }));
+  act(() => MockWS.instances[0]._open());
+  act(() => MockWS.instances[0]._drop(1006));
+  unmount();
+  act(() => vi.advanceTimersByTime(60000));
+  expect(MockWS.instances.length).toBe(1);
 });

--- a/src/quodeq/ui/src/styles/drawer.css
+++ b/src/quodeq/ui/src/styles/drawer.css
@@ -1,5 +1,45 @@
 /* Embedded-terminal container (distinct from styles/terminal.css, which is the
    dashboard design-system aesthetic). Class prefix: tty-. */
+.tty-wrap {
+  position: relative;   /* anchors the connection-state overlay */
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}
+
+/* Connection-state banner over the terminal (disconnected / busy / refused).
+   Centered near the top so it doesn't cover the prompt line at the bottom. */
+.tty-overlay {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.75rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+  z-index: 2;
+  white-space: nowrap;
+}
+.tty-overlay-btn {
+  padding: 2px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-surface-alt);
+  color: var(--color-accent);
+  font-family: inherit;
+  font-size: inherit;
+  cursor: pointer;
+}
+.tty-overlay-btn:hover { border-color: var(--color-accent); }
+
 .tty-root {
   width: 100%;
   height: 100%;

--- a/tests/api/test_terminal_routes.py
+++ b/tests/api/test_terminal_routes.py
@@ -190,6 +190,37 @@ def test_ws_single_active_connection_refuses_second():
 
 
 @_ws_test
+def test_ws_busy_close_uses_dedicated_code():
+    # The client must NOT auto-reconnect against a held lock (it would ping-pong
+    # and spam the other window), so the refusal carries close code 4002.
+    with _serve(_LiveManager()) as port:
+        with _connect(port) as a:
+            assert a.receive(timeout=2) == "0ready\n"
+            with _connect(port) as b:
+                with pytest.raises(simple_websocket.ConnectionClosed) as exc:
+                    b.receive(timeout=2)   # banner frame...
+                    b.receive(timeout=2)   # ...then the close
+                assert exc.value.reason == 4002
+
+
+@_ws_test
+def test_ws_gate_refusal_close_uses_dedicated_code():
+    # Bad Origin -> gate refuses the handshake with close code 4003 so the
+    # client reports it instead of retrying forever.
+    with _serve(_LiveManager()) as port:
+        c = simple_websocket.Client(
+            f"ws://127.0.0.1:{port}/api/terminal/ws",
+            headers={"Origin": "http://evil.example"})
+        try:
+            with pytest.raises(simple_websocket.ConnectionClosed) as exc:
+                c.receive(timeout=2)
+            assert exc.value.reason == 4003
+        finally:
+            with contextlib.suppress(Exception):
+                c.close()
+
+
+@_ws_test
 def test_ws_spawn_failure_closes_cleanly_and_frees_lock():
     with _serve(_FlakyManager()) as port:
         with _connect(port) as first:       # ensure_session raises -> clean close


### PR DESCRIPTION
## Problem

When the embedded terminal's WebSocket dies (server restart, crash, sleep/wake), the pane keeps looking alive while **silently eating every keystroke**: `send()` no-ops on a closed socket and nothing renders for the closed state. Hit twice in live debugging during the artifact investigation (#776); the existing `restartKey` reconnect machinery was only wired to the Settings restart button.

## Fix

- **`useTerminalSocket`**: auto-reconnects with capped exponential backoff (500 ms doubling to 5 s) after an unexpected close; `reconnectNow()` skips the pending backoff; a successful open resets it. Pending retries are cancelled on unmount/restart.
- **`TerminalPane`**: status banner over the terminal for the three not-connected states (disconnected/reconnecting, busy, refused) with a retry button. No overlay flash during the initial handshake.
- **Server**: refusals now close with dedicated app codes, `4002` (single-connection lock held by another window) and `4003` (gate refused), so the client reports instead of retry-looping against the lock, which would spam the already-open banner into the owning window forever. Unexpected drops (1006 etc.) are the only retried closes.

A pleasant side effect: after reconnecting, the fit-on-open effect resizes the fresh PTY, so a running TUI repaints immediately.

## Verification

- 8 hook tests (backoff growth, busy/refused no-retry, immediate manual retry, timer cleanup on unmount), 3 new pane overlay tests, 2 new WS integration tests for the close codes. Full suites: 860 UI tests, 19 route/terminal tests, all green.
- Live in the browser against a real server: killed the server mid-session, banner appeared; restarted the server, the pane auto-reconnected within the backoff window and the fresh prompt accepted input. Busy and refused paths verified at the protocol level (banner + 4002, clean 4003).

🤖 Generated with [Claude Code](https://claude.com/claude-code)