### PR TITLE
fix(assistant): apply dismiss/delete rescore to assistant read tools

### DIFF
--- a/src/quodeq/assistant/tools/_overview.py
+++ b/src/quodeq/assistant/tools/_overview.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from quodeq.assistant.tools._context import ToolContext
 from quodeq.assistant.tools._registry import ToolError, ToolRegistry, ToolSpec
 from quodeq.services import _fs_reports
+from quodeq.services.scoring import rescore_accumulated
 
 
 def _get_overview(ctx: ToolContext, as_of: str | None = None) -> dict:
@@ -23,6 +24,11 @@ def _get_overview(ctx: ToolContext, as_of: str | None = None) -> dict:
     payload = _fs_reports.get_accumulated(str(ctx.reports_dir), ctx.project_id, as_of)
     if payload is None:
         raise ToolError(f"no accumulated data for project: {ctx.project_id}")
+    # Project-wide dismiss/delete rescore: the raw accumulated payload keeps
+    # the baked pre-triage scores, so without this the assistant quotes lower
+    # scores than the Overview shows for the same project (no-op when the
+    # project has no active dismissals/deletions).
+    payload = rescore_accumulated(payload, ctx.reports_dir, ctx.project_id)
     dimensions = [
         {
             "dimension": d.get("dimension"),

--- a/src/quodeq/assistant/tools/_read_tools.py
+++ b/src/quodeq/assistant/tools/_read_tools.py
@@ -6,8 +6,12 @@ import json
 
 from quodeq.assistant.tools._context import ToolContext
 from quodeq.assistant.tools._registry import ToolError, ToolRegistry, ToolSpec
+from quodeq.core.types import to_camel_dict
 from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
 from quodeq.services import _fs_reports
+from quodeq.services.deleted import deleted_keys
+from quodeq.services.dismissed import dismissed_keys
+from quodeq.services.scoring import rescore_accumulated, scored_run_dimensions
 from quodeq.services.standards import StandardsService
 
 def _require_run(ctx: ToolContext):
@@ -24,20 +28,52 @@ def _has_run(ctx: ToolContext) -> bool:
     return ctx.run_dir is not None and ctx.run_dir.exists()
 
 
-def _accumulated_dims(ctx: ToolContext) -> list[dict] | None:
+def _accumulated_dims(ctx: ToolContext, *, rescored: bool = True) -> list[dict] | None:
     """Per-dimension-latest composition (the dashboard/overview data).
 
     Each entry is one dimension sourced from ITS OWN latest run — so the set
     can span several runs, exactly like the dashboard. Carries overallScore/
     Grade, principles, violations and the source run (``fromRunId``). Returns
     None when the session has no project scope.
+
+    By default the project-wide dismiss/delete rescore is applied so the
+    scores the model quotes match the Overview (``get_project_scores``) — the
+    raw ``compute_accumulated`` payload filters dismissed violations from the
+    lists but leaves the baked pre-triage scores untouched.
+    ``rescored=False`` returns that raw payload; it exists for
+    ``finding_keys_in_scope``, which must keep seeing every finding a
+    dismiss/verify key could legitimately reference.
     """
     if ctx.reports_dir is None or ctx.project_id is None:
         return None
     payload = _fs_reports.get_accumulated(str(ctx.reports_dir), ctx.project_id, None)
     if payload is None:
         return None
+    if rescored:
+        payload = rescore_accumulated(payload, ctx.reports_dir, ctx.project_id)
     return payload.get("dimensions", []) or []
+
+
+def _scored_run_dims(ctx: ToolContext) -> list[dict] | None:
+    """The selected run's dimensions with the project-wide dismiss/delete
+    rescore applied, as camelCase dicts.
+
+    Routes through ``scored_run_dimensions`` — the same seam the explorer,
+    dashboard and dimension detail read through — so the assistant quotes the
+    same dismiss-adjusted score as every UI surface. Returns None when the
+    project has no active dismissals/deletions (callers keep the raw eval-JSON
+    read: byte-identical output, no parse round-trip) or when the run's
+    location can't be resolved against the reports tree (fail-open: raw data
+    beats erroring the chat turn).
+    """
+    project_dir = ctx.run_dir.parent
+    try:
+        if not dismissed_keys(project_dir) and not deleted_keys(project_dir):
+            return None
+        dims = scored_run_dimensions(project_dir.parent, project_dir.name, ctx.run_dir.name)
+    except Exception:  # noqa: BLE001 - unresolvable layout: serve raw, not a ToolError
+        return None
+    return [to_camel_dict(d) for d in dims]
 
 
 def _no_scope_error() -> ToolError:
@@ -149,7 +185,10 @@ def finding_keys_in_scope(ctx: ToolContext) -> set[tuple]:
                 pass
     else:
         try:
-            for d in (_accumulated_dims(ctx) or []):
+            # rescored=False: the identity check must keep seeing every finding
+            # a dismiss/verify key could reference, including already-dismissed
+            # ones (idempotent re-dismiss / verify must still match).
+            for d in (_accumulated_dims(ctx, rescored=False) or []):
                 for v in (d.get("violations") or []):
                     _add(v)
         except (ToolError, OSError, ValueError):
@@ -181,6 +220,11 @@ def _get_scores(ctx: ToolContext) -> dict:
         eval_dir = ctx.run_dir / "evaluation"
         if not eval_dir.is_dir():
             raise ToolError("no evaluation reports in this run")
+        scored = _scored_run_dims(ctx)
+        if scored is not None:
+            return {d["dimension"]: {
+                "score": d.get("overallScore"), "grade": d.get("overallGrade"),
+            } for d in scored if d.get("dimension")}
         out = {}
         for path in sorted(eval_dir.glob("*.json")):
             data = json.loads(path.read_text(encoding="utf-8"))
@@ -207,6 +251,19 @@ def _get_report(ctx: ToolContext, dimension: str) -> dict:
                ("dimension", "overallScore", "overallGrade", "principles",
                 "totals", "coveragePct")}
         viols = data.get("violations") or []
+        scored = _scored_run_dims(ctx)
+        if scored is not None:
+            entry = next((d for d in scored if d.get("dimension") == dimension), None)
+            if entry is not None:
+                # Swap in the dismiss-adjusted fields; keep the raw report's
+                # shape (coveragePct etc.) untouched. Principles get the same
+                # "name" normalization as the accumulated branch below.
+                out["overallScore"] = entry.get("overallScore")
+                out["overallGrade"] = entry.get("overallGrade")
+                out["principles"] = [{**p, "name": p.get("name") or p.get("principle")}
+                                     for p in (entry.get("principles") or [])]
+                out["totals"] = entry.get("totals")
+                viols = entry.get("violations") or []
         out["violations"] = [_trim_violation(v) for v in viols[:_REPORT_VIOLATION_CAP]]
         return out
     dims = _accumulated_dims(ctx)
@@ -269,11 +326,19 @@ def _violations_from_run(ctx: ToolContext, dimension: str | None):
                 f"no report for dimension: {dimension} in this run. "
                 "Check get_scores for available dimensions, or get_overview "
                 "for accumulated scores across runs.")
+        scored = _scored_run_dims(ctx)
+        if scored is not None:
+            entry = next((d for d in scored if d.get("dimension") == dimension), None)
+            if entry is not None:
+                return entry.get("violations") or [], dimension
         return json.loads(path.read_text(encoding="utf-8")).get("violations") or [], dimension
     if not eval_dir.is_dir():
         raise ToolError(
             "no evaluation reports in this run. Try get_overview for "
             "accumulated scores across runs.")
+    scored = _scored_run_dims(ctx)
+    if scored is not None:
+        return [v for d in scored for v in (d.get("violations") or [])], None
     raw: list = []
     for p in sorted(eval_dir.glob("*.json")):
         raw.extend(json.loads(p.read_text(encoding="utf-8")).get("violations") or [])

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -516,6 +516,30 @@ def _rescore_accumulated_response(
     return {**accumulated, "dimensions": new_dims, "summary": new_summary}
 
 
+def rescore_accumulated(
+    accumulated: dict[str, Any] | None,
+    reports_root: Path, project: str,
+    params: ScoringParams | None = None,
+) -> dict[str, Any] | None:
+    """Public seam: project-wide dismiss/delete rescore for an accumulated payload.
+
+    Callers that read ``compute_accumulated`` directly (rather than through
+    ``get_project_scores``) get scores that ignore dismissals/deletions --
+    ``filter_dismissed_from_dimensions`` drops the violations but leaves the
+    baked scores untouched. Route the payload through here so every consumer
+    reports the same dismiss-adjusted score as the Overview. No-op when the
+    project has no active dismissals or deletions.
+
+    When *params* is None the saved grade-formula params are loaded, matching
+    ``get_project_scores``.
+    """
+    if not accumulated:
+        return accumulated
+    if params is None:
+        params = load_params()
+    return _rescore_accumulated_response(accumulated, reports_root, project, params=params)
+
+
 def get_project_scores(
     reports_root: Path, project: str, as_of: str | None = None,
 ) -> dict[str, Any] | None:

--- a/tests/services/test_scoring_parity.py
+++ b/tests/services/test_scoring_parity.py
@@ -250,6 +250,92 @@ def test_deletion_actually_moves_the_card_score(tmp_path, monkeypatch):
     assert after > before, f"deleting the critical should raise the card score; {before} -> {after}"
 
 
+def _assistant_ctx(tmp_path, reports_root: Path, project: str, run_dir: Path | None):
+    """A real assistant ToolContext over the parity fixture's project."""
+    from quodeq.assistant.tools import ToolContext
+    from quodeq.data.sqlite.assistant_repository import AssistantRepository
+
+    repo = AssistantRepository(tmp_path / "assistant.db")
+    repo.create_session(session_id="s1", provider="ollama")
+    return ToolContext(
+        repository=repo, session_id="s1", run_dir=run_dir, repo_root=None,
+        evaluators_dir=tmp_path / "e", compiled_dir=tmp_path / "c",
+        dimensions_file=tmp_path / "d.json",
+        project_id=project, reports_dir=reports_root,
+    )
+
+
+def test_assistant_tools_agree_after_dismissal(tmp_path):
+    """The assistant's read tools serve the dismiss-adjusted score everywhere.
+
+    Regression: the assistant tool layer was another missed read path in the
+    same class as the dashboard/trend/card disparities. ``get_scores`` /
+    ``get_report`` / ``get_violations`` (run scope) read the raw eval JSON, and
+    the accumulated scope plus ``get_overview`` read ``compute_accumulated``
+    WITHOUT the project-wide rescore -- so the assistant quoted raw pre-triage
+    scores (and re-surfaced dismissed findings) while the Overview showed the
+    dismiss-adjusted grade.
+    """
+    from dataclasses import replace as dc_replace
+
+    from quodeq.assistant.tools import build_registry
+
+    reports_root = tmp_path / "evaluations"
+    project = "proj-uuid"
+    run_dir = _build_run_with_violations(reports_root, project)
+    _dismiss_and_freeze_sql(
+        reports_root / project, run_dir, {"req": "R1", "file": "a.py", "line": 1})
+
+    # Reference: the Overview's dismiss-adjusted accumulated score.
+    gps = get_project_scores(reports_root, project, None)
+    accumulated = _num(_perf_score(gps["accumulated"]["dimensions"]))
+    assert accumulated is not None
+
+    # Run scope: get_scores / get_report / get_violations.
+    run_ctx = _assistant_ctx(tmp_path, reports_root, project, run_dir)
+    run_reg = build_registry(run_ctx)
+    scores = run_reg.dispatch("get_scores", {})["result"]
+    assert _num(scores[_DIM]["score"]) == accumulated, (
+        f"assistant run-scope get_scores {scores[_DIM]['score']} != accumulated {accumulated}")
+
+    report = run_reg.dispatch("get_report", {"dimension": _DIM})["result"]
+    assert _num(report["overallScore"]) == accumulated
+    assert not any(v["file"] == "a.py" and v["line"] == 1 for v in report["violations"]), (
+        "dismissed finding must not resurface in assistant get_report")
+
+    viols = run_reg.dispatch("get_violations", {"dimension": _DIM})["result"]
+    assert viols["count"] == 4, "get_violations must exclude the dismissed finding"
+
+    # Overview (accumulated) scope: get_scores + get_overview.
+    over_ctx = dc_replace(run_ctx, run_dir=None)
+    over_reg = build_registry(over_ctx)
+    over_scores = over_reg.dispatch("get_scores", {})["result"]
+    assert _num(over_scores[_DIM]["score"]) == accumulated, (
+        f"assistant overview get_scores {over_scores[_DIM]['score']} != accumulated {accumulated}")
+
+    overview = over_reg.dispatch("get_overview", {})["result"]
+    over_dim = next(d for d in overview["dimensions"] if d["dimension"] == _DIM)
+    assert _num(over_dim["score"]) == accumulated, (
+        f"assistant get_overview {over_dim['score']} != accumulated {accumulated}")
+
+
+def test_dismissed_finding_stays_in_assistant_action_scope(tmp_path):
+    """Rescoring the read tools must NOT hide dismissed findings from the
+    dismiss/verify identity check -- ``finding_keys_in_scope`` keeps reading the
+    raw sources so an action targeting an already-dismissed finding still
+    matches (idempotent re-dismiss / verify)."""
+    from quodeq.assistant.tools._read_tools import finding_keys_in_scope
+
+    reports_root = tmp_path / "evaluations"
+    project = "proj-uuid"
+    run_dir = _build_run_with_violations(reports_root, project)
+    _dismiss_and_freeze_sql(
+        reports_root / project, run_dir, {"req": "R1", "file": "a.py", "line": 1})
+
+    run_ctx = _assistant_ctx(tmp_path, reports_root, project, run_dir)
+    assert ("R1", "a.py", 1) in finding_keys_in_scope(run_ctx)
+
+
 def test_dismissal_actually_moves_the_score(tmp_path):
     """Guard: the fixture's dismissal genuinely changes the score.
 


### PR DESCRIPTION
## Problem

Asking the assistant about security on the quodeq project returned "4.6/10 Poor, Authenticity 1.9/10 critical" while the Overview showed 8.1/10 Good for the same project, and the assistant re-listed path-traversal findings already triaged and dismissed as false positives.

## Root cause

The assistant read tools were another missed read path in the known scoring-disparity class (#735 dashboard detail, #738 trend, #744 project card):

- **Overview scope**: `_accumulated_dims` / `get_overview` read `compute_accumulated` directly. That payload filters dismissed violations from the lists but explicitly leaves scores untouched (`filter_dismissed_from_dimensions`: "Leaves compliance, principles, overall_score, overall_grade unchanged"). The Overview's `/scores` applies `_rescore_accumulated_response` on top; the assistant never did.
- **Run scope**: `get_scores`/`get_report`/`get_violations` read the raw eval JSON straight off disk, so neither scores nor violation lists reflected dismissals/deletions.

## Fix

- New public seam `scoring.rescore_accumulated(...)` (wraps the same `_rescore_accumulated_response` the Overview uses); applied in `_accumulated_dims` and `_get_overview`. No-op when the project has no active dismissals/deletions, so the monkeypatched-fixture tests and untriaged projects are byte-identical.
- Run scope routes through `scored_run_dimensions` (the shared explorer/dashboard/dimension-detail seam), gated on active dismiss/delete keys; fail-open to the raw read when the run's location can't be resolved.
- `finding_keys_in_scope` pinned to the raw payload (`rescored=False`) so dismiss/verify identity matching keeps seeing already-dismissed findings.

## Verification

Real-data check on the 212-run quodeq project (d33f1fd0):

| Path | Security |
|---|---|
| raw accumulated (old assistant path) | 4.6/10 Poor |
| Overview /scores (reference) | 8.1/10 Good |
| assistant get_scores / get_overview / get_report (fixed) | 8.1/10 Good |

- `test_scoring_parity.py` extended with the assistant tools (the coverage gap that let this slip) + a guard that dismissed findings stay visible to the dismiss/verify identity check.
- Full suite: 4444 passed, 1 skipped.

## Blast radius

Assistant tool layer only. `_fs_reports.get_accumulated` itself is unchanged; its other consumer (the legacy `/api/projects/<p>/accumulated` endpoint, no remaining UI callers) keeps current behavior. All UI/dashboard/scoring endpoints untouched.