### PR TITLE
fix(jobs): watchdog kills the whole process tree, not just the parent

### DIFF
--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -46,7 +46,6 @@ __all__ = [
 # NOTE: logging in inner layer — tracked for middleware extraction
 _logger = logging.getLogger(__name__)
 _REPORT_PATH_MARKER = "Report path:"
-_PROCESS_WAIT_TIMEOUT_S = 30
 _EXIT_CODE_SPAWN_FAILURE = -1
 _EXIT_CODE_TIMEOUT = -9
 _DEFAULT_LIST_LIMIT = 100
@@ -428,11 +427,14 @@ class JobManager:
                 if self._watchdog_should_kill(job_id, started_at):
                     elapsed = int(time.time() - started_at)
                     _logger.warning("Job %s watchdog killing after %ds", job_id, elapsed)
-                    process.kill()
-                    try:
-                        process.wait(timeout=_PROCESS_WAIT_TIMEOUT_S)
-                    except subprocess.TimeoutExpired:
-                        pass
+                    # Kill the whole process GROUP (TERM -> grace -> KILL), not
+                    # just the parent PID. The subprocess is spawned
+                    # start_new_session=True, so a bare process.kill() would
+                    # orphan the subagent pool + AI-CLI children (leaking tokens
+                    # and CPU, and letting them write into the abandoned run
+                    # dir). _terminate_process matches the cancel/shutdown paths
+                    # and waits internally.
+                    _terminate_process(process)
                     exit_code = _EXIT_CODE_TIMEOUT
                     break
         with self._lock:

--- a/tests/services/test_job_manager.py
+++ b/tests/services/test_job_manager.py
@@ -381,6 +381,8 @@ class TestMonitorProcess:
         from quodeq.services import jobs as jobs_mod
         monkeypatch.setenv("QUODEQ_JOB_TIMEOUT_S", "0.05")
         monkeypatch.setattr(jobs_mod, "_WATCHDOG_POLL_INTERVAL_S", 0.01)
+        # Group-wide terminate would signal a real pid; stub it to the fake's kill.
+        monkeypatch.setattr(jobs_mod, "_terminate_process", lambda p: p.kill())
 
         store = InMemoryJobStore()
         mgr = JobManager(job_store=store)
@@ -442,6 +444,9 @@ class TestMonitorProcess:
         from quodeq.services import jobs as jobs_mod
         monkeypatch.setattr(jobs_mod, "_WATCHDOG_POLL_INTERVAL_S", 0.01)
         monkeypatch.setattr(jobs_mod, "_WATCHDOG_DEADLINE_GRACE_S", 0.02)
+        # The watchdog must terminate the whole process tree, not just the
+        # parent PID; patch it to the stub's own kill so the loop can break.
+        monkeypatch.setattr(jobs_mod, "_terminate_process", lambda p: p.kill())
 
         store = InMemoryJobStore()
         mgr = JobManager(job_store=store)
@@ -454,6 +459,39 @@ class TestMonitorProcess:
         mgr._monitor_process("j1", proc)
 
         assert proc.killed is True
+        assert job.exit_code == _EXIT_CODE_TIMEOUT
+        assert job.status == STATUS_FAILED
+
+    def test_watchdog_kill_terminates_the_process_tree(self, monkeypatch):
+        """The watchdog must kill the process GROUP, not just the parent PID.
+
+        The subprocess is spawned start_new_session=True, so a bare
+        process.kill() SIGKILLs only the parent — the subagent pool + AI-CLI
+        children are orphaned (token/CPU leak) and can keep writing into the
+        abandoned run dir. Every other kill path goes through
+        _terminate_process (group-wide, TERM->grace->KILL); the watchdog
+        must too.
+        """
+        from quodeq.services import jobs as jobs_mod
+        monkeypatch.setenv("QUODEQ_JOB_TIMEOUT_S", "0.05")
+        monkeypatch.setattr(jobs_mod, "_WATCHDOG_POLL_INTERVAL_S", 0.01)
+        calls = []
+
+        def fake_terminate(p):
+            calls.append(p)
+            p.kill()  # let the stub's wait() start returning so the loop ends
+
+        monkeypatch.setattr(jobs_mod, "_terminate_process", fake_terminate)
+
+        store = InMemoryJobStore()
+        mgr = JobManager(job_store=store)
+        job = Job("j1", STATUS_RUNNING, ["cmd"], "now", None, None)
+        store.put(job)
+        proc = _NeverExitsProcess()
+        mgr._processes["j1"] = proc
+        mgr._monitor_process("j1", proc)
+
+        assert calls == [proc], "watchdog kill must go through _terminate_process"
         assert job.exit_code == _EXIT_CODE_TIMEOUT
         assert job.status == STATUS_FAILED
 


### PR DESCRIPTION
Confirmed finding F2 from the 1.6.1 flagship eval-lifecycle audit.

## Problem

`JobManager._monitor_process` killed a wedged run (deadline exceeded, or `QUODEQ_JOB_TIMEOUT_S` cap) with a bare `process.kill()`. The evaluation subprocess is spawned `start_new_session=True`, making it a process-group leader, so `process.kill()` SIGKILLs **only the parent PID**:

- The subagent pool workers and the AI-CLI child processes in that group are **not** signalled — they're reparented to init and keep consuming API tokens / CPU, and can keep writing into the abandoned run directory.
- SIGKILL can't be caught, so `RunLifecycleContext`'s signal handlers / atexit hook never run and `status.json` stays non-terminal. The in-memory `Job` is flipped to `failed`, but the index row stays `running` until the 30s stale sweep — so the Evaluate tab and History disagree for that window.

Every other kill path already uses the group-aware `_terminate_process` (cancel → `_terminate_process`, shutdown → `_kill_tree`). Only the watchdog used the bare, non-group, no-grace kill — despite its own `_WATCHDOG_DEADLINE_GRACE_S` comment promising the graceful-cancel path a chance to finalize.

## Fix

The watchdog now calls `_terminate_process(process)` — SIGTERM to the whole group, grace window, then SIGKILL — identical to the cancel path. It waits internally, so the redundant post-kill `process.wait` and its now-unused `_PROCESS_WAIT_TIMEOUT_S` constant are removed.

## Testing

- New test asserts the watchdog kill routes through `_terminate_process` (not bare `process.kill()`), with status `failed` + `_EXIT_CODE_TIMEOUT`. The two existing watchdog-kill tests are updated to stub `_terminate_process` (a group-wide terminate would signal a real PID otherwise).
- Full suite: 4488 passed.

Part of the 1.6.1 flagship audit; more eval-lifecycle PRs follow (concurrent-start guard, SSE shape mismatch, CLI marker reconciliation) alongside the data-store eligibility and terminal-reconnect fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)