### PR TITLE
fix(ui): group score history by the local calendar day, not the UTC date

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.test.jsx
@@ -39,3 +39,30 @@ describe('useAccumulatedComputations dimTrends (as-of)', () => {
     expect(dimTrends.maintainability.delta).toBe(3);
   });
 });
+
+describe('useAccumulatedComputations selectedDayDimNames (multi-run day)', () => {
+  // Two runs on the SAME day evaluating different dimensions, plus an older
+  // day. The day-highlight must union the whole day, not just the newest
+  // run (v1.6.0 bug report: only the last evaluation's cards lit up).
+  const MULTI_RUN_DAY_TREND = [
+    { runId: 'm1', dateISO: '2026-07-12T14:00:00', dateLabel: 'Jul 12', numericAverage: 9, overallGrade: 'A', dimensions: ['security'], dimensionDetails: [{ dimension: 'security', score: 9 }] },
+    { runId: 'm2', dateISO: '2026-07-12T09:00:00', dateLabel: 'Jul 12', numericAverage: 8, overallGrade: 'B', dimensions: ['maintainability'], dimensionDetails: [{ dimension: 'maintainability', score: 8 }] },
+    { runId: 'm3', dateISO: '2026-07-10T10:00:00', dateLabel: 'Jul 10', numericAverage: 6, overallGrade: 'C', dimensions: ['reliability'], dimensionDetails: [{ dimension: 'reliability', score: 6 }] },
+  ];
+
+  it('unions dimensions across every run of the selected day', () => {
+    const { selectedDayDimNames } = renderHook(() => useAccumulatedComputations({
+      accumulated: { summary: { numericAverage: 8 }, dimensions: DIMS },
+      accumulatedDimensions: DIMS,
+      availableRuns: [],
+      dailyRuns: null,
+      overviewRunIndex: 0,
+      trend: MULTI_RUN_DAY_TREND,
+      selectedRunId: 'm1',
+      granularity: 'day',
+    })).result.current;
+    expect(selectedDayDimNames.has('security')).toBe(true);
+    expect(selectedDayDimNames.has('maintainability')).toBe(true);
+    expect(selectedDayDimNames.has('reliability')).toBe(false);
+  });
+});

--- a/src/quodeq/ui/src/utils/dailyGrouping.js
+++ b/src/quodeq/ui/src/utils/dailyGrouping.js
@@ -1,13 +1,37 @@
 /**
- * ISO-8601 week key (Monday start; week 1 contains the first Thursday).
- * Operates timezone-naively on the YYYY-MM-DD prefix via Date.UTC, matching
- * how the day grouping slices the date string.
+ * Local calendar-day key (YYYY-MM-DD) for a trend entry's dateISO.
+ *
+ * Backend dates are UTC instants ("...T22:30:00Z") while every user-facing
+ * date renders in the viewer's local timezone. Bucketing by the UTC slice
+ * put a 00:30-local run in the previous day's group: the row displayed
+ * 12 Jul while the grouping filed it under 11 Jul. Date-only strings carry
+ * no timezone context and pass through unchanged; unparseable strings fall
+ * back to the slice so garbage still groups stably.
+ *
+ * @param {string} dateISO
+ * @returns {string}
+ */
+export function localDayKey(dateISO) {
+  const s = dateISO || '';
+  if (s.length <= 10) return s.slice(0, 10);
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return s.slice(0, 10);
+  return [
+    d.getFullYear(),
+    String(d.getMonth() + 1).padStart(2, '0'),
+    String(d.getDate()).padStart(2, '0'),
+  ].join('-');
+}
+
+/**
+ * ISO-8601 week key (Monday start; week 1 contains the first Thursday) of
+ * the entry's LOCAL calendar day.
  *
  * @param {string} dateISO
  * @returns {string} e.g. "2026-W13", or "" when the date is missing/invalid
  */
 export function isoWeekKey(dateISO) {
-  const datePart = (dateISO || '').slice(0, 10);
+  const datePart = localDayKey(dateISO);
   const [y, m, d] = datePart.split('-').map(Number);
   if (!y || !m || !d) return '';
   const date = new Date(Date.UTC(y, m - 1, d));
@@ -20,7 +44,8 @@ export function isoWeekKey(dateISO) {
 }
 
 /**
- * Bucket key for a trend/run entry's date at the given granularity.
+ * Bucket key for a trend/run entry's date at the given granularity, based
+ * on the LOCAL calendar day so grouping agrees with the dates users see.
  * Empty dates produce "" (their own group), matching legacy day behavior.
  *
  * @param {string} dateISO
@@ -28,9 +53,9 @@ export function isoWeekKey(dateISO) {
  * @returns {string}
  */
 export function bucketKey(dateISO, granularity = 'day') {
-  if (granularity === 'month') return (dateISO || '').slice(0, 7);
+  if (granularity === 'month') return localDayKey(dateISO).slice(0, 7);
   if (granularity === 'week') return isoWeekKey(dateISO);
-  return (dateISO || '').slice(0, 10);
+  return localDayKey(dateISO);
 }
 
 /**

--- a/src/quodeq/ui/src/utils/dailyGrouping.test.js
+++ b/src/quodeq/ui/src/utils/dailyGrouping.test.js
@@ -27,6 +27,55 @@ const AVAILABLE_RUNS = [
 ];
 
 // ---------------------------------------------------------------------------
+// bucketKey: local-day semantics for UTC instants
+// ---------------------------------------------------------------------------
+
+/** The local calendar day the UI displays for an instant (what
+ * formatShortDate/toLocaleDateString render), as YYYY-MM-DD. */
+function displayedLocalDay(iso) {
+  const d = new Date(iso);
+  return [
+    d.getFullYear(),
+    String(d.getMonth() + 1).padStart(2, '0'),
+    String(d.getDate()).padStart(2, '0'),
+  ].join('-');
+}
+
+test('bucketKey: UTC instants bucket by the LOCAL calendar day the UI displays', () => {
+  // Backend dates are UTC instants ("...Z") while every user-facing date
+  // renders local. Slicing the UTC date put a 00:30-local run in the
+  // previous day's bucket: the row said 12 Jul, the grouping said 11 Jul.
+  const iso = '2026-07-11T23:30:00Z';
+  assert.equal(bucketKey(iso, 'day'), displayedLocalDay(iso));
+});
+
+test('bucketKey: month bucket follows the local day', () => {
+  const iso = '2026-06-30T23:30:00Z';
+  assert.equal(bucketKey(iso, 'month'), displayedLocalDay(iso).slice(0, 7));
+});
+
+test('bucketKey: week bucket follows the local day', () => {
+  // 23:30Z on Sunday 2026-07-12 is already Monday (next ISO week) in any
+  // timezone east of UTC+0:30.
+  const iso = '2026-07-12T23:30:00Z';
+  const localDay = displayedLocalDay(iso);
+  const [y, m, d] = localDay.split('-').map(Number);
+  const date = new Date(Date.UTC(y, m - 1, d));
+  const dayNum = date.getUTCDay() || 7;
+  date.setUTCDate(date.getUTCDate() + 4 - dayNum);
+  const isoYear = date.getUTCFullYear();
+  const yearStart = new Date(Date.UTC(isoYear, 0, 1));
+  const weekNo = Math.ceil(((date - yearStart) / 86400000 + 1) / 7);
+  const expected = `${isoYear}-W${String(weekNo).padStart(2, '0')}`;
+  assert.equal(bucketKey(iso, 'week'), expected);
+});
+
+test('bucketKey: date-only strings pass through unchanged (no timezone context)', () => {
+  assert.equal(bucketKey('2026-07-11', 'day'), '2026-07-11');
+  assert.equal(bucketKey('2026-07-11', 'month'), '2026-07');
+});
+
+// ---------------------------------------------------------------------------
 // collapseByDay
 // ---------------------------------------------------------------------------
 

--- a/src/quodeq/ui/src/utils/formatters.js
+++ b/src/quodeq/ui/src/utils/formatters.js
@@ -1,5 +1,5 @@
 import { getGradeThresholds } from './gradeThresholds.js';
-import { isoWeekKey } from './dailyGrouping.js';
+import { isoWeekKey, localDayKey } from './dailyGrouping.js';
 
 /**
  * Grade-to-CSS-class mapping.
@@ -271,10 +271,15 @@ const PERIOD_MONTH_NAMES = [
 
 /**
  * Human label for a score-history bucket at the given grouping granularity.
- * - day   -> the entry's specific date label (e.g. "25 Mar 2026")
- * - month -> "March 2026" (from the YYYY-MM prefix; timezone-naive)
- * - week  -> "Week 13, 2026" (from the ISO week key)
+ * - day   -> the entry's LOCAL date (e.g. "25 Mar 2026")
+ * - month -> "March 2026" (from the local calendar day)
+ * - week  -> "Week 13, 2026" (ISO week of the local calendar day)
  * Falls back to the entry's dateLabel (then dateISO) when unparseable.
+ *
+ * All three derive from the same local-day key the grouping uses
+ * (bucketKey/localDayKey), so a run's label always names the bucket it
+ * sits in. The server's dateLabel is UTC-rendered and disagrees with the
+ * local day for runs near midnight; it is only a fallback here.
  *
  * @param {{ dateISO?: string, dateLabel?: string }} entry
  * @param {'day'|'week'|'month'} [granularity='day']
@@ -284,7 +289,7 @@ export function formatPeriodLabel(entry, granularity = 'day') {
   const iso = entry?.dateISO || '';
   const fallback = entry?.dateLabel || iso;
   if (granularity === 'month') {
-    const [y, m] = iso.slice(0, 7).split('-');
+    const [y, m] = localDayKey(iso).slice(0, 7).split('-');
     const idx = Number(m) - 1;
     return (y && PERIOD_MONTH_NAMES[idx]) ? `${PERIOD_MONTH_NAMES[idx]} ${y}` : fallback;
   }
@@ -292,6 +297,14 @@ export function formatPeriodLabel(entry, granularity = 'day') {
     const key = isoWeekKey(iso); // 'YYYY-Www' or ''
     const [y, w] = key.split('-W');
     return (y && w) ? `Week ${Number(w)}, ${y}` : fallback;
+  }
+  if (iso.length > 10) {
+    // Same "25 Mar 2026" shape the server's dateLabel uses, but from the
+    // LOCAL date so the label names the bucket the run actually sits in.
+    const d = new Date(iso);
+    if (!Number.isNaN(d.getTime())) {
+      return `${d.getDate()} ${PERIOD_MONTH_NAMES[d.getMonth()].slice(0, 3)} ${d.getFullYear()}`;
+    }
   }
   return fallback;
 }


### PR DESCRIPTION
## Problem (v1.6.0 bug report, item 4)

The Overview's day/week/month grouping bucketed runs by slicing the **UTC** date out of `dateISO`, while every user-facing date renders in the viewer's **local** timezone. For a UTC+2 user, a run at 00:30 local displayed as one day but grouped, highlighted, and labeled under the previous day, so "group by day" did not match the day the user actually ran the evaluations.

The reported "only the last evaluation's cards highlighted" symptom on the tester's machine was mostly caused by the discarded-run zombie fixed in #790 (cancelled/discarded runs are intentionally excluded from the accumulated Overview and its highlight union). The day-union logic itself already unions all runs of a bucket; this PR pins that behavior with the previously missing panel-level test and fixes the one genuine grouping defect found: UTC bucketing.

## Changes

- `localDayKey` in `dailyGrouping.js`: local calendar day for timestamped ISO strings; date-only strings pass through unchanged. `bucketKey` (day/week/month) and `isoWeekKey` now derive from it.
- `formatPeriodLabel` derives all three granularities from the same local day, keeping the server's "25 Mar 2026" label shape, so a run's label always names the bucket it sits in.
- New panel-level test: `useAccumulatedComputations` unions dimensions across every run of the selected day (two same-day runs with different dimensions both highlight).

## Testing

- New bucketing tests assert bucket == displayed local day; suites run green under TZ=UTC, Europe/Amsterdam, and America/Los_Angeles (node:test 281 passed, vitest 885 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)