### PR TITLE
feat(ui): show excluded file count in live-scan coverage header

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -161,7 +161,7 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
   if (!jobId) return null;
 
   const dims = progress?.dimensions || [];
-  const { totalFiles, takenFiles, overallPct, projectTotal, cachedFiles, coveredFiles, coveredPct } =
+  const { totalFiles, takenFiles, overallPct, projectTotal, cachedFiles, coveredFiles, coveredPct, excludedFiles } =
     computeOverallProgress(progress);
   // Segmented coverage view only when there is actually a cached portion to
   // show — full scans and legacy runs keep the familiar run-only display.
@@ -220,7 +220,7 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
           <div className="scan-progress__meta">
             <span>
               {showCoverage ? (
-                <><strong>{coveredFiles} / {projectTotal}</strong> files · {coveredPct}% total{totalFiles > 0 ? <> · this run {takenFiles} / {totalFiles}</> : <> · nothing new this run</>}</>
+                <><strong>{coveredFiles} / {projectTotal}</strong> files · {coveredPct}% total{excludedFiles > 0 && <> · {excludedFiles} excluded (size cap)</>}{totalFiles > 0 ? <> · this run {takenFiles} / {totalFiles}</> : <> · nothing new this run</>}</>
               ) : totalFiles > 0 ? (
                 <><strong>{takenFiles} / {totalFiles}</strong> checks · {overallPct}%</>
               ) : <strong>preparing…</strong>}

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.test.jsx
@@ -177,6 +177,31 @@ describe('ScanProgress total coverage (incremental runs)', () => {
     expect(container.querySelector('.scan-progress__bar-fill--cached')).toBeNull();
   });
 
+  it('appends the excluded count to the coverage line when files were excluded', async () => {
+    const payload = coveragePayload();
+    payload.dimensions[0].filesExcluded = 3;
+    getEvaluationProgress.mockResolvedValue(payload);
+    withEvalLog(<ScanProgress job={baseJob} />, ctx);
+    expect(await screen.findByText('88 / 100')).toBeInTheDocument();
+    expect(screen.getByText(/3 excluded \(size cap\)/)).toBeInTheDocument();
+  });
+
+  it('shows no excluded segment when the payload reports zero excluded', async () => {
+    const payload = coveragePayload();
+    payload.dimensions[0].filesExcluded = 0;
+    getEvaluationProgress.mockResolvedValue(payload);
+    withEvalLog(<ScanProgress job={baseJob} />, ctx);
+    expect(await screen.findByText('88 / 100')).toBeInTheDocument();
+    expect(screen.queryByText(/excluded/)).toBeNull();
+  });
+
+  it('shows no excluded segment on legacy payloads without the field', async () => {
+    getEvaluationProgress.mockResolvedValue(coveragePayload());
+    withEvalLog(<ScanProgress job={baseJob} />, ctx);
+    expect(await screen.findByText('88 / 100')).toBeInTheDocument();
+    expect(screen.queryByText(/excluded/)).toBeNull();
+  });
+
   it('fully-cached re-scan shows coverage, not preparing', async () => {
     // Nothing new to analyze this run: totalFiles 0 but full coverage data.
     getEvaluationProgress.mockResolvedValue({

--- a/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.js
+++ b/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.js
@@ -38,11 +38,12 @@ export function dimFileEstimate(progress) {
 }
 
 const NO_COVERAGE = { projectTotal: null, cachedFiles: null, coveredFiles: null, coveredPct: null };
+const NO_EXCLUDED = { excludedFiles: null };
 
 export function computeOverallProgress(progress) {
   const dims = progress?.dimensions || [];
   if (dims.length === 0) {
-    return { totalFiles: 0, takenFiles: 0, overallPct: 0, ...NO_COVERAGE };
+    return { totalFiles: 0, takenFiles: 0, overallPct: 0, ...NO_COVERAGE, ...NO_EXCLUDED };
   }
 
   // "preparing…" only when *nothing* is known yet — i.e. no dim has
@@ -52,7 +53,7 @@ export function computeOverallProgress(progress) {
   const anyDimStarted = dims.some((d) => d?.state === 'running' || d?.state === 'done');
   const anyTotalKnown = dims.some((d) => (d?.files?.total ?? 0) > 0);
   if (!anyDimStarted && !anyTotalKnown) {
-    return { totalFiles: 0, takenFiles: 0, overallPct: 0, ...NO_COVERAGE };
+    return { totalFiles: 0, takenFiles: 0, overallPct: 0, ...NO_COVERAGE, ...NO_EXCLUDED };
   }
 
   // Sum across dims using whatever total each one carries. Pending dims
@@ -65,6 +66,9 @@ export function computeOverallProgress(progress) {
   let hasCoverage = true;
   let cachedFiles = 0;
   let projectTotal = 0;
+  // Files over the API size cap. The cap is dim-agnostic, so every dim
+  // reports the same count — max, not sum, or N dims would multiply it.
+  let excludedFiles = null;
   for (const d of dims) {
     takenFiles += d?.files?.taken ?? 0;
     totalFiles += d?.files?.total ?? 0;
@@ -73,6 +77,9 @@ export function computeOverallProgress(progress) {
       projectTotal += d.filesProjectTotal;
     } else {
       hasCoverage = false;
+    }
+    if (Number.isFinite(d?.filesExcluded)) {
+      excludedFiles = Math.max(excludedFiles ?? 0, d.filesExcluded);
     }
   }
 
@@ -87,5 +94,5 @@ export function computeOverallProgress(progress) {
       }
     : NO_COVERAGE;
 
-  return { totalFiles, takenFiles, overallPct: pct(takenFiles, totalFiles), ...coverage };
+  return { totalFiles, takenFiles, overallPct: pct(takenFiles, totalFiles), ...coverage, excludedFiles };
 }

--- a/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.test.js
@@ -68,6 +68,7 @@ test('computeOverallProgress: returns zeros when progress is null', () => {
   assert.deepEqual(r, {
     totalFiles: 0, takenFiles: 0, overallPct: 0,
     projectTotal: null, cachedFiles: null, coveredFiles: null, coveredPct: null,
+    excludedFiles: null,
   });
 });
 
@@ -354,6 +355,69 @@ test('computeOverallProgress: completed incremental run reads full coverage', ()
   const r = computeOverallProgress(progress);
   assert.equal(r.coveredFiles, 100);
   assert.equal(r.coveredPct, 100);
+});
+
+// ---------------------------------------------------------------------------
+// computeOverallProgress — excluded files (API size cap)
+// ---------------------------------------------------------------------------
+
+test('computeOverallProgress: excludedFiles is the max across dims, not the sum', () => {
+  // The size cap is dim-agnostic: every dim reports the same excluded
+  // count. Summing would multiply it by the number of dims.
+  const progress = {
+    projectFiles: 100,
+    dimensions: [
+      { id: 'security',    state: 'running', files: { taken: 8, total: 20 },
+        filesCached: 80, filesProjectTotal: 100, filesExcluded: 3 },
+      { id: 'reliability', state: 'pending', files: { taken: 0, total: 10 },
+        filesCached: 90, filesProjectTotal: 100, filesExcluded: 3 },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.excludedFiles, 3);
+});
+
+test('computeOverallProgress: excludedFiles is null when no dim carries the field (legacy run)', () => {
+  const progress = {
+    projectFiles: 100,
+    dimensions: [
+      { id: 'security', state: 'running', files: { taken: 8, total: 20 },
+        filesCached: 80, filesProjectTotal: 100 },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.excludedFiles, null);
+});
+
+test('computeOverallProgress: excludedFiles is 0 when dims report zero excluded', () => {
+  const progress = {
+    projectFiles: 100,
+    dimensions: [
+      { id: 'security', state: 'running', files: { taken: 8, total: 20 },
+        filesCached: 80, filesProjectTotal: 100, filesExcluded: 0 },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.excludedFiles, 0);
+});
+
+test('computeOverallProgress: excludedFiles reads the dims that carry it when others lack it', () => {
+  // Mixed payload (e.g. a dim added mid-rollout): use whatever is known.
+  const progress = {
+    projectFiles: 100,
+    dimensions: [
+      { id: 'security',    state: 'running', files: { taken: 8, total: 20 },
+        filesCached: 80, filesProjectTotal: 100, filesExcluded: 5 },
+      { id: 'reliability', state: 'pending', files: { taken: 0, total: 10 } },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.excludedFiles, 5);
+});
+
+test('computeOverallProgress: excludedFiles is null when progress is null or empty', () => {
+  assert.equal(computeOverallProgress(null).excludedFiles, null);
+  assert.equal(computeOverallProgress({ dimensions: [] }).excludedFiles, null);
 });
 
 test('computeOverallProgress: fully-cached re-scan keeps coverage despite empty queues', () => {


### PR DESCRIPTION
## Summary
Follow-up to #786, which made the pipeline exclude files over the API size cap honestly and added a per-dimension `filesExcluded` field to the scan-progress payload. This PR surfaces that count in the dashboard.

- `computeOverallProgress` (scanProgressTotals.js) now returns `excludedFiles`: the **max** of `filesExcluded` across dims. The size cap is dim-agnostic, so every dim reports the same number; summing would multiply it by the dim count. Legacy payloads without the field yield `null`.
- The live-scan coverage meta line (ScanProgress.jsx) appends "N excluded (size cap)" when the count is > 0: `178 / 200 files . 89% total . 3 excluded (size cap) . this run 8 / 30`. Zero or missing counts render nothing, with no dangling separator.

## Test plan
- New unit tests in scanProgressTotals.test.js: max-not-sum across dims, null for legacy payloads, zero case, mixed payloads (some dims lacking the field), null/empty progress.
- New component tests in ScanProgress.test.jsx: badge renders with the count, absent when excluded is 0, absent on legacy payloads.
- Full UI suites green: 277 node tests, 873 vitest tests.
- Verified end-to-end against a fake running run (real API server + built static UI): header showed "3 excluded (size cap)" from the real `/progress` payload, and the segment disappeared live when the fixture's excluded count was set to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)