### PR TITLE
fix(analysis): enforce the API file-size cap at enumeration, not silently at dispatch

### DIFF
--- a/src/quodeq/analysis/_dim_estimates.py
+++ b/src/quodeq/analysis/_dim_estimates.py
@@ -30,12 +30,14 @@ from typing import Any
 
 from quodeq.analysis._types import RunConfig
 from quodeq.analysis.cache import LocalFileBackend, classify_files_via_cache
+from quodeq.analysis.dispatch_policy import api_file_size_cap
 from quodeq.analysis.subagents._source_files import _list_source_files
 from quodeq.shared.dim_estimates_io import (
     DIM_ESTIMATES_FILENAME,
     read_dim_estimates,
     write_dim_estimates,
 )
+from quodeq.shared.logging import log_info
 
 __all__ = [
     "DIM_ESTIMATES_FILENAME",
@@ -58,10 +60,24 @@ def compute_dim_estimates(
     estimates: dict[str, dict[str, Any]] = {}
     file_filter = config.options.incremental_file_filter
     cache = LocalFileBackend()
+    excluded_logged = False
     for dim_id in dimensions:
-        files, _ext = _list_source_files(config, dim_id, ignore_file_filter=True)
+        files, _ext, excluded = _list_source_files(config, dim_id, ignore_file_filter=True)
+        n_excluded = len(excluded)
+        if n_excluded and not excluded_logged:
+            # The excluded set is dim-agnostic (size cap only), so log it
+            # once per run, not once per dimension.
+            log_info(
+                f"  {n_excluded} file(s) excluded from analysis: over the API "
+                f"file-size cap ({api_file_size_cap()} bytes). Raise "
+                f"QUODEQ_MAX_API_FILE_SIZE to include them."
+            )
+            excluded_logged = True
         if not files:
-            estimates[dim_id] = {"count": 0, "reason": "empty", "total": 0, "cached": 0}
+            estimates[dim_id] = {
+                "count": 0, "reason": "empty", "total": 0, "cached": 0,
+                "excluded": n_excluded,
+            }
             continue
         if config.options.incremental:
             classify = classify_files_via_cache(config, dim_id, files, cache)
@@ -74,10 +90,17 @@ def compute_dim_estimates(
             estimates[dim_id] = {
                 "count": miss_count, "reason": reason,
                 "total": len(files), "cached": len(files) - miss_count,
+                "excluded": n_excluded,
             }
         elif file_filter is not None:
             count = sum(1 for f in files if f in file_filter)
-            estimates[dim_id] = {"count": count, "reason": "diff", "total": count, "cached": 0}
+            estimates[dim_id] = {
+                "count": count, "reason": "diff", "total": count, "cached": 0,
+                "excluded": n_excluded,
+            }
         else:
-            estimates[dim_id] = {"count": len(files), "reason": "full", "total": len(files), "cached": 0}
+            estimates[dim_id] = {
+                "count": len(files), "reason": "full", "total": len(files), "cached": 0,
+                "excluded": n_excluded,
+            }
     return estimates

--- a/src/quodeq/analysis/_types.py
+++ b/src/quodeq/analysis/_types.py
@@ -83,10 +83,27 @@ class RunConfig:
 
     @property
     def source_file_count(self) -> int:
-        """Derive source file count from the target or manifest."""
+        """Files the active provider can actually analyze.
+
+        This is the coverage denominator (``coveragePct = files_read /
+        source_file_count``). For API providers, files over the dispatch
+        size cap can never be read, so counting them would pin coverage
+        below 100% forever; they are excluded here to match what the
+        queue/estimates enumerate. CLI providers have no cap and keep the
+        raw manifest count.
+        """
         if self.target:
-            return self.target.total_files
-        return self.manifest.total_files if self.manifest else 0
+            files, total = self.target.source_files, self.target.total_files
+        elif self.manifest:
+            files, total = self.manifest.source_files, self.manifest.total_files
+        else:
+            return 0
+        # Late import: dispatch_policy reads provider config; keep _types a leaf.
+        from quodeq.analysis import dispatch_policy  # noqa: PLC0415
+        if not files or not dispatch_policy.provider_is_api():
+            return total
+        dispatchable, _excluded = dispatch_policy.split_api_dispatchable(self.src, files)
+        return len(dispatchable)
 
 
 @dataclass(frozen=True)

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -232,7 +232,7 @@ def process_dimension_with_cache(
         # once per process. Best-effort: never blocks the run.
         maybe_collect_legacy_entries(cache.root)
 
-    files, _ext = _list_source_files(config, dim_id)
+    files, _ext, _excluded = _list_source_files(config, dim_id)
     if not files:
         # Nothing to classify — defer to existing path so the no-files
         # warning + single-agent fallback runs unchanged.

--- a/src/quodeq/analysis/dispatch_policy.py
+++ b/src/quodeq/analysis/dispatch_policy.py
@@ -1,0 +1,58 @@
+"""Single source of truth for which files an API provider can dispatch.
+
+API providers (Ollama, omlx, ...) inline file contents into the prompt, so
+oversized files cannot be dispatched and are capped by
+``QUODEQ_MAX_API_FILE_SIZE``. CLI providers (claude, gemini, codex) read
+files through their own tools and have no such cap.
+
+The queue builder / estimates (``_list_source_files``) and the dispatch-time
+worker (``_gather_api_source_files``) MUST share this predicate. When they
+diverged, files entered the queue, were taken, then silently dropped at
+dispatch: no ``file_done`` marker, no cache entry, re-queued as misses on
+every incremental run — and dim coverage never converged to 100%.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from quodeq.analysis._provider_cache import get_provider_configs
+from quodeq.shared.utils import get_ai_cmd
+
+_DEFAULT_MAX_API_FILE_SIZE = 15000
+
+
+def api_file_size_cap() -> int:
+    """Max file size (bytes, exclusive) an API provider will dispatch."""
+    raw = os.environ.get("QUODEQ_MAX_API_FILE_SIZE", "")
+    try:
+        return int(raw) if raw else _DEFAULT_MAX_API_FILE_SIZE
+    except ValueError:
+        return _DEFAULT_MAX_API_FILE_SIZE
+
+
+def provider_is_api(ai_cmd: str | None = None) -> bool:
+    """True when the active (or given) provider dispatches via direct API."""
+    cmd = ai_cmd or get_ai_cmd()
+    return get_provider_configs().get(cmd, {}).get("type", "cli") == "api"
+
+
+def split_api_dispatchable(
+    root: Path, rel_files: list[str],
+) -> tuple[list[str], list[str]]:
+    """Split *rel_files* into (dispatchable, excluded), preserving order.
+
+    A file is excluded when it is missing/unreadable or its size reaches
+    ``api_file_size_cap()`` — exactly the set an API worker cannot send.
+    """
+    cap = api_file_size_cap()
+    dispatchable: list[str] = []
+    excluded: list[str] = []
+    for f in rel_files:
+        try:
+            size = (root / f).stat().st_size
+        except OSError:
+            excluded.append(f)
+            continue
+        (dispatchable if size < cap else excluded).append(f)
+    return dispatchable, excluded

--- a/src/quodeq/analysis/mcp/router.py
+++ b/src/quodeq/analysis/mcp/router.py
@@ -149,9 +149,16 @@ class FindingsRouter:
             worker's completion record.
           - on ``status="error"``: the accumulated findings are popped and
             dropped without invoking the callback. The next run re-dispatches.
+          - on ``status="skipped"``: like ``error`` (no cache entry), but it
+            neither feeds the failure-streak breaker nor the post-run
+            reachability guard. Written for files the worker cannot dispatch
+            at all (API size cap / missing on disk) — an explicit record that
+            the file was considered, not a transient failure to retry loudly.
         """
-        if status not in ("ok", "error"):
-            raise ValueError(f"mark_file_done: status must be 'ok' or 'error', got {status!r}")
+        if status not in ("ok", "error", "skipped"):
+            raise ValueError(
+                f"mark_file_done: status must be 'ok', 'error', or 'skipped', got {status!r}"
+            )
         payload: dict = {"_marker": "file_done", "file": file, "status": status}
         if reason is not None:
             payload["reason"] = reason

--- a/src/quodeq/analysis/subagents/_consolidated.py
+++ b/src/quodeq/analysis/subagents/_consolidated.py
@@ -128,7 +128,7 @@ def process_consolidated_dimensions(
     evidence_dir = config.work_dir or config.src
 
     # 1. List source files
-    files, extensions = _list_source_files(config, dimensions[0])
+    files, extensions, _excluded = _list_source_files(config, dimensions[0])
     if not files:
         log_warning("No source files for consolidated analysis")
         return {}

--- a/src/quodeq/analysis/subagents/_source_files.py
+++ b/src/quodeq/analysis/subagents/_source_files.py
@@ -1,6 +1,7 @@
 """Source file listing and filtering for subagent queues."""
 from __future__ import annotations
 
+from quodeq.analysis import dispatch_policy
 from quodeq.analysis._types import RunConfig
 from quodeq.analysis.subagents.priority import PriorityContext, prioritize_files
 from quodeq.shared.logging import log_warning
@@ -8,11 +9,15 @@ from quodeq.shared.logging import log_warning
 
 def _list_source_files(
     config: RunConfig, dim_id: str, *, ignore_file_filter: bool = False,
-) -> tuple[list[str], set[str]]:
+) -> tuple[list[str], set[str], list[str]]:
     """List source files for the subagent queue from the target or manifest.
 
-    Returns (files, extensions) or ([], set()) if none found.
+    Returns (files, extensions, excluded) or ([], set(), []) if none found.
     Files are returned in priority order (most important first).
+
+    ``excluded`` holds files the active provider can never dispatch (API
+    size cap) — kept out of ``files`` so queues, estimates, and coverage
+    denominators all agree with what the worker will actually send.
     """
     # Prefer target-scoped files when available
     if config.target is not None and config.target.source_files:
@@ -22,7 +27,13 @@ def _list_source_files(
         files = config.manifest.source_files
         extensions = set(config.manifest.language_stats.keys()) if config.manifest.language_stats else set()
     else:
-        return [], set()
+        return [], set(), []
+
+    excluded: list[str] = []
+    if dispatch_policy.provider_is_api():
+        files, excluded = dispatch_policy.split_api_dispatchable(config.src, files)
+        if not files:
+            return [], extensions, excluded
 
     # Prioritize files: most important first
     category = None
@@ -47,4 +58,4 @@ def _list_source_files(
         filter_set = config.options.incremental_file_filter
         files = [f for f in files if f in filter_set]
 
-    return files, extensions
+    return files, extensions, excluded

--- a/src/quodeq/analysis/subagents/runner.py
+++ b/src/quodeq/analysis/subagents/runner.py
@@ -114,7 +114,7 @@ def process_dimension_with_subagents(
     """
     evidence_dir = config.work_dir or config.src
 
-    files, extensions = _list_source_files(config, dim_id)
+    files, extensions, _excluded = _list_source_files(config, dim_id)
     if not files:
         log_warning(
             f"[{idx}/{ctx.total}] {dim_id} -- no source files for subagent queue"

--- a/src/quodeq/analysis/subprocess.py
+++ b/src/quodeq/analysis/subprocess.py
@@ -101,7 +101,21 @@ def _run_cli_analysis(
         _check_process_result(process, stream_err)
 
 
-_MAX_API_PROMPT_CHARS = int(os.environ.get("QUODEQ_MAX_API_PROMPT_CHARS", "30000"))  # Target prompt size for local models (~8K tokens)
+_DEFAULT_MAX_API_PROMPT_CHARS = 30000  # Target inlined-file budget for local models (~8K tokens)
+
+
+def _api_prompt_char_budget() -> int:
+    """Max bytes of file content to inline per model call.
+
+    Read per call (not at import) so QUODEQ_MAX_API_PROMPT_CHARS can be
+    raised together with QUODEQ_MAX_API_FILE_SIZE / QUODEQ_CONTEXT_SIZE
+    when running larger-context models.
+    """
+    raw = os.environ.get("QUODEQ_MAX_API_PROMPT_CHARS", "")
+    try:
+        return int(raw) if raw else _DEFAULT_MAX_API_PROMPT_CHARS
+    except ValueError:
+        return _DEFAULT_MAX_API_PROMPT_CHARS
 
 
 def _load_skip_dirs() -> frozenset[str]:
@@ -158,7 +172,7 @@ def _gather_source_files(work_dir: Path) -> list[Path]:
     total_chars = 0
     for f in code_files + markup_files:
         size = stat_cache[f]
-        if total_chars + size > _MAX_API_PROMPT_CHARS:
+        if total_chars + size > _api_prompt_char_budget():
             continue
         selected.append(f)
         total_chars += size
@@ -346,6 +360,32 @@ def _gather_api_source_files(
     return _gather_source_files(work_dir)
 
 
+def _batch_files_by_size(files: list[Path], budget: int) -> list[list[Path]]:
+    """Greedy, order-preserving split so one model call's inlined file
+    content stays within *budget* bytes.
+
+    A single file over the budget still dispatches solo: the call may come
+    back truncated, but then only that file gets the error marker and
+    re-dispatches, instead of dragging its batchmates down with it.
+    """
+    batches: list[list[Path]] = []
+    current: list[Path] = []
+    current_size = 0
+    for f in files:
+        try:
+            size = f.stat().st_size
+        except OSError:
+            size = 0
+        if current and current_size + size > budget:
+            batches.append(current)
+            current, current_size = [], 0
+        current.append(f)
+        current_size += size
+    if current:
+        batches.append(current)
+    return batches
+
+
 def _run_api_analysis_bridge(
     work_dir: Path, prompt: str, stream_file: Path, cfg: AnalysisConfig,
 ) -> None:
@@ -353,8 +393,10 @@ def _run_api_analysis_bridge(
 
     Builds its own prompt using assemble_api_prompt() instead of the CLI
     prompt, which contains MCP tool-use instructions that confuse API models.
+    Files are dispatched in size-budgeted sub-batches (one model call each)
+    so a batch of large files cannot overflow the model context.
     """
-    from quodeq.analysis._api_runner import run_api_analysis, ApiRunnerConfig
+    from quodeq.analysis import _api_runner
 
     model, api_base, api_key = _resolve_provider_config(cfg)
 
@@ -370,38 +412,40 @@ def _run_api_analysis_bridge(
 
     overrides = load_project_overrides(work_dir)
     standards_text = _load_standards_text(cfg.compiled_dir, cfg.dimension, overrides=overrides)
-    api_prompt = assemble_api_prompt(
-        source_files=source_files,
-        standards_text=standards_text,
-        dimension=cfg.dimension or "general",
-        repo_name=str(work_dir.name),
-        repo_root=work_dir,
-    )
 
-    # POSIX-style separators: paths flow into findings (file fields,
-    # downstream JSONL projection) and into the prompt; the rest of the
-    # pipeline assumes forward slashes (path-role classifier, enrichment,
-    # SQLite store). Backslashes on Windows would break those joins.
-    rel_paths = [f.relative_to(work_dir).as_posix() for f in source_files]
-    run_api_analysis(
-        prompt=api_prompt,
-        jsonl_file=jsonl_file,
-        config=ApiRunnerConfig(
-            model=model,
-            api_base=api_base,
-            api_key=api_key,
-            context_size=cfg.context_size,
-        ),
-        compiled_dir=cfg.compiled_dir,
-        dimension=cfg.dimension,
-        work_dir=work_dir,
-        source_file_paths=rel_paths,
-        # Wire the synchronous cache-write closure when the pool layer
-        # supplied a RunConfig carrier. Legacy callers pass nothing and
-        # the API runner simply skips the cache write.
-        run_config=cfg.run_config,
-        dim_id=cfg.dimension,
-    )
+    for batch in _batch_files_by_size(source_files, _api_prompt_char_budget()):
+        api_prompt = assemble_api_prompt(
+            source_files=batch,
+            standards_text=standards_text,
+            dimension=cfg.dimension or "general",
+            repo_name=str(work_dir.name),
+            repo_root=work_dir,
+        )
+
+        # POSIX-style separators: paths flow into findings (file fields,
+        # downstream JSONL projection) and into the prompt; the rest of the
+        # pipeline assumes forward slashes (path-role classifier, enrichment,
+        # SQLite store). Backslashes on Windows would break those joins.
+        rel_paths = [f.relative_to(work_dir).as_posix() for f in batch]
+        _api_runner.run_api_analysis(
+            prompt=api_prompt,
+            jsonl_file=jsonl_file,
+            config=_api_runner.ApiRunnerConfig(
+                model=model,
+                api_base=api_base,
+                api_key=api_key,
+                context_size=cfg.context_size,
+            ),
+            compiled_dir=cfg.compiled_dir,
+            dimension=cfg.dimension,
+            work_dir=work_dir,
+            source_file_paths=rel_paths,
+            # Wire the synchronous cache-write closure when the pool layer
+            # supplied a RunConfig carrier. Legacy callers pass nothing and
+            # the API runner simply skips the cache write.
+            run_config=cfg.run_config,
+            dim_id=cfg.dimension,
+        )
 
     stream_file.write_text('{"type":"api_runner","status":"complete"}\n', encoding="utf-8")
     _log.debug("API analysis complete, evidence written to %s", jsonl_file)

--- a/src/quodeq/analysis/subprocess.py
+++ b/src/quodeq/analysis/subprocess.py
@@ -23,6 +23,7 @@ from quodeq.analysis._command import (
 )
 from quodeq.analysis._config import AnalysisConfig, HeartbeatCallback, _SpawnPaths
 from quodeq.analysis._process import AnalysisError, _check_process_result, _spawn_and_monitor
+from quodeq.analysis import dispatch_policy
 from quodeq.analysis._provider_cache import get_provider_configs
 from quodeq.analysis.api_prompt_assembly import assemble_api_prompt
 from quodeq.analysis.stream.counters import count_files_in_stream
@@ -101,7 +102,6 @@ def _run_cli_analysis(
 
 
 _MAX_API_PROMPT_CHARS = int(os.environ.get("QUODEQ_MAX_API_PROMPT_CHARS", "30000"))  # Target prompt size for local models (~8K tokens)
-_MAX_API_FILE_SIZE = int(os.environ.get("QUODEQ_MAX_API_FILE_SIZE", "15000"))  # Skip files larger than 15KB
 
 
 def _load_skip_dirs() -> frozenset[str]:
@@ -144,7 +144,7 @@ def _gather_source_files(work_dir: Path) -> list[Path]:
         if f in stat_cache
         and not any(p in f.parts for p in _SKIP_DIRS)
         and not any(p.startswith(".") for p in f.relative_to(work_dir).parts)
-        and 0 < stat_cache[f] < _MAX_API_FILE_SIZE
+        and 0 < stat_cache[f] < dispatch_policy.api_file_size_cap()
     ]
     # Prioritize code files over markup
     code_files = [f for f in filtered if f.suffix in _CODE_EXTS]
@@ -296,6 +296,23 @@ def _resolve_provider_config(cfg: AnalysisConfig) -> tuple[str, str, str]:
     return model, api_base, api_key
 
 
+def _write_skip_markers(jsonl_file: Path, skipped: list[str], reason: str) -> None:
+    """Append ``file_done: skipped`` markers for taken-but-undispatched files.
+
+    Invariant: every file taken from a queue must end with a marker. A
+    silent drop leaves the file uncached, so every incremental run re-queues
+    and re-drops it — the dim never converges (the perpetual-97% bug).
+    ``skipped`` (unlike ``error``) does not feed the failure-streak breaker
+    or the post-run reachability guard.
+    """
+    from quodeq.analysis.mcp.router import FindingsRouter  # noqa: PLC0415
+    jsonl_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(jsonl_file, "a", encoding="utf-8") as fh:
+        router = FindingsRouter(fh)
+        for f in skipped:
+            router.mark_file_done(file=f, status="skipped", reason=reason)
+
+
 def _gather_api_source_files(
     work_dir: Path, cfg: AnalysisConfig, jsonl_file: Path, stream_file: Path,
 ) -> list[Path] | None:
@@ -306,10 +323,18 @@ def _gather_api_source_files(
     if cfg.queue_path and cfg.queue_path.exists():
         queue = FileQueue(cfg.queue_path)
         taken = queue.take(count=min(cfg.max_files_per_agent or 10, 3), agent_id=cfg.agent_id)
-        source_files = [
-            work_dir / f for f in taken
-            if (work_dir / f).exists() and (work_dir / f).stat().st_size < _MAX_API_FILE_SIZE
-        ]
+        # Enumeration applies the same predicate, so dropped files here mean
+        # the file changed (or vanished) between queue build and dispatch.
+        dispatchable, dropped = dispatch_policy.split_api_dispatchable(work_dir, taken)
+        if dropped:
+            _write_skip_markers(
+                jsonl_file, dropped,
+                reason=(
+                    f"skipped: missing or over the API file-size cap "
+                    f"({dispatch_policy.api_file_size_cap()} bytes)"
+                ),
+            )
+        source_files = [work_dir / f for f in dispatchable]
         _log.debug("Took %d files from queue for API analysis", len(source_files))
         if not source_files:
             # Don't touch jsonl_file — it's the SHARED `{dim}_evidence.jsonl`

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -41,7 +41,8 @@ class _DimProgress:
     estimate_reason: str | None = None  # see _dim_estimates module docstring
     exit_reason: str | None = None
     files_cached: int | None = None        # files already analyzed in previous runs
-    files_project_total: int | None = None  # all source files for this dim
+    files_project_total: int | None = None  # all dispatchable source files for this dim
+    files_excluded: int | None = None       # files the provider can never dispatch (size cap)
 
 
 @dataclass
@@ -258,6 +259,7 @@ def build_scan_progress(
         estimate_reason = estimate_meta["reason"] if estimate_meta else None
         files_cached = estimate_meta["cached"] if estimate_meta else None
         files_project_total = estimate_meta["total"] if estimate_meta else None
+        files_excluded = estimate_meta["excluded"] if estimate_meta else None
 
         tally = tally_unique_findings(evidence_dir / f"{dim_id}_evidence.jsonl")
         elapsed = _dim_elapsed_s(dim_id, run_dir, d_state)
@@ -278,6 +280,7 @@ def build_scan_progress(
             exit_reason=exit_reason,
             files_cached=files_cached,
             files_project_total=files_project_total,
+            files_excluded=files_excluded,
         ))
 
     return _ScanProgress(

--- a/src/quodeq/shared/dim_estimates_io.py
+++ b/src/quodeq/shared/dim_estimates_io.py
@@ -12,20 +12,22 @@ shared package.
 
 Each value is normalised to::
 
-    {"count": int, "reason": str, "total": int, "cached": int}
+    {"count": int, "reason": str, "total": int, "cached": int, "excluded": int}
 
-- ``count``  — cache misses this run will dispatch for the dim.
-- ``reason`` — short tag explaining the estimate (see
+- ``count``    — cache misses this run will dispatch for the dim.
+- ``reason``   — short tag explaining the estimate (see
   ``compute_dim_estimates`` for the tag vocabulary).
-- ``total``  — all source files for the dim (overall project size).
-- ``cached`` — files already analyzed in previous runs.
+- ``total``    — all dispatchable source files for the dim.
+- ``cached``   — files already analyzed in previous runs.
+- ``excluded`` — files the provider can never dispatch (API size cap);
+  kept out of ``total`` so coverage can reach 100%.
 
 Legacy fallbacks for older/partial payloads:
 
 - Missing ``total`` falls back to ``count``.
-- Missing ``cached`` falls back to ``0``.
+- Missing ``cached`` / ``excluded`` fall back to ``0``.
 - A bare int value (pre-dates the reason tag) becomes
-  ``{"count": v, "reason": "", "total": v, "cached": 0}``.
+  ``{"count": v, "reason": "", "total": v, "cached": 0, "excluded": 0}``.
 """
 from __future__ import annotations
 
@@ -67,7 +69,7 @@ def read_dim_estimates(run_dir: Path) -> dict[str, dict[str, Any]]:
         return {}
     out: dict[str, dict[str, Any]] = {}
     for k, v in data.items():
-        # Current format: {"count": int, "reason": str, "total": int, "cached": int}.
+        # Current format: {"count", "reason", "total", "cached", "excluded"}.
         if isinstance(v, dict) and isinstance(v.get("count"), int):
             count = v["count"]
             out[k] = {
@@ -75,8 +77,9 @@ def read_dim_estimates(run_dir: Path) -> dict[str, dict[str, Any]]:
                 "reason": str(v.get("reason", "")),
                 "total": v["total"] if isinstance(v.get("total"), int) else count,
                 "cached": v["cached"] if isinstance(v.get("cached"), int) else 0,
+                "excluded": v["excluded"] if isinstance(v.get("excluded"), int) else 0,
             }
         # Legacy format: a bare int. Older runs predate the reason tag.
         elif isinstance(v, int):
-            out[k] = {"count": v, "reason": "", "total": v, "cached": 0}
+            out[k] = {"count": v, "reason": "", "total": v, "cached": 0, "excluded": 0}
     return out

--- a/tests/analysis/test_api_size_cap_dispatch.py
+++ b/tests/analysis/test_api_size_cap_dispatch.py
@@ -1,0 +1,262 @@
+"""The API-provider file-size cap must be enforced at enumeration, not
+silently at dispatch (the perpetual-97%-coverage bug).
+
+Bug: ``_gather_api_source_files`` dropped files over ``QUODEQ_MAX_API_FILE_SIZE``
+*after* taking them from the queue, without writing any ``file_done`` marker.
+The files never entered the cache, so every incremental run re-counted them as
+misses, re-queued them, and re-skipped them. The same ~3% of files haunted
+every run and dim coverage never reached 100%.
+
+The fix has one rule: the queue builder / estimates (``_list_source_files``)
+and the dispatch-time worker must share ONE dispatchability predicate
+(``quodeq.analysis.dispatch_policy``), and any file the worker still drops
+must leave an explicit ``skipped`` marker behind.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.analysis._dim_estimates import compute_dim_estimates
+from quodeq.analysis._types import AnalysisOptions, RunConfig
+from quodeq.analysis.cache import LocalFileBackend
+from quodeq.analysis.manifest_models import AnalysisTarget, SourceManifest
+from quodeq.analysis.subagents._source_files import _list_source_files
+
+CAP = 200  # small test cap, applied via QUODEQ_MAX_API_FILE_SIZE
+
+
+def _make_config(src: Path, file_names: list[str]) -> RunConfig:
+    target = AnalysisTarget(
+        name="t", language="python", source_files=sorted(file_names),
+        total_files=len(file_names),
+        language_stats={"py": len(file_names)},
+    )
+    manifest = SourceManifest(targets=[target], total_files=len(file_names))
+    return RunConfig(
+        src=src, language="python", standards_dir=None,
+        work_dir=src, manifest=manifest,
+        options=AnalysisOptions(subagent_model="test-model", incremental=False),
+    )
+
+
+def _write_repo(src: Path) -> None:
+    """One dispatchable file, one over the cap."""
+    src.mkdir(parents=True, exist_ok=True)
+    (src / "small.py").write_text("# small\n")
+    (src / "big.py").write_text("# big\n" + "x = 1\n" * CAP)
+
+
+@pytest.fixture
+def api_provider(monkeypatch):
+    monkeypatch.setenv("QUODEQ_MAX_API_FILE_SIZE", str(CAP))
+    with patch("quodeq.analysis.dispatch_policy.provider_is_api", return_value=True):
+        yield
+
+
+@pytest.fixture
+def cli_provider(monkeypatch):
+    monkeypatch.setenv("QUODEQ_MAX_API_FILE_SIZE", str(CAP))
+    with patch("quodeq.analysis.dispatch_policy.provider_is_api", return_value=False):
+        yield
+
+
+class TestEnumerationAppliesCap:
+    def test_list_source_files_excludes_oversized_for_api_provider(
+        self, tmp_path: Path, api_provider,
+    ):
+        src = tmp_path / "src"
+        _write_repo(src)
+        config = _make_config(src, ["small.py", "big.py"])
+
+        files, _ext, excluded = _list_source_files(config, "security")
+
+        assert files == ["small.py"]
+        assert excluded == ["big.py"]
+
+    def test_list_source_files_keeps_oversized_for_cli_provider(
+        self, tmp_path: Path, cli_provider,
+    ):
+        src = tmp_path / "src"
+        _write_repo(src)
+        config = _make_config(src, ["small.py", "big.py"])
+
+        files, _ext, excluded = _list_source_files(config, "security")
+
+        assert sorted(files) == ["big.py", "small.py"]
+        assert excluded == []
+
+    def test_dim_estimates_totals_exclude_oversized(self, tmp_path: Path, api_provider):
+        src = tmp_path / "src"
+        _write_repo(src)
+        config = _make_config(src, ["small.py", "big.py"])
+
+        result = compute_dim_estimates(config, ["security"])
+
+        # The oversized file can never be dispatched, so it must not be part
+        # of count/total (the coverage denominator) -- it is reported apart.
+        assert result["security"]["count"] == 1
+        assert result["security"]["total"] == 1
+        assert result["security"]["excluded"] == 1
+
+    def test_dim_estimates_incremental_never_requeues_excluded(
+        self, tmp_path: Path, api_provider,
+    ):
+        """The original symptom: with a warm cache for every dispatchable
+        file, an incremental run must have NOTHING left to dispatch."""
+        from quodeq.analysis.cache import CacheEntry, build_cache_key_for_file
+
+        src = tmp_path / "src"
+        _write_repo(src)
+        config = _make_config(src, ["small.py", "big.py"])
+        config.options.incremental = True
+        cache = LocalFileBackend(root=tmp_path / "cache")
+        key = build_cache_key_for_file(config, "small.py", "security")
+        cache.put(key, CacheEntry(
+            key=key, schema_version=1, findings=[],
+            files_read=1, file_path="small.py", dimension="security",
+            model_id="test-model",
+        ))
+
+        with patch(
+            "quodeq.analysis._dim_estimates.LocalFileBackend", return_value=cache,
+        ):
+            result = compute_dim_estimates(config, ["security"])
+
+        assert result["security"]["count"] == 0
+        assert result["security"]["cached"] == 1
+        assert result["security"]["total"] == 1
+
+
+class TestCoverageDenominator:
+    def test_source_file_count_reflects_api_eligibility(
+        self, tmp_path: Path, api_provider,
+    ):
+        src = tmp_path / "src"
+        _write_repo(src)
+        config = _make_config(src, ["small.py", "big.py"])
+
+        assert config.source_file_count == 1
+
+    def test_source_file_count_unchanged_for_cli_provider(
+        self, tmp_path: Path, cli_provider,
+    ):
+        src = tmp_path / "src"
+        _write_repo(src)
+        config = _make_config(src, ["small.py", "big.py"])
+
+        assert config.source_file_count == 2
+
+
+class TestWorkerNeverDropsSilently:
+    def _analysis_config(self, queue_path: Path, jsonl_file: Path):
+        from quodeq.analysis._config import AnalysisConfig
+        return AnalysisConfig(
+            queue_path=queue_path, jsonl_file=jsonl_file,
+            max_files_per_agent=10, agent_id="a1",
+        )
+
+    def test_gather_writes_skipped_marker_for_oversized_taken_file(
+        self, tmp_path: Path, api_provider,
+    ):
+        from quodeq.analysis.subagents.file_queue import FileQueue
+        from quodeq.analysis.subprocess import _gather_api_source_files
+
+        src = tmp_path / "src"
+        _write_repo(src)
+        queue_path = tmp_path / "q.json"
+        FileQueue(queue_path, ["small.py", "big.py"])
+        jsonl_file = tmp_path / "security_evidence.jsonl"
+        stream_file = tmp_path / "a1.stream"
+
+        source_files = _gather_api_source_files(
+            src, self._analysis_config(queue_path, jsonl_file), jsonl_file, stream_file,
+        )
+
+        assert source_files == [src / "small.py"]
+        markers = [
+            json.loads(line)
+            for line in jsonl_file.read_text().splitlines()
+            if json.loads(line).get("_marker") == "file_done"
+        ]
+        assert markers == [{
+            "_marker": "file_done", "file": "big.py", "status": "skipped",
+            "reason": markers[0]["reason"],
+        }]
+        assert "size" in markers[0]["reason"]
+
+    def test_gather_writes_skipped_marker_even_when_nothing_dispatchable(
+        self, tmp_path: Path, api_provider,
+    ):
+        from quodeq.analysis.subagents.file_queue import FileQueue
+        from quodeq.analysis.subprocess import _gather_api_source_files
+
+        src = tmp_path / "src"
+        _write_repo(src)
+        queue_path = tmp_path / "q.json"
+        FileQueue(queue_path, ["big.py"])
+        jsonl_file = tmp_path / "security_evidence.jsonl"
+        stream_file = tmp_path / "a1.stream"
+
+        source_files = _gather_api_source_files(
+            src, self._analysis_config(queue_path, jsonl_file), jsonl_file, stream_file,
+        )
+
+        assert source_files is None
+        content = jsonl_file.read_text()
+        assert '"status": "skipped"' in content.replace('": "', '": "') or "skipped" in content
+
+
+class TestSkippedMarkerSemantics:
+    def test_router_accepts_skipped_status(self, tmp_path: Path):
+        from quodeq.analysis.mcp.router import FindingsRouter
+
+        out = tmp_path / "ev.jsonl"
+        calls: list[tuple[str, list]] = []
+        with out.open("w", encoding="utf-8") as fh:
+            router = FindingsRouter(fh, on_file_done=lambda f, fs: calls.append((f, fs)))
+            router.mark_file_done(file="big.py", status="skipped", reason="too large")
+
+        entry = json.loads(out.read_text().strip())
+        assert entry["status"] == "skipped"
+        assert calls == []  # skipped must never write a cache entry
+
+    def test_failure_streak_ignores_skipped_markers(self, tmp_path: Path):
+        from quodeq.analysis.cache._failure_streak import FailureStreakWatcher
+
+        jsonl = tmp_path / "ev.jsonl"
+        lines = [
+            json.dumps({"_marker": "file_done", "file": f"f{i}.py", "status": "skipped"})
+            for i in range(50)
+        ]
+        jsonl.write_text("\n".join(lines) + "\n")
+
+        watcher = FailureStreakWatcher(jsonl, threshold=3)
+        offset, streak, recent = watcher._scan_once(0, 0, [])
+        assert streak == 0
+        assert recent == []
+
+
+class TestEstimatesSidecarRoundTrip:
+    def test_excluded_survives_write_read_round_trip(self, tmp_path: Path):
+        from quodeq.shared.dim_estimates_io import read_dim_estimates, write_dim_estimates
+
+        estimates = {"security": {
+            "count": 3, "reason": "incremental", "total": 10, "cached": 7, "excluded": 2,
+        }}
+        write_dim_estimates(tmp_path, estimates)
+        assert read_dim_estimates(tmp_path) == estimates
+
+    def test_legacy_payload_defaults_excluded_to_zero(self, tmp_path: Path):
+        from quodeq.shared.dim_estimates_io import (
+            DIM_ESTIMATES_FILENAME, read_dim_estimates,
+        )
+
+        (tmp_path / DIM_ESTIMATES_FILENAME).write_text(
+            json.dumps({"security": {"count": 5, "reason": "incremental"}})
+        )
+        loaded = read_dim_estimates(tmp_path)
+        assert loaded["security"]["excluded"] == 0

--- a/tests/analysis/test_api_size_cap_dispatch.py
+++ b/tests/analysis/test_api_size_cap_dispatch.py
@@ -240,6 +240,75 @@ class TestSkippedMarkerSemantics:
         assert recent == []
 
 
+class TestSizeAwareBatching:
+    """Raising the size cap must not overflow the context via multi-file
+    batches: one model call's inlined file content stays within the prompt
+    char budget, and an oversized file dispatches solo."""
+
+    def _files(self, tmp_path: Path, sizes: list[int]) -> list[Path]:
+        out = []
+        for i, size in enumerate(sizes):
+            p = tmp_path / f"f{i}.py"
+            p.write_text("x" * size)
+            out.append(p)
+        return out
+
+    def test_greedy_packing_preserves_order(self, tmp_path: Path):
+        from quodeq.analysis.subprocess import _batch_files_by_size
+
+        files = self._files(tmp_path, [100, 100, 100, 100])
+        batches = _batch_files_by_size(files, budget=250)
+
+        assert batches == [files[0:2], files[2:4]]
+
+    def test_oversized_file_goes_solo(self, tmp_path: Path):
+        from quodeq.analysis.subprocess import _batch_files_by_size
+
+        files = self._files(tmp_path, [50, 900, 50])
+        batches = _batch_files_by_size(files, budget=300)
+
+        assert batches == [[files[0]], [files[1]], [files[2]]]
+
+    def test_empty_input_yields_no_batches(self, tmp_path: Path):
+        from quodeq.analysis.subprocess import _batch_files_by_size
+
+        assert _batch_files_by_size([], budget=300) == []
+
+    def test_bridge_makes_one_api_call_per_sub_batch(
+        self, tmp_path: Path, api_provider, monkeypatch,
+    ):
+        from unittest.mock import patch as mpatch
+        from quodeq.analysis._config import AnalysisConfig
+        from quodeq.analysis.subagents.file_queue import FileQueue
+        from quodeq.analysis.subprocess import _run_api_analysis_bridge
+
+        src = tmp_path / "src"
+        src.mkdir()
+        for name in ("a.py", "b.py", "c.py"):
+            (src / name).write_text("x = 1\n" * 20)  # 120 bytes each
+        queue_path = tmp_path / "q.json"
+        FileQueue(queue_path, ["a.py", "b.py", "c.py"])
+        jsonl_file = tmp_path / "security_evidence.jsonl"
+        cfg = AnalysisConfig(
+            queue_path=queue_path, jsonl_file=jsonl_file,
+            max_files_per_agent=10, agent_id="a1", dimension="security",
+        )
+
+        monkeypatch.setenv("QUODEQ_MAX_API_PROMPT_CHARS", "150")
+        calls: list[list[str]] = []
+        with mpatch(
+            "quodeq.analysis.subprocess._resolve_provider_config",
+            return_value=("m", "http://localhost:1", ""),
+        ), mpatch(
+            "quodeq.analysis._api_runner.run_api_analysis",
+            side_effect=lambda **kw: calls.append(kw["source_file_paths"]),
+        ):
+            _run_api_analysis_bridge(src, "prompt", tmp_path / "a1.stream", cfg)
+
+        # 120B each with a 150B budget: every file gets its own call.
+        assert calls == [["a.py"], ["b.py"], ["c.py"]]
+
+
 class TestEstimatesSidecarRoundTrip:
     def test_excluded_survives_write_read_round_trip(self, tmp_path: Path):
         from quodeq.shared.dim_estimates_io import read_dim_estimates, write_dim_estimates

--- a/tests/analysis/test_dim_estimates.py
+++ b/tests/analysis/test_dim_estimates.py
@@ -64,7 +64,7 @@ class TestComputeDimEstimates:
         config = _make_config(src, ["a.py", "b.py", "c.py"], incremental=False)
 
         result = compute_dim_estimates(config, ["security"])
-        assert result["security"] == {"count": 3, "reason": "full", "total": 3, "cached": 0}
+        assert result["security"] == {"count": 3, "reason": "full", "total": 3, "cached": 0, "excluded": 0}
 
     def test_diff_mode_intersects_filter(self, tmp_path: Path):
         src = tmp_path / "src"
@@ -75,7 +75,7 @@ class TestComputeDimEstimates:
         )
 
         result = compute_dim_estimates(config, ["security"])
-        assert result["security"] == {"count": 2, "reason": "diff", "total": 2, "cached": 0}
+        assert result["security"] == {"count": 2, "reason": "diff", "total": 2, "cached": 0, "excluded": 0}
 
     def test_empty_dim_returns_zero_with_empty_reason(self, tmp_path: Path):
         src = tmp_path / "src"
@@ -98,7 +98,7 @@ class TestComputeDimEstimates:
             return_value=LocalFileBackend(root=tmp_path / "fresh-cache"),
         ):
             result = compute_dim_estimates(config, ["security"])
-        assert result["security"] == {"count": 2, "reason": "first-run", "total": 2, "cached": 0}
+        assert result["security"] == {"count": 2, "reason": "first-run", "total": 2, "cached": 0, "excluded": 0}
 
     def test_incremental_partial_cache_marks_incremental(self, tmp_path: Path):
         src = tmp_path / "src"
@@ -112,7 +112,7 @@ class TestComputeDimEstimates:
             return_value=cache,
         ):
             result = compute_dim_estimates(config, ["security"])
-        assert result["security"] == {"count": 1, "reason": "incremental", "total": 3, "cached": 2}
+        assert result["security"] == {"count": 1, "reason": "incremental", "total": 3, "cached": 2, "excluded": 0}
 
     def test_incremental_full_cache_returns_zero(self, tmp_path: Path):
         src = tmp_path / "src"
@@ -136,8 +136,8 @@ class TestPersistence:
     def test_write_and_read_round_trip(self, tmp_path: Path):
         run_dir = tmp_path / "run"
         estimates = {
-            "security": {"count": 3, "reason": "incremental", "total": 10, "cached": 7},
-            "reliability": {"count": 0, "reason": "empty", "total": 0, "cached": 0},
+            "security": {"count": 3, "reason": "incremental", "total": 10, "cached": 7, "excluded": 1},
+            "reliability": {"count": 0, "reason": "empty", "total": 0, "cached": 0, "excluded": 0},
         }
         write_dim_estimates(run_dir, estimates)
         loaded = read_dim_estimates(run_dir)
@@ -165,7 +165,7 @@ class TestPersistence:
         run_dir.mkdir()
         (run_dir / DIM_ESTIMATES_FILENAME).write_text(json.dumps({"security": 5}))
         loaded = read_dim_estimates(run_dir)
-        assert loaded == {"security": {"count": 5, "reason": "", "total": 5, "cached": 0}}
+        assert loaded == {"security": {"count": 5, "reason": "", "total": 5, "cached": 0, "excluded": 0}}
 
     def test_read_legacy_dict_without_coverage_fields_normalises(self, tmp_path: Path):
         # Runs from before the total/cached fields: total falls back to count,
@@ -176,7 +176,7 @@ class TestPersistence:
             json.dumps({"security": {"count": 5, "reason": "incremental"}})
         )
         loaded = read_dim_estimates(run_dir)
-        assert loaded == {"security": {"count": 5, "reason": "incremental", "total": 5, "cached": 0}}
+        assert loaded == {"security": {"count": 5, "reason": "incremental", "total": 5, "cached": 0, "excluded": 0}}
 
 
 class TestFreshRunSafety:

--- a/tests/analysis/test_source_gathering.py
+++ b/tests/analysis/test_source_gathering.py
@@ -117,7 +117,14 @@ class TestGatherApiSourceFiles:
         result = _gather_api_source_files(tmp_path, cfg, jsonl_file, stream_file)
 
         assert result is None
-        assert jsonl_file.read_text() == existing
+        content = jsonl_file.read_text()
+        # Prior findings survive untouched; the undispatchable files get
+        # explicit skipped markers appended (never a silent drop).
+        assert content.startswith(existing)
+        import json
+        markers = [json.loads(line) for line in content.splitlines()[2:]]
+        assert {m["file"] for m in markers} == {"missing1.py", "missing2.py", "missing3.py"}
+        assert all(m["_marker"] == "file_done" and m["status"] == "skipped" for m in markers)
 
 
 class TestLoadSkipDirs:

--- a/tests/engine/test_file_priority.py
+++ b/tests/engine/test_file_priority.py
@@ -232,6 +232,6 @@ class TestPrioritizationIntegration:
             target=target,
             manifest=SourceManifest(targets=[target], total_files=2),
         )
-        files, _ = _list_source_files(config, "security")
+        files, _, _ = _list_source_files(config, "security")
         # src/auth.py should come before tests/test_stuff.py
         assert files.index("src/auth.py") < files.index("tests/test_stuff.py")

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -10,7 +10,7 @@ src/quodeq/analysis/mcp/enricher.py:18:context
 src/quodeq/analysis/mcp/enricher.py:19:context
 src/quodeq/analysis/mcp/findings_server.py:20:context
 src/quodeq/analysis/mcp/findings_server.py:21:context
-src/quodeq/analysis/subprocess.py:248:llm_bridge
+src/quodeq/analysis/subprocess.py:262:llm_bridge
 src/quodeq/api/_evaluation_routes.py:21:analysis
 src/quodeq/api/import_project.py:30:data
 src/quodeq/api/import_project.py:31:data


### PR DESCRIPTION
## Problem

On API-provider projects (Ollama/omlx), Overview coverage was pinned at ~97% and never reached 100%.

`_gather_api_source_files` dropped files over `QUODEQ_MAX_API_FILE_SIZE` (15KB) **after** taking them from the queue, without writing any `file_done` marker. No marker means no cache entry, so every incremental run re-counted the same files as misses, re-queued them, and re-dropped them. On the quodeq self-eval project this was the same 48 files (the repo's largest: `App.jsx`, `services/dashboard.py`, `evaluation_mixin.py`, the big test suites) every night: `filesRead 1548 / sourceFileCount 1596 = 97.0%`, forever.

Root cause class: the queue builder / estimates and the dispatch-time worker each had their own dispatchability predicate, and they diverged (same producer/consumer divergence class as the dismiss identity-key bug).

## Fix (commit 1)

- **New `quodeq/analysis/dispatch_policy.py`**: single shared predicate (`provider_is_api`, `api_file_size_cap`, `split_api_dispatchable`) used by BOTH `_list_source_files` (enumeration) and `_gather_api_source_files` (dispatch). CLI providers are unaffected (no cap).
- **`_list_source_files` returns `(files, extensions, excluded)`**: queues, dim estimates, and cache classification now agree with what the worker will actually send.
- **Honest coverage denominator**: `RunConfig.source_file_count` (feeds `coveragePct`) counts only dispatchable files for API providers, so a fully-analyzed project reads 100%.
- **Invariant: every taken file ends with a marker.** Files the worker still cannot dispatch (changed/vanished between queue build and dispatch) get an explicit `file_done status="skipped"` marker. `skipped` neither trips the failure-streak breaker nor feeds the reachability guard, and never writes a cache entry.
- **Exclusions surfaced**: `dim_estimates.json` and the scan-progress payload carry an `excluded` count, and the run log announces once: `N file(s) excluded from analysis: over the API file-size cap (15000 bytes). Raise QUODEQ_MAX_API_FILE_SIZE to include them.`

## Size-budgeted sub-batches (commit 2)

Raising the cap must not overflow the model context: one call previously inlined the whole taken batch (up to 3 files). `_run_api_analysis_bridge` now splits taken files into sub-batches whose summed size stays within `QUODEQ_MAX_API_PROMPT_CHARS` (now read per call), one API call each. A file over the budget dispatches solo, so a truncated response only re-dispatches that file instead of its whole batch. This makes `QUODEQ_MAX_API_FILE_SIZE=65536` (+ `QUODEQ_CONTEXT_SIZE`) a safe way to bring the excluded files into coverage.

## Verification

- 16 tests in `tests/analysis/test_api_size_cap_dispatch.py` (enumeration filter, CLI unaffected, denominator, skip markers on both worker paths, streak-breaker immunity, sidecar round-trip, greedy batching, one-call-per-sub-batch bridge test); full suite 4458 passed.
- End-to-end on a fixture repo (3 small files + one 15,780-byte file) with the Ollama provider:
  - run 1: `coveragePct 100.0`, `dim_estimates {"count": 3, "total": 3, "excluded": 1}`, big file never queued, all taken files have `ok` markers
  - run 2 (incremental, no changes): `3 hits / 0 misses`, nothing re-queued — the dim converges
  - run 3 (one changed file): dispatches through the sub-batch loop, `2 hits / 1 miss`, clean `ok` marker
- Import baseline: one grandfathered `llm_bridge` entry shifted line number from code added above it; regenerated per the gate's documented stale-entry rule (no new violations).

## Notes

- Existing runs' caches are untouched; the first run after this lands re-scores with the honest denominator.
- UI display of the `excluded` count (e.g. in the scan header meta line) is a small follow-up; the payload already carries it.
- Chunking files larger than the context window remains a possible follow-up (quodeq's largest file today is 55KB, so not needed yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)