### PR TITLE
fix(ui): running evaluations never leak partial scores into the Overview chart

### DIFF
--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -23,7 +23,7 @@ from quodeq.services._cache import make_lru_dimension_fetcher
 from quodeq.services._dashboard_stale import collect_stale_dimensions
 from quodeq.services._dashboard_trend import build_accumulated_trend
 from quodeq.services._trend_fetcher import make_trend_fetcher
-from quodeq.services.dim_resolution import is_eligible_for_default_view
+from quodeq.services.scoring_view import is_eligible_for_default_view, select_trend_runs
 from quodeq.services.dismissed import filter_dismissed_from_dimensions
 
 _logger = logging.getLogger(__name__)
@@ -442,9 +442,10 @@ def _compute_dashboard_payload(
 ) -> _DashboardPayload:
     """Compute history-dependent parts of the dashboard response."""
     selected_dim_names = {d.dimension for d in ctx.dimensions}
-    # Exclude cancelled/failed runs — they produce misleading points on the
-    # history chart. They remain visible in availableRuns for the UI.
-    scoreable_runs = [r for r in runs if r.status not in ("cancelled", "failed")]
+    # Shared trend rule (scoring_view.select_trend_runs): cancelled/failed
+    # runs are excluded — misleading history points. They remain visible in
+    # availableRuns for the UI.
+    scoreable_runs = select_trend_runs(runs)
     # Re-find the selected run's index inside scoreable_runs. ctx.index is
     # the index in the full unfiltered run list, which can exceed
     # len(history_runs) when cancelled/failed runs sit above the selected

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -37,6 +37,7 @@ from quodeq.services._trend_fetcher import make_rescoring_fetcher, make_trend_fe
 from quodeq.services.accumulated import compute_accumulated
 from quodeq.services.dashboard import _make_run_dimension_fetcher
 from quodeq.services.grade_formula import load_params
+from quodeq.services.scoring_view import select_trend_runs
 from quodeq.services.deleted import deleted_keys
 from quodeq.services.dismissed import dismissed_keys
 from quodeq.services._fs_projects import find_children
@@ -588,10 +589,11 @@ def get_project_scores(
 
     # Build trend using the appropriate fetcher: scalar fast path when there
     # are no active dismissals/deletions, rescoring (findings) path otherwise.
-    # Exclude cancelled/failed runs — their partial scores are misleading on
-    # the history chart. They remain in availableRuns so the UI can show them
-    # when the user asks for them explicitly.
-    scoreable_runs = [r for r in all_runs if r.status not in ("cancelled", "failed")]
+    # Shared trend rule (scoring_view.select_trend_runs): cancelled/failed
+    # runs are excluded — their partial scores are misleading on the history
+    # chart. They remain in availableRuns so the UI can show them when the
+    # user asks for them explicitly.
+    scoreable_runs = select_trend_runs(all_runs)
     history_runs = scoreable_runs[:_max_history_runs()]
     # Only completed runs may be persisted to the score cache: an in-progress
     # run's scalar set is still growing, and the cache version can't see that,

--- a/src/quodeq/services/scoring_view/__init__.py
+++ b/src/quodeq/services/scoring_view/__init__.py
@@ -30,6 +30,7 @@ from ._states import (
     is_trustable_run,
     is_eligible_for_default_view,
     select_default_view_runs,
+    select_trend_runs,
 )
 
 # ---------------------------------------------------------------------------
@@ -71,6 +72,7 @@ __all__ = [
     "is_trustable_run",
     "is_eligible_for_default_view",
     "select_default_view_runs",
+    "select_trend_runs",
     # Models
     "DimResolution",
     "BucketView",

--- a/src/quodeq/services/scoring_view/_states.py
+++ b/src/quodeq/services/scoring_view/_states.py
@@ -175,6 +175,32 @@ def select_default_view_runs(run_infos):
     return [r for r in run_infos if r.status == RUN_STATE_CANCELLED]
 
 
+def select_trend_runs(run_infos):
+    """The run set behind ``dashboard.trend`` / the score-history data.
+
+    ``complete`` and ``in_progress`` runs; ``cancelled`` and ``failed``
+    are dropped — their partial scores are misleading as history points.
+    They remain in ``availableRuns`` so the UI can surface them when the
+    user asks explicitly.
+
+    ``in_progress`` entries stay in the trend because the History table
+    renders its "running" row from them; the CLIENT keeps them from
+    representing chart buckets or the day-highlight union
+    (``dailyGrouping.isBucketEligible``), mirroring the default view's
+    wait-until-terminal rule.
+
+    Used by:
+      - ``dashboard._compute_dashboard_payload`` — history window.
+      - ``scoring.get_project_scores`` — the /scores trend.
+
+    Args/returns are ``RunInfo``-shaped objects; order is preserved.
+    """
+    return [
+        r for r in run_infos
+        if r.status not in (RUN_STATE_CANCELLED, RUN_STATE_FAILED)
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Public exports
 # ---------------------------------------------------------------------------
@@ -192,4 +218,5 @@ __all__ = [
     "is_trustable_run",
     "is_eligible_for_default_view",
     "select_default_view_runs",
+    "select_trend_runs",
 ]

--- a/src/quodeq/ui/src/utils/dailyGrouping.js
+++ b/src/quodeq/ui/src/utils/dailyGrouping.js
@@ -59,9 +59,31 @@ export function bucketKey(dateISO, granularity = 'day') {
 }
 
 /**
+ * Whether a trend entry may represent its bucket in the chart, the
+ * day-highlight union, and the per-dimension sparklines.
+ *
+ * In-progress runs carry a PARTIAL cumulative average that moves as each
+ * dimension finishes; the Overview cards deliberately wait for the
+ * umbrella run to terminate (the backend's default-view rule). Letting a
+ * running run supply a chart point or "analyzed today" highlight made
+ * those surfaces disagree with the cards mid-scan. History keeps its own
+ * live-run row, so running evaluations stay visible there.
+ *
+ * Entries without a status (legacy payloads) stay eligible.
+ *
+ * @param {{status?: string}} entry
+ * @returns {boolean}
+ */
+export function isBucketEligible(entry) {
+  return (entry?.status || '') !== 'in_progress';
+}
+
+/**
  * Collapse trend entries (newest-first) into one entry per period bucket,
- * keeping the first (newest) entry of each bucket — the most up-to-date
- * accumulated state for that period.
+ * keeping the first (newest) ELIGIBLE entry of each bucket — the most
+ * up-to-date terminal accumulated state for that period. A bucket whose
+ * only entries are in-progress is omitted entirely (nothing terminal to
+ * show yet), matching the empty overview of a first-run-in-flight project.
  *
  * @param {Array} trend - Trend entries, newest first
  * @param {'day'|'week'|'month'} [granularity='day']
@@ -71,11 +93,16 @@ export function collapseByPeriod(trend, granularity = 'day') {
   if (!trend || trend.length === 0) return trend;
   const collapsed = [];
   let currentKey = null;
+  let bucketFilled = false;
   for (const entry of trend) {
     const key = bucketKey(entry.dateISO, granularity);
     if (key !== currentKey) {
       currentKey = key;
+      bucketFilled = false;
+    }
+    if (!bucketFilled && isBucketEligible(entry)) {
       collapsed.push({ ...entry });
+      bucketFilled = true;
     }
   }
   return collapsed;
@@ -97,6 +124,7 @@ export function collectPeriodDimensions(trend, selectedRunId, granularity = 'day
   if (!selectedKey) return new Set();
   const names = new Set();
   for (const t of trend) {
+    if (!isBucketEligible(t)) continue; // running run's dims aren't "analyzed" yet
     if (bucketKey(t.dateISO, granularity) === selectedKey) {
       for (const dim of t.dimensions || []) names.add(dim.toLowerCase());
     }
@@ -150,6 +178,7 @@ export function extractDimensionPeriodSeries(trend, dimensionName, granularity =
   const seen = new Set();
   const out = [];
   for (const entry of trend) {
+    if (!isBucketEligible(entry)) continue; // partial mid-scan point
     const key = bucketKey(entry?.dateISO, granularity);
     if (seen.has(key)) continue;
     const details = entry?.dimensionDetails;

--- a/src/quodeq/ui/src/utils/dailyGrouping.test.js
+++ b/src/quodeq/ui/src/utils/dailyGrouping.test.js
@@ -76,6 +76,57 @@ test('bucketKey: date-only strings pass through unchanged (no timezone context)'
 });
 
 // ---------------------------------------------------------------------------
+// in-progress runs never represent a bucket
+// ---------------------------------------------------------------------------
+// A running run's trend entry carries a PARTIAL cumulative average that
+// moves as each dimension finishes. The Overview cards wait for the run to
+// terminate; the chart, highlight union, and sparklines must do the same
+// or they disagree with the cards mid-scan.
+
+const TREND_WITH_RUNNING = [
+  { runId: 'live', dateISO: '2026-03-25T16:00:00', status: 'in_progress', numericAverage: 5.1, dimensions: ['security'], dimensionDetails: [{ dimension: 'security', score: 5.1 }] },
+  { runId: 'done2', dateISO: '2026-03-25T10:00:00', status: 'complete', numericAverage: 9.2, dimensions: ['maintainability'], dimensionDetails: [{ dimension: 'maintainability', score: 9.2 }] },
+  { runId: 'done1', dateISO: '2026-03-24T10:00:00', status: 'complete', numericAverage: 8.0, dimensions: ['security'], dimensionDetails: [{ dimension: 'security', score: 8.0 }] },
+];
+
+test('collapseByPeriod: an in-progress newest entry does not represent its bucket', () => {
+  const result = collapseByPeriod(TREND_WITH_RUNNING, 'day');
+  assert.equal(result.length, 2);
+  assert.equal(result[0].runId, 'done2'); // Mar 25: terminal run wins, not "live"
+  assert.equal(result[1].runId, 'done1');
+});
+
+test('collapseByPeriod: a bucket with only an in-progress entry is omitted', () => {
+  const trend = [
+    { runId: 'live', dateISO: '2026-03-26T09:00:00', status: 'in_progress', numericAverage: 4.0 },
+    { runId: 'done1', dateISO: '2026-03-24T10:00:00', status: 'complete', numericAverage: 8.0 },
+  ];
+  const result = collapseByPeriod(trend, 'day');
+  assert.equal(result.length, 1);
+  assert.equal(result[0].runId, 'done1');
+});
+
+test('collectPeriodDimensions: an in-progress run does not contribute to the day union', () => {
+  const dims = collectPeriodDimensions(TREND_WITH_RUNNING, 'done2', 'day');
+  assert.ok(dims.has('maintainability'));
+  assert.ok(!dims.has('security'), 'running run dims are not "analyzed" yet');
+});
+
+test('extractDimensionPeriodSeries: an in-progress entry never supplies a bucket point', () => {
+  const series = extractDimensionPeriodSeries(TREND_WITH_RUNNING, 'security', 'day');
+  // Mar 25's security only exists in the running run -> no Mar 25 point;
+  // Mar 24's terminal 8.0 is the latest security point.
+  assert.deepEqual(series.map((s) => s.runId), ['done1']);
+});
+
+test('entries without a status stay eligible (legacy payloads)', () => {
+  const trend = [
+    { runId: 'r1', dateISO: '2026-03-25T10:00:00', numericAverage: 9.0 },
+  ];
+  assert.equal(collapseByPeriod(trend, 'day').length, 1);
+});
+
+// ---------------------------------------------------------------------------
 // collapseByDay
 // ---------------------------------------------------------------------------
 

--- a/src/quodeq/ui/src/utils/scoreFiltering.js
+++ b/src/quodeq/ui/src/utils/scoreFiltering.js
@@ -5,7 +5,7 @@
  * returned by the unified /scores endpoint.
  */
 
-import { bucketKey } from './dailyGrouping.js';
+import { bucketKey, isBucketEligible } from './dailyGrouping.js';
 
 const roundOneDecimal = (n) => Math.round(n * 10) / 10;
 
@@ -65,6 +65,11 @@ export function filterTrendByVisibleStandardsDaily(trend, periodTrend, visibleSe
   const visibleKeys = new Set();
   const rawReversed = [...trend].reverse(); // oldest first
   for (const entry of rawReversed) {
+    // A running run's partial dims must not enter the bucket average: the
+    // Overview header reads the selected bucket's numericAverage, and the
+    // cards deliberately exclude in-progress runs — a partial score here
+    // makes the headline disagree with the cards mid-scan.
+    if (!isBucketEligible(entry)) continue;
     let hasVisible = false;
     for (const d of (entry.dimensionDetails || [])) {
       const dimId = (d.dimension || '').toLowerCase();

--- a/src/quodeq/ui/src/utils/scoreFiltering.period.test.js
+++ b/src/quodeq/ui/src/utils/scoreFiltering.period.test.js
@@ -39,3 +39,23 @@ test('day granularity (3-arg legacy call) is unchanged: one entry per visible da
   // a3's day (Mar 28) has no visible eval, so it's dropped at day granularity — unchanged behavior.
   assert.deepEqual(result.map((r) => r.runId), ['a4', 'a2', 'a1']);
 });
+
+test('in-progress entries never contribute to a bucket accumulated average', () => {
+  // A running run's partial dims must not overwrite the bucket average:
+  // the Overview header reads the selected bucket's numericAverage, and the
+  // cards deliberately exclude in-progress runs, so a partial score here
+  // makes the headline disagree with the cards mid-scan.
+  const trend = [
+    { runId: 'live', dateISO: '2026-04-14T20:00:00', status: 'in_progress',
+      dimensions: ['security'],
+      dimensionDetails: [{ dimension: 'security', score: 2 }] },
+    { runId: 'done', dateISO: '2026-04-14T10:00:00', status: 'complete',
+      dimensions: ['security'],
+      dimensionDetails: [{ dimension: 'security', score: 8 }] },
+  ];
+  const periodTrend = collapseByPeriod(trend, 'day'); // [done] (live skipped)
+  const result = filterTrendByVisibleStandardsDaily(trend, periodTrend, new Set(['security']), 'day');
+  assert.equal(result.length, 1);
+  assert.equal(result[0].runId, 'done');
+  assert.equal(result[0].numericAverage, 8); // not dragged to 2 by the running run
+});

--- a/tests/services/scoring_view/test_states.py
+++ b/tests/services/scoring_view/test_states.py
@@ -190,3 +190,29 @@ class TestSelectDefaultViewRuns:
         from quodeq.services.scoring_view import select_default_view_runs
         runs = [self._run("r1", "failed")]
         assert select_default_view_runs(runs) == []
+
+
+class TestSelectTrendRuns:
+    """The trend/history-chart run set, centralised next to its siblings.
+
+    Behavior-preserving move of the inline 'not cancelled/failed' filters
+    from dashboard.py and scoring/__init__.py: the trend includes
+    in_progress entries (History renders their 'running' row from trend),
+    while the CLIENT keeps them from representing chart buckets
+    (dailyGrouping.isBucketEligible).
+    """
+
+    @staticmethod
+    def _run(run_id, status):
+        from quodeq.services.ports import RunInfo
+        return RunInfo(run_id=run_id, date_iso="2026-01-01", date_label="Jan 01", status=status)
+
+    def test_keeps_complete_and_in_progress_drops_cancelled_and_failed(self):
+        from quodeq.services.scoring_view import select_trend_runs
+        runs = [
+            self._run("r4", "in_progress"),
+            self._run("r3", "complete"),
+            self._run("r2", "cancelled"),
+            self._run("r1", "failed"),
+        ]
+        assert [r.run_id for r in select_trend_runs(runs)] == ["r4", "r3"]


### PR DESCRIPTION
## Problem (deferred audit finding 6)

The trend deliberately includes in-progress runs (History renders its "running" row from them), but every chart-facing surface picked bucket representatives with no status awareness. Mid-scan, the score-history chart's latest bucket, the Overview headline, the day-highlight union, and the per-dimension sparklines could all show a running run's PARTIAL cumulative average while the dimension cards correctly stayed on the last complete run. This was the remaining confirmed source of "weird Overview data during a background evaluation".

## Changes

- New `dailyGrouping.isBucketEligible` rule (in-progress entries are ineligible), applied to:
  - `collapseByPeriod`: the bucket representative is the newest ELIGIBLE entry; a bucket whose only entries are in-progress is omitted, matching the empty overview of a first-run-in-flight project.
  - `collectPeriodDimensions`: a running run's dims don't highlight as "analyzed" until the run terminates (the cards don't count their scores yet either).
  - `extractDimensionPeriodSeries`: sparklines never take a partial point.
  - `filterTrendByVisibleStandardsDaily`: the bucket accumulated-average walk skips in-progress entries (browser E2E caught this one; the headline read 5.3 while the cards showed 8.3).
- History is untouched: running evaluations still show their live row there, and the Evaluate tab keeps the in-progress card.
- Server side, the trend's run-set rule moves into `scoring_view.select_trend_runs` (behavior preserving), replacing the duplicated inline `not in ("cancelled", "failed")` filters in dashboard.py and scoring/__init__.py, so the trend rule now lives next to `select_default_view_runs` and the other centralised eligibility predicates.

## Testing

- TDD: new grouping tests (bucket representative skips in-progress, in-progress-only bucket omitted, union and sparkline exclusion, legacy no-status entries stay eligible), a scoreFiltering test for the bucket-average walk, and a `select_trend_runs` unit test.
- Full suites: backend 4488 passed, vitest 892, node:test 287.
- Browser E2E with two complete runs + a live in-progress run carrying a partial 2.0 score: header 8.3 (+2.0) agrees with the cards, chart shows MIN 6.3 / MAX 8.3 with the partial 5.2 average appearing nowhere, both dimension cards highlighted from the terminal run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
