### PR TITLE
fix(jobs): isolate the job store and make pruning/eviction sane

### DIFF
--- a/src/quodeq/services/_job_model.py
+++ b/src/quodeq/services/_job_model.py
@@ -156,8 +156,19 @@ class InMemoryJobStore:
 _logger = logging.getLogger(__name__)
 
 def _default_persist_dir() -> Path:
-    """Read persist dir from env at call time for lazy configuration."""
-    return Path(os.environ.get("QUODEQ_JOB_PERSIST_DIR", str(Path.home() / ".quodeq" / "run" / "jobs")))
+    """Read persist dir from env at call time for lazy configuration.
+
+    Resolution: QUODEQ_JOB_PERSIST_DIR, else ``run/jobs`` next to the index
+    DB (mirroring get_score_cache_path, so the test suite's
+    QUODEQ_INDEX_DB_PATH override auto-isolates this store too), which
+    itself defaults to ``~/.quodeq``. Hardcoding the home fallback here let
+    pytest runs write fake jobs into the developer's real dashboard.
+    """
+    explicit = os.environ.get("QUODEQ_JOB_PERSIST_DIR")
+    if explicit:
+        return Path(explicit)
+    from quodeq.shared._env import get_index_db_path
+    return Path(get_index_db_path()).parent / "run" / "jobs"
 _STALE_JOB_AGE_S = 24 * 60 * 60  # 24 hours
 
 
@@ -274,6 +285,10 @@ class FileJobStore:
                 if job.status == "running":
                     job.status = "failed"
                     job.exit_code = -1
+                    # Stamp an end time or _cleanup_stale (which only prunes
+                    # jobs with ended_at) keeps the flipped job forever.
+                    if not job.ended_at:
+                        job.ended_at = datetime.now(timezone.utc).isoformat()
                     self._jobs[job.job_id] = job
                     self._write(job)
                 else:

--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -380,11 +380,14 @@ class JobManager:
     def _evict_completed_jobs(self) -> None:
         """Remove oldest completed/failed/cancelled jobs beyond _MAX_COMPLETED_JOBS."""
         all_jobs = self._store.list()
-        completed = [j.job_id for j in all_jobs if j.status != STATUS_RUNNING]
+        completed = [j for j in all_jobs if j.status != STATUS_RUNNING]
         excess = len(completed) - _MAX_COMPLETED_JOBS
         if excess > 0:
-            for jid in completed[:excess]:
-                self._store.delete(jid)
+            # Oldest first, or a store wedged with old junk would evict the
+            # user's newest real runs while the junk survived.
+            completed.sort(key=lambda j: j.ended_at or j.started_at or "")
+            for job in completed[:excess]:
+                self._store.delete(job.job_id)
 
     @property
     def _job_timeout_cap_s(self) -> float:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,11 @@ def _isolate_quodeq_home(tmp_path_factory: pytest.TempPathFactory,
     monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(home / "index.db"))
     monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(home / "evaluations"))
     monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(home / "cache"))
+    # Belt-and-braces: _default_persist_dir now derives from the index-db
+    # parent, but tests that build a JobManager without a store must never
+    # touch the real ~/.quodeq/run/jobs again (it was wedged with fake jobs
+    # named job-wire/sample-project that surfaced in the real dashboard).
+    monkeypatch.setenv("QUODEQ_JOB_PERSIST_DIR", str(home / "run" / "jobs"))
 
 
 class DummyProcess:

--- a/tests/services/test_job_manager.py
+++ b/tests/services/test_job_manager.py
@@ -521,3 +521,34 @@ def test_list_jobs_warns_on_deprecated_reports_root_kwarg(tmp_path):
         and "reports_root" in str(w.message)
         for w in caught
     ), f"expected DeprecationWarning about reports_root, got: {[str(w.message) for w in caught]}"
+
+
+class TestEvictionOrder:
+    def test_evicts_oldest_completed_first(self):
+        """Eviction beyond _MAX_COMPLETED_JOBS must drop the OLDEST jobs.
+
+        The victims used to be taken in store-iteration order, so a store
+        wedged with old junk (crash leftovers, test pollution) could evict
+        the user's newest real runs while the junk survived.
+        """
+        from quodeq.services.jobs import _MAX_COMPLETED_JOBS
+
+        store = InMemoryJobStore()
+        mgr = JobManager(job_store=store)
+        total = _MAX_COMPLETED_JOBS + 3
+        # Insert NEWEST first so naive iteration-order eviction picks the
+        # newest as victims and the test goes red.
+        for i in reversed(range(total)):
+            store.put(Job(
+                f"j{i:03d}", "done", ["echo"],
+                "2026-01-01T00:00:00+00:00",
+                f"2026-01-01T00:{i // 60:02d}:{i % 60:02d}+00:00", 0,
+            ))
+        mgr._evict_completed_jobs()
+        remaining = {j.job_id for j in store.list()}
+        assert len(remaining) == _MAX_COMPLETED_JOBS
+        # j000..j002 have the oldest ended_at values and must be the victims.
+        assert "j000" not in remaining
+        assert "j001" not in remaining
+        assert "j002" not in remaining
+        assert f"j{total - 1:03d}" in remaining

--- a/tests/services/test_job_model.py
+++ b/tests/services/test_job_model.py
@@ -14,6 +14,7 @@ from quodeq.services._job_model import (
     Job,
     InMemoryJobStore,
     FileJobStore,
+    _default_persist_dir,
     _job_to_json,
     _job_from_json,
     _MAX_LOG_LINES,
@@ -384,6 +385,28 @@ class TestFileJobStore:
         store = FileJobStore(persist_dir=tmp_path)
         assert store.get("j1") is not None
 
+    def test_flipped_running_job_gets_ended_at(self, tmp_path: Path):
+        """A crashed 'running' job flipped to failed must get an ended_at.
+
+        Without it, _cleanup_stale skips the job forever (it only prunes
+        jobs with ended_at), so crash/test leftovers accumulate until they
+        wedge the completed-jobs cap and evict real history instead.
+        """
+        data = {
+            "job_id": "j1",
+            "status": "running",
+            "command": ["echo"],
+            "started_at": "2026-01-01T00:00:00+00:00",
+        }
+        (tmp_path / "j1.json").write_text(json.dumps(data))
+        store = FileJobStore(persist_dir=tmp_path)
+        job = store.get("j1")
+        assert job is not None
+        assert job.status == "failed"
+        assert job.ended_at, "flipped jobs must be prunable by _cleanup_stale"
+        on_disk = json.loads((tmp_path / "j1.json").read_text())
+        assert on_disk["ended_at"], "the flip must be persisted with ended_at"
+
     def test_write_failure_does_not_crash(self, tmp_path: Path, monkeypatch):
         """If writing to disk fails, put() should not raise."""
         store = FileJobStore(persist_dir=tmp_path)
@@ -403,6 +426,32 @@ class TestFileJobStore:
 # ---------------------------------------------------------------------------
 # REPORT_PATH_RE
 # ---------------------------------------------------------------------------
+
+
+class TestDefaultPersistDir:
+    """The job store's default location must follow the rest of the state.
+
+    It used to honor only QUODEQ_JOB_PERSIST_DIR and otherwise hardcode
+    ~/.quodeq/run/jobs, so pytest runs (which isolate QUODEQ_INDEX_DB_PATH
+    but not this) polluted the developer's real dashboard with fake jobs.
+    Deriving from the index-db parent mirrors get_score_cache_path's idiom:
+    one env override isolates every sibling store.
+    """
+
+    def test_derives_from_index_db_path(self, tmp_path: Path, monkeypatch):
+        monkeypatch.delenv("QUODEQ_JOB_PERSIST_DIR", raising=False)
+        monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(tmp_path / "idx.db"))
+        assert _default_persist_dir() == tmp_path / "run" / "jobs"
+
+    def test_explicit_env_wins(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("QUODEQ_JOB_PERSIST_DIR", str(tmp_path / "explicit"))
+        monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(tmp_path / "idx.db"))
+        assert _default_persist_dir() == tmp_path / "explicit"
+
+    def test_falls_back_to_home_without_any_env(self, monkeypatch):
+        monkeypatch.delenv("QUODEQ_JOB_PERSIST_DIR", raising=False)
+        monkeypatch.delenv("QUODEQ_INDEX_DB_PATH", raising=False)
+        assert _default_persist_dir() == Path.home() / ".quodeq" / "run" / "jobs"
 
 
 class TestReportPathRegex:


### PR DESCRIPTION
## Problem (audit finding)

Running pytest on a dev machine polluted the real dashboard. `FileJobStore` hardcoded `~/.quodeq/run/jobs` (honoring only `QUODEQ_JOB_PERSIST_DIR`, which the test isolation fixture never set), so tests that construct a `JobManager` without an explicit store wrote fake jobs (`job-wire`, `sample-project`, command `false`) into the developer's real store. Those flowed straight into `GET /api/evaluations`, and two retention bugs made them effectively immortal:

- The running-to-failed flip on load left `ended_at` unset, so `_cleanup_stale` (which only prunes jobs with an end time) never aged them out.
- Cap eviction (`_MAX_COMPLETED_JOBS = 100`) picked victims in store-iteration order, so a store wedged with old junk could evict the user's newest real runs while the junk survived. The real store on the reporting machine was wedged at exactly the cap, mostly junk.

## Changes

- `_default_persist_dir` derives from the index-db parent (`<index-db dir>/run/jobs`), mirroring `get_score_cache_path`'s idiom, so the test suite's `QUODEQ_INDEX_DB_PATH` override auto-isolates the job store too. `QUODEQ_JOB_PERSIST_DIR` still wins; the production default is unchanged (`~/.quodeq/run/jobs`).
- `tests/conftest.py` also sets `QUODEQ_JOB_PERSIST_DIR` explicitly, belt and braces.
- The running-to-failed flip stamps `ended_at` so flipped jobs age out after 24h.
- `_evict_completed_jobs` sorts victims oldest-first by `ended_at`/`started_at`.

## Testing

TDD: new tests for the persist-dir derivation (explicit env wins, index-db parent, home fallback), the `ended_at` stamp on flip, and oldest-first eviction (fixture inserts newest-first so iteration-order eviction goes red). Full suite: 4473 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)