### PR TITLE
fix(lifecycle): eliminate SIGTERM races in run status handling

### DIFF
--- a/src/quodeq/shared/run_lifecycle.py
+++ b/src/quodeq/shared/run_lifecycle.py
@@ -80,11 +80,16 @@ class RunLifecycleContext:
 
     def __enter__(self) -> "RunLifecycleContext":
         cancellation.reset()
-        self._write(RunState.PENDING)
-        self._seed_dimension_states()
+        # Handlers and the atexit fallback must be in place before status.json
+        # first appears on disk: external cancellers (dashboard, e2e tests)
+        # treat its existence as "safe to signal", so a SIGTERM landing in the
+        # gap would hit the default handler and kill the run with the status
+        # stuck at pending.
         self._install_signal_handlers()
         atexit.register(self._finalize_on_atexit)
         self._atexit_registered = True
+        self._write(RunState.PENDING)
+        self._seed_dimension_states()
         self._transition(RunState.RUNNING)
         self._heartbeat.start()
         self._resources.start()

--- a/src/quodeq/shared/run_status.py
+++ b/src/quodeq/shared/run_status.py
@@ -47,7 +47,13 @@ _ALLOWED_TRANSITIONS: dict[RunState, frozenset[RunState]] = {
     RunState.CANCELLED: frozenset(),
 }
 
-_write_lock = threading.Lock()
+# Reentrant: the lifecycle SIGINT/SIGTERM handler runs on the main thread and
+# writes status itself. A plain Lock deadlocks when the signal interrupts a
+# frame that is already inside write_status holding the lock. Cross-thread
+# exclusion is unchanged; the atomic tmp+rename keeps reentrant interleaving
+# consistent (the handler raises SystemExit, so the interrupted write's
+# remaining statements never run).
+_write_lock = threading.RLock()
 
 
 class IllegalTransitionError(RuntimeError):

--- a/tests/ci/test_cli_signals.py
+++ b/tests/ci/test_cli_signals.py
@@ -7,10 +7,14 @@ impossible to reliably send SIGTERM while the process is still alive via
 external polling.
 
 We therefore use a thin wrapper script (written to *tmp_path* per-test) that
-monkey-patches ``quodeq.analysis._pipeline._run_dry_run`` to sleep for one
-second before returning, giving us a reliable window in which to deliver
-SIGTERM.  This avoids touching production code while still exercising the
-real signal-handling path in ``RunLifecycleContext``.
+monkey-patches ``quodeq.analysis._pipeline._run_dry_run`` to write a ready
+marker and then sleep before returning. The test waits for the marker — not
+merely for status.json to exist — which guarantees the child is inside the
+interruptible pause with the lifecycle signal handlers installed before
+SIGTERM is sent. The pause is generous (tens of seconds) because SIGTERM cuts
+it short; it is a ceiling, not a duration. This avoids touching production
+code while still exercising the real signal-handling path in
+``RunLifecycleContext``.
 """
 from __future__ import annotations
 
@@ -35,17 +39,18 @@ pytestmark = pytest.mark.timeout(180)
 # ---------------------------------------------------------------------------
 
 _WRAPPER_TEMPLATE = textwrap.dedent("""\
-    \"\"\"Thin wrapper: patches dry-run to sleep so SIGTERM can interrupt it.\"\"\"
+    \"\"\"Thin wrapper: patches dry-run to pause so SIGTERM can interrupt it.\"\"\"
     import sys, time
-    from unittest.mock import patch
-
-    # Patch _run_dry_run to sleep for {pause}s before returning, so an
-    # external SIGTERM has a reliable window to arrive.
-    _orig = None
+    from pathlib import Path
 
     def _slow_dry_run(*args, **kwargs):
         import quodeq.analysis._pipeline as _pl
         result = _pl.__dict__["_run_dry_run_orig"](*args, **kwargs)
+        # Handshake: tell the test we are mid-run with the lifecycle signal
+        # handlers live, then linger in an interruptible sleep. SIGTERM cuts
+        # the sleep short, so {pause}s is a ceiling, not a duration — it is
+        # only waited out if signal delivery fails entirely.
+        Path({marker!r}).touch()
         time.sleep({pause})
         return result
 
@@ -58,10 +63,10 @@ _WRAPPER_TEMPLATE = textwrap.dedent("""\
 """)
 
 
-def _write_wrapper(tmp_path: Path, pause: float = 1.0) -> Path:
-    """Write a wrapper script that slows the dry-run and return its path."""
+def _write_wrapper(tmp_path: Path, marker: Path, pause: float = 45.0) -> Path:
+    """Write a wrapper script that pauses the dry-run and return its path."""
     script = tmp_path / "_slow_cli.py"
-    script.write_text(_WRAPPER_TEMPLATE.format(pause=pause))
+    script.write_text(_WRAPPER_TEMPLATE.format(marker=str(marker), pause=pause))
     return script
 
 
@@ -90,7 +95,8 @@ def test_sigterm_writes_cancelled_status(tmp_path: Path) -> None:
     reports = tmp_path / "reports"
     reports.mkdir()
 
-    wrapper = _write_wrapper(tmp_path, pause=1.0)
+    marker = tmp_path / "sigterm_ready"
+    wrapper = _write_wrapper(tmp_path, marker)
     env = {**os.environ, "QUODEQ_EVALUATIONS_DIR": str(reports)}
 
     proc = subprocess.Popen(
@@ -98,21 +104,28 @@ def test_sigterm_writes_cancelled_status(tmp_path: Path) -> None:
         cwd=tmp_path, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
     )
 
-    # Wait for run_dir + status.json to exist (up to 10 s).
-    run_dir: Path | None = None
-    for _ in range(200):
-        projects = [d for d in reports.iterdir() if d.is_dir()]
-        if projects:
-            runs = [d for d in projects[0].iterdir() if d.is_dir()]
-            if runs and (runs[0] / "status.json").exists():
-                run_dir = runs[0]
-                break
+    # Wait for the handshake marker: it is written from inside the paused
+    # dry-run, so once it exists the child is guaranteed to be inside the
+    # lifecycle context with signal handlers installed and the run_dir
+    # (including status.json) already on disk.
+    deadline = time.monotonic() + 60
+    while not marker.exists():
+        if proc.poll() is not None:
+            _out, err = proc.communicate()
+            pytest.fail(f"CLI exited before reaching the dry-run pause: {err.decode()}")
+        if time.monotonic() > deadline:
+            proc.kill()
+            proc.wait()
+            pytest.fail("CLI did not reach the dry-run pause within 60 s")
         time.sleep(0.05)
 
-    if run_dir is None:
+    projects = [d for d in reports.iterdir() if d.is_dir()]
+    runs = [d for d in projects[0].iterdir() if d.is_dir()] if projects else []
+    if not runs or not (runs[0] / "status.json").exists():
         proc.kill()
         proc.wait()
-        pytest.fail("CLI did not create status.json within 10 s")
+        pytest.fail("run_dir/status.json missing even though the dry-run pause was reached")
+    run_dir = runs[0]
 
     # Send SIGTERM and wait for process to exit.
     proc.send_signal(signal.SIGTERM)

--- a/tests/shared/test_run_lifecycle.py
+++ b/tests/shared/test_run_lifecycle.py
@@ -88,6 +88,71 @@ def test_signal_handler_sets_process_cancel_event(tmp_path: Path) -> None:
         cancellation.reset()
 
 
+@_POSIX_SIGNALS
+def test_signal_handlers_installed_before_first_status_write(tmp_path: Path) -> None:
+    """Handlers must be live before status.json first appears on disk.
+
+    External cancellers (dashboard, e2e tests) treat the existence of
+    status.json as "safe to SIGTERM". If __enter__ wrote the file before
+    installing handlers, a signal landing in that gap would hit the default
+    handler and kill the run with the status stuck at pending.
+    """
+    from quodeq.shared import run_lifecycle as rl
+
+    order: list[str] = []
+    real_signal = signal.signal
+    real_write = rl.write_status
+
+    def recording_signal(sig, handler):
+        order.append("install")
+        return real_signal(sig, handler)
+
+    def recording_write(*args, **kwargs):
+        order.append("write")
+        return real_write(*args, **kwargs)
+
+    with patch.object(rl.signal, "signal", side_effect=recording_signal), \
+         patch.object(rl, "write_status", side_effect=recording_write):
+        with _ctx(tmp_path):
+            pass
+
+    assert "install" in order and "write" in order
+    assert order.index("install") < order.index("write")
+
+
+@_POSIX_SIGNALS
+@pytest.mark.timeout(30)
+def test_sigterm_mid_status_write_does_not_deadlock(tmp_path: Path) -> None:
+    """A signal interrupting a status write must not deadlock the handler.
+
+    The SIGTERM handler runs on the main thread and writes status.json
+    itself. When the interrupted frame is already inside write_status
+    holding the module write lock, a non-reentrant lock blocks the handler
+    forever — observed as the CLI never exiting after SIGTERM under
+    full-suite load.
+    """
+    import os
+
+    fired = {"done": False}
+    orig_replace = Path.replace
+
+    def replace_and_signal(self, target):
+        if not fired["done"] and self.name == "status.json.tmp":
+            fired["done"] = True
+            # Delivered to the main thread while _write_lock is held; the
+            # handler runs at the next bytecode boundary, still inside it.
+            os.kill(os.getpid(), signal.SIGTERM)
+        return orig_replace(self, target)
+
+    with pytest.raises(SystemExit):
+        with _ctx(tmp_path) as ctx:
+            with patch.object(Path, "replace", replace_and_signal):
+                ctx.set_phase("analyzing")
+    status = read_status(tmp_path)
+    assert status["state"] == "cancelled"
+    assert status["exit_reason"] == "signal_SIGTERM"
+
+
 def test_context_enter_resets_stale_cancel_event(tmp_path: Path) -> None:
     """Entering a new lifecycle context must clear leftover cancel state
     so a second run in the same process does not see cancellation from the first."""


### PR DESCRIPTION
## Problem

`tests/ci/test_cli_signals.py::test_sigterm_writes_cancelled_status` failed intermittently during full-suite runs but passed in isolation. Reproduced under 12-way CPU load: 3/25 failures, all hanging with **"CLI did not exit after SIGTERM within 30 s"**.

Investigation found two real bugs in the production signal path, both reproduced deterministically:

1. **Signal-handler deadlock.** The SIGTERM handler runs on the main thread and writes `status.json` itself. If the signal interrupts a frame that is already inside `write_status` holding the module `_write_lock` (a non-reentrant `threading.Lock`) — likely exactly when an external canceller reacts to `status.json` appearing, since the process does several rapid status writes at startup — the handler blocks on that lock forever. The CLI never exits and the run is stranded in a non-terminal state.

2. **Handlers installed after status.json appears.** `RunLifecycleContext.__enter__` wrote `status.json` (pending) before installing signal handlers. Any canceller that treats the file's existence as "safe to signal" (the dashboard, the e2e test) could hit the default SIGTERM handler in that gap, killing the run with status stuck at `pending`. Widening the gap to 0.5 s reproduced this 100%.

## Fix

- `run_status._write_lock` is now an `RLock`: same-thread reentry from the handler proceeds instead of deadlocking, cross-thread exclusion is unchanged, and the atomic tmp+rename keeps the file consistent (the handler raises `SystemExit`, so the interrupted write's rename never runs).
- `__enter__` installs signal handlers and the atexit fallback **before** the first status write.

## Tests

- Two new regression tests in `tests/shared/test_run_lifecycle.py`: handler-install-before-first-write ordering, and a real SIGTERM delivered mid-status-write (fails by deadlock/timeout on the old code).
- `test_cli_signals.py` no longer races `status.json` existence against a 1 s sleep: the wrapper writes a ready marker from inside the paused dry-run (guaranteeing handlers are live), and the pause is a 45 s interruptible ceiling that SIGTERM cuts short — the test still completes in under a second.

## Verification

- Single test: 25/25 under full CPU load (22/25 before the fix).
- `tests/ci` + `tests/shared` 3× under load: 305 passed each run.
- Full suite: 4426 passed, 8 skipped.