### PR TITLE
feat(assistant): stop button cancels the in-flight turn

### DIFF
--- a/src/quodeq/api/assistant_routes.py
+++ b/src/quodeq/api/assistant_routes.py
@@ -19,11 +19,16 @@ from quodeq.api._assistant_helpers import (
 from quodeq.api._sse_log_helpers import sse_line
 from quodeq.api.assistant_workspace_routes import register_assistant_workspace_routes
 from quodeq.assistant import get_provider_configs
+from quodeq.assistant.cancel import CancelToken
 from quodeq.assistant.orchestrator import TurnRequest, run_turn, write_safe_provider
 from quodeq.assistant.skills import RESERVED_COMMANDS, load_skills
 from quodeq.assistant.tools._actions import ACTION_DESCRIPTIONS, ACTION_TYPES, ACTIONS, ActionConflict
 
 _running_turns: set[str] = set()
+# Cancel token per session with a /messages turn in flight; the /stop route
+# fires it. Workspace actions (apply/pr) claim the turn slot too but are not
+# stoppable, so they never appear here.
+_cancel_tokens: dict[str, CancelToken] = {}
 _running_lock = threading.Lock()
 
 
@@ -135,6 +140,7 @@ def register_assistant_routes(app: Flask) -> None:
             if sid in _running_turns:
                 return jsonify({"error": "a turn is already running"}), 409
             _running_turns.add(sid)
+            cancel = _cancel_tokens[sid] = CancelToken()
         # Everything from here through Thread.start() must free the slot on
         # failure — otherwise an exception (e.g. build_tool_context blowing
         # up) leaves `sid` in `_running_turns` forever and every future POST
@@ -175,17 +181,34 @@ def register_assistant_routes(app: Flask) -> None:
 
             def _worker():
                 try:
-                    run_turn(turn, repository=repo, tool_ctx=tool_ctx)
+                    run_turn(turn, repository=repo, tool_ctx=tool_ctx, cancel=cancel)
                 finally:
                     with _running_lock:
                         _running_turns.discard(sid)
+                        _cancel_tokens.pop(sid, None)
 
             threading.Thread(target=_worker, daemon=True).start()
         except Exception:
             with _running_lock:
                 _running_turns.discard(sid)
+                _cancel_tokens.pop(sid, None)
             raise
         return jsonify({"accepted": True}), 202
+
+    @app.post("/api/assistant/sessions/<sid>/stop")
+    def stop_assistant_turn(sid: str):
+        if get_repository(app).get_session(sid) is None:
+            return jsonify({"error": "unknown session"}), 404
+        with _running_lock:
+            token = _cancel_tokens.get(sid)
+        if token is None:
+            return jsonify({"error": "no turn running"}), 409
+        # Fire outside the lock: cancel() runs kill hooks (proc-tree kill /
+        # client close) that must not serialize other sessions' turn claims.
+        token.cancel()
+        # 202: the turn thread still has to unwind; the SSE `stopped` frame is
+        # the authoritative end-of-turn signal for the UI.
+        return jsonify({"stopping": True}), 202
 
     @app.get("/api/assistant/sessions/<sid>/events")
     def assistant_events(sid: str):

--- a/src/quodeq/assistant/adapters/_api.py
+++ b/src/quodeq/assistant/adapters/_api.py
@@ -7,6 +7,9 @@ import os
 from dataclasses import dataclass
 from typing import Callable
 
+import queue
+import threading
+
 import httpx
 import openai
 
@@ -14,6 +17,7 @@ from quodeq.assistant.adapters._fallback import (
     FALLBACK_CONTRACT,
     extract_prompted_tool_call,
 )
+from quodeq.assistant.cancel import CancelToken, TurnCancelled
 from quodeq.assistant.guard import MAX_TOOL_ITERATIONS, guard_tool_result
 from quodeq.assistant.tools._registry import ToolRegistry
 
@@ -63,7 +67,51 @@ def _default_client(config: ApiTurnConfig):
     )
 
 
-def _stream_once(client, config, messages, registry, emit):
+_STREAM_DONE = object()
+
+
+def _iter_with_cancel(stream, cancel):
+    """Yield `stream`'s chunks while staying cancellable during a BLOCKED read.
+
+    The blocking reads happen in a dedicated daemon reader thread feeding a
+    queue; this (turn-thread) side polls the queue with a short timeout and
+    checks the token each tick. Closing the HTTP client from another thread
+    does NOT reliably wake a thread blocked in a socket read (live-verified on
+    macOS: the read hung and the turn slot stayed claimed), so a cancel must
+    never depend on another chunk arriving. On cancel the stranded reader is
+    abandoned; it holds only the dying connection, not the turn slot.
+    """
+    # Unbounded so the reader NEVER blocks on put: after a cancel the consumer
+    # stops draining, and a blocked put would strand the reader even once the
+    # connection finally delivers. Growth is bounded by the post-put check.
+    q: queue.Queue = queue.Queue()
+
+    def _read():
+        try:
+            for chunk in stream:
+                q.put(chunk)
+                if cancel.cancelled:
+                    return  # consumer is gone; stop producing
+            q.put(_STREAM_DONE)
+        except Exception as exc:  # noqa: BLE001 - delivered to the consumer
+            q.put(exc)
+
+    threading.Thread(target=_read, daemon=True).start()
+    while True:
+        if cancel.cancelled:
+            raise TurnCancelled("")
+        try:
+            item = q.get(timeout=0.25)
+        except queue.Empty:
+            continue
+        if item is _STREAM_DONE:
+            return
+        if isinstance(item, Exception):
+            raise item
+        yield item
+
+
+def _stream_once(client, config, messages, registry, emit, cancel):
     """One streamed completion. Returns (text, tool_calls) where tool_calls is
     a list of {"id", "name", "arguments"} assembled from streamed deltas."""
     kwargs = {"model": config.model, "messages": messages, "stream": True}
@@ -74,27 +122,35 @@ def _stream_once(client, config, messages, registry, emit):
         kwargs["extra_body"] = extra
     text_parts: list[str] = []
     calls: dict[int, dict] = {}
-    for chunk in client.chat.completions.create(**kwargs):
-        if not chunk.choices:
-            continue
-        delta = chunk.choices[0].delta
-        if getattr(delta, "content", None):
-            text_parts.append(delta.content)
-            emit({"type": "token", "text": delta.content})
-        for tc in getattr(delta, "tool_calls", None) or []:
-            slot = calls.setdefault(tc.index, {"id": None, "name": None, "arguments": ""})
-            if tc.id:
-                slot["id"] = tc.id
-            if tc.function and tc.function.name:
-                slot["name"] = tc.function.name
-            if tc.function and tc.function.arguments:
-                slot["arguments"] += tc.function.arguments
+    try:
+        for chunk in _iter_with_cancel(client.chat.completions.create(**kwargs), cancel):
+            if not chunk.choices:
+                continue
+            delta = chunk.choices[0].delta
+            if getattr(delta, "content", None):
+                text_parts.append(delta.content)
+                emit({"type": "token", "text": delta.content})
+            for tc in getattr(delta, "tool_calls", None) or []:
+                slot = calls.setdefault(tc.index, {"id": None, "name": None, "arguments": ""})
+                if tc.id:
+                    slot["id"] = tc.id
+                if tc.function and tc.function.name:
+                    slot["name"] = tc.function.name
+                if tc.function and tc.function.arguments:
+                    slot["arguments"] += tc.function.arguments
+    except Exception:
+        # cancel() closes the client to interrupt a stalled read; the read
+        # then raises here. That's the stop succeeding, not a turn failure.
+        if cancel.cancelled:
+            raise TurnCancelled("".join(text_parts)) from None
+        raise
     return "".join(text_parts), [calls[i] for i in sorted(calls)]
 
 
 def run_api_turn(*, messages: list[dict], config: ApiTurnConfig,
                  registry: ToolRegistry, emit: Callable[[dict], None],
-                 client_factory=None) -> str:
+                 client_factory=None, cancel: CancelToken | None = None) -> str:
+    cancel = cancel or CancelToken()
     convo = list(messages)
     if not config.native_tools:
         convo = [dict(convo[0], content=convo[0]["content"] + FALLBACK_CONTRACT),
@@ -103,8 +159,17 @@ def run_api_turn(*, messages: list[dict], config: ApiTurnConfig,
     factory = client_factory or _default_client
     text = ""
     with factory(config) as client:
+        # Stop endpoint: closing the client interrupts a blocked/stalled read
+        # (e.g. a local model still cold-loading emits no chunks to poll on).
+        close = getattr(client, "close", None)
+        if close is not None:
+            cancel.register_kill(close)
         for _ in range(config.max_tool_iterations):
-            text, tool_calls = _stream_once(client, config, convo, registry, emit)
+            if cancel.cancelled:
+                raise TurnCancelled(text)
+            text, tool_calls = _stream_once(client, config, convo, registry, emit, cancel)
+            if cancel.cancelled:
+                raise TurnCancelled(text)
             if not config.native_tools:
                 prompted = extract_prompted_tool_call(text)
                 if prompted is None:

--- a/src/quodeq/assistant/adapters/_cli.py
+++ b/src/quodeq/assistant/adapters/_cli.py
@@ -17,6 +17,7 @@ from quodeq.assistant.adapters._cli_config import load_cli_chat_config
 from quodeq.assistant.adapters._cli_spawn import (
     build_chat_env, external_sandbox_prefix, scratch_cwd, spawn_turn)
 from quodeq.assistant.adapters._linereader import iter_lines
+from quodeq.assistant.cancel import CancelToken, TurnCancelled
 from quodeq.assistant.mcp import _config as mcp_config
 from quodeq.data.sqlite.assistant_repository import AssistantRepository
 from quodeq.shared._process_kill import kill_proc_tree as _kill_proc_tree
@@ -67,7 +68,7 @@ def _raw_error_line(line: str) -> str | None:
 def _run_once(cfg: CliTurnConfig, cli_cfg, *, prompt: str, session_id: str,
               prior_session_id: str | None, new_session_id: str,
               repository: AssistantRepository, emit: Callable[[dict], None],
-              spawn_fn) -> tuple[str, str | None, int, str | None, str | None]:
+              spawn_fn, cancel: CancelToken) -> tuple[str, str | None, int, str | None, str | None]:
     mcp_config_path = None
     mcp_config_arg = None
     if cli_cfg.mcp_style == "config-file":
@@ -112,6 +113,10 @@ def _run_once(cfg: CliTurnConfig, cli_cfg, *, prompt: str, session_id: str,
         # wall-clock guard: a hung/silent CLI can't wedge the turn slot forever
         timer = threading.Timer(TURN_TIMEOUT_S, lambda: _kill_proc_tree(proc))
         timer.start()
+        # Stop endpoint: cancelling the token kills the process tree, which
+        # EOFs stdout below and lets the turn unwind (runs immediately if the
+        # stop already landed).
+        cancel.register_kill(lambda: _kill_proc_tree(proc))
         texts, errors, raw_errors, parsed_sid = [], [], [], spec.session_id
         last_emitted = None
         saw_result = False
@@ -185,8 +190,12 @@ def _run_once(cfg: CliTurnConfig, cli_cfg, *, prompt: str, session_id: str,
 
 def run_cli_turn(*, messages: list[dict], config: CliTurnConfig, session_id: str,
                  prior_session_id: str | None, repository: AssistantRepository,
-                 emit: Callable[[dict], None], spawn_fn=None) -> str:
+                 emit: Callable[[dict], None], spawn_fn=None,
+                 cancel: CancelToken | None = None) -> str:
     spawn_fn = spawn_fn or spawn_turn
+    cancel = cancel or CancelToken()
+    if cancel.cancelled:  # stop landed before the turn even spawned
+        raise TurnCancelled("")
     cli_cfg = load_cli_chat_config(config.provider)
     prompt = _latest_user(messages)
     if cli_cfg.system_prompt_style == "message-prefix":
@@ -207,7 +216,13 @@ def run_cli_turn(*, messages: list[dict], config: CliTurnConfig, session_id: str
     final, _sid, _rc, structured_error, raw_error = _run_once(
         config, cli_cfg, prompt=prompt, session_id=session_id,
         prior_session_id=prior_session_id, new_session_id=str(uuid.uuid4()),
-        repository=repository, emit=emit, spawn_fn=spawn_fn)
+        repository=repository, emit=emit, spawn_fn=spawn_fn, cancel=cancel)
+    # A stopped turn is neither a failure nor a rebuild trigger: the kill
+    # leaves empty/partial output and often a nonzero exit, all of which the
+    # paths below would misread (rebuilding would RERUN the turn the user
+    # just stopped). Unwind with whatever text already streamed.
+    if cancel.cancelled:
+        raise TurnCancelled(final)
     # rebuild from the full transcript when a resumed turn came back empty, or
     # when it reported a structured failure (a partial answer before an explicit
     # error is not trustworthy). A non-empty answer with only a benign non-zero
@@ -217,7 +232,9 @@ def run_cli_turn(*, messages: list[dict], config: CliTurnConfig, session_id: str
         final, _sid, _rc, structured_error, raw_error = _run_once(
             config, cli_cfg, prompt=_full_transcript(messages), session_id=session_id,
             prior_session_id=None, new_session_id=str(uuid.uuid4()),
-            repository=repository, emit=emit, spawn_fn=spawn_fn)
+            repository=repository, emit=emit, spawn_fn=spawn_fn, cancel=cancel)
+        if cancel.cancelled:
+            raise TurnCancelled(final)
     if structured_error:
         raise RuntimeError(structured_error)
     if final == "":

--- a/src/quodeq/assistant/cancel.py
+++ b/src/quodeq/assistant/cancel.py
@@ -1,0 +1,59 @@
+"""Per-turn cancellation: the signal the stop endpoint uses to end a turn.
+
+A CancelToken is created per in-flight turn (by the /messages route) and
+handed down through run_turn into the adapter. Adapters poll `cancelled` at
+loop boundaries AND register kill hooks for their blocking externals (the CLI
+subprocess, the HTTP client) so cancel() interrupts a stalled read immediately
+instead of waiting for the next chunk that may never come.
+"""
+from __future__ import annotations
+
+import threading
+from typing import Callable
+
+
+class TurnCancelled(Exception):
+    """The user stopped the turn. Carries any partial answer already streamed
+    so the orchestrator can persist what the user actually saw."""
+
+    def __init__(self, partial: str = "") -> None:
+        super().__init__("turn stopped")
+        self.partial = partial
+
+
+class CancelToken:
+    def __init__(self) -> None:
+        self._event = threading.Event()
+        self._lock = threading.Lock()
+        self._kill_hooks: list[Callable[[], None]] = []
+
+    @property
+    def cancelled(self) -> bool:
+        return self._event.is_set()
+
+    def wait(self, timeout: float | None = None) -> bool:
+        return self._event.wait(timeout)
+
+    def cancel(self) -> None:
+        """Set the flag and run every registered kill hook (once)."""
+        with self._lock:
+            self._event.set()
+            hooks, self._kill_hooks = self._kill_hooks, []
+        for hook in hooks:
+            try:
+                hook()
+            except Exception:  # noqa: BLE001 - kill hooks are best-effort
+                pass
+
+    def register_kill(self, hook: Callable[[], None]) -> None:
+        """Run `hook` when cancelled; immediately if already cancelled (a stop
+        can land in the window between the route creating the token and the
+        adapter spawning its process/client)."""
+        with self._lock:
+            if not self._event.is_set():
+                self._kill_hooks.append(hook)
+                return
+        try:
+            hook()
+        except Exception:  # noqa: BLE001 - kill hooks are best-effort
+            pass

--- a/src/quodeq/assistant/orchestrator.py
+++ b/src/quodeq/assistant/orchestrator.py
@@ -10,6 +10,7 @@ from quodeq.assistant.adapters._api import ApiTurnConfig, run_api_turn
 from quodeq.assistant.adapters._capabilities import supports_native_tools
 from quodeq.assistant.adapters._cli import CliTurnConfig, run_cli_turn
 from quodeq.assistant.adapters._cli_config import load_cli_chat_config
+from quodeq.assistant.cancel import CancelToken, TurnCancelled
 from quodeq.assistant.guard import (
     MAX_TOOL_ITERATIONS, SKILL_MAX_TOOL_ITERATIONS, WRITE_MAX_TOOL_ITERATIONS)
 from quodeq.assistant.skills import load_skills
@@ -89,10 +90,11 @@ def _mcp_server_args(request: TurnRequest, tool_ctx: ToolContext) -> list[str]:
 
 def run_turn(request: TurnRequest, *, repository: AssistantRepository,
              tool_ctx: ToolContext, turn_fn=None, capability_fn=None,
-             cli_turn_fn=None) -> None:
+             cli_turn_fn=None, cancel: CancelToken | None = None) -> None:
     turn_fn = turn_fn or run_api_turn
     capability_fn = capability_fn or supports_native_tools
     cli_turn_fn = cli_turn_fn or run_cli_turn
+    cancel = cancel or CancelToken()
     emit = lambda frame: repository.append_event(request.session_id, frame)  # noqa: E731
     try:
         skill_name, text = _split_skill(request.text)
@@ -141,7 +143,7 @@ def run_turn(request: TurnRequest, *, repository: AssistantRepository,
                 ),
                 session_id=request.session_id,
                 prior_session_id=(repository.get_session(request.session_id) or {}).get("cli_session_id"),
-                repository=repository, emit=emit,
+                repository=repository, emit=emit, cancel=cancel,
             )
         else:
             config = ApiTurnConfig(
@@ -159,9 +161,15 @@ def run_turn(request: TurnRequest, *, repository: AssistantRepository,
             if write_on:
                 register_write_tools(registry, tool_ctx)
             final = turn_fn(messages=messages, config=config,
-                            registry=registry, emit=emit)
+                            registry=registry, emit=emit, cancel=cancel)
         repository.add_message(request.session_id, "assistant", final)
         emit({"type": "done"})
+    except TurnCancelled as exc:
+        # User-initiated stop, not a failure. Persist any partial answer so
+        # the next turn's replayed history matches what the user saw.
+        if exc.partial:
+            repository.add_message(request.session_id, "assistant", exc.partial)
+        emit({"type": "stopped"})
     except Exception as exc:  # noqa: BLE001 - turn thread must never die silently
         _logger.exception("assistant turn failed for session %s", request.session_id)
         emit({"type": "error", "message": str(exc)})

--- a/src/quodeq/ui/src/api/assistant.js
+++ b/src/quodeq/ui/src/api/assistant.js
@@ -9,6 +9,11 @@ export function postAssistantMessage(sessionId, body) {
     { method: 'POST', body: JSON.stringify(body) });
 }
 
+export function stopAssistantTurn(sessionId) {
+  return request(`/assistant/sessions/${encodeURIComponent(sessionId)}/stop`,
+    { method: 'POST' });
+}
+
 export function applyAssistantAction(actionId) {
   return request(`/assistant/actions/${encodeURIComponent(actionId)}/apply`, { method: 'POST' });
 }

--- a/src/quodeq/ui/src/components/CopyButton.jsx
+++ b/src/quodeq/ui/src/components/CopyButton.jsx
@@ -88,6 +88,15 @@ export function PencilIcon() {
   );
 }
 
+// Filled square: stop the in-flight assistant turn.
+export function StopIcon() {
+  return (
+    <svg width={ICON_SIZE} height={ICON_SIZE} viewBox={ICON_VIEWBOX} fill="currentColor" stroke="none" aria-hidden="true">
+      <rect x="6" y="6" width="12" height="12" rx="2" />
+    </svg>
+  );
+}
+
 export default function CopyButton({ onClick, label, className, icon, 'aria-label': ariaLabel }) {
   const [copied, setCopied] = useState(false);
 

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawer.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawer.jsx
@@ -4,6 +4,7 @@ import { MessageList } from './MessageList.jsx';
 import { CommandMenu } from './CommandMenu.jsx';
 import { AssistantWelcome } from './AssistantWelcome.jsx';
 import { buildMetaResponse, matchCommands, parseMetaCommand } from './commands.js';
+import { StopIcon } from '../../components/CopyButton.jsx';
 
 /**
  * Residual assistant content rendered inside the shared BottomDrawer host.
@@ -17,7 +18,7 @@ import { buildMetaResponse, matchCommands, parseMetaCommand } from './commands.j
  */
 export function AssistantPane({ uiState }) {
   const {
-    messages, streaming, error, sendMessage,
+    messages, streaming, error, sendMessage, stopTurn,
     catalog, addLocalExchange, resetConversation,
   } = useAssistantDrawer();
   const [draft, setDraft] = useState('');
@@ -84,6 +85,13 @@ export function AssistantPane({ uiState }) {
           disabled={streaming}
           rows={1}
         />
+        {streaming && (
+          <button type="button" className="assistant-stop-btn"
+            onClick={stopTurn}
+            aria-label="Stop generating" title="Stop generating">
+            <StopIcon />
+          </button>
+        )}
       </div>
     </>
   );

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawer.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawer.test.jsx
@@ -12,7 +12,7 @@ const state = {
     { role: 'local', text: '**Commands** listed' },
     { role: 'tool', name: 'get_report', argsSummary: '{"dimension":"security"}' },
   ],
-  streaming: false, error: null, sendMessage: vi.fn(),
+  streaming: false, error: null, sendMessage: vi.fn(), stopTurn: vi.fn(),
   catalog: null, addLocalExchange: vi.fn(), resetConversation: vi.fn(),
 };
 vi.mock('./AssistantDrawerProvider.jsx', () => ({ useAssistantDrawer: () => state }));
@@ -21,6 +21,7 @@ import { AssistantPane } from './AssistantDrawer.jsx';
 
 beforeEach(() => {
   state.sendMessage.mockClear();
+  state.stopTurn.mockClear();
   state.addLocalExchange.mockClear();
   state.resetConversation.mockClear();
 });
@@ -90,4 +91,17 @@ it('shows the welcome panel when the transcript is empty', () => {
   render(<AssistantPane uiState={{ view: 'overview' }} />);
   expect(screen.getByText(/explain scores/i)).toBeInTheDocument();
   state.messages = prev;
+});
+
+it('shows a Stop control while a turn is streaming and it stops the turn', () => {
+  state.streaming = true;
+  render(<AssistantPane uiState={{}} />);
+  fireEvent.click(screen.getByRole('button', { name: /stop/i }));
+  expect(state.stopTurn).toHaveBeenCalled();
+  state.streaming = false;
+});
+
+it('hides the Stop control when no turn is running', () => {
+  render(<AssistantPane uiState={{}} />);
+  expect(screen.queryByRole('button', { name: /stop/i })).toBeNull();
 });

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { createAssistantSession, fetchAssistantCatalog, fetchAssistantWorkspace, postAssistantMessage } from '../../api/assistant.js';
+import { createAssistantSession, fetchAssistantCatalog, fetchAssistantWorkspace, postAssistantMessage, stopAssistantTurn } from '../../api/assistant.js';
 import useAssistantProvider from '../settings/hooks/useAssistantProvider.js';
 import useTerminalSettings from '../settings/hooks/useTerminalSettings.js';
 import { useAssistantStream } from './useAssistantStream.js';
@@ -287,6 +287,18 @@ export function AssistantDrawerProvider({ children }) {
     }
   }, [sessionId, stream.messages.length, webEnabled, writeEnabled]);
 
+  // Ask the server to cancel the in-flight turn. turnActive stays true until
+  // the stream's terminal `stopped` frame arrives (server truth, same as
+  // done/error), so the UI can't unlock before the turn thread actually ends.
+  const stopTurn = useCallback(async () => {
+    if (!sessionId || !turnActive) return;
+    try {
+      await stopAssistantTurn(sessionId);
+    } catch (err) {
+      setLocalError(`Couldn't stop the turn: ${err?.message || err}`);
+    }
+  }, [sessionId, turnActive]);
+
   // Client-answered meta-commands (/help, /skills, /actions): show the user
   // turn and the local response in the transcript without any server call.
   const addLocalExchange = useCallback((userText, responseText) => {
@@ -312,8 +324,8 @@ export function AssistantDrawerProvider({ children }) {
     writeEnabled, toggleWriteEnabled, repoInfo, workspace, refreshWorkspace,
     sessionId,
     catalog, addLocalExchange,
-    startSession, sendMessage, resetConversation,
-  }), [isOpen, open, close, toggle, closeActiveTab, openPanels, activeTab, openTab, selectTab, toggleTopbar, terminalEnabled, height, setHeight, maximized, toggleMaximized, messages, turnActive, stream.error, localError, sessionId, sessionMeta, webEnabled, toggleWebEnabled, writeEnabled, toggleWriteEnabled, repoInfo, workspace, refreshWorkspace, catalog, addLocalExchange, startSession, sendMessage, resetConversation]);
+    startSession, sendMessage, stopTurn, resetConversation,
+  }), [isOpen, open, close, toggle, closeActiveTab, openPanels, activeTab, openTab, selectTab, toggleTopbar, terminalEnabled, height, setHeight, maximized, toggleMaximized, messages, turnActive, stream.error, localError, sessionId, sessionMeta, webEnabled, toggleWebEnabled, writeEnabled, toggleWriteEnabled, repoInfo, workspace, refreshWorkspace, catalog, addLocalExchange, startSession, sendMessage, stopTurn, resetConversation]);
 
   return (
     <AssistantDrawerContext.Provider value={value}>

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.test.jsx
@@ -5,6 +5,7 @@ import { AssistantDrawerProvider, useAssistantDrawer } from './AssistantDrawerPr
 vi.mock('../../api/assistant.js', () => ({
   createAssistantSession: vi.fn(async () => ({ sessionId: 's1' })),
   postAssistantMessage: vi.fn(async () => ({ accepted: true })),
+  stopAssistantTurn: vi.fn(async () => ({ stopping: true })),
   assistantEventsUrl: (id, a) => `/api/assistant/sessions/${id}/events?after=${a}`,
   fetchAssistantCatalog: vi.fn(async () => ({ commands: [], skills: [], actions: [] })),
 }));
@@ -15,7 +16,7 @@ vi.mock('./useAssistantStream.js', () => ({
     return { messages: [], streaming: false, error: null, reset: vi.fn() };
   },
 }));
-import { createAssistantSession, postAssistantMessage, fetchAssistantCatalog } from '../../api/assistant.js';
+import { createAssistantSession, postAssistantMessage, stopAssistantTurn, fetchAssistantCatalog } from '../../api/assistant.js';
 
 function Probe() {
   const d = useAssistantDrawer();
@@ -36,6 +37,7 @@ function Probe() {
       <button onClick={d.toggle}>toggle</button>
       <button onClick={() => d.openTab('assistant')}>openAssistant</button>
       <button onClick={() => d.sendMessage('hi', { activeTab: 'overview' })}>send</button>
+      <button onClick={d.stopTurn}>stop</button>
       <button onClick={d.resetConversation}>reset</button>
       <button onClick={() => d.addLocalExchange?.('/help', 'HELP TEXT')}>localExchange</button>
     </div>
@@ -219,4 +221,28 @@ it('addLocalExchange appends a user and a local message', async () => {
   expect(hookRef.messages).toHaveLength(2);
   expect(hookRef.messages[0]).toMatchObject({ role: 'user', text: '/help', atIndex: 0 });
   expect(hookRef.messages[1]).toMatchObject({ role: 'local', text: 'HELP TEXT', atIndex: 0 });
+});
+
+it('stopTurn posts a stop for the active session while a turn is in flight', async () => {
+  render(<AssistantDrawerProvider><Probe /></AssistantDrawerProvider>);
+  await act(async () => { screen.getByText('start').click(); });
+  await act(async () => { screen.getByText('send').click(); });   // turn in flight
+  await act(async () => { screen.getByText('stop').click(); });
+  expect(stopAssistantTurn).toHaveBeenCalledWith('s1');
+});
+
+it('stopTurn is a no-op when no turn is in flight', async () => {
+  render(<AssistantDrawerProvider><Probe /></AssistantDrawerProvider>);
+  await act(async () => { screen.getByText('start').click(); });
+  await act(async () => { screen.getByText('stop').click(); });   // nothing running
+  expect(stopAssistantTurn).not.toHaveBeenCalled();
+});
+
+it('stopTurn failure surfaces an error instead of dying silently', async () => {
+  stopAssistantTurn.mockRejectedValueOnce(new Error('stop failed'));
+  render(<AssistantDrawerProvider><Probe /></AssistantDrawerProvider>);
+  await act(async () => { screen.getByText('start').click(); });
+  await act(async () => { screen.getByText('send').click(); });
+  await act(async () => { screen.getByText('stop').click(); });
+  expect(screen.getByTestId('error').textContent).toContain('stop failed');
 });

--- a/src/quodeq/ui/src/features/assistant/useAssistantStream.js
+++ b/src/quodeq/ui/src/features/assistant/useAssistantStream.js
@@ -78,6 +78,10 @@ export function useAssistantStream(sessionId, { onDone } = {}) {
         append({ role: 'action', actionId: frame.actionId, actionType: frame.actionType, summary: frame.summary }); }
       else if (frame.type === 'warning') { beginContent(); flushTokens(); append({ role: 'warning', message: frame.message }); }
       else if (frame.type === 'error') { flushTokens(); setError(frame.message || 'error'); endTurn(); }
+      // User-initiated stop: terminal like done (turn over, stream stays
+      // open), plus a visible marker so the truncated answer isn't mistaken
+      // for a complete one.
+      else if (frame.type === 'stopped') { flushTokens(); append({ role: 'warning', message: 'Stopped.' }); endTurn(); }
       else if (frame.type === 'done') { endTurn(); }
       else if (frame.type === 'heartbeat') { /* liveness only: resetInactivity() already ran above */ }
     };

--- a/src/quodeq/ui/src/features/assistant/useAssistantStream.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/useAssistantStream.test.jsx
@@ -159,3 +159,21 @@ it('a null JSON payload frame is ignored instead of crashing', () => {
   expect(result.current.messages.length).toBe(0);
   expect(result.current.error).toBe(null);
 });
+
+it('a stopped frame ends the turn with a stop marker, not an error', () => {
+  const onDone = vi.fn();
+  const { result } = renderHook(() => useAssistantStream('s1', { onDone }));
+  const es = MockES.instances[0];
+  act(() => { es.emit('message', { type: 'token', text: 'partial' }); });
+  flush();
+  act(() => { es.emit('message', { type: 'stopped' }); });
+  flush();
+  expect(result.current.streaming).toBe(false);
+  expect(result.current.error).toBeNull();
+  expect(onDone).toHaveBeenCalledTimes(1);
+  // the partial answer stays, followed by a visible stop marker
+  expect(result.current.messages.find((m) => m.role === 'assistant').text).toBe('partial');
+  expect(result.current.messages.some((m) => m.role === 'warning' && /stopped/i.test(m.message))).toBe(true);
+  // the connection survives for the next turn, like done
+  expect(es.closed).toBeFalsy();
+});

--- a/src/quodeq/ui/src/styles/assistant.css
+++ b/src/quodeq/ui/src/styles/assistant.css
@@ -385,6 +385,30 @@
   cursor: not-allowed;
 }
 
+/* Stop button: overlays the right edge of the (disabled) input while a turn
+   streams. The row is position:relative, so anchor to it. */
+.assistant-stop-btn {
+  position: absolute;
+  right: 1.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 0.375rem;
+  background: var(--color-surface-alt);
+  color: var(--color-accent);
+  cursor: pointer;
+}
+
+.assistant-stop-btn:hover {
+  border-color: var(--color-accent);
+}
+
 .sr-only {
   position: absolute;
   width: 1px;

--- a/tests/api/test_assistant_routes.py
+++ b/tests/api/test_assistant_routes.py
@@ -667,3 +667,50 @@ def test_create_session_write_unavailable_for_unsafe_provider(client, monkeypatc
     data = resp.get_json()
     assert data["repoAttached"] is True
     assert data["writeAvailable"] is False
+
+
+# ---- stop-turn endpoint -----------------------------------------------------
+
+def test_stop_unknown_session_404(client):
+    assert client.post("/api/assistant/sessions/nope/stop").status_code == 404
+
+
+def test_stop_without_running_turn_409(client):
+    sid = client.post("/api/assistant/sessions",
+                      json={"provider": "ollama", "model": "m"}).get_json()["sessionId"]
+    resp = client.post(f"/api/assistant/sessions/{sid}/stop")
+    assert resp.status_code == 409
+
+
+def test_stop_cancels_running_turn_and_frees_the_token(client, monkeypatch):
+    import threading
+    started, finished = threading.Event(), threading.Event()
+
+    def fake_run_turn(request, *, repository, tool_ctx, cancel, **kw):
+        started.set()
+        assert cancel.wait(timeout=5)  # blocks until the stop route cancels
+        finished.set()
+
+    monkeypatch.setattr("quodeq.api.assistant_routes.run_turn", fake_run_turn)
+    sid = client.post("/api/assistant/sessions",
+                      json={"provider": "ollama", "model": "m"}).get_json()["sessionId"]
+    assert client.post(f"/api/assistant/sessions/{sid}/messages",
+                       json={"text": "hi"}).status_code == 202
+    assert started.wait(timeout=5)
+
+    resp = client.post(f"/api/assistant/sessions/{sid}/stop")
+    assert resp.status_code == 202
+    assert resp.get_json() == {"stopping": True}
+    assert finished.wait(timeout=5)
+
+    # once the worker unwinds, the token is gone: a second stop has nothing to
+    # cancel, and a new message can claim the turn slot again
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        if client.post(f"/api/assistant/sessions/{sid}/stop").status_code == 409:
+            break
+        time.sleep(0.01)
+    else:
+        pytest.fail("cancel token not cleaned up after the turn ended")
+    assert client.post(f"/api/assistant/sessions/{sid}/messages",
+                       json={"text": "again"}).status_code == 202

--- a/tests/assistant/test_api_adapter.py
+++ b/tests/assistant/test_api_adapter.py
@@ -154,3 +154,130 @@ def test_extra_body_openai_uses_reasoning_effort(monkeypatch):
     assert body["reasoning_effort"] == "none"
     assert "chat_template_kwargs" not in body
     assert "num_ctx" not in body
+
+
+# ---- stop-turn cancellation -------------------------------------------------
+
+class ClosableFakeClient(FakeClient):
+    def __init__(self, scripts):
+        super().__init__(scripts)
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def test_cancel_mid_stream_raises_turn_cancelled_with_partial():
+    import pytest
+    from quodeq.assistant.cancel import CancelToken, TurnCancelled
+    token = CancelToken()
+    client = ClosableFakeClient([[_delta("Hel"), _delta("lo"), _delta(finish="stop")]])
+    frames = []
+
+    def emit(frame):
+        frames.append(frame)
+        token.cancel()  # user hits Stop after the first streamed token
+
+    with pytest.raises(TurnCancelled) as exc:
+        run_api_turn(messages=[{"role": "user", "content": "hi"}],
+                     config=_config(), registry=_registry(),
+                     emit=emit, client_factory=lambda c: client, cancel=token)
+    assert exc.value.partial == "Hel"
+    assert [f["text"] for f in frames if f["type"] == "token"] == ["Hel"]
+
+
+def test_precancelled_closes_client_and_skips_request():
+    import pytest
+    from quodeq.assistant.cancel import CancelToken, TurnCancelled
+    token = CancelToken()
+    token.cancel()
+    client = ClosableFakeClient([])
+
+    with pytest.raises(TurnCancelled) as exc:
+        run_api_turn(messages=[{"role": "user", "content": "hi"}],
+                     config=_config(), registry=_registry(),
+                     emit=lambda f: None, client_factory=lambda c: client, cancel=token)
+    assert exc.value.partial == ""
+    assert client.calls == []      # never asked the model anything
+    assert client.closed is True   # kill hook ran immediately
+
+
+def test_stream_error_while_cancelled_is_turn_cancelled():
+    # cancel() closes the HTTP client to interrupt a stalled stream; the read
+    # then raises in the turn thread. That exception is the cancellation
+    # succeeding, not a turn failure.
+    import pytest
+    from quodeq.assistant.cancel import CancelToken, TurnCancelled
+    token = CancelToken()
+
+    def dying_stream():
+        yield _delta("Hel")
+        raise RuntimeError("connection closed mid-read")
+
+    client = ClosableFakeClient([dying_stream()])
+
+    def emit(frame):
+        token.cancel()
+
+    with pytest.raises(TurnCancelled) as exc:
+        run_api_turn(messages=[{"role": "user", "content": "hi"}],
+                     config=_config(), registry=_registry(),
+                     emit=emit, client_factory=lambda c: client, cancel=token)
+    assert exc.value.partial == "Hel"
+
+
+def test_stream_error_without_cancel_still_raises():
+    import pytest
+
+    def dying_stream():
+        yield _delta("Hel")
+        raise RuntimeError("connection dropped")
+
+    client = ClosableFakeClient([dying_stream()])
+    with pytest.raises(RuntimeError, match="connection dropped"):
+        run_api_turn(messages=[{"role": "user", "content": "hi"}],
+                     config=_config(), registry=_registry(),
+                     emit=lambda f: None, client_factory=lambda c: client)
+
+
+def test_cancel_interrupts_a_stalled_stream_read():
+    # Live-repro regression: cancel() while the turn thread is BLOCKED inside
+    # the chunk read (model stalled / connection wedged). Closing the client
+    # from another thread does not reliably wake a blocked socket read, so the
+    # turn must not depend on another chunk arriving to notice the cancel.
+    import threading
+    import time
+    import pytest
+    from quodeq.assistant.cancel import CancelToken, TurnCancelled
+    token = CancelToken()
+    release = threading.Event()
+
+    def stalled_stream():
+        yield _delta("Hel")
+        release.wait(timeout=30)  # blocks like a dead connection: no data, no EOF
+        yield _delta("lo")
+
+    client = ClosableFakeClient([stalled_stream()])
+    outcome = {}
+
+    def _turn():
+        try:
+            run_api_turn(messages=[{"role": "user", "content": "hi"}],
+                         config=_config(), registry=_registry(),
+                         emit=lambda f: None, client_factory=lambda c: client,
+                         cancel=token)
+            outcome["result"] = "returned"
+        except TurnCancelled as exc:
+            outcome["result"] = "cancelled"
+            outcome["partial"] = exc.partial
+
+    t = threading.Thread(target=_turn, daemon=True)
+    t.start()
+    time.sleep(0.3)   # let the turn consume "Hel" and block in the stalled read
+    token.cancel()
+    t.join(timeout=3)
+    release.set()     # unblock the abandoned reader so the test process exits clean
+    if t.is_alive():
+        pytest.fail("turn thread still blocked 3s after cancel()")
+    assert outcome["result"] == "cancelled"
+    assert outcome["partial"] == "Hel"

--- a/tests/assistant/test_cancel.py
+++ b/tests/assistant/test_cancel.py
@@ -1,0 +1,60 @@
+"""CancelToken / TurnCancelled: the stop-turn signalling primitives."""
+from quodeq.assistant.cancel import CancelToken, TurnCancelled
+
+
+def test_token_starts_uncancelled():
+    assert CancelToken().cancelled is False
+
+
+def test_cancel_sets_flag_and_runs_registered_hooks():
+    token = CancelToken()
+    hits = []
+    token.register_kill(lambda: hits.append("kill"))
+    token.cancel()
+    assert token.cancelled is True
+    assert hits == ["kill"]
+
+
+def test_register_after_cancel_runs_hook_immediately():
+    # Covers the stop-races-turn-startup window: the adapter registers its
+    # kill hook after the route already cancelled the token.
+    token = CancelToken()
+    token.cancel()
+    hits = []
+    token.register_kill(lambda: hits.append("late"))
+    assert hits == ["late"]
+
+
+def test_hook_exception_does_not_block_other_hooks():
+    token = CancelToken()
+    hits = []
+
+    def boom():
+        raise RuntimeError("kill failed")
+
+    token.register_kill(boom)
+    token.register_kill(lambda: hits.append("second"))
+    token.cancel()
+    assert token.cancelled is True
+    assert hits == ["second"]
+
+
+def test_cancel_is_idempotent_and_hooks_run_once():
+    token = CancelToken()
+    hits = []
+    token.register_kill(lambda: hits.append(1))
+    token.cancel()
+    token.cancel()
+    assert hits == [1]
+
+
+def test_wait_reflects_cancellation():
+    token = CancelToken()
+    assert token.wait(timeout=0.01) is False
+    token.cancel()
+    assert token.wait(timeout=0.01) is True
+
+
+def test_turn_cancelled_carries_partial_text():
+    assert TurnCancelled("partial answer").partial == "partial answer"
+    assert TurnCancelled().partial == ""

--- a/tests/assistant/test_cli_adapter.py
+++ b/tests/assistant/test_cli_adapter.py
@@ -417,3 +417,88 @@ def test_non_json_cli_error_line_raises_message(tmp_path):
         run_cli_turn(messages=[{"role": "user", "content": "hi"}], config=_config(tmp_path),
                      session_id="s1", prior_session_id=None, repository=repo,
                      emit=lambda f: None, spawn_fn=lambda argv, *, cwd, env: FakeProc(lines, returncode=1))
+
+
+# ---- stop-turn cancellation -------------------------------------------------
+
+def test_cancel_mid_turn_raises_turn_cancelled_with_partial(tmp_path):
+    from quodeq.assistant.cancel import CancelToken, TurnCancelled
+    repo = _repo(tmp_path)
+    token = CancelToken()
+    lines = [
+        '{"type": "assistant", "message": {"content": [{"type": "text", "text": "Hel"}]}}',
+        '{"type": "result", "result": "Hello"}',
+    ]
+
+    def emit(frame):
+        token.cancel()  # user hits Stop right after the first streamed token
+
+    with pytest.raises(TurnCancelled) as exc:
+        run_cli_turn(messages=[{"role": "user", "content": "hi"}],
+                     config=_config(tmp_path), session_id="s1", prior_session_id=None,
+                     repository=repo, emit=emit, cancel=token,
+                     spawn_fn=lambda argv, *, cwd, env: FakeProc(lines))
+    assert exc.value.partial == "Hello"
+
+
+def test_cancel_kills_the_cli_process(tmp_path):
+    from quodeq.assistant.cancel import CancelToken, TurnCancelled
+    repo = _repo(tmp_path)
+    token = CancelToken()
+    proc = FakeProc(['{"type": "assistant", "message": {"content": [{"type": "text", "text": "x"}]}}'])
+
+    def emit(frame):
+        token.cancel()
+
+    with pytest.raises(TurnCancelled):
+        run_cli_turn(messages=[{"role": "user", "content": "hi"}],
+                     config=_config(tmp_path), session_id="s1", prior_session_id=None,
+                     repository=repo, emit=emit, cancel=token,
+                     spawn_fn=lambda argv, *, cwd, env: proc)
+    # the token's kill hook (not the exit-path cleanup: poll() reports the
+    # scripted proc as already exited) must have killed the process tree
+    assert proc.killed is True
+
+
+def test_precancelled_token_spawns_nothing(tmp_path):
+    from quodeq.assistant.cancel import CancelToken, TurnCancelled
+    repo = _repo(tmp_path)
+    token = CancelToken()
+    token.cancel()
+    spawns = []
+
+    def spawn(argv, *, cwd, env):
+        spawns.append(argv)
+        return FakeProc([])
+
+    with pytest.raises(TurnCancelled):
+        run_cli_turn(messages=[{"role": "user", "content": "hi"}],
+                     config=_config(tmp_path), session_id="s1", prior_session_id=None,
+                     repository=repo, emit=lambda f: None, cancel=token, spawn_fn=spawn)
+    assert spawns == []
+
+
+def test_cancelled_turn_never_rebuilds(tmp_path):
+    # A cancelled resumed turn that produced no text must raise TurnCancelled,
+    # NOT trigger the empty-output session rebuild (which would rerun the whole
+    # turn against the model the user just stopped).
+    from quodeq.assistant.cancel import CancelToken, TurnCancelled
+    repo = _repo(tmp_path)
+    token = CancelToken()
+    spawns = []
+    tool_line = ('{"type": "assistant", "message": {"content": '
+                 '[{"type": "tool_use", "name": "get_scores", "input": {}}]}}')
+
+    def spawn(argv, *, cwd, env):
+        spawns.append(argv)
+        return FakeProc([tool_line])
+
+    def emit(frame):
+        token.cancel()  # stop lands during the tool call, before any text
+
+    with pytest.raises(TurnCancelled) as exc:
+        run_cli_turn(messages=[{"role": "user", "content": "hi"}],
+                     config=_config(tmp_path), session_id="s1", prior_session_id="old-sid",
+                     repository=repo, emit=emit, cancel=token, spawn_fn=spawn)
+    assert len(spawns) == 1
+    assert exc.value.partial == ""

--- a/tests/assistant/test_orchestrator.py
+++ b/tests/assistant/test_orchestrator.py
@@ -255,7 +255,7 @@ def test_cli_config_carries_system_prompt_and_skill_block(setup):
     repo, ctx = setup
     captured = {}
 
-    def fake_cli(*, messages, config, session_id, prior_session_id, repository, emit):
+    def fake_cli(*, messages, config, session_id, prior_session_id, repository, emit, **_):
         captured["config"] = config
         return "answer"
 
@@ -272,7 +272,7 @@ def test_cli_config_skill_block_empty_without_skill(setup):
     repo, ctx = setup
     captured = {}
 
-    def fake_cli(*, messages, config, session_id, prior_session_id, repository, emit):
+    def fake_cli(*, messages, config, session_id, prior_session_id, repository, emit, **_):
         captured["config"] = config
         return "answer"
 
@@ -288,7 +288,7 @@ def test_skill_turns_get_extra_iterations(setup):
     repo, ctx = setup
     captured = {}
 
-    def fake_api(*, messages, config, registry, emit):
+    def fake_api(*, messages, config, registry, emit, **_):
         captured["config"] = config
         return "ok"
 
@@ -303,3 +303,64 @@ def test_skill_turns_get_extra_iterations(setup):
                           provider="ollama", model="m")
     run_turn(request, repository=repo, tool_ctx=ctx, turn_fn=fake_api)
     assert captured["config"].max_tool_iterations == 6
+
+
+# ---- stop-turn cancellation -------------------------------------------------
+
+def test_cancelled_cli_turn_emits_stopped_and_persists_partial(setup, monkeypatch):
+    from quodeq.assistant.cancel import TurnCancelled
+    repo, ctx = setup
+    monkeypatch.setattr("quodeq.assistant.orchestrator.get_provider_configs",
+                        lambda: {"claude": {"type": "cli"}})
+
+    def cancelled_cli_turn(**kwargs):
+        raise TurnCancelled("partial answer")
+
+    monkeypatch.setattr("quodeq.assistant.orchestrator.run_cli_turn", cancelled_cli_turn)
+    req = TurnRequest(session_id="s1", text="hi", ui_state=None, api_base="", api_key=None,
+                      provider="claude", model="sonnet")
+    run_turn(req, repository=repo, tool_ctx=ctx)
+    msgs = repo.list_messages("s1")
+    # the partial answer the user watched stream must survive in the history
+    assert (msgs[-1]["role"], msgs[-1]["content"]) == ("assistant", "partial answer")
+    frames = [f for _, f in repo.events_after("s1", 0)]
+    assert frames[-1]["type"] == "stopped"
+    assert not any(f["type"] == "error" for f in frames)
+
+
+def test_cancelled_turn_without_partial_persists_no_assistant_message(setup):
+    from quodeq.assistant.cancel import TurnCancelled
+    repo, ctx = setup
+
+    def cancelled_turn(**_):
+        raise TurnCancelled("")
+
+    run_turn(_request(), repository=repo, tool_ctx=ctx, turn_fn=cancelled_turn,
+             capability_fn=lambda *a, **k: True)
+    assert [m["role"] for m in repo.list_messages("s1")] == ["user"]
+    frames = [f for _, f in repo.events_after("s1", 0)]
+    assert frames[-1]["type"] == "stopped"
+
+
+def test_run_turn_threads_cancel_token_to_adapter(setup):
+    from quodeq.assistant.cancel import CancelToken
+    repo, ctx = setup
+    seen = {}
+
+    def fake_turn(*, cancel, **_):
+        seen["default"] = cancel
+        return "hi"
+
+    run_turn(_request(), repository=repo, tool_ctx=ctx, turn_fn=fake_turn,
+             capability_fn=lambda *a, **k: True)
+    assert isinstance(seen["default"], CancelToken)
+
+    token = CancelToken()
+
+    def fake_turn2(*, cancel, **_):
+        seen["explicit"] = cancel
+        return "hi"
+
+    run_turn(_request(), repository=repo, tool_ctx=ctx, turn_fn=fake_turn2,
+             capability_fn=lambda *a, **k: True, cancel=token)
+    assert seen["explicit"] is token

--- a/tests/assistant/test_orchestrator_write.py
+++ b/tests/assistant/test_orchestrator_write.py
@@ -38,7 +38,7 @@ def _request(write_enabled):
 
 
 def _capture_turn(seen):
-    def fake_turn(*, messages, config, registry, emit):
+    def fake_turn(*, messages, config, registry, emit, **_):
         seen["names"] = registry.names()
         seen["iters"] = config.max_tool_iterations
         seen["system"] = messages[0]["content"]
@@ -82,7 +82,7 @@ def test_cli_branch_passes_write_args(tmp_path, repo, monkeypatch):
     seen = {}
 
     def fake_cli_turn(*, messages, config, session_id, prior_session_id,
-                      repository, emit):
+                      repository, emit, **_):
         seen["args"] = config.mcp_server_args
         seen["worktree_dir"] = config.worktree_dir
         return "ok"
@@ -104,7 +104,7 @@ def test_write_enabled_gemini_turn_stays_read_only(tmp_path, repo, monkeypatch):
     seen = {}
 
     def fake_cli_turn(*, messages, config, session_id, prior_session_id,
-                      repository, emit):
+                      repository, emit, **_):
         seen["args"] = config.mcp_server_args
         seen["worktree_dir"] = config.worktree_dir
         seen["system"] = messages[0]["content"]

--- a/tests/assistant/test_write_flow_e2e.py
+++ b/tests/assistant/test_write_flow_e2e.py
@@ -27,7 +27,7 @@ def test_edit_diff_apply_roundtrip(tmp_path, monkeypatch):
         evaluators_dir=tmp_path / "e", compiled_dir=tmp_path / "c",
         dimensions_file=tmp_path / "d.json", project_id="proj")
 
-    def scripted_model_turn(*, messages, config, registry, emit):
+    def scripted_model_turn(*, messages, config, registry, emit, **_):
         # the "model": edit a file, self-review the diff, report done
         out = registry.dispatch("edit_repo_file", {
             "path": "app.py", "old_string": "x = 1", "new_string": "x = 2"})


### PR DESCRIPTION
## What

A running assistant turn could not be cancelled: a hung or slow turn blocked the session (every new message 409s "a turn is already running") until the CLI adapter's 300s watchdog fired, and "New conversation" is disabled while streaming, exactly when you want out. This PR adds a stop-square button in the composer while a turn streams, backed by `POST /api/assistant/sessions/<sid>/stop`.

## How

- **`assistant/cancel.py`**: `CancelToken` (cooperative flag + kill hooks that run immediately if registered after the cancel, covering stop-races-startup) and `TurnCancelled` (carries the partial answer).
- **Routes**: per-session token registry next to `_running_turns`; stop returns 404 (unknown session), 409 (nothing running), or 202. The SSE `stopped` frame is the authoritative end-of-turn signal.
- **CLI adapter**: cancel kills the turn's process tree; a cancelled turn raises `TurnCancelled` instead of triggering the empty-output session rebuild (which would rerun the turn the user just stopped) or a bogus error.
- **API adapter**: chunks are consumed through a daemon reader thread + queue so the turn thread polls the token every 250ms even while a read is blocked.
- **Orchestrator**: on `TurnCancelled`, persists the partial answer (history matches what the user saw) and emits a terminal `stopped` frame.
- **UI**: stop button posts /stop and waits for the server's frame (no optimistic unlock); the `stopped` frame ends the turn like `done`, keeps the SSE open, and appends a "Stopped." marker so a truncated answer isn't mistaken for a complete one.

## The bug the first implementation had (and its regression test)

The obvious approach, registering `client.close()` as the kill hook and polling per chunk, failed live: closing the httpx client from another thread does not wake a thread blocked in a socket read on macOS. The turn thread hung inside the read (token flow froze, no terminal frame, slot claimed until the 500s read timeout). `test_cancel_interrupts_a_stalled_stream_read` reproduces exactly that and pins the reader-thread fix; `client.close()` remains as a best-effort nudge to stop the model generating.

## Testing

- TDD throughout: 20 new tests (token primitives, both adapters incl. the stalled-read repro, orchestrator stopped-frame semantics, route lifecycle incl. token cleanup, stream hook, provider, composer).
- Full suites green: 4437 backend, 858 frontend.
- Live-verified against Ollama gemma4:12b-mlx in the dev dashboard: stopped a streaming turn in ~2s (partial answer + "Stopped." marker, input unlocked), then a follow-up turn completed normally, proving the slot was freed.

Sibling PR: #777 (drawer hide chevron).

🤖 Generated with [Claude Code](https://claude.com/claude-code)