### PR TITLE
fix(ui): evaluation card shows the job's own project, never the stale selection

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -96,20 +96,25 @@ function useNativeTitlebarSync(effectiveDark) {
  */
 function EvaluateCase({ serverHealth, evaluation, selectedProject, projects, onGoToProjects, onGoToSettings, preselectDims }) {
   const { connected, setConnected } = serverHealth;
-  const { job, jobError, liveViolations, handleStartEvaluation, handleEvalDismiss, cancelEvaluation } = evaluation;
+  const { job, jobError, liveViolations, handleStartEvaluation, handleEvalDismiss, cancelEvaluation, startedProject } = evaluation;
   const projectInfo = projects?.find(p => (p.id || p.name) === selectedProject) || null;
   // The in-progress card describes the running job's own project, which can
   // differ from the UI's global selection. Resolve it the same way so the
-  // card label follows the job rather than the selection.
+  // card label follows the job rather than the selection. Before the
+  // report-path marker resolves outputProject, the project the job was
+  // started for fills the gap; the global selection is never used.
   const jobProjectInfo = job?.outputProject
     ? (projects?.find(p => (p.id || p.name) === job.outputProject) || null)
+    : null;
+  const startedProjectInfo = startedProject
+    ? (projects?.find(p => (p.id || p.name) === startedProject) || null)
     : null;
   return (
     <>
       {!connected && <ServerDisconnectedOverlay onReconnect={() => setConnected(true)} />}
       <EvaluateScreen
         evaluation={{ job, jobError, liveViolations }}
-        context={{ selectedProject, projectInfo, jobProjectInfo, preselectDims }}
+        context={{ selectedProject, projectInfo, jobProjectInfo, startedProjectInfo, preselectDims }}
         actions={{ onStart: handleStartEvaluation, onDismiss: handleEvalDismiss, onCancel: cancelEvaluation, onGoToProjects, onGoToSettings }}
       />
     </>

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -113,7 +113,7 @@ function NoProjectSelected({ onGoToProjects }) {
 
 export default function EvaluateScreen({ evaluation, context, actions }) {
   const { job, jobError, liveViolations } = evaluation;
-  const { selectedProject, projectInfo, jobProjectInfo, preselectDims } = context;
+  const { selectedProject, projectInfo, jobProjectInfo, startedProjectInfo, preselectDims } = context;
   const { onStart: onStartEvaluation, onDismiss, onCancel, onGoToProjects, onGoToSettings } = actions;
   const [toastKey, setToastKey] = useState(0);
   const [toastVisible, setToastVisible] = useState(false);
@@ -125,7 +125,9 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
   const wrappedOnStart = (payload) => {
     setToastVisible(false);
     setToastKey(k => k + 1);
-    onStartEvaluation(payload);
+    // Pass the result through: false means the start was blocked, and the
+    // card uses that to keep one-shot state (clean-scan "once") armed.
+    return onStartEvaluation(payload);
   };
 
   return (
@@ -143,9 +145,8 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
 
         <EvaluationStatus
           job={job}
-          project={selectedProject}
-          projectInfo={projectInfo}
           jobProjectInfo={jobProjectInfo}
+          startedProjectInfo={startedProjectInfo}
           liveViolations={liveViolations}
           onDismiss={onDismiss}
           onCancel={onCancel}

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
@@ -63,12 +63,20 @@ export function buildEvaluationPayload({ repo, selectedDims, branch, scopePath, 
 
 function buildAndSubmit(onStart, formState) {
   const { repo, selectedDims, branch, scopePath, cleanScan, setRepo, setSelectedDims, setBranch, setScopePath, setCleanScan } = formState;
-  onStart(buildEvaluationPayload({ repo, selectedDims, branch, scopePath, cleanScan }));
+  const result = onStart(buildEvaluationPayload({ repo, selectedDims, branch, scopePath, cleanScan }));
+  // Blocked start (another evaluation is running): keep the form and the
+  // one-shot clean toggle intact so the user's retry submits the same thing.
+  if (result === false) return;
   setRepo('');
   setSelectedDims(new Set());
   setBranch(null);
   setScopePath(null);
-  if (cleanScan === 'once') setCleanScan('off');
+  if (cleanScan === 'once') {
+    Promise.resolve(result).then(
+      () => setCleanScan('off'),
+      () => {},
+    );
+  }
 }
 
 function useEvaluationForm(onStart, onValidationFail) {

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -61,14 +61,17 @@ function JobIdLine({ jobId, aiProvider, aiModel }) {
   );
 }
 
-export default function EvaluationStatus({ job, project, projectInfo, jobProjectInfo, liveViolations = {}, onDismiss, onCancel, hasEvaluations }) {
+export default function EvaluationStatus({ job, jobProjectInfo, startedProjectInfo, liveViolations = {}, onDismiss, onCancel, hasEvaluations }) {
   if (!job) return null;
   // Prefer the running job's own project so the card stays accurate when the
   // UI's global selection points at a different project than the job is
-  // actually scanning. Fall back to the selected project when the job's
-  // project can't be resolved (e.g. before the report-path marker fires).
+  // actually scanning. Before the report-path marker resolves it, fall back
+  // to the project the job was STARTED for. Never fall back to the global
+  // selection: switching projects mid-run would mislabel a running
+  // evaluation with a project it never touched. Unknown beats wrong.
   const jobProjectLabel = jobProjectInfo?.displayName || jobProjectInfo?.name || null;
-  const projectLabel = jobProjectLabel || projectInfo?.displayName || projectInfo?.name || project || null;
+  const startedLabel = startedProjectInfo?.displayName || startedProjectInfo?.name || null;
+  const projectLabel = jobProjectLabel || startedLabel || null;
 
   return (
     <div className="panel evaluate-panel--terminal">

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
@@ -64,31 +64,44 @@ describe('JobIdLine', () => {
 });
 
 describe('project label', () => {
-  const selectedInfo = { id: 'uuid-b', name: 'project-b', displayName: 'Project B' };
+  const startedInfo = { id: 'uuid-c', name: 'project-c', displayName: 'Project C' };
   const jobInfo = { id: 'uuid-a', name: 'project-a', displayName: 'Project A' };
 
-  it("shows the running job's own project, not the globally-selected one", () => {
+  it("shows the running job's own project when resolvable", () => {
     renderWithClient(
       <EvaluationStatus
         job={{ ...baseJob, status: 'running', outputProject: 'uuid-a' }}
-        project="uuid-b"
-        projectInfo={selectedInfo}
         jobProjectInfo={jobInfo}
+        startedProjectInfo={startedInfo}
       />
     );
     expect(screen.getByText('Project A')).toBeInTheDocument();
-    expect(screen.queryByText('Project B')).toBeNull();
+    expect(screen.queryByText('Project C')).toBeNull();
   });
 
-  it("falls back to the selected project when the job's project is not resolvable", () => {
+  it("falls back to the project the job was started for before the report-path marker fires", () => {
     renderWithClient(
       <EvaluationStatus
         job={{ ...baseJob, status: 'running' }}
-        project="uuid-b"
-        projectInfo={selectedInfo}
         jobProjectInfo={null}
+        startedProjectInfo={startedInfo}
       />
     );
-    expect(screen.getByText('Project B')).toBeInTheDocument();
+    expect(screen.getByText('Project C')).toBeInTheDocument();
+  });
+
+  it('never labels the card with the globally-selected project', () => {
+    // Regression (v1.6.0): the card used to fall back to the UI's global
+    // selection, so switching projects mid-run showed the wrong name on a
+    // running evaluation. When the job's project is unknown, show nothing.
+    renderWithClient(
+      <EvaluationStatus
+        job={{ ...baseJob, status: 'running' }}
+        jobProjectInfo={null}
+        startedProjectInfo={null}
+      />
+    );
+    const header = document.querySelector('.evaluate-panel__top');
+    expect(header.textContent).not.toMatch(/Project [ABC]/);
   });
 });

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -18,12 +18,16 @@ const EVAL_OPTIONS_HINT = (
 
 const NO_STANDARDS_MESSAGE = 'Select at least one standard before evaluating.';
 
-export function buildScanPayload({ info, branch, scopePath, selectedDims, cleanScan }) {
+export function buildScanPayload({ info, branch, scopePath, selectedDims, cleanScan, project }) {
   const payload = { repo: info.path };
   payload.dimensions = [...selectedDims];
   if (branch) payload.branch = branch;
   if (scopePath) payload.scopePath = scopePath;
   payload.cleanScan = cleanScan !== 'off';
+  // UI-side bookkeeping (stripped before the HTTP call): lets the
+  // in-progress card label itself with the launching project before the
+  // backend's report-path marker resolves the job's own project.
+  if (project) payload.uiProject = project;
   return payload;
 }
 
@@ -73,7 +77,7 @@ function useReEvalInfo(project, initialInfo, { getProjectInfo, relocateProject }
   return { info, error, urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore };
 }
 
-function useDimensionSelection(allDimensions, info, branch, scopePath, onStart, onValidationFail, preselectDims = []) {
+function useDimensionSelection(allDimensions, info, branch, scopePath, onStart, onValidationFail, preselectDims = [], project = null) {
   const [selectedDims, setSelectedDims] = useState(new Set());
   const [cleanScan, setCleanScan] = useState('off');
 
@@ -113,8 +117,17 @@ function useDimensionSelection(allDimensions, info, branch, scopePath, onStart, 
       onValidationFail?.(NO_STANDARDS_MESSAGE);
       return;
     }
-    onStart(buildScanPayload({ info, branch, scopePath, selectedDims, cleanScan }));
-    if (cleanScan === 'once') setCleanScan('off');
+    const result = onStart(buildScanPayload({ info, branch, scopePath, selectedDims, cleanScan, project }));
+    // Consume the one-shot clean toggle only when the start actually went
+    // through. A blocked start (another evaluation running) returns false;
+    // a failed start rejects. Eating the toggle in either case makes the
+    // user's retry silently run incremental.
+    if (cleanScan === 'once' && result !== false) {
+      Promise.resolve(result).then(
+        () => setCleanScan('off'),
+        () => {},
+      );
+    }
   };
 
   return { selectedDims, toggleDim, selectAll, clearAll, handleScan, cleanScan, setCleanScan };
@@ -135,7 +148,7 @@ function useReEvaluateCard(project, onStart, projectInfo, preselectDims) {
   const { scanData } = useScanData(isLocal ? project : null);
 
   const { selectedDims, toggleDim, selectAll, clearAll, handleScan, cleanScan, setCleanScan } =
-    useDimensionSelection(allDimensions, info, branch, scopePath, onStart, showToast, preselectDims);
+    useDimensionSelection(allDimensions, info, branch, scopePath, onStart, showToast, preselectDims, project);
 
   return {
     info, error, allDimensions, selectedDims,

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.test.jsx
@@ -63,6 +63,18 @@ describe('buildScanPayload', () => {
     const payload = buildScanPayload({ ...baseState, scopePath: null });
     expect(payload).not.toHaveProperty('scopePath');
   });
+
+  it('carries the launching project id as uiProject', () => {
+    // The in-progress card labels itself with the job's own project; the
+    // launching project id bridges the gap until the backend resolves it.
+    const payload = buildScanPayload({ ...baseState, project: 'uuid-x' });
+    expect(payload.uiProject).toBe('uuid-x');
+  });
+
+  it('omits uiProject when no project is known', () => {
+    const payload = buildScanPayload({ ...baseState });
+    expect(payload).not.toHaveProperty('uiProject');
+  });
 });
 
 function makeFakeApi(overrides = {}) {
@@ -156,6 +168,56 @@ describe('ReEvaluateCard ephemeral gating', () => {
     // Scan button is not disabled
     const button = screen.getByRole('button', { name: /^▸\s*scan$|^scan$|running\.\.\./i });
     expect(button).not.toBeDisabled();
+  });
+});
+
+describe('ReEvaluateCard clean-scan once consumption', () => {
+  beforeEach(() => { invalidateDimensionCache(); });
+
+  const localInfo = { name: 'demo', path: '/repos/myproj', location: 'local', ephemeral: false, evaluable: true };
+  const apiWithDims = () => makeFakeApi({
+    getProjectInfo: vi.fn().mockResolvedValue(localInfo),
+    listPlugins: vi.fn().mockResolvedValue([{ dimensions: [
+      { id: 'security', label: 'Security' },
+    ] }]),
+  });
+
+  async function armOnceToggle(user) {
+    await user.click(screen.getByRole('button', { name: /clean scan/i }));
+    await user.click(screen.getByRole('button', { name: /just this scan/i }));
+    expect(screen.getByRole('button', { name: /clean scan/i })).toHaveAttribute('aria-pressed', 'true');
+  }
+
+  it('keeps the once toggle armed when the start is blocked', async () => {
+    // Regression (v1.6.0): a start swallowed by the running-job guard still
+    // consumed the one-shot clean toggle, so the user's retry silently ran
+    // incremental and counted a discarded run's files as analyzed.
+    const { default: userEvent } = await import('@testing-library/user-event');
+    const user = userEvent.setup();
+    const onStart = vi.fn().mockReturnValue(false);
+    renderCard({ project: 'p-once', projectInfo: localInfo, api: apiWithDims(), onStart, preselectDims: ['security'] });
+    await waitFor(() => expect(screen.getByRole('button', { name: /security/i })).toHaveAttribute('aria-pressed', 'true'));
+
+    await armOnceToggle(user);
+    await user.click(screen.getByRole('button', { name: /^▸\s*scan$|^scan$/i }));
+
+    expect(onStart).toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /clean scan/i })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('consumes the once toggle when the start goes through', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event');
+    const user = userEvent.setup();
+    const onStart = vi.fn().mockResolvedValue({ jobId: 'j1' });
+    renderCard({ project: 'p-once2', projectInfo: localInfo, api: apiWithDims(), onStart, preselectDims: ['security'] });
+    await waitFor(() => expect(screen.getByRole('button', { name: /security/i })).toHaveAttribute('aria-pressed', 'true'));
+
+    await armOnceToggle(user);
+    await user.click(screen.getByRole('button', { name: /^▸\s*scan$|^scan$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /clean scan/i })).toHaveAttribute('aria-pressed', 'false');
+    });
   });
 });
 

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -83,6 +83,10 @@ export function useEvaluation() {
   const queryClient = useQueryClient();
   const [jobId, setJobId] = useState(null);
   const [jobError, setJobError] = useState(null);
+  // Project id the current job was started for (UI-side). Bridges the gap
+  // until the backend's report-path marker resolves job.outputProject, so
+  // the in-progress card never has to guess from the global selection.
+  const [startedProject, setStartedProject] = useState(null);
 
   // SSE side-effect — writes status/dimensions/findings into cache.
   // No-op when VITE_USE_SSE_EVENTS is off; refetchInterval below covers.
@@ -159,17 +163,22 @@ export function useEvaluation() {
   // --- Mutations -------------------------------------------------------
   const startMutation = useMutation({
     mutationFn: (input) => {
+      // uiProject is client-side bookkeeping (which project launched this
+      // job) — strip it so it never reaches the HTTP payload.
+      const { uiProject, ...rest } = input;
       // preparePayload throws on missing provider/model — let the error
       // propagate to onError so jobError gets set with a useful message.
-      const prepared = preparePayload(input);
+      const prepared = preparePayload(rest);
       return api.startEvaluation(prepared).then((created) => ({
         ...created,
         repo: prepared.repo,
+        uiProject,
       }));
     },
     onSuccess: (created) => {
       setJobError(null);
       setJobId(created.jobId);
+      setStartedProject(created.uiProject || null);
       queryClient.setQueryData(evaluationKeys.status(created.jobId), created);
       // Invalidate the project subtree so History (and any other view
       // backed by project queries) shows the freshly-started run as
@@ -199,6 +208,7 @@ export function useEvaluation() {
           queryClient.removeQueries({ queryKey: evaluationKeys.evaluation(jobId) });
         }
         setJobId(null);
+        setStartedProject(null);
       } else if (jobId) {
         queryClient.invalidateQueries({ queryKey: evaluationKeys.evaluation(jobId) });
       }
@@ -255,6 +265,7 @@ export function useEvaluation() {
     }
     setJobId(null);
     setJobError(null);
+    setStartedProject(null);
   }, [jobId, queryClient]);
 
   return {
@@ -264,5 +275,6 @@ export function useEvaluation() {
     startEvaluation,
     clearJob,
     cancelEvaluation,
+    startedProject,
   };
 }

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
@@ -176,6 +176,27 @@ describe("useEvaluation", () => {
     });
   });
 
+  it("tracks the project an evaluation was started for and strips it from the API payload", async () => {
+    // The in-progress card needs the launching project's identity before
+    // the backend's report-path marker resolves outputProject. uiProject
+    // is UI-side bookkeeping only and must not leak into the HTTP body.
+    fakeApi.startEvaluation.mockResolvedValue({
+      jobId: "j-started", status: "pending", dimensions: [],
+    });
+    const { result } = renderHook(() => useEvaluation(), { wrapper: makeWrapper() });
+    await act(async () => {
+      await result.current.startEvaluation({
+        repo: "x", dimensions: [], uiProject: "uuid-b",
+      });
+    });
+    expect(result.current.startedProject).toBe("uuid-b");
+    expect(fakeApi.startEvaluation).toHaveBeenCalledWith(
+      expect.not.objectContaining({ uiProject: expect.anything() }),
+    );
+    act(() => result.current.clearJob());
+    expect(result.current.startedProject).toBeNull();
+  });
+
   it("cancelEvaluation with discard clears the job immediately", async () => {
     // With discard the server deletes the run entirely (dir + index row +
     // job entry). Any further status polling would 404, so the hook must

--- a/src/quodeq/ui/src/hooks/useEvaluationLifecycle.js
+++ b/src/quodeq/ui/src/hooks/useEvaluationLifecycle.js
@@ -16,7 +16,12 @@ export function useEvaluationLifecycle({ settings, navigation, projects, storage
   const storage = _storage || localStorage;
   const { navTab, navReset } = navigation;
   const { loadProjects, setProjects, selectProjectAndRun } = projects;
-  const { job, jobError, liveViolations, startEvaluation, clearJob, cancelEvaluation } = useEvaluation();
+  const { job, jobError, liveViolations, startEvaluation, clearJob, cancelEvaluation, startedProject } = useEvaluation();
+  // Set when a start request is refused because another evaluation is
+  // already running. Surfaced through jobError so the Evaluate screen's
+  // toast shows it; a silent refusal left users believing the visible
+  // (older) evaluation was the one they just launched.
+  const [blockedStartError, setBlockedStartError] = useState(null);
 
   const [analysisPower, setAnalysisPower] = useState(() => {
     try { return Number(storage.getItem(POWER_KEY)) || DEFAULT_ANALYSIS_POWER; } catch (e) { console.warn('localStorage unavailable:', e); return DEFAULT_ANALYSIS_POWER; }
@@ -47,10 +52,15 @@ export function useEvaluationLifecycle({ settings, navigation, projects, storage
     // request (e.g. user clicked through the onboarding wizard while a
     // re-evaluation was already in flight on a different project) would
     // otherwise overwrite the live job state and confuse the lifecycle.
+    // Returns false so callers can keep one-shot UI state (the clean-scan
+    // "once" toggle) instead of consuming it for a start that never ran.
     if (job && job.status === 'running') {
-      console.warn('[evaluation] start request ignored — a job is already running');
-      return;
+      setBlockedStartError(
+        'An evaluation is already running. Cancel it or wait for it to finish.',
+      );
+      return false;
     }
+    setBlockedStartError(null);
     const activeProvider = storage.getItem(ACTIVE_PROVIDER_KEY) || '';
     const get = (key) => storage.getItem(providerKey(activeProvider, key));
     // Ollama uses a single analysis model; CLI providers use tier-based selection.
@@ -62,13 +72,19 @@ export function useEvaluationLifecycle({ settings, navigation, projects, storage
     } else {
       subagentModel = get(`model-${TIER_NAMES[analysisPower - 1]}`) || get('model') || undefined;
     }
-    startEvaluation({ ...payload, subagentModel });
+    // Swallow the rejection on the copy we discard: startMutation's onError
+    // already surfaces failures via jobError. Callers get the original
+    // promise so they can react to success/failure themselves.
+    const started = startEvaluation({ ...payload, subagentModel });
+    Promise.resolve(started).catch(() => {});
+    return started;
   }
 
   function handleEvalDismiss(action) {
     if (action === 'view') {
       navReset();
     }
+    setBlockedStartError(null);
     clearJob();
   }
 
@@ -76,9 +92,9 @@ export function useEvaluationLifecycle({ settings, navigation, projects, storage
   const isLocalApi = LOCAL_API_PROVIDERS.has(activeProvider);
 
   return {
-    job, jobError, liveViolations,
+    job, jobError: jobError || blockedStartError, liveViolations,
     analysisPower, setAnalysisPower, persistAnalysisPower,
     handleStartEvaluation, handleEvalDismiss, cancelEvaluation,
-    isLocalApi,
+    isLocalApi, startedProject,
   };
 }

--- a/src/quodeq/ui/src/hooks/useEvaluationLifecycle.test.jsx
+++ b/src/quodeq/ui/src/hooks/useEvaluationLifecycle.test.jsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// The lifecycle hook composes useEvaluation; mock it so tests can control
+// the job state without a QueryClient or API layer.
+const evaluationState = {
+  job: null,
+  jobError: null,
+  liveViolations: {},
+  startEvaluation: vi.fn(),
+  clearJob: vi.fn(),
+  cancelEvaluation: vi.fn(),
+  startedProject: null,
+};
+vi.mock("../features/evaluation/hooks/useEvaluation.js", () => ({
+  useEvaluation: () => evaluationState,
+  LOCAL_API_PROVIDERS: new Set(["ollama", "llamacpp", "omlx"]),
+}));
+
+import { useEvaluationLifecycle } from "./useEvaluationLifecycle.js";
+
+function renderLifecycle() {
+  return renderHook(() =>
+    useEvaluationLifecycle({
+      settings: {},
+      navigation: { navTab: vi.fn(), navReset: vi.fn() },
+      projects: {
+        loadProjects: vi.fn().mockResolvedValue([]),
+        setProjects: vi.fn(),
+        selectProjectAndRun: vi.fn(),
+      },
+    }),
+  );
+}
+
+describe("useEvaluationLifecycle blocked start", () => {
+  beforeEach(() => {
+    evaluationState.job = null;
+    evaluationState.jobError = null;
+    evaluationState.startEvaluation = vi.fn();
+    localStorage.setItem("cc-active-provider", "ollama");
+    localStorage.setItem("cc-ollama-model", "llama3.1");
+  });
+
+  it("surfaces a visible error instead of silently ignoring a start while a job runs", () => {
+    // Regression (v1.6.0): pressing scan while another evaluation ran was
+    // swallowed with only a console.warn. The user believed the visible
+    // (older) evaluation was the one they just launched.
+    evaluationState.job = { jobId: "j-running", status: "running" };
+    const { result } = renderLifecycle();
+
+    act(() => {
+      result.current.handleStartEvaluation({ repo: "x", dimensions: [] });
+    });
+
+    expect(evaluationState.startEvaluation).not.toHaveBeenCalled();
+    expect(result.current.jobError).toMatch(/already running/i);
+  });
+
+  it("clears the blocked-start error once a start goes through", () => {
+    evaluationState.job = { jobId: "j-running", status: "running" };
+    const { result, rerender } = renderLifecycle();
+    act(() => {
+      result.current.handleStartEvaluation({ repo: "x", dimensions: [] });
+    });
+    expect(result.current.jobError).toMatch(/already running/i);
+
+    evaluationState.job = null;
+    rerender();
+    act(() => {
+      result.current.handleStartEvaluation({ repo: "y", dimensions: [] });
+    });
+    expect(evaluationState.startEvaluation).toHaveBeenCalled();
+    expect(result.current.jobError).toBeNull();
+  });
+
+  it("returns false from a blocked start so callers can keep one-shot UI state", () => {
+    // ReEvaluateCard consumes the clean-scan "once" toggle when a start
+    // succeeds; a blocked start must not eat it.
+    evaluationState.job = { jobId: "j-running", status: "running" };
+    const { result } = renderLifecycle();
+    let returned;
+    act(() => {
+      returned = result.current.handleStartEvaluation({ repo: "x", dimensions: [] });
+    });
+    expect(returned).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem (v1.6.0 bug report, items 1 and 3)

Stacked on #790 (both touch `useEvaluation.js`).

- The in-progress evaluation card fell back to the **globally selected** project name whenever the job's `outputProject` was unresolved: the whole window before the report-path marker fires, and the full run for jobs adopted from the CLI. Switching projects around a running evaluation labeled the card with a project the evaluation never touched.
- Pressing scan while another evaluation was running was silently swallowed (`console.warn` only), so the user kept watching the OLD evaluation believing it was the one they just launched. That silent refusal also **consumed one-shot UI state**: the clean-scan "once" toggle and the new-evaluation form were reset for a start that never happened, which is how a retry silently ran incremental and re-counted a discarded run's files.

## Changes

- `useEvaluation` tracks `startedProject`: the project id a start was issued for, passed as `uiProject` in the payload and stripped before the HTTP call.
- `EvaluationStatus` labels from the job's own project, then the started-for project, and never the global selection. Unknown beats wrong: if neither is resolvable the card shows no project name.
- `useEvaluationLifecycle` surfaces a blocked start as a visible toast ("An evaluation is already running. Cancel it or wait for it to finish.") and returns `false` so callers can keep one-shot state.
- `ReEvaluateCard` and `EvaluationForm` consume the clean-scan "once" toggle only when the start actually goes through; a blocked or failed start keeps it armed. `EvaluationForm` also keeps the whole form intact on a blocked start.

## Testing

- Updated `EvaluationStatus` label tests: job-project wins, started-project bridges the pre-marker gap, and a regression test that the global selection is never rendered.
- New `useEvaluationLifecycle` tests for the blocked-start error lifecycle and `false` return.
- New `useEvaluation` test for `startedProject` tracking + payload stripping; new `ReEvaluateCard` tests for once-toggle preservation on blocked starts.
- Full UI suite: 884 passed (both vitest and node:test runners).
- Browser E2E: adopted running run renders its own project name on the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)