### PR TITLE
fix(evaluation): background-completion guard + explicit intent on DELETE

### DIFF
--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -221,14 +221,33 @@ def register_evaluation_item_routes(app: Flask, provider: ActionProvider) -> Non
     def cancel_or_delete_evaluation(job_id: str) -> Response | tuple[Response, int]:
         """DELETE on a running job cancels it. DELETE on a finished job removes it from history.
 
-        Query: ``?discard=true`` on a running job also wipes the in-flight
-        dim queue + fingerprint snapshots so the next run treats the work
-        as never-happened (forces a full rescan for any dim that didn't
-        finish scoring on its own).
+        Query: ``?intent=cancel|delete`` declares what the client is asking
+        for. Without it, the action is inferred from the momentary status
+        (legacy behavior), which is race-prone: a run finishing while the
+        cancel dialog is open, or a double-clicked cancel, used to fall
+        through to the permanent-purge branch and erase a run the user
+        chose to keep. With intent=cancel this endpoint can never purge;
+        with intent=delete it never silently cancels.
+
+        ``?discard=true`` on a cancel also wipes the run entirely so the
+        next run treats the work as never-happened.
         """
         snapshot = provider.get_evaluation_status(job_id, reports_dir=_reports_dir())
         if snapshot is None:
             body, status = error_response("Job not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+        intent = request.args.get("intent", "").lower() or None
+        if intent == "cancel" and snapshot.status != "running":
+            body, status = error_response(
+                "Evaluation already finished. Nothing was cancelled.",
+                HTTPStatus.CONFLICT, "ALREADY_FINISHED",
+            )
+            return jsonify(body), status
+        if intent == "delete" and snapshot.status == "running":
+            body, status = error_response(
+                "Evaluation is still running. Cancel it before deleting.",
+                HTTPStatus.CONFLICT, "STILL_RUNNING",
+            )
             return jsonify(body), status
         if snapshot.status == "running":
             discard = request.args.get("discard", "").lower() == "true"

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -172,24 +172,27 @@ export function getEvaluationProgress(jobId) {
 }
 
 /**
+ * Cancel a running evaluation. Declares intent=cancel so the server can
+ * never route this to the permanent-purge branch, even if the run finished
+ * while the confirm dialog was open (it 409s instead and the run is kept).
  * @param {string} jobId
  * @param {{discard?: boolean}} [opts]
  * @returns {Promise<Object>}
  */
 export function cancelEvaluation(jobId, opts = {}) {
-  const qs = opts.discard ? '?discard=true' : '';
+  const qs = opts.discard ? '?intent=cancel&discard=true' : '?intent=cancel';
   return request(`/evaluations/${encodeURIComponent(jobId)}${qs}`, { method: 'DELETE' });
 }
 
 /**
- * Permanently delete a non-running evaluation from history (removes scan dir + index row).
- * The server DELETE endpoint routes running jobs to cancel and finished jobs to purge —
- * this helper is the semantic alias UI callers use when they want the purge path.
+ * Permanently delete a non-running evaluation from history (removes scan
+ * dir + index row). Declares intent=delete so a run that is unexpectedly
+ * still running is refused (409) instead of being silently cancelled.
  * @param {string} jobId
  * @returns {Promise<Object>}
  */
 export function deleteEvaluation(jobId) {
-  return request(`/evaluations/${encodeURIComponent(jobId)}`, { method: 'DELETE' });
+  return request(`/evaluations/${encodeURIComponent(jobId)}?intent=delete`, { method: 'DELETE' });
 }
 
 // ── Dimension Eval ──────────────────────────────────────────────────────

--- a/src/quodeq/ui/src/api/index.test.jsx
+++ b/src/quodeq/ui/src/api/index.test.jsx
@@ -58,3 +58,34 @@ describe('registerProject', () => {
     expect(caught.status).toBe(400);
   });
 });
+
+describe('cancelEvaluation / deleteEvaluation intent', () => {
+  // The server routes DELETE by declared intent; without these flags a run
+  // finishing mid-dialog used to get permanently purged by a cancel click.
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ ok: true }) });
+  });
+
+  it('cancelEvaluation declares intent=cancel', async () => {
+    const { cancelEvaluation } = await import('./index.js');
+    await cancelEvaluation('j1');
+    const [url] = global.fetch.mock.calls[0];
+    expect(url).toContain('/evaluations/j1?intent=cancel');
+    expect(url).not.toContain('discard');
+  });
+
+  it('cancelEvaluation with discard keeps intent=cancel', async () => {
+    const { cancelEvaluation } = await import('./index.js');
+    await cancelEvaluation('j1', { discard: true });
+    const [url] = global.fetch.mock.calls[0];
+    expect(url).toContain('intent=cancel');
+    expect(url).toContain('discard=true');
+  });
+
+  it('deleteEvaluation declares intent=delete', async () => {
+    const { deleteEvaluation } = await import('./index.js');
+    await deleteEvaluation('ext-r1');
+    const [url] = global.fetch.mock.calls[0];
+    expect(url).toContain('/evaluations/ext-r1?intent=delete');
+  });
+});

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -125,7 +125,7 @@ export function useAppState() {
   const visibleDailyRuns = useVisibleRuns(rawDailyRuns, dashboard, activePage.page, setSelectedRun, granularity);
   const { overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect } = useRunNavigator({ selectedRun, availableRuns: visibleDailyRuns, onRunChange: handleRunChange, onNavigate: handleNavigate });
   const prefetchHandlers = usePrefetchAdjacentRuns({ selectedProject, availableRuns: visibleDailyRuns, overviewRunIndex });
-  const evalLifecycle = useEvaluationLifecycle({ settings, navigation: { navTab, navReset }, projects: { loadProjects, setProjects, selectProjectAndRun } });
+  const evalLifecycle = useEvaluationLifecycle({ settings, navigation: { navTab, navReset }, projects: { loadProjects, setProjects, selectProjectAndRun }, selectedProject });
 
   // Refresh all dashboard data (including latestAccumulated) when an evaluation
   // finishes. This uses the *active* refetch (not the lazy refreshDashboard the

--- a/src/quodeq/ui/src/hooks/useEvaluationLifecycle.js
+++ b/src/quodeq/ui/src/hooks/useEvaluationLifecycle.js
@@ -12,7 +12,7 @@ const DEFAULT_ANALYSIS_POWER = 2;
  * Extracts evaluation-specific state and side effects from App so that
  * App only wires the hook's return values into the component tree.
  */
-export function useEvaluationLifecycle({ settings, navigation, projects, storage: _storage }) {
+export function useEvaluationLifecycle({ settings, navigation, projects, selectedProject = null, storage: _storage }) {
   const storage = _storage || localStorage;
   const { navTab, navReset } = navigation;
   const { loadProjects, setProjects, selectProjectAndRun } = projects;
@@ -42,7 +42,15 @@ export function useEvaluationLifecycle({ settings, navigation, projects, storage
       loadProjects()
         .then((list) => setProjects(list))
         .catch((err) => console.error('Failed to refresh projects:', err));
-      selectProjectAndRun(job.outputProject, job.outputRunId);
+      // Only move the selection to the finished run when the user is
+      // already on that project (or has none selected, e.g. first-eval
+      // onboarding). Unconditional switching yanked a user browsing
+      // project B into project A the moment A's background run finished,
+      // without any nav reset. The evaluate card's "view results" button
+      // remains the explicit way to jump to another project's results.
+      if (!selectedProject || job.outputProject === selectedProject) {
+        selectProjectAndRun(job.outputProject, job.outputRunId);
+      }
     }
     prevJobRef.current = job;
   }, [job]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/quodeq/ui/src/hooks/useEvaluationLifecycle.test.jsx
+++ b/src/quodeq/ui/src/hooks/useEvaluationLifecycle.test.jsx
@@ -19,7 +19,7 @@ vi.mock("../features/evaluation/hooks/useEvaluation.js", () => ({
 
 import { useEvaluationLifecycle } from "./useEvaluationLifecycle.js";
 
-function renderLifecycle() {
+function renderLifecycle({ selectedProject = null, selectProjectAndRun = vi.fn() } = {}) {
   return renderHook(() =>
     useEvaluationLifecycle({
       settings: {},
@@ -27,11 +27,54 @@ function renderLifecycle() {
       projects: {
         loadProjects: vi.fn().mockResolvedValue([]),
         setProjects: vi.fn(),
-        selectProjectAndRun: vi.fn(),
+        selectProjectAndRun,
       },
+      selectedProject,
     }),
   );
 }
+
+describe("useEvaluationLifecycle background completion", () => {
+  beforeEach(() => {
+    evaluationState.job = null;
+    evaluationState.jobError = null;
+    evaluationState.startEvaluation = vi.fn();
+  });
+
+  it("does not switch the selection when another project's run finishes", () => {
+    // Regression: a background eval finishing on project A yanked a user
+    // viewing project B to A's data, without a nav reset.
+    evaluationState.job = {
+      jobId: "j-done", status: "done",
+      outputProject: "project-a", outputRunId: "run-a1",
+    };
+    const selectProjectAndRun = vi.fn();
+    renderLifecycle({ selectedProject: "project-b", selectProjectAndRun });
+    expect(selectProjectAndRun).not.toHaveBeenCalled();
+  });
+
+  it("selects the finished run when it belongs to the viewed project", () => {
+    evaluationState.job = {
+      jobId: "j-done", status: "done",
+      outputProject: "project-b", outputRunId: "run-b1",
+    };
+    const selectProjectAndRun = vi.fn();
+    renderLifecycle({ selectedProject: "project-b", selectProjectAndRun });
+    expect(selectProjectAndRun).toHaveBeenCalledWith("project-b", "run-b1");
+  });
+
+  it("adopts the finished run when no project is selected", () => {
+    // First-eval onboarding: nothing selected yet, so showing the fresh
+    // results is what the user expects.
+    evaluationState.job = {
+      jobId: "j-done", status: "done",
+      outputProject: "project-a", outputRunId: "run-a1",
+    };
+    const selectProjectAndRun = vi.fn();
+    renderLifecycle({ selectedProject: null, selectProjectAndRun });
+    expect(selectProjectAndRun).toHaveBeenCalledWith("project-a", "run-a1");
+  });
+});
 
 describe("useEvaluationLifecycle blocked start", () => {
   beforeEach(() => {

--- a/tests/api/test_eval_delete_intent.py
+++ b/tests/api/test_eval_delete_intent.py
@@ -1,0 +1,99 @@
+"""DELETE /api/evaluations/<job_id> must honor explicit client intent.
+
+The endpoint used to infer cancel-vs-delete purely from the momentary
+snapshot status, so a run finishing while the cancel dialog was open (or a
+double-clicked cancel) fell through to the permanent-purge branch and
+erased a run the user explicitly chose to keep.
+
+With ?intent=cancel the request can never purge: if the run is already
+terminal it returns 409 and the run stays. With ?intent=delete a run that
+is unexpectedly still running returns 409 instead of being silently
+cancelled. Requests without intent keep the legacy status-based behavior.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from quodeq.api.app import create_app
+from quodeq.core.types import JobSnapshot
+
+ORIGIN = {"Origin": "http://localhost"}
+
+
+def _make_client(status: str):
+    provider = MagicMock()
+    provider.get_evaluation_status.return_value = JobSnapshot(
+        job_id="j1", status=status,
+        output_project="proj", output_run_id="run-1",
+    )
+    provider.cancel_evaluation.return_value = True
+    provider.delete_evaluation.return_value = True
+    app = create_app(provider)
+    return app.test_client(), provider
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch, tmp_path):
+    monkeypatch.delenv("QUODEQ_API_KEY", raising=False)
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(tmp_path))
+
+
+class TestCancelIntent:
+    def test_cancel_intent_on_running_job_cancels(self):
+        client, provider = _make_client("running")
+        resp = client.delete("/api/evaluations/j1?intent=cancel", headers=ORIGIN)
+        assert resp.status_code == 200
+        assert resp.get_json()["action"] == "cancelled"
+        provider.cancel_evaluation.assert_called_once()
+        provider.delete_evaluation.assert_not_called()
+
+    def test_cancel_intent_never_purges_a_finished_run(self):
+        """The dialog-open race: run finished before the DELETE arrived."""
+        client, provider = _make_client("done")
+        resp = client.delete("/api/evaluations/j1?intent=cancel", headers=ORIGIN)
+        assert resp.status_code == 409
+        provider.delete_evaluation.assert_not_called()
+        provider.cancel_evaluation.assert_not_called()
+
+    def test_cancel_intent_never_purges_a_just_cancelled_run(self):
+        """The double-click race: first cancel flipped the status already."""
+        client, provider = _make_client("cancelled")
+        resp = client.delete(
+            "/api/evaluations/j1?intent=cancel&discard=true", headers=ORIGIN,
+        )
+        assert resp.status_code == 409
+        provider.delete_evaluation.assert_not_called()
+
+
+class TestDeleteIntent:
+    def test_delete_intent_on_finished_run_deletes(self):
+        client, provider = _make_client("done")
+        resp = client.delete("/api/evaluations/j1?intent=delete", headers=ORIGIN)
+        assert resp.status_code == 200
+        assert resp.get_json()["action"] == "deleted"
+        provider.delete_evaluation.assert_called_once()
+
+    def test_delete_intent_refuses_a_running_run(self):
+        """Stale client row: the run is actually still running. Refuse
+        instead of silently cancelling under a delete request."""
+        client, provider = _make_client("running")
+        resp = client.delete("/api/evaluations/j1?intent=delete", headers=ORIGIN)
+        assert resp.status_code == 409
+        provider.cancel_evaluation.assert_not_called()
+        provider.delete_evaluation.assert_not_called()
+
+
+class TestLegacyNoIntent:
+    def test_running_without_intent_cancels(self):
+        client, provider = _make_client("running")
+        resp = client.delete("/api/evaluations/j1", headers=ORIGIN)
+        assert resp.status_code == 200
+        assert resp.get_json()["action"] == "cancelled"
+
+    def test_finished_without_intent_deletes(self):
+        client, provider = _make_client("done")
+        resp = client.delete("/api/evaluations/j1", headers=ORIGIN)
+        assert resp.status_code == 200
+        assert resp.get_json()["action"] == "deleted"


### PR DESCRIPTION
## Problems (audit findings)

Stacked on #791 (shares the evaluation hooks). Two independent fixes:

**1. Background-completion project hijack.** `useEvaluationLifecycle` called `selectProjectAndRun` unconditionally when any background evaluation finished: a user browsing project B was yanked into project A's data the moment A's run completed, with no nav reset (pushed detail pages kept B's breadcrumb over A's data). Now the selection only moves when the finished run belongs to the project being viewed, or when nothing is selected yet (first-eval onboarding). The project list still refreshes either way.

**2. DELETE endpoint data-loss races.** `DELETE /api/evaluations/<id>` inferred cancel-vs-delete from the momentary snapshot status. Confirmed races: a run finishing while the cancel dialog was open meant the "Keep findings" click fell into the permanent-purge branch and erased the completed run; and a double-clicked cancel (the first request blocks ~2s in the terminal-status wait) sent a second DELETE that saw the now-cancelled status and purged the kept run. The client now declares intent: `intent=cancel` can never purge (409 `ALREADY_FINISHED` when the run is already terminal, run kept), and `intent=delete` never silently cancels (409 `STILL_RUNNING`). Requests without intent keep the legacy inference for external callers.

## Testing

- TDD: lifecycle tests for the completion guard (other-project finish does not switch, same-project does, no-selection adopts); route tests for all intent x status combinations including both race shapes; API-client tests pin the URLs.
- Full suites: backend 4475 passed, vitest 890, node:test 277.
- Browser E2E on a fake running run: cancel with "Keep findings" preserves the run dir and evidence and flips status to cancelled; a follow-up `intent=cancel` on the terminal run returns 409 and keeps the run; `intent=delete` then purges it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)