### PR TITLE
fix(ui): use logo LoadingScreen on standard detail instead of text fallback

### DIFF
--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -12,6 +12,7 @@ import {
   SevBadge,
   SectionLabel,
 } from '../../../components/terminal/index.js';
+import LoadingScreen from '../../../components/LoadingScreen.jsx';
 import PrinciplesRadial from './PrinciplesRadial.jsx';
 import PrinciplesCardsRow from './PrinciplesCardsRow.jsx';
 import DimensionScoreHistoryPanel from './DimensionScoreHistoryPanel.jsx';
@@ -122,7 +123,7 @@ export default function ExplorerPage({
   }, [d.evalData, d.allViolations, activeRunId]);
   useRegisterWindowSpec('fixplan', fixPlanSpec);
 
-  if (d.loading) return <div className="loading" role="status" aria-live="polite">Loading…</div>;
+  if (d.loading) return <LoadingScreen />;
   if (d.error) return <div className="inline-error">Failed to load evaluation data. Please try again or check the console for details.</div>;
   if (!d.evalData) return <div className="empty-state"><h2>No data found</h2></div>;
 

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.test.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.test.jsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import ExplorerPage from './ExplorerPage.jsx';
+
+vi.mock('./explorerDataHooks.js', () => ({
+  useExplorerData: () => ({ loading: true, evalData: null, allViolations: [] }),
+  buildEvalPrincipalFn: () => () => ({}),
+}));
+
+vi.mock('../hooks/useStandardDescriptions.js', () => ({
+  useStandardDescriptions: () => ({ standardDescription: '' }),
+}));
+
+vi.mock('../../side-pane/index.js', () => ({
+  useRegisterWindowSpec: () => {},
+  ReportContent: () => null,
+}));
+
+describe('ExplorerPage', () => {
+  it('shows the shared logo LoadingScreen while data loads, not a text fallback', () => {
+    const { container } = render(<ExplorerPage project="demo" dimension="security" />);
+    expect(container.querySelector('.loading-screen')).toBeInTheDocument();
+    expect(container.textContent).not.toMatch(/loading/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Entering a standard/dimension detail from an Overview card flashed a plain text `Loading…` div, unlike every other page (Dashboard, Map, History, Violations) which shows the shared quodeq-logo `LoadingScreen`.
- Swap the text fallback in `ExplorerPage` for `<LoadingScreen />` and add a regression test asserting the logo screen renders (and no text fallback) while data loads.

## Verification
- New `ExplorerPage.test.jsx` passes; full UI suite 886/886 green.
- Browser-verified via Vite dev server: a MutationObserver during card-click navigation recorded `.loading-screen` appearing and zero text-loading occurrences; detail page renders normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)