### PR TITLE
fix(assistant): guard workspace discard + make action apply/reject atomic

### DIFF
--- a/src/quodeq/api/assistant_routes.py
+++ b/src/quodeq/api/assistant_routes.py
@@ -259,13 +259,23 @@ def register_assistant_routes(app: Flask) -> None:
         spec = ACTIONS.get(action["action_type"])
         if spec is None:
             return jsonify({"error": "unsupported action type"}), 400
+        # Atomically claim the drafted->applied transition BEFORE running the
+        # side effect, so a double-click / two-tab race can't run spec.apply
+        # twice (which double-ran the dismiss rescore). The loser sees a
+        # non-drafted row and 409s. On failure we release back to drafted so
+        # the user can retry.
+        if not repo.set_action_status(action_id, "applied", expected="drafted"):
+            fresh = repo.get_action(action_id)
+            state = fresh["status"] if fresh else "gone"
+            return jsonify({"error": f"action already {state}"}), 409
         try:
             result = spec.apply(action["payload"], current_app)
         except ValueError as exc:
+            repo.set_action_status(action_id, "drafted")
             return jsonify({"error": str(exc)}), 400
         except ActionConflict as exc:
+            repo.set_action_status(action_id, "drafted")
             return jsonify({"error": str(exc)}), 409
-        repo.set_action_status(action_id, "applied")
         return jsonify({"applied": True, "result": result}), 200
 
     @app.post("/api/assistant/actions/<action_id>/reject")
@@ -274,9 +284,11 @@ def register_assistant_routes(app: Flask) -> None:
         action = repo.get_action(action_id)
         if action is None:
             return jsonify({"error": "unknown action"}), 404
-        # Same replay guard as apply: an applied action must not flip to
-        # rejected on a stale card click or SSE replay.
-        if action["status"] != "drafted":
-            return jsonify({"error": f"action already {action['status']}"}), 409
-        repo.set_action_status(action_id, "rejected")
+        # Same replay guard as apply, made atomic: an applied action must
+        # not flip to rejected on a stale card click, SSE replay, or a race
+        # with a concurrent apply. The compare-and-set wins at most once.
+        if not repo.set_action_status(action_id, "rejected", expected="drafted"):
+            fresh = repo.get_action(action_id)
+            state = fresh["status"] if fresh else "gone"
+            return jsonify({"error": f"action already {state}"}), 409
         return jsonify({"status": "rejected"}), 200

--- a/src/quodeq/api/assistant_workspace_routes.py
+++ b/src/quodeq/api/assistant_workspace_routes.py
@@ -142,11 +142,25 @@ def register_assistant_workspace_routes(app: Flask) -> None:
             return err
         if row is None:
             return jsonify({"error": "no worktree"}), 404
-        if row["status"] not in ("active", "stale"):
-            return jsonify({"error": f"worktree already {row['status']}"}), 409
+        from quodeq.api.assistant_routes import _release_turn, _try_claim_turn
+        # Claim the turn slot like apply/pr: without this, discard raced an
+        # in-flight apply (overwriting "applied" with "discarded" while the
+        # changes sat in the user's real tree) and pulled the worktree out
+        # from under a running write turn.
+        if not _try_claim_turn(sid):
+            return jsonify({"error": "a turn or workspace action is in progress;"
+                            " wait for it to finish"}), 409
         try:
-            _manager(row).remove()
-        except WorktreeError as exc:
-            return jsonify({"error": str(exc)}), 500
-        repo.set_worktree_status(sid, "discarded")
-        return jsonify({"discarded": True})
+            row = repo.get_worktree(sid)  # re-read under the claim
+            if row is None:
+                return jsonify({"error": "no worktree"}), 404
+            if row["status"] not in ("active", "stale"):
+                return jsonify({"error": f"worktree already {row['status']}"}), 409
+            try:
+                _manager(row).remove()
+            except WorktreeError as exc:
+                return jsonify({"error": str(exc)}), 500
+            repo.set_worktree_status(sid, "discarded")
+            return jsonify({"discarded": True})
+        finally:
+            _release_turn(sid)

--- a/src/quodeq/data/sqlite/assistant_repository.py
+++ b/src/quodeq/data/sqlite/assistant_repository.py
@@ -115,11 +115,29 @@ class AssistantRepository:
         row["payload"] = json.loads(row.pop("payload_json"))
         return row
 
-    def set_action_status(self, action_id: str, status: str) -> None:
+    def set_action_status(
+        self, action_id: str, status: str, *, expected: str | None = None,
+    ) -> bool:
+        """Set an action's status; return whether a row was updated.
+
+        With ``expected`` the write is a compare-and-set
+        (``WHERE id=? AND status=?``), so a caller can atomically claim a
+        transition — two concurrent applies of the same action can't both
+        win and double-run the side effect. Without ``expected`` the write
+        is unconditional (back-compat for the rollback path).
+        """
         with self._connect() as conn:
-            conn.execute(
-                "UPDATE actions SET status = ? WHERE id = ?", (status, action_id)
-            )
+            if expected is None:
+                cur = conn.execute(
+                    "UPDATE actions SET status = ? WHERE id = ?",
+                    (status, action_id),
+                )
+            else:
+                cur = conn.execute(
+                    "UPDATE actions SET status = ? WHERE id = ? AND status = ?",
+                    (status, action_id, expected),
+                )
+            return cur.rowcount == 1
 
     def append_event(self, session_id: str, frame: dict[str, Any]) -> int:
         with self._connect() as conn:

--- a/tests/api/test_assistant_workspace_routes.py
+++ b/tests/api/test_assistant_workspace_routes.py
@@ -91,6 +91,43 @@ def test_discard_removes_worktree(app, client, repo):
     assert store.get_worktree(sid)["status"] == "discarded"
 
 
+def test_discard_blocked_while_turn_in_flight(app, client, repo):
+    # Regression: discard raced apply/pr and in-flight write turns because it
+    # was the only mutating workspace route with no turn-slot claim. A held
+    # slot must 409 discard and leave the worktree intact.
+    sid, store, manager = _session_with_worktree(app, client, repo)
+    import quodeq.api.assistant_routes as ar
+    with ar._running_lock:
+        ar._running_turns.add(sid)
+    try:
+        resp = client.post(f"/api/assistant/sessions/{sid}/workspace/discard")
+        assert resp.status_code == 409
+        assert manager.path.exists()
+        assert store.get_worktree(sid)["status"] == "active"
+    finally:
+        with ar._running_lock:
+            ar._running_turns.discard(sid)
+
+
+def test_discard_claims_turn_slot_and_releases(app, client, repo, monkeypatch):
+    sid, store, _ = _session_with_worktree(app, client, repo)
+    import quodeq.api.assistant_routes as ar
+    from quodeq.assistant.worktree import WorktreeManager
+    seen = {}
+    orig = WorktreeManager.remove
+
+    def spy(self, delete_branch=True):
+        with ar._running_lock:
+            seen["claimed"] = sid in ar._running_turns
+        return orig(self, delete_branch=delete_branch)
+
+    monkeypatch.setattr(WorktreeManager, "remove", spy)
+    resp = client.post(f"/api/assistant/sessions/{sid}/workspace/discard")
+    assert resp.status_code == 200 and seen["claimed"] is True
+    with ar._running_lock:
+        assert sid not in ar._running_turns  # released after
+
+
 def test_pr_fail_soft_keeps_branch(app, client, repo, monkeypatch):
     sid, store, manager = _session_with_worktree(app, client, repo)
     # fixture repo has no origin: push fails, endpoint stays 200 fail-soft

--- a/tests/data/sqlite/test_assistant_repository.py
+++ b/tests/data/sqlite/test_assistant_repository.py
@@ -71,3 +71,32 @@ def test_set_cli_session_id(tmp_path):
     repo.create_session(session_id="s1", provider="claude")
     repo.set_cli_session_id("s1", "uuid-123")
     assert repo.get_session("s1")["cli_session_id"] == "uuid-123"
+
+
+def test_set_action_status_conditional_transition_is_atomic(tmp_path):
+    """A guarded transition wins exactly once, so a double apply can't
+    double-run the side effect. Without expected=, the write is unconditional
+    (back-compat)."""
+    repo = _repo(tmp_path)
+    repo.create_session(session_id="s1", provider="ollama")
+    repo.create_action(
+        action_id="a1", session_id="s1", action_type="create_standard",
+        payload={"id": "x"}, content_hash="h",
+    )
+    # First claim of drafted -> applied wins.
+    assert repo.set_action_status("a1", "applied", expected="drafted") is True
+    assert repo.get_action("a1")["status"] == "applied"
+    # Second claim from drafted loses: the row is no longer drafted.
+    assert repo.set_action_status("a1", "applied", expected="drafted") is False
+    assert repo.get_action("a1")["status"] == "applied"
+
+
+def test_set_action_status_unconditional_still_works(tmp_path):
+    repo = _repo(tmp_path)
+    repo.create_session(session_id="s1", provider="ollama")
+    repo.create_action(
+        action_id="a1", session_id="s1", action_type="create_standard",
+        payload={"id": "x"}, content_hash="h",
+    )
+    assert repo.set_action_status("a1", "applied") is True
+    assert repo.get_action("a1")["status"] == "applied"


### PR DESCRIPTION
Two confirmed findings from the 1.6.1 flagship audit of the v1.6.0 AI Assistant write path.

## C1 — Discard raced apply/PR and in-flight write turns (data integrity + misleading success)

Discard was the only mutating workspace route with no `_try_claim_turn` claim; apply and PR both take one and re-read the row under it. So:

- **Apply then Discard** (two tabs, or a stale panel): apply claims the slot and begins `apply_to_repo()`, which mutates the user's real working tree. Discard, unguarded, reads the still-`active` row, removes the worktree, and overwrites `"applied"` with `"discarded"`. Final state: the changes are sitting uncommitted in the user's tree, but the drawer shows "Changes discarded." The user believes nothing was applied.
- **Discard during a write turn**: discard removes the worktree out from under a running message turn, so the model's next `edit_repo_file`/`get_worktree_diff` dies with an opaque `WorktreeError`.

Discard now claims the turn slot and re-reads the worktree row under the claim, exactly like apply/PR.

## C3 — Action apply/reject was non-atomic (double-run of dismiss rescore)

`apply`/`reject` were check-then-act: they read `status == "drafted"`, then wrote status with an unconditional `UPDATE ... WHERE id=?`. Two concurrent applies of the same action (double-click, two tabs) both passed the check and both ran `spec.apply` — for `dismiss_finding` that ran the rescore pipeline twice.

`set_action_status` now takes an optional `expected=` for a compare-and-set (`WHERE id=? AND status=?`) and returns whether it won. `apply` claims `drafted -> applied` atomically **before** the side effect and rolls back to `drafted` on failure; `reject` claims `drafted -> rejected`. The loser 409s.

## Testing

- New repository tests: conditional transition wins exactly once; unconditional write still works (back-compat for the rollback path).
- New route tests: discard 409s while a turn slot is held and leaves the worktree intact; discard claims and releases the slot around `remove()`.
- Existing double-apply-409 and reject tests still pass. Full suite: 4491 passed.

Part of a 1.6.1 flagship-quality audit; separate PRs follow for assistant worktree/db hygiene, terminal reconnect UX, and evaluation-lifecycle races (watchdog process-tree kill, SSE shape mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)