### PR TITLE
fix(terminal): reset on reconnect, block input while disconnected, honest busy button

### DIFF
--- a/src/quodeq/ui/src/features/terminal/TerminalPane.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.jsx
@@ -67,6 +67,16 @@ export default function TerminalPane({ active }) {
     active: paneLive,
     restartKey,
     onData: (s) => termRef.current?.write(s),
+    // Reset the screen on every (re)connect before the server replays
+    // scrollback, so a reconnect to a still-alive backend repaints history
+    // instead of appending a duplicate copy under it. Also re-enable input
+    // (it's disabled while disconnected — see the status effect below).
+    onOpen: () => {
+      const term = termRef.current;
+      if (!term) return;
+      try { term.reset(); } catch { /* noop */ }
+      term.options.disableStdin = false;
+    },
   });
 
   // The size must reach the PTY only once the socket is OPEN. The resize sent
@@ -166,6 +176,19 @@ export default function TerminalPane({ active }) {
     try { fitRef.current.fit(); resize(termRef.current.cols, termRef.current.rows); } catch { /* noop */ }
   }, [active, resize]);
 
+  // While the socket is not open, disable xterm input. send() already no-ops
+  // when disconnected, so keystrokes would otherwise vanish silently into a
+  // dead shell (and buffering them is unsafe — the line would land in a fresh
+  // shell on reconnect). disableStdin makes xterm ignore input while the
+  // "disconnected" overlay explains why. Declared after the mount effect so
+  // termRef is set when this first runs. `paneLive` is a dep so it re-runs
+  // once the terminal has mounted.
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+    term.options.disableStdin = status !== 'open';
+  }, [status, paneLive]);
+
   // Bubble phase (NOT capture): xterm's textarea must receive the keydown
   // first so special keys (Delete/Backspace/arrows/Enter) work; we then stop
   // it bubbling to the window so the app's global handlers (Ctrl+[ history,
@@ -182,7 +205,10 @@ export default function TerminalPane({ active }) {
   // initial handshake resolves in milliseconds and a flash would be noise.
   const overlay = {
     reconnecting: { text: 'Terminal disconnected. Reconnecting…', btn: 'Retry now' },
-    busy: { text: 'Terminal is already open in another window.', btn: 'Use it here' },
+    // Only one window may hold the single PTY. There is no takeover, so the
+    // button offers an honest Retry (which succeeds once the other window is
+    // closed) rather than a "Use it here" that silently does nothing.
+    busy: { text: 'Terminal is open in another window. Close it there, then retry.', btn: 'Retry' },
     refused: { text: 'Terminal connection refused by the server.', btn: 'Retry' },
   }[status];
   return (

--- a/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom/vitest';
 
 const fakeTerm = { open: vi.fn(), write: vi.fn(), dispose: vi.fn(), loadAddon: vi.fn(),
   onData: vi.fn(), onResize: vi.fn(), focus: vi.fn(), attachCustomKeyEventHandler: vi.fn(),
+  reset: vi.fn(),
   cols: 80, rows: 24, options: {} };
 // Use `function` (not arrow) implementations so vi.fn() produces a constructible
 // mock: xterm's Terminal/FitAddon are always invoked with `new` in TerminalPane.
@@ -17,9 +18,13 @@ vi.mock('../../api/terminal.js', () => ({
   terminalSocketUrl: () => 'ws://localhost/api/terminal/ws',
 }));
 // Mock the socket hook: jsdom has no real terminal WS to reach, and the
-// overlay tests need to drive each connection status directly.
+// overlay tests need to drive each connection status directly. lastSocketOpts
+// captures the options so a test can invoke the pane's onOpen callback.
 const socketState = { status: 'open', send: vi.fn(), resize: vi.fn(), reconnectNow: vi.fn() };
-vi.mock('./useTerminalSocket.js', () => ({ useTerminalSocket: vi.fn(() => socketState) }));
+let lastSocketOpts = null;
+vi.mock('./useTerminalSocket.js', () => ({
+  useTerminalSocket: vi.fn((opts) => { lastSocketOpts = opts; return socketState; }),
+}));
 import TerminalPane from './TerminalPane.jsx';
 
 it('mounts an xterm terminal when active', async () => {
@@ -75,9 +80,35 @@ it('shows a reconnecting banner when the socket drops, and Retry calls reconnect
   expect(socketState.reconnectNow).toHaveBeenCalled();
 });
 
-it('shows a busy banner when another window owns the terminal', async () => {
+it('shows a busy banner and an honest Retry (not a fake takeover) when another window owns the terminal', async () => {
   socketState.status = 'busy';
   render(<TerminalPane active />);
   const overlay = await screen.findByTestId('tty-overlay');
-  expect(overlay).toHaveTextContent('already open in another window');
+  expect(overlay).toHaveTextContent('open in another window');
+  // The old "Use it here" button promised a takeover that never happened
+  // (no lock eviction). The button must not claim to take over.
+  expect(screen.queryByRole('button', { name: 'Use it here' })).toBeNull();
+});
+
+it('resets xterm on every socket (re)open so a live-backend reconnect does not duplicate scrollback', async () => {
+  const { vi: _vi } = await import('vitest');
+  socketState.status = 'open';
+  fakeTerm.reset.mockClear();
+  fakeTerm.options = {};
+  render(<TerminalPane active />);
+  await screen.findByTestId('tty-root');
+  // Simulate the socket (re)opening: the pane's onOpen must reset the screen
+  // BEFORE the server's scrollback replay lands, and re-enable input.
+  expect(typeof lastSocketOpts.onOpen).toBe('function');
+  lastSocketOpts.onOpen();
+  expect(fakeTerm.reset).toHaveBeenCalled();
+  expect(fakeTerm.options.disableStdin).toBe(false);
+});
+
+it('disables stdin while disconnected so keystrokes are not silently swallowed', async () => {
+  socketState.status = 'reconnecting';
+  fakeTerm.options = {};
+  render(<TerminalPane active />);
+  await screen.findByTestId('tty-root');
+  expect(fakeTerm.options.disableStdin).toBe(true);
 });

--- a/src/quodeq/ui/src/features/terminal/useTerminalSocket.js
+++ b/src/quodeq/ui/src/features/terminal/useTerminalSocket.js
@@ -12,7 +12,7 @@ const RETRY_BASE_MS = 500;
 const RETRY_MAX_MS = 5000;
 
 // status: 'idle' | 'connecting' | 'open' | 'reconnecting' | 'busy' | 'refused'
-export function useTerminalSocket({ active, onData, restartKey = 0 }) {
+export function useTerminalSocket({ active, onData, onOpen, restartKey = 0 }) {
   const [status, setStatus] = useState('idle');
   // Bumped internally to open a fresh socket after an unexpected close.
   const [gen, setGen] = useState(0);
@@ -21,6 +21,12 @@ export function useTerminalSocket({ active, onData, restartKey = 0 }) {
   const attemptsRef = useRef(0);
   const onDataRef = useRef(onData);
   onDataRef.current = onData;
+  // Fired on EVERY socket open (initial and reconnect), before the first
+  // data frame, so the pane can reset xterm before the server replays
+  // scrollback — otherwise a live-backend reconnect appends the whole
+  // history under the existing buffer (prints twice on sleep/wake).
+  const onOpenRef = useRef(onOpen);
+  onOpenRef.current = onOpen;
 
   // An external restart (Settings kill -> fresh PTY) starts a fresh backoff
   // history; only an internal retry keeps counting attempts.
@@ -33,7 +39,13 @@ export function useTerminalSocket({ active, onData, restartKey = 0 }) {
     const ws = new WebSocket(terminalSocketUrl());
     wsRef.current = ws;
     setStatus(attemptsRef.current > 0 ? 'reconnecting' : 'connecting');
-    ws.onopen = () => { attemptsRef.current = 0; setStatus('open'); };
+    ws.onopen = () => {
+      attemptsRef.current = 0;
+      // Runs before onmessage (WS delivers open before any frame), so the
+      // reset lands ahead of the scrollback replay.
+      onOpenRef.current?.();
+      setStatus('open');
+    };
     ws.onclose = (e) => {
       if (wsRef.current === ws) wsRef.current = null;
       if (e?.code === CLOSE_BUSY) { setStatus('busy'); return; }

--- a/src/quodeq/ui/src/features/terminal/useTerminalSocket.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/useTerminalSocket.test.jsx
@@ -46,6 +46,23 @@ it('does not connect when inactive', () => {
   expect(MockWS.instances.length).toBe(0);
 });
 
+it('fires onOpen on EVERY socket open so the pane can reset before scrollback replay', () => {
+  // The server replays scrollback on every connect; without a reset the
+  // client appends it under the existing buffer and the whole session
+  // prints twice on a live-backend reconnect (sleep/wake). onOpen lets the
+  // pane term.reset() first, on the initial open AND every reconnect.
+  const opens = [];
+  const { result } = renderHook(() => useTerminalSocket({
+    active: true, onData: () => {}, onOpen: () => opens.push('open'),
+  }));
+  act(() => MockWS.instances[0]._open());
+  expect(opens).toEqual(['open']);
+  act(() => MockWS.instances[0]._drop(1006));
+  act(() => result.current.reconnectNow());
+  act(() => MockWS.instances[1]._open());
+  expect(opens).toEqual(['open', 'open']);
+});
+
 it('auto-reconnects after an unexpected close, with growing backoff', () => {
   vi.useFakeTimers();
   const { result } = renderHook(() => useTerminalSocket({ active: true, onData: () => {} }));


### PR DESCRIPTION
Reconnect-UX findings from the 1.6.1 flagship terminal audit (the WS security story was verified airtight — no change there).

## T1 / T3 — scrollback duplicated on reconnect; dead output after restart

The server replays scrollback on **every** WS connect, and the client wrote it into xterm with no reset (the only `term.reset()` was behind the Settings "Restart"). So:

- **Live backend reconnect** (sleep/wake, flaky link): `ensure_session` finds the backend alive and replays up to 256 KB of history, which xterm appends *under* the existing buffer — the whole session prints twice (N× over a flaky link), and because the replay is raw ANSI it also scrambles rendering.
- **After a real server restart**: the prior dead output stays on screen with a fresh prompt beneath it and no signal the shell was replaced.

`useTerminalSocket` now fires an `onOpen` callback on **every** socket open (before the first data frame — WS delivers `open` before any `message`). The pane `term.reset()`s there, so the replayed scrollback always paints onto a clean screen: full history from a live backend, or the fresh prompt from a respawned one (which now also visibly clears, signalling the reset).

## T4 — keystrokes silently dropped while disconnected

`send()` no-ops unless the socket is OPEN, but the xterm textarea kept focus, so typing during a drop vanished. The pane now sets xterm's `disableStdin` off only while connected — input is ignored outright while the "disconnected" overlay explains why. Buffering was rejected deliberately: a half-typed line must not land in a *fresh* shell on reconnect.

## T2 — "Use it here" was a dead-end lie

The busy overlay button promised a takeover that never happened (there is no lock eviction); it just retried against the still-held lock and got 4002 again. Relabelled to an honest **Retry** with "Terminal is open in another window. Close it there, then retry." — which succeeds once the other window closes. (True lock eviction would need a new close code + anti-ping-pong handling; deferred as a deliberate follow-up.)

## Testing

- TDD: hook test that `onOpen` fires on every (re)open; pane tests that a (re)open resets xterm and re-enables stdin, that stdin is disabled while reconnecting, and that the busy overlay no longer offers "Use it here". Full UI suite: 900 passed.

Independent of the other 1.6.1 audit PRs (#798 assistant, #799 watchdog, #800 eligibility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)