### PR TITLE
fix(terminal): deflake WS terminal tests (handshake frame coalescing + lock-release ordering)

### DIFF
--- a/src/quodeq/api/terminal_routes.py
+++ b/src/quodeq/api/terminal_routes.py
@@ -111,11 +111,11 @@ def register_terminal_routes(app: Flask, manager: TerminalManager | None = None)
                     ws.send("0" + sb)
             except Exception:
                 # Spawn failure or early disconnect must not propagate past
-                # flask-sock (would surface as a 500); close cleanly instead.
-                try:
-                    ws.close()
-                except Exception:
-                    pass
+                # flask-sock (would surface as a 500). Don't close here:
+                # flask-sock sends the close frame after this handler returns,
+                # i.e. after the outer finally has released _conn_lock, so a
+                # client that reconnects the instant it sees the close finds
+                # the lock free instead of a spurious "already open" refusal.
                 return
 
             stop = threading.Event()

--- a/tests/api/test_terminal_routes.py
+++ b/tests/api/test_terminal_routes.py
@@ -167,7 +167,7 @@ def _serve(manager):
 def _connect(port):
     # werkzeug's WS handshake exposes request.host without the port, so the
     # Origin must match that (browsers keep Host+Origin consistent for real).
-    c = simple_websocket.Client(
+    c = _Client(
         f"ws://127.0.0.1:{port}/api/terminal/ws",
         headers={"Origin": "http://127.0.0.1"})
     try:
@@ -177,15 +177,42 @@ def _connect(port):
             c.close()
 
 
+# Receive timeouts are upper bounds, not waits: generous so a CPU-starved
+# server thread (full-suite load) can't turn a passing test into a flake.
+_RECV_TIMEOUT = 10
+
+
+if _WS_OK:
+    class _Client(simple_websocket.Client):
+        """Work around a simple-websocket (<= 1.1.0) client handshake bug.
+
+        Client.handshake() feeds recv'd bytes to wsproto but consumes only the
+        first event (AcceptConnection). Our server sends scrollback (and maybe
+        a close) microseconds after the 101, so under suite load those frames
+        coalesce into the same recv: their events stay queued inside wsproto
+        while the reader thread blocks on recv() for bytes that never come,
+        and receive() times out — the flake this suite used to have.
+        """
+        def handshake(self):
+            super().handshake()
+            # Drain events queued during the handshake. Safe: the reader
+            # thread only starts after handshake() returns. A drained server
+            # close sets connected=False, which would make Base.__init__
+            # raise — undo that and let the reader thread see EOF instead;
+            # close_reason is already recorded for ConnectionClosed.
+            self._handle_events()
+            self.connected = True
+
+
 @_ws_test
 def test_ws_single_active_connection_refuses_second():
     with _serve(_LiveManager()) as port:
         with _connect(port) as a:
-            assert a.receive(timeout=2) == "0ready\n"   # A acquired the conn lock
+            assert a.receive(timeout=_RECV_TIMEOUT) == "0ready\n"   # A acquired the conn lock
             with _connect(port) as b:
                 msg = None
                 with contextlib.suppress(simple_websocket.ConnectionClosed):
-                    msg = b.receive(timeout=2)
+                    msg = b.receive(timeout=_RECV_TIMEOUT)
                 assert msg is not None and "already open" in msg
 
 
@@ -225,7 +252,7 @@ def test_ws_spawn_failure_closes_cleanly_and_frees_lock():
     with _serve(_FlakyManager()) as port:
         with _connect(port) as first:       # ensure_session raises -> clean close
             with contextlib.suppress(simple_websocket.ConnectionClosed):
-                first.receive(timeout=2)    # must not hang / must not 500
+                first.receive(timeout=_RECV_TIMEOUT)    # must not hang / must not 500
         # the conn lock's finally released even though spawn failed -> reattach works
         with _connect(port) as second:
-            assert second.receive(timeout=2) == "0ready\n"
+            assert second.receive(timeout=_RECV_TIMEOUT) == "0ready\n"


### PR DESCRIPTION
## Summary

`tests/api/test_terminal_routes.py::test_ws_spawn_failure_closes_cleanly_and_frees_lock` failed intermittently during full-suite runs while passing in isolation. Investigation found two independent issues:

### Root cause 1 (primary): simple-websocket client handshake swallows coalesced frames
simple-websocket (<= 1.1.0) `Client.handshake()` consumes only the first wsproto event (the `AcceptConnection`). The terminal server sends scrollback microseconds after the 101, so under CPU load the data frame arrives coalesced in the same TCP read as the handshake response: its event stays queued inside wsproto while the client reader thread blocks on `recv()` — `receive()` then times out. A timestamped repro shows the server send completing *before* the client finishes the handshake, followed by 10s of silence.

**Fix:** a `_Client` test subclass drains the queued events right after the handshake (the reader thread has not started yet, so this is single-threaded) and keeps the constructor alive when a server close was drained. Receive timeouts also go 2s -> 10s (upper bounds only — the module still runs in ~3s).

### Root cause 2 (secondary): close frame sent before conn-lock release
The spawn-failure path closed the WebSocket explicitly and only released `_conn_lock` afterwards in the outer `finally`. A client reconnecting the instant it sees the close frame could hit a spurious "already open in another window" refusal. A 50ms delay probe between close and release reproduced the reported assertion 100% of the time.

**Fix:** don't close explicitly on spawn failure — flask-sock sends the close frame after the handler returns, i.e. after the lock release, giving a proper happens-before edge.

## Verification
- Pre-fix: 16–17 of 40 module runs failed under 10 CPU-burner processes; post-fix: **0 of 40** under identical load.
- Green with adversarial 50ms delay probes at both preemption points.
- Full suite passes (one unrelated pre-existing flake in `tests/ci/test_cli_signals.py`, tracked separately).