### PR TITLE
fix(scoring): agree across dashboard/Overview/History for no-complete-run projects

### DIFF
--- a/src/quodeq/services/_accumulated_data.py
+++ b/src/quodeq/services/_accumulated_data.py
@@ -18,8 +18,18 @@ class _DimensionBuckets:
 
 
 def _has_valid_score(dim: DimensionResult) -> bool:
-    """Return True if the dimension carries a usable overall score."""
-    return bool(dim.overall_score)
+    """Return True if the dimension carries a usable, trustworthy score.
+
+    Requires a non-empty ``overall_score`` AND that the model actually
+    inspected files. A coverage-0 eval (``files_read == 0``) is the stub
+    ``_score_completed_evidence`` writes at cancel time when no findings
+    landed; its score is meaningless and must not drive the accumulated
+    Overview (the same ``filesRead > 0`` trust rule ``scoring_view`` uses).
+    A missing ``files_read`` (None, legacy evals) is trusted as before.
+    """
+    if not dim.overall_score:
+        return False
+    return dim.files_read != 0
 
 
 def _classify_dimension(

--- a/src/quodeq/services/_fs_metadata.py
+++ b/src/quodeq/services/_fs_metadata.py
@@ -93,13 +93,18 @@ def _read_accumulated_summary(
             # a different grade than the Overview whenever the newest run
             # was cancelled/failed/in_progress.
             from quodeq.services.scoring_view import select_default_view_runs  # noqa: PLC0415
+            from quodeq.services._accumulated_data import _has_valid_score  # noqa: PLC0415
             view_runs = select_default_view_runs(runs)
             latest_by_dim: dict[str, object] = {}
             files_count: int | None = None
             for run in view_runs:
                 dims = read_run_data(reports_root, entry_name, run.run_id)
                 for d in dims:
-                    if d.dimension and d.dimension not in latest_by_dim:
+                    # Same trust gate as the accumulated Overview
+                    # (_has_valid_score): skip a coverage-0 stub so the card
+                    # falls through to a real older run instead of showing
+                    # the stub's inflated grade.
+                    if d.dimension and d.dimension not in latest_by_dim and _has_valid_score(d):
                         latest_by_dim[d.dimension] = d
                     if files_count is None and d.source_file_count:
                         files_count = d.source_file_count

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -390,6 +390,17 @@ def _build_dashboard_result(
     }
 
 
+# Fallback order for the "latest" default run when none is complete. Each
+# tier is tried newest-first; a failed run is only headlined when nothing
+# else remains (handled after this list). Complete mirrors the Overview's
+# is_eligible_for_default_view; cancelled matches its cancelled fallback.
+_LATEST_FALLBACK_ORDER = (
+    is_eligible_for_default_view,               # complete
+    lambda status: status == "cancelled",
+    lambda status: status == "in_progress",
+)
+
+
 def _resolve_selected_run(runs: list[RunInfo], run: str) -> tuple[RunInfo, int]:
     """Return the selected RunInfo and its index in *runs*, raising FileNotFoundError if absent.
 
@@ -404,18 +415,25 @@ def _resolve_selected_run(runs: list[RunInfo], run: str) -> tuple[RunInfo, int]:
     drift.
 
     If no run is complete (fresh project, only run still in progress,
-    every attempt cancelled), fall back to ``runs[0]`` rather than
-    refusing to render. Users can still navigate to a specific partial
+    every attempt cancelled), fall back by trust order — cancelled, then
+    in_progress — and only headline a ``failed`` run when there is nothing
+    else. A failed run must not headline the dashboard while a cancelled
+    run with real kept-findings data exists, or the headline would show
+    untrustworthy data the Overview cards (which never fall back to
+    ``failed``) refuse to show. Users can still navigate to any specific
     run via the score-history chart or history table.
 
     Note: run IDs are opaque UUIDs (no sensitive data), safe to include in
     error messages.
     """
     if run == _LATEST_RUN:
-        selected_run = next(
-            (r for r in runs if is_eligible_for_default_view(r.status)),
-            runs[0],
-        )
+        selected_run = None
+        for accept in _LATEST_FALLBACK_ORDER:
+            selected_run = next((r for r in runs if accept(r.status)), None)
+            if selected_run:
+                break
+        if selected_run is None:
+            selected_run = runs[0]  # only failed runs remain; show the newest
     else:
         selected_run = next((item for item in runs if item.run_id == run), None)
     if not selected_run:

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -48,17 +48,17 @@ function trimTrailingZero(n) {
 }
 
 function computeDeltas(rows) {
-  // Aligns 1:1 with `rows` (which may include in-progress stubs at the
-  // front). In-progress entries have no score, so their delta is null and
-  // we compare each completed row against the next completed one.
+  // Aligns 1:1 with `rows`, which may include scoreless stub rows
+  // (in-progress runs at the front, cancelled partial rows interleaved).
+  // A scoreless row has no delta, and each scored row compares against the
+  // next SCORED row so a stub in between doesn't null out a real delta.
   return rows.map((entry, i) => {
-    if (entry.status === 'in_progress') return null;
-    let nextIdx = i + 1;
-    while (nextIdx < rows.length && rows[nextIdx].status === 'in_progress') nextIdx++;
-    if (nextIdx >= rows.length) return null;
     const curr = parseFloat(entry.numericAverage);
+    if (Number.isNaN(curr)) return null;
+    let nextIdx = i + 1;
+    while (nextIdx < rows.length && Number.isNaN(parseFloat(rows[nextIdx].numericAverage))) nextIdx++;
+    if (nextIdx >= rows.length) return null;
     const prev = parseFloat(rows[nextIdx].numericAverage);
-    if (Number.isNaN(curr) || Number.isNaN(prev)) return null;
     return Math.round((curr - prev) * 10) / 10;
   });
 }
@@ -111,6 +111,49 @@ function buildInProgressStubs(availableRuns, trend) {
     // scoring yet. Clicking would land on an empty dashboard, so the row is
     // rendered as not-yet-ready.
     .map((r) => ({ runId: r.runId, dateLabel: r.dateLabel, dateISO: null, status: 'in_progress', hasScoredDims: false }));
+}
+
+function buildCancelledStubs(availableRuns, trend) {
+  // Cancelled runs are stripped from `trend` server-side (they're not chart
+  // points), but their kept-findings scores still drive the Overview when no
+  // complete run exists. Surface them as partial, dated rows so History and
+  // the Overview agree instead of showing scores over an empty table.
+  const trendIds = new Set((trend || []).map((e) => e.runId));
+  return (availableRuns || [])
+    .filter((r) => r.status === 'cancelled' && !trendIds.has(r.runId))
+    .map((r) => ({
+      runId: r.runId, dateLabel: r.dateLabel, dateISO: r.dateISO ?? null,
+      status: 'cancelled', hasScoredDims: true,
+    }));
+}
+
+/**
+ * Ordered rows for the History table: in-progress runs on top (running now),
+ * then cancelled partial rows interleaved with the (already newest-first)
+ * trend by date. Cancelled runs are absent from `trend`, so without this a
+ * project whose only runs are cancelled shows an empty History while the
+ * Overview shows their scores.
+ */
+export function assembleHistoryRows(availableRuns, trend) {
+  const inProgress = buildInProgressStubs(availableRuns, trend);
+  const cancelled = buildCancelledStubs(availableRuns, trend);
+  const dated = [...cancelled, ...(trend || [])].sort(
+    (a, b) => (b.dateISO || '').localeCompare(a.dateISO || ''),
+  );
+  return [...inProgress, ...dated];
+}
+
+/**
+ * Assembled rows minus hidden (failed) runs — the rows the table actually
+ * shows. The "no evaluations yet" guard checks this (not just `trend`), so
+ * a project whose only runs are cancelled still populates History instead
+ * of short-circuiting to empty while the Overview shows their scores.
+ */
+export function visibleHistoryRows(availableRuns, trend) {
+  const statusById = new Map((availableRuns || []).map((r) => [r.runId, r.status]));
+  return assembleHistoryRows(availableRuns, trend).filter(
+    (r) => !HIDDEN_STATUSES.has(statusById.get(r.runId) ?? r.status),
+  );
 }
 
 function NotReadyToast({ message, onDismiss }) {
@@ -290,7 +333,7 @@ function HistoryContent({ data, callbacks, runNav, languageSub }) {
   const { trend, selectedRunId, availableRuns } = data;
   const { onRunClick, onRunHover, onRunHoverEnd, onRunChange, onDeleteRun } = callbacks;
   const { runNavLabel, overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest } = runNav;
-  const inProgressStubs = useMemo(() => buildInProgressStubs(availableRuns, trend), [availableRuns, trend]);
+  const historyRows = useMemo(() => assembleHistoryRows(availableRuns, trend), [availableRuns, trend]);
   // Toast state for clicks on running runs that have no scored dimensions yet.
   // toastKey forces remount so consecutive clicks restart the auto-dismiss timer.
   const [toastKey, setToastKey] = useState(0);
@@ -309,9 +352,8 @@ function HistoryContent({ data, callbacks, runNav, languageSub }) {
   // `content-visibility: auto` on `.history-row` (see styles/history.css),
   // so there's no need for a "Load all" pagination toggle.
   const visible = useMemo(() => {
-    const combined = [...inProgressStubs, ...trend];
-    return combined.filter((entry) => !isHiddenStatus(entry.runId));
-  }, [inProgressStubs, trend, statusByRunId]);  // eslint-disable-line react-hooks/exhaustive-deps
+    return historyRows.filter((entry) => !isHiddenStatus(entry.runId));
+  }, [historyRows, statusByRunId]);  // eslint-disable-line react-hooks/exhaustive-deps
   const deltas = useMemo(() => computeDeltas(visible), [visible]);
 
   return (
@@ -449,7 +491,11 @@ export default function HistoryPage({ trend: rawTrend, selection, availableRuns,
       </HistoryEmptyShell>
     );
   }
-  if (!trend || trend.length === 0) {
+  // Guard on the rows the table will actually show (trend + cancelled +
+  // in-progress, minus hidden failures), not just `trend`. A project whose
+  // only runs are cancelled has an empty trend but real rows to list, and
+  // its scores already show on the Overview.
+  if (visibleHistoryRows(availableRuns, trend).length === 0) {
     if (loading || isFetching) return <LoadingScreen />;
     const projectName = projectInfo?.displayName || projectInfo?.name || selectedProject;
     return (

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.stubs.test.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.stubs.test.jsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { assembleHistoryRows, visibleHistoryRows } from './HistoryPage.jsx';
+
+// Cancelled runs are stripped from `trend` server-side (they're not chart
+// points), but the Overview still shows their kept-findings scores when no
+// complete run exists. History must therefore surface them too, or an
+// all-cancelled project shows Overview scores over an empty History table.
+describe('assembleHistoryRows', () => {
+  it('surfaces a cancelled run (absent from trend) as a partial, dated row', () => {
+    const availableRuns = [
+      { runId: 'r-cancelled', status: 'cancelled', dateISO: '2026-05-02T10:00:00Z', dateLabel: '2 May 2026' },
+    ];
+    const rows = assembleHistoryRows(availableRuns, []);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      runId: 'r-cancelled', status: 'cancelled', hasScoredDims: true,
+      dateISO: '2026-05-02T10:00:00Z',
+    });
+  });
+
+  it('interleaves cancelled runs with trend rows by date, newest first', () => {
+    const trend = [
+      { runId: 't-new', status: 'complete', dateISO: '2026-05-03T10:00:00Z', numericAverage: 9 },
+      { runId: 't-old', status: 'complete', dateISO: '2026-05-01T10:00:00Z', numericAverage: 7 },
+    ];
+    const availableRuns = [
+      { runId: 't-new', status: 'complete', dateISO: '2026-05-03T10:00:00Z' },
+      { runId: 'r-cancelled', status: 'cancelled', dateISO: '2026-05-02T10:00:00Z', dateLabel: '2 May' },
+      { runId: 't-old', status: 'complete', dateISO: '2026-05-01T10:00:00Z' },
+    ];
+    const rows = assembleHistoryRows(availableRuns, trend);
+    expect(rows.map((r) => r.runId)).toEqual(['t-new', 'r-cancelled', 't-old']);
+  });
+
+  it('keeps in-progress runs on top and does not duplicate trend runs', () => {
+    const trend = [{ runId: 't1', status: 'complete', dateISO: '2026-05-01T10:00:00Z', numericAverage: 8 }];
+    const availableRuns = [
+      { runId: 'live', status: 'in_progress', dateLabel: 'now' },
+      { runId: 't1', status: 'complete', dateISO: '2026-05-01T10:00:00Z' },
+    ];
+    const rows = assembleHistoryRows(availableRuns, trend);
+    expect(rows.map((r) => r.runId)).toEqual(['live', 't1']);
+    expect(rows[0].status).toBe('in_progress');
+  });
+});
+
+describe('visibleHistoryRows', () => {
+  it('surfaces cancelled runs even when trend is empty (all-cancelled project)', () => {
+    // The empty-trend "no evaluations yet" guard must not hide cancelled
+    // runs whose scores the Overview shows.
+    const availableRuns = [
+      { runId: 'c1', status: 'cancelled', dateISO: '2026-05-02T10:00:00Z', dateLabel: '2 May' },
+      { runId: 'c2', status: 'cancelled', dateISO: '2026-05-01T10:00:00Z', dateLabel: '1 May' },
+    ];
+    const rows = visibleHistoryRows(availableRuns, []);
+    expect(rows.map((r) => r.runId)).toEqual(['c1', 'c2']);
+  });
+
+  it('excludes failed runs (all-failed project stays empty)', () => {
+    const availableRuns = [
+      { runId: 'f1', status: 'failed', dateISO: '2026-05-01T10:00:00Z' },
+    ];
+    expect(visibleHistoryRows(availableRuns, [])).toEqual([]);
+  });
+});

--- a/src/quodeq/ui/src/utils/scoreFiltering.accumulated.test.js
+++ b/src/quodeq/ui/src/utils/scoreFiltering.accumulated.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { filterAccumulatedByVisibleStandards } from './scoreFiltering.js';
+
+// The header SCORE normally uses the trend's accumulated average (to agree
+// with the History chart). But for an all-cancelled project the trend is
+// empty (cancelled runs aren't chart points), while the accumulated
+// dimension cards DO show scores. Falling through to null there made the
+// header read "—" over cards showing 6.0 — the same no-complete-run
+// inconsistency this batch unifies. Fall back to the accumulated summary.
+
+const ACC = {
+  dimensions: [{ dimension: 'security', overallScore: '6.0/10', totals: { violationCount: 0, complianceCount: 0 } }],
+  summary: { numericAverage: 6.0, overallGrade: 'Adequate' },
+};
+const VISIBLE = new Set(['security']);
+
+test('empty trend: header number falls back to the accumulated summary', () => {
+  const out = filterAccumulatedByVisibleStandards(ACC, VISIBLE, [], null);
+  assert.equal(out.summary.numericAverage, 6.0);
+});
+
+test('populated trend still wins (unchanged behavior)', () => {
+  const trend = [{ runId: 'r1', numericAverage: 8.2 }];
+  const out = filterAccumulatedByVisibleStandards(ACC, VISIBLE, trend, 'r1');
+  assert.equal(out.summary.numericAverage, 8.2);
+});

--- a/src/quodeq/ui/src/utils/scoreFiltering.js
+++ b/src/quodeq/ui/src/utils/scoreFiltering.js
@@ -110,11 +110,18 @@ export function filterAccumulatedByVisibleStandards(accumulated, visibleSet, fil
     visibleSet.has((d.dimension || '').toLowerCase())
   );
 
-  // Use the trend's accumulated average (consistent with History)
+  // Use the trend's accumulated average (consistent with History). When the
+  // trend is empty — e.g. an all-cancelled project, whose runs aren't chart
+  // points but whose kept-findings scores still populate the cards — fall
+  // back to the accumulated summary so the header number agrees with the
+  // dimension cards instead of reading "—" over visible scores.
   const selectedIdx = selectedRunId ? filteredTrend.findIndex((t) => t.runId === selectedRunId) : 0;
   const idx = selectedIdx >= 0 ? selectedIdx : 0;
   const trendAvg = idx < filteredTrend.length ? parseFloat(filteredTrend[idx]?.numericAverage) : null;
-  const numericAverage = (trendAvg != null && !isNaN(trendAvg)) ? trendAvg : null;
+  const summaryAvg = parseFloat(accumulated.summary?.numericAverage);
+  const numericAverage = (trendAvg != null && !isNaN(trendAvg))
+    ? trendAvg
+    : (!isNaN(summaryAvg) ? summaryAvg : null);
   const prevIdx = idx + 1;
   const prevAvg = prevIdx < filteredTrend.length ? parseFloat(filteredTrend[prevIdx]?.numericAverage) : null;
 

--- a/tests/services/test_accumulated.py
+++ b/tests/services/test_accumulated.py
@@ -68,6 +68,39 @@ def _setup_project(tmp_path: Path, project: str, runs: list[tuple[str, list[Dime
 # _numeric_average
 # ---------------------------------------------------------------------------
 
+class TestZeroCoverageStubExcluded:
+    """A cancelled run's coverage-0 stub eval (filesRead=0) must not drive
+    the accumulated Overview. _score_completed_evidence can write such a stub
+    at cancel time when no findings landed; its score is meaningless. The
+    accumulated reader falls through to an older run with real coverage."""
+
+    def _info(self, run_id):
+        from quodeq.services.ports import RunInfo
+        return RunInfo(run_id=run_id, date_iso="2024-01-01", date_label="Jan 01")
+
+    def test_zero_files_read_dim_falls_through_to_real_run(self):
+        from quodeq.services._accumulated_data import _read_all_run_data
+        stub = _dim("security", "9.9", "A", filesRead=0)   # coverage-0 stub, newest
+        real = _dim("security", "6.0", "C", filesRead=5)   # real, older
+        fetch = {"r2": [stub], "r1": [real]}
+        latest, _prev, _prev_run = _read_all_run_data(
+            Path("/x"), "proj", [self._info("r2"), self._info("r1")],
+            ["r2", "r1"], get_run_data=lambda rid: fetch[rid],
+        )
+        assert latest["security"].overall_score == "6.0"
+
+    def test_missing_files_read_is_still_trusted(self):
+        # Legacy evals carry no filesRead (None); those must stay valid.
+        from quodeq.services._accumulated_data import _read_all_run_data
+        legacy = _dim("security", "8.0", "A")  # no filesRead field
+        fetch = {"r1": [legacy]}
+        latest, _p, _pr = _read_all_run_data(
+            Path("/x"), "proj", [self._info("r1")], ["r1"],
+            get_run_data=lambda rid: fetch[rid],
+        )
+        assert latest["security"].overall_score == "8.0"
+
+
 class TestNumericAverage:
     def test_computes_average(self):
         """Two dimensions with scores 8.0 and 6.0 should average to 7.0."""

--- a/tests/services/test_dashboard.py
+++ b/tests/services/test_dashboard.py
@@ -235,6 +235,37 @@ class TestBuildDashboard:
             result = build_dashboard(str(tmp_path), "proj", "latest")
         assert result["selectedRun"]["runId"] == "r2"
 
+    def test_latest_prefers_cancelled_over_newer_failed(self, tmp_path):
+        # A failed run must not headline the dashboard while a cancelled run
+        # (with real kept-findings data) exists — mirror the Overview's
+        # select_default_view_runs rule so the two surfaces agree.
+        failed = RunInfo(run_id="r-failed", date_iso="2024-03-01", date_label="2024-03-01", status="failed")
+        cancelled = RunInfo(run_id="r-cancelled", date_iso="2024-02-01", date_label="2024-02-01", status="cancelled")
+        dims = [_dim("security", "B", "7.0")]
+        summary = DimensionSummary(dimensions_count=1, overall_grade="B", numeric_average=7.0)
+        with (
+            patch("quodeq.services.dashboard.list_runs", return_value=[failed, cancelled]),
+            patch("quodeq.services.dashboard.read_run_data", return_value=dims),
+            patch("quodeq.services.dashboard.summarize_dimensions", return_value=summary),
+        ):
+            result = build_dashboard(str(tmp_path), "proj", "latest")
+        assert result["selectedRun"]["runId"] == "r-cancelled"
+
+    def test_latest_all_failed_still_renders_newest(self, tmp_path):
+        # If every run failed there's nothing trustworthy, but the dashboard
+        # must still render something rather than error — pick the newest.
+        failed1 = RunInfo(run_id="r2", date_iso="2024-03-01", date_label="2024-03-01", status="failed")
+        failed2 = RunInfo(run_id="r1", date_iso="2024-02-01", date_label="2024-02-01", status="failed")
+        dims = [_dim("security", "B", "7.0")]
+        summary = DimensionSummary(dimensions_count=1, overall_grade="B", numeric_average=7.0)
+        with (
+            patch("quodeq.services.dashboard.list_runs", return_value=[failed1, failed2]),
+            patch("quodeq.services.dashboard.read_run_data", return_value=dims),
+            patch("quodeq.services.dashboard.summarize_dimensions", return_value=summary),
+        ):
+            result = build_dashboard(str(tmp_path), "proj", "latest")
+        assert result["selectedRun"]["runId"] == "r2"
+
     def test_explicit_run_selection_overrides_latest_default(self, tmp_path):
         # Explicit selection by run_id navigates to that run regardless of
         # state — users can still inspect partial runs from the bar chart.

--- a/tests/services/test_fs_metadata.py
+++ b/tests/services/test_fs_metadata.py
@@ -135,7 +135,8 @@ class TestReadAccumulatedSummary:
         from quodeq.core.types import DimensionResult
         from quodeq.services.ports import RunInfo
 
-        dim = DimensionResult(dimension="security", source_file_count=10)
+        dim = DimensionResult(dimension="security", overall_score="8.5/10",
+                              overall_grade="A", files_read=10, source_file_count=10)
         mock_read.return_value = [dim]
         mock_summary = type("S", (), {"overall_grade": "A", "numeric_average": 8.5})()
         mock_summarize.return_value = mock_summary
@@ -458,7 +459,8 @@ class TestCardUsesDefaultViewRuns:
 
         monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
         mock_read.return_value = [
-            DimensionResult(dimension="security", source_file_count=5),
+            DimensionResult(dimension="security", overall_score="7.0/10",
+                            overall_grade="B", files_read=5, source_file_count=5),
         ]
         mock_summarize.return_value = type(
             "S", (), {"overall_grade": "B", "numeric_average": 7.0},
@@ -488,7 +490,8 @@ class TestCardUsesDefaultViewRuns:
 
         monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
         mock_read.return_value = [
-            DimensionResult(dimension="security", source_file_count=5),
+            DimensionResult(dimension="security", overall_score="6.0/10",
+                            overall_grade="C", files_read=5, source_file_count=5),
         ]
         mock_summarize.return_value = type(
             "S", (), {"overall_grade": "C", "numeric_average": 6.0},
@@ -503,3 +506,35 @@ class TestCardUsesDefaultViewRuns:
         read_run_ids = {call.args[2] for call in mock_read.call_args_list}
         assert read_run_ids == {"run-cancelled"}
         assert grade == "C"
+
+    @patch("quodeq.services._fs_metadata.read_run_data")
+    def test_card_skips_zero_coverage_stub_like_the_overview(
+        self, mock_read, monkeypatch,
+    ):
+        """A newer cancelled run's coverage-0 stub (filesRead=0) must not
+        drive the project card, exactly like the accumulated Overview. The
+        card fell through to the real older run's score."""
+        from quodeq.core.types import DimensionResult
+        from quodeq.services.ports import RunInfo
+
+        monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
+        per_run = {
+            "run-stub": [DimensionResult(
+                dimension="security", overall_score="9.9/10", overall_grade="A",
+                files_read=0, source_file_count=10,
+            )],
+            "run-real": [DimensionResult(
+                dimension="security", overall_score="6.0/10", overall_grade="C",
+                files_read=5, source_file_count=10,
+            )],
+        }
+        mock_read.side_effect = lambda root, proj, run_id: per_run[run_id]
+        runs = [
+            RunInfo(run_id="run-stub", date_iso="2026-01-02", date_label="Jan 02", status="cancelled"),
+            RunInfo(run_id="run-real", date_iso="2026-01-01", date_label="Jan 01", status="cancelled"),
+        ]
+        grade, score, files = _read_accumulated_summary(
+            Path("/r"), "proj-card-stub", runs,
+        )
+        # The card score must be the real run's 6.0, not the stub's 9.9.
+        assert score == 6.0, f"card took the coverage-0 stub, got {score}"


### PR DESCRIPTION
Confirmed findings F4.1 / F4.2 / F4.3 from the 1.6.1 flagship data-store audit — four surfaces disagreed when a project has no complete run (only cancelled/failed).

## Problems

- **F4.1** — `dashboard._resolve_selected_run("latest")` fell back to `runs[0]` (any status), so a **failed** run headlined the run-detail view while the Overview (`select_default_view_runs`, never failed) showed a cancelled run or nothing.
- **F4.2** — neither the accumulated Overview nor the project-card summary gated on coverage, so a cancelled run's `filesRead=0` stub (written by `_score_completed_evidence` when no findings landed) drove both with an inflated grade. On the fixture the newest cancelled run's `9.9` stub headlined while the real kept-findings run scored `6.0`.
- **F4.3** — cancelled runs are stripped from `trend` server-side (not chart points), so History's "no evaluations yet" guard (keyed on `trend.length`) hid a project whose only runs are cancelled — while the Overview showed their scores. Empty History over a populated Overview.
- Fold-in (browser-caught): the Overview header SCORE derived from the empty trend read "—" over cards showing `6.0`.

## Fixes

- `_resolve_selected_run` fallback walks a trust order (complete → cancelled → in_progress) and only headlines a failed run when nothing else remains.
- `_has_valid_score` now also requires `files_read != 0` (matching `scoring_view`'s trust rule); the project-card path reuses it. Missing/legacy `files_read` stays trusted.
- New `assembleHistoryRows` / `visibleHistoryRows` surface cancelled runs as partial dated rows; the empty-state guard checks those. `computeDeltas` generalised to skip any scoreless stub row.
- `filterAccumulatedByVisibleStandards` falls back to the accumulated summary when the trend is empty.

## Testing

- TDD across backend (dashboard fallback; accumulated + card zero-coverage exclusion, legacy `None` kept) and UI (row assembly, empty-guard, header fallback). Full suites: backend 4493, UI 897.
- **Browser-verified** on an all-cancelled fixture (2 kept-findings runs + 1 coverage-0 `9.9` stub): Overview `6.0`, header `6.0`, project card `6.0 C`, History lists all 3 runs — the `9.9` stub drives nothing. The browser pass caught the History empty-guard short-circuit the unit test alone missed.

Independent of the other 1.6.1 audit PRs (assistant #798, watchdog #799).

🤖 Generated with [Claude Code](https://claude.com/claude-code)