### PR TITLE
fix(scoring): one run-eligibility rule for project card and Overview

### DIFF
--- a/src/quodeq/services/_fs_metadata.py
+++ b/src/quodeq/services/_fs_metadata.py
@@ -87,9 +87,16 @@ def _read_accumulated_summary(
 
     def _compute() -> dict:
         try:
+            # Same run-set selection as the accumulated Overview
+            # (complete-only, cancelled fallback, never failed or
+            # in_progress). Iterating ALL runs newest-first gave the card
+            # a different grade than the Overview whenever the newest run
+            # was cancelled/failed/in_progress.
+            from quodeq.services.scoring_view import select_default_view_runs  # noqa: PLC0415
+            view_runs = select_default_view_runs(runs)
             latest_by_dim: dict[str, object] = {}
             files_count: int | None = None
-            for run in runs:
+            for run in view_runs:
                 dims = read_run_data(reports_root, entry_name, run.run_id)
                 for d in dims:
                     if d.dimension and d.dimension not in latest_by_dim:

--- a/src/quodeq/services/accumulated.py
+++ b/src/quodeq/services/accumulated.py
@@ -12,7 +12,7 @@ from quodeq.core.scoring.params import DEFAULT_PARAMS, ScoringParams, dimension_
 from quodeq.core.types import DimensionResult, to_camel_dict
 from quodeq.services._cache import make_lru_dimension_fetcher
 from quodeq.services.deleted import filter_deleted_from_dimensions
-from quodeq.services.dim_resolution import is_eligible_for_default_view
+from quodeq.services.scoring_view import select_default_view_runs
 from quodeq.services.dismissed import filter_dismissed_from_dimensions
 from quodeq.services._fs_projects import find_children as _find_children
 from quodeq.services.ports import RunInfo, calculate_trend, list_runs, most_frequent_grade, parse_numeric_score
@@ -170,21 +170,16 @@ def _compute_result(
     If no complete run exists but cancelled runs do (fresh project where
     every attempt was stopped early), fall back to those — better to
     show what real data we have than to render a blank dashboard. The
-    fallback explicitly excludes ``in_progress`` so a brand-new project
-    whose first run is still alive starts blank, matching the rule that
-    in-progress dims never count toward the overview.
+    fallback excludes ``in_progress`` (a brand-new project whose first
+    run is still alive starts blank) and ``failed`` (the run errored;
+    its partial scoring must not masquerade as the project grade).
 
-    The eligibility predicate is the shared
-    ``dim_resolution.is_eligible_for_default_view`` rule, used by both
-    this call site and ``dashboard._resolve_selected_run`` so the
-    headline and cards always read from the same set of runs.
+    The run-set selection is the shared
+    ``scoring_view.select_default_view_runs`` rule, also used by the
+    repositories screen's project-card summary so the card grade always
+    matches the Overview behind the click.
     """
-    eligible_run_infos = [r for r in all_run_infos if is_eligible_for_default_view(r.status)]
-    if not eligible_run_infos:
-        # Fall back to terminal-but-not-complete runs (cancelled), still
-        # excluding in_progress. ``_read_all_run_data``'s per-eval-file
-        # trustworthiness check filters out stub evals from these.
-        eligible_run_infos = [r for r in all_run_infos if r.status != "in_progress"]
+    eligible_run_infos = select_default_view_runs(all_run_infos)
     return _build_accumulated_for_runs(reports_root, project, eligible_run_infos, cache_config, params)
 
 

--- a/src/quodeq/services/scoring_view/__init__.py
+++ b/src/quodeq/services/scoring_view/__init__.py
@@ -29,6 +29,7 @@ from ._states import (
     is_successful_run,
     is_trustable_run,
     is_eligible_for_default_view,
+    select_default_view_runs,
 )
 
 # ---------------------------------------------------------------------------
@@ -69,6 +70,7 @@ __all__ = [
     "is_successful_run",
     "is_trustable_run",
     "is_eligible_for_default_view",
+    "select_default_view_runs",
     # Models
     "DimResolution",
     "BucketView",

--- a/src/quodeq/services/scoring_view/_states.py
+++ b/src/quodeq/services/scoring_view/_states.py
@@ -147,6 +147,34 @@ def is_eligible_for_default_view(status: str) -> bool:
     return status == RUN_STATE_COMPLETE
 
 
+def select_default_view_runs(run_infos):
+    """The single run-set selection for the accumulated/default view.
+
+    ``complete`` runs when any exist. Otherwise fall back to ``cancelled``
+    runs (a keep-findings cancel is real data the user chose to keep, and
+    a fresh project whose every attempt was stopped early should still
+    show what it has). ``in_progress`` never feeds the default view (the
+    umbrella run hasn't terminated) and ``failed`` never does either (the
+    run errored; partial scoring is suspect) — including in the fallback,
+    so a partial failed run cannot masquerade as the project grade.
+
+    Used by:
+      - ``accumulated._compute_result`` — the Overview cards/headline.
+      - ``_fs_metadata._read_accumulated_summary`` — the repositories
+        screen's project-card grade.
+
+    Both consult this single function so the card a user sees on the
+    project list always matches the Overview behind the click.
+
+    Args/returns are ``RunInfo``-shaped objects (anything with a
+    ``status`` attribute); order is preserved.
+    """
+    eligible = [r for r in run_infos if is_eligible_for_default_view(r.status)]
+    if eligible:
+        return eligible
+    return [r for r in run_infos if r.status == RUN_STATE_CANCELLED]
+
+
 # ---------------------------------------------------------------------------
 # Public exports
 # ---------------------------------------------------------------------------
@@ -163,4 +191,5 @@ __all__ = [
     "is_successful_run",
     "is_trustable_run",
     "is_eligible_for_default_view",
+    "select_default_view_runs",
 ]

--- a/tests/services/scoring_view/test_states.py
+++ b/tests/services/scoring_view/test_states.py
@@ -151,3 +151,42 @@ class TestPredicateConsistency:
                 assert is_trustable_run(status), (
                     f"{status}/{reason} is successful but NOT trustable."
                 )
+
+
+class TestSelectDefaultViewRuns:
+    """One shared rule for which runs feed the accumulated/default view.
+
+    The Overview (accumulated._compute_result) and the repositories-screen
+    project card must consult the same selection or their grades diverge:
+    the card used to take the newest run of ANY status while the Overview
+    took complete-only. And the fallback used to include failed runs,
+    letting a partial failed run masquerade as a normal project grade.
+    """
+
+    @staticmethod
+    def _run(run_id, status):
+        from quodeq.services.ports import RunInfo
+        return RunInfo(run_id=run_id, date_iso="2026-01-01", date_label="Jan 01", status=status)
+
+    def test_complete_runs_win(self):
+        from quodeq.services.scoring_view import select_default_view_runs
+        runs = [
+            self._run("r3", "cancelled"),
+            self._run("r2", "complete"),
+            self._run("r1", "failed"),
+        ]
+        assert [r.run_id for r in select_default_view_runs(runs)] == ["r2"]
+
+    def test_fallback_uses_cancelled_but_never_failed(self):
+        from quodeq.services.scoring_view import select_default_view_runs
+        runs = [
+            self._run("r3", "failed"),
+            self._run("r2", "cancelled"),
+            self._run("r1", "in_progress"),
+        ]
+        assert [r.run_id for r in select_default_view_runs(runs)] == ["r2"]
+
+    def test_failed_only_project_gets_nothing(self):
+        from quodeq.services.scoring_view import select_default_view_runs
+        runs = [self._run("r1", "failed")]
+        assert select_default_view_runs(runs) == []

--- a/tests/services/test_accumulated.py
+++ b/tests/services/test_accumulated.py
@@ -255,3 +255,36 @@ class TestComputeAccumulated:
         assert result is not None
         assert result["dimensions"] == []
         assert result["summary"]["dimensionCount"] == 0
+
+
+class TestFallbackExcludesFailed:
+    def test_failed_only_project_yields_empty_overview(self, tmp_path: Path):
+        # A failed run's partial evals must not masquerade as the project
+        # grade: the run errored before producing trustworthy data (this is
+        # what _compute_result's docstring always claimed; the fallback
+        # code included failed runs anyway).
+        reports_root = _setup_project(tmp_path, "proj", [
+            ("run1", [_dim("security", "3.0", "D")]),
+        ])
+        (reports_root / "proj" / "run1" / "status.json").write_text(
+            json.dumps({"state": "failed"}),
+        )
+        result = compute_accumulated(str(reports_root), "proj", None)
+        assert result is not None
+        assert result["dimensions"] == []
+        assert result["summary"]["dimensionCount"] == 0
+
+    def test_fallback_prefers_cancelled_and_skips_failed(self, tmp_path: Path):
+        reports_root = _setup_project(tmp_path, "proj", [
+            ("run2", [_dim("security", "9.0", "A")]),
+            ("run1", [_dim("security", "6.0", "C")]),
+        ])
+        (reports_root / "proj" / "run2" / "status.json").write_text(
+            json.dumps({"state": "failed"}),
+        )
+        (reports_root / "proj" / "run1" / "status.json").write_text(
+            json.dumps({"state": "cancelled"}),
+        )
+        result = compute_accumulated(str(reports_root), "proj", None)
+        assert result is not None
+        assert result["dimensions"][0]["overallScore"] == "6.0"

--- a/tests/services/test_fs_metadata.py
+++ b/tests/services/test_fs_metadata.py
@@ -440,3 +440,66 @@ class TestHasFingerprints:
             quodeq_logger.propagate = orig_propagate
         assert result is False
         assert "Could not read fingerprint dir" in caplog.text
+
+
+class TestCardUsesDefaultViewRuns:
+    @patch("quodeq.services._fs_metadata.summarize_dimensions")
+    @patch("quodeq.services._fs_metadata.read_run_data")
+    def test_newer_noncomplete_run_does_not_drive_the_card(
+        self, mock_read, mock_summarize, monkeypatch,
+    ):
+        """The repositories card must consult the same run set as the
+        Overview (select_default_view_runs). It used to iterate ALL runs
+        newest-first, so a newer cancelled/failed run gave the card a
+        different grade than the Overview showed after clicking in.
+        """
+        from quodeq.core.types import DimensionResult
+        from quodeq.services.ports import RunInfo
+
+        monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
+        mock_read.return_value = [
+            DimensionResult(dimension="security", source_file_count=5),
+        ]
+        mock_summarize.return_value = type(
+            "S", (), {"overall_grade": "B", "numeric_average": 7.0},
+        )()
+        runs = [
+            RunInfo(run_id="run-cancelled", date_iso="2026-01-03", date_label="Jan 03", status="cancelled"),
+            RunInfo(run_id="run-failed", date_iso="2026-01-02", date_label="Jan 02", status="failed"),
+            RunInfo(run_id="run-complete", date_iso="2026-01-01", date_label="Jan 01", status="complete"),
+        ]
+        grade, score, files = _read_accumulated_summary(
+            Path("/r"), "proj-card-eligibility", runs,
+        )
+        read_run_ids = {call.args[2] for call in mock_read.call_args_list}
+        assert read_run_ids == {"run-complete"}, (
+            "card must read only the default-view run set, got: "
+            f"{read_run_ids}"
+        )
+        assert grade == "B"
+
+    @patch("quodeq.services._fs_metadata.summarize_dimensions")
+    @patch("quodeq.services._fs_metadata.read_run_data")
+    def test_card_falls_back_to_cancelled_when_no_complete_run(
+        self, mock_read, mock_summarize, monkeypatch,
+    ):
+        from quodeq.core.types import DimensionResult
+        from quodeq.services.ports import RunInfo
+
+        monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
+        mock_read.return_value = [
+            DimensionResult(dimension="security", source_file_count=5),
+        ]
+        mock_summarize.return_value = type(
+            "S", (), {"overall_grade": "C", "numeric_average": 6.0},
+        )()
+        runs = [
+            RunInfo(run_id="run-cancelled", date_iso="2026-01-02", date_label="Jan 02", status="cancelled"),
+            RunInfo(run_id="run-failed", date_iso="2026-01-01", date_label="Jan 01", status="failed"),
+        ]
+        grade, score, files = _read_accumulated_summary(
+            Path("/r"), "proj-card-fallback", runs,
+        )
+        read_run_ids = {call.args[2] for call in mock_read.call_args_list}
+        assert read_run_ids == {"run-cancelled"}
+        assert grade == "C"


### PR DESCRIPTION
## Problem (audit finding)

Two of the five run-eligibility rules in the scoring stack contradicted each other in user-visible ways:

- The repositories-screen project card (`_read_accumulated_summary`) iterated ALL runs newest-first with no status filter, while the accumulated Overview uses complete runs only. Any project whose newest run was cancelled, failed, or in progress showed one grade on the card and a different grade after clicking in.
- The accumulated fallback (used when a project has no complete run) included **failed** runs, despite `_compute_result`'s own docstring saying failed runs are excluded outright. A partial failed run could masquerade as a normal-looking project grade with nothing labeling it failed.

## Changes

New shared seam `scoring_view.select_default_view_runs`: complete runs when any exist; fallback to cancelled runs only (keep-findings cancels are data the user chose to keep); `in_progress` and `failed` never feed the default view, fallback included. Both `accumulated._compute_result` and `_fs_metadata._read_accumulated_summary` consult it, so the card and the Overview cannot drift again — same centralisation pattern as `is_eligible_for_default_view` (which this composes).

## Testing

TDD: unit tests for the new selection rule, accumulated tests for the failed-only and cancelled-vs-failed fallback cases, and card tests asserting the summary reads only the default-view run set (newer cancelled/failed runs ignored, cancelled fallback when no complete run exists). Full suite: 4475 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)