### PR TITLE
fix(grade-formula): report partial applies instead of silently keeping stale grades

### DIFF
--- a/src/quodeq/api/_grade_formula_routes.py
+++ b/src/quodeq/api/_grade_formula_routes.py
@@ -42,14 +42,17 @@ def _parse_params(data: dict) -> tuple:
     return params, None
 
 
-def _state_payload(applied: int | None = None) -> dict:
+def _state_payload(result: "grade_formula.ApplyResult | None" = None) -> dict:
     payload = {
         "current": params_to_dict(grade_formula.load_params()),
         "defaults": params_to_dict(DEFAULT_PARAMS),
         "isCustom": grade_formula.is_custom(),
     }
-    if applied is not None:
-        payload["applied"] = applied
+    if result is not None:
+        payload["applied"] = result.rescored
+        # Surface a partial apply so the client can warn that some runs still
+        # show the old formula, instead of the endpoint claiming full success.
+        payload["failed"] = len(result.failed)
     return payload
 
 
@@ -66,14 +69,14 @@ def register_grade_formula_routes(app: Flask) -> None:
         if err:
             return err
         grade_formula.save_params(params)
-        applied = grade_formula.apply_to_all_runs(Path(reports_dir()))
-        return jsonify(_state_payload(applied=applied))
+        result = grade_formula.apply_to_all_runs(Path(reports_dir()))
+        return jsonify(_state_payload(result=result))
 
     @app.delete("/api/grade-formula")
     def delete_grade_formula() -> Response:
         grade_formula.reset_params()
-        applied = grade_formula.apply_to_all_runs(Path(reports_dir()))
-        return jsonify(_state_payload(applied=applied))
+        result = grade_formula.apply_to_all_runs(Path(reports_dir()))
+        return jsonify(_state_payload(result=result))
 
     @app.post("/api/grade-formula/preview")
     def preview_grade_formula() -> Response | tuple[Response, int]:

--- a/src/quodeq/services/grade_formula.py
+++ b/src/quodeq/services/grade_formula.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import json
 import logging
+import time
+from dataclasses import dataclass
 from pathlib import Path
 
 from quodeq.core.scoring.params import (
@@ -99,30 +101,65 @@ def _event_log_runs(project_dir: Path) -> list[Path]:
     )
 
 
-def apply_to_all_runs(reports_root: Path) -> int:
+@dataclass(frozen=True)
+class ApplyResult:
+    """Outcome of a grade-formula apply across all runs.
+
+    ``failed`` lists the run-dir names that could not be rescored (a locked
+    or corrupt evaluation.db, etc.). A non-empty ``failed`` means the apply
+    was PARTIAL: those runs keep their old-formula grades and disagree with
+    their rescored siblings, so the caller must surface it rather than
+    report a silent success.
+    """
+    rescored: int
+    failed: list[str]
+
+
+# Transient failures (a momentarily-locked evaluation.db while a background
+# scoring thread writes) clear on their own, so a bounded retry recovers the
+# common case before a run is reported failed.
+_APPLY_RETRIES = 2
+_APPLY_RETRY_SLEEP_S = 0.15
+
+
+def apply_to_all_runs(reports_root: Path) -> ApplyResult:
     """Rescore every run that has an events.jsonl with the currently saved params.
 
     Legacy runs without an event log cannot be rescored and are skipped.
     Always clears the dashboard cache (even when nothing was rescored, e.g.
-    when *reports_root* does not exist). Returns the number of runs rescored.
+    when *reports_root* does not exist). Returns an ``ApplyResult`` with the
+    rescored count and the run-dir names that failed after retries — a
+    partial apply is reported, not swallowed, so the UI can warn the user
+    that some runs still show the old formula.
     """
     from quodeq.data.projection.grade_projector import recompute_grades  # noqa: PLC0415
     from quodeq.services.dashboard import clear_shared_dimension_cache  # noqa: PLC0415
 
     params = load_params()
-    count = 0
+    rescored = 0
+    failed: list[str] = []
     if reports_root.is_dir():
         for project_dir in sorted(p for p in reports_root.iterdir() if p.is_dir()):
             for run_dir in sorted(r for r in project_dir.iterdir() if r.is_dir()):
                 if not (run_dir / "events.jsonl").is_file():
                     continue
-                try:
-                    recompute_grades(run_dir, params=params)
-                    count += 1
-                except Exception:  # noqa: BLE001 — one bad run must not block the rest
-                    _logger.warning("Rescore failed for %s; skipping.", run_dir, exc_info=True)
+                for attempt in range(_APPLY_RETRIES + 1):
+                    try:
+                        recompute_grades(run_dir, params=params)
+                        rescored += 1
+                        break
+                    except Exception:  # noqa: BLE001 — one bad run must not block the rest
+                        if attempt < _APPLY_RETRIES:
+                            time.sleep(_APPLY_RETRY_SLEEP_S)
+                            continue
+                        failed.append(run_dir.name)
+                        _logger.warning(
+                            "Rescore failed for %s after %d attempts; it will "
+                            "keep the old formula's grades.",
+                            run_dir, _APPLY_RETRIES + 1, exc_info=True,
+                        )
     clear_shared_dimension_cache()
-    return count
+    return ApplyResult(rescored=rescored, failed=failed)
 
 
 def preview_scores(

--- a/src/quodeq/ui/src/features/grade-formula/GradeFormulaPage.jsx
+++ b/src/quodeq/ui/src/features/grade-formula/GradeFormulaPage.jsx
@@ -17,7 +17,7 @@ export default function GradeFormulaPage({ navigation }) {
   const projectId = navigation?.selectedProject || null;
   const [tab, setTab] = useState('severity');
   const {
-    draft, isCustom, isDirty, preview, busy, error, update, apply, resetToDefaults,
+    draft, isCustom, isDirty, preview, busy, error, partialNotice, update, apply, resetToDefaults,
   } = useGradeFormula(projectId);
 
   const onApply = async () => {
@@ -102,6 +102,7 @@ export default function GradeFormulaPage({ navigation }) {
             : isCustom ? 'custom formula active' : 'Q² defaults active'}
         </span>
         {error ? <span className="gf-dirty-hint">{error}</span> : null}
+        {partialNotice ? <span className="gf-dirty-hint" role="alert">{partialNotice}</span> : null}
       </div>
       <p className="settings-description" style={{ marginTop: 8 }}>
         These parameters do not affect the insufficient-evidence gate. Principles with too

--- a/src/quodeq/ui/src/features/grade-formula/useGradeFormula.js
+++ b/src/quodeq/ui/src/features/grade-formula/useGradeFormula.js
@@ -20,6 +20,10 @@ export default function useGradeFormula(projectId) {
   const [preview, setPreview] = useState(null); // {before, after} or null
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState(null);
+  // Set when an apply/reset rescored some runs but not all (a locked/corrupt
+  // evaluation.db). Those runs keep the OLD formula's grades, so warn rather
+  // than let the mismatch look like a bug.
+  const [partialNotice, setPartialNotice] = useState(null);
   const debounceRef = useRef(null);
   const loadedRef = useRef(false); // true once the initial GET has populated draft
   const queryClient = useQueryClient();
@@ -73,12 +77,17 @@ export default function useGradeFormula(projectId) {
     });
   }, [requestPreview]);
 
+  const noticeFor = (d) => (d.failed > 0
+    ? `Applied, but ${d.failed} run${d.failed === 1 ? '' : 's'} could not be rescored and still show the old formula. Try applying again.`
+    : null);
+
   const apply = useCallback(async () => {
-    setBusy(true); setError(null);
+    setBusy(true); setError(null); setPartialNotice(null);
     try {
       const d = await saveGradeFormula(draft);
       setSaved(d.current); setDraft(d.current); setIsCustom(d.isCustom);
       setGradeThresholds(d.current.gradeThresholds);
+      setPartialNotice(noticeFor(d));
       invalidateScoreQueries();
       requestPreview(d.current);
       return d.applied;
@@ -91,11 +100,12 @@ export default function useGradeFormula(projectId) {
   }, [draft, requestPreview, invalidateScoreQueries]);
 
   const resetToDefaults = useCallback(async () => {
-    setBusy(true); setError(null);
+    setBusy(true); setError(null); setPartialNotice(null);
     try {
       const d = await resetGradeFormula();
       setSaved(d.current); setDraft(d.current); setIsCustom(d.isCustom);
       setGradeThresholds(d.current.gradeThresholds);
+      setPartialNotice(noticeFor(d));
       invalidateScoreQueries();
       requestPreview(d.current);
     } catch {
@@ -105,5 +115,5 @@ export default function useGradeFormula(projectId) {
     }
   }, [requestPreview, invalidateScoreQueries]);
 
-  return { draft, defaults, isCustom, isDirty, preview, busy, error, update, apply, resetToDefaults };
+  return { draft, defaults, isCustom, isDirty, preview, busy, error, partialNotice, update, apply, resetToDefaults };
 }

--- a/tests/api/test_grade_formula_api.py
+++ b/tests/api/test_grade_formula_api.py
@@ -44,9 +44,9 @@ def test_get_returns_defaults_and_is_custom_false(client, formula_path):
 
 
 def test_put_saves_and_applies(client, formula_path, monkeypatch):
-    applied = {}
     monkeypatch.setattr(
-        grade_formula, "apply_to_all_runs", lambda root: applied.setdefault("n", 7) or 7,
+        grade_formula, "apply_to_all_runs",
+        lambda root: grade_formula.ApplyResult(rescored=7, failed=[]),
     )
     payload = params_to_dict(dataclasses.replace(DEFAULT_PARAMS, base_k=0.3))
     resp = client.put("/api/grade-formula", json=payload, headers=_ORIGIN)
@@ -54,7 +54,22 @@ def test_put_saves_and_applies(client, formula_path, monkeypatch):
     body = resp.get_json()
     assert body["isCustom"] is True
     assert body["applied"] == 7
+    assert body["failed"] == 0
     assert grade_formula.load_params().base_k == 0.3
+
+
+def test_put_reports_partial_apply(client, formula_path, monkeypatch):
+    # A run that couldn't be rescored is surfaced so the client can warn the
+    # user rather than the endpoint claiming a clean success.
+    monkeypatch.setattr(
+        grade_formula, "apply_to_all_runs",
+        lambda root: grade_formula.ApplyResult(rescored=5, failed=["run-x", "run-y"]),
+    )
+    payload = params_to_dict(dataclasses.replace(DEFAULT_PARAMS, base_k=0.3))
+    resp = client.put("/api/grade-formula", json=payload, headers=_ORIGIN)
+    body = resp.get_json()
+    assert body["applied"] == 5
+    assert body["failed"] == 2
 
 
 def test_put_rejects_invalid_params_with_400(client, formula_path):
@@ -66,7 +81,10 @@ def test_put_rejects_invalid_params_with_400(client, formula_path):
 
 
 def test_delete_resets_to_defaults(client, formula_path, monkeypatch):
-    monkeypatch.setattr(grade_formula, "apply_to_all_runs", lambda root: 0)
+    monkeypatch.setattr(
+        grade_formula, "apply_to_all_runs",
+        lambda root: grade_formula.ApplyResult(rescored=0, failed=[]),
+    )
     grade_formula.save_params(dataclasses.replace(DEFAULT_PARAMS, base_k=0.3))
     resp = client.delete("/api/grade-formula", headers=_ORIGIN)
     assert resp.status_code == 200

--- a/tests/services/test_grade_formula.py
+++ b/tests/services/test_grade_formula.py
@@ -145,8 +145,44 @@ def test_apply_to_all_runs_rescores_and_skips_legacy(tmp_path, formula_path):
     legacy.mkdir()  # no events.jsonl → must be skipped
 
     grade_formula.save_params(_STRICT)
-    count = grade_formula.apply_to_all_runs(tmp_path)
-    assert count == 1
+    result = grade_formula.apply_to_all_runs(tmp_path)
+    assert result.rescored == 1
+    assert result.failed == []
+
+
+def test_apply_to_all_runs_reports_failed_runs_and_continues(tmp_path, formula_path, monkeypatch):
+    # A run whose recompute keeps failing (e.g. a genuinely corrupt db) must
+    # be REPORTED in .failed rather than silently skipped — otherwise it keeps
+    # serving old-formula grades while its siblings show the new formula, with
+    # the apply falsely reporting full success. Other runs still rescore and
+    # the cache is still cleared.
+    project = tmp_path / "proj"
+    for name in ("run-good", "run-bad"):
+        d = project / name
+        d.mkdir(parents=True)
+        (d / "events.jsonl").write_text("")
+
+    seen = []
+
+    def flaky(run_dir, params=None):
+        seen.append(run_dir.name)
+        if run_dir.name == "run-bad":
+            raise RuntimeError("database is locked")
+
+    monkeypatch.setattr(
+        "quodeq.data.projection.grade_projector.recompute_grades", flaky,
+    )
+    cleared = {"n": 0}
+    monkeypatch.setattr(
+        "quodeq.services.dashboard.clear_shared_dimension_cache",
+        lambda: cleared.__setitem__("n", cleared["n"] + 1),
+    )
+
+    result = grade_formula.apply_to_all_runs(tmp_path)
+    assert result.rescored == 1
+    assert result.failed == ["run-bad"]
+    assert "run-good" in seen
+    assert cleared["n"] == 1  # cache cleared despite the partial failure
 
 
 def test_apply_to_all_runs_clears_cache_when_root_missing(formula_path, monkeypatch, tmp_path):
@@ -158,8 +194,9 @@ def test_apply_to_all_runs_clears_cache_when_root_missing(formula_path, monkeypa
         cleared["called"] = True
     monkeypatch.setattr(dashboard, "clear_shared_dimension_cache", fake_clear)
 
-    count = grade_formula.apply_to_all_runs(tmp_path / "does-not-exist")
-    assert count == 0
+    result = grade_formula.apply_to_all_runs(tmp_path / "does-not-exist")
+    assert result.rescored == 0
+    assert result.failed == []
     assert cleared["called"] is True
 
 

--- a/tests/services/test_scoring_sql_overlay.py
+++ b/tests/services/test_scoring_sql_overlay.py
@@ -138,7 +138,7 @@ def test_get_project_scores_reflects_applied_custom_params_without_dismissals(
     # Apply custom params: saves the formula and rewrites every run's SQL grades.
     grade_formula.save_params(_STRICT)
     applied = grade_formula.apply_to_all_runs(reports_root)
-    assert applied == 1
+    assert applied.rescored == 1
 
     custom_rows = {r["dimension"]: r for r in SQLiteStateStore(run_dir).read_dimension_scores()}
     custom_security = custom_rows["security"]
@@ -205,7 +205,7 @@ def test_read_run_data_overlays_sql_principle_grades_after_apply(
     )
 
     grade_formula.save_params(_STRICT)
-    assert grade_formula.apply_to_all_runs(reports_root) == 1
+    assert grade_formula.apply_to_all_runs(reports_root).rescored == 1
 
     custom_p1 = next(
         r for r in SQLiteStateStore(run_dir).read_principle_grades()
@@ -238,7 +238,7 @@ def test_read_run_data_keeps_eval_time_principle_on_name_mismatch(
     )
 
     grade_formula.save_params(_STRICT)
-    assert grade_formula.apply_to_all_runs(reports_root) == 1
+    assert grade_formula.apply_to_all_runs(reports_root).rescored == 1
     custom_rows = {r["dimension"]: r for r in SQLiteStateStore(run_dir).read_dimension_scores()}
 
     dims = read_run_data(reports_root, project, "run1")


### PR DESCRIPTION
Confirmed finding F2.1 from the 1.6.1 flagship data-store audit.

## Problem

`apply_to_all_runs` (behind PUT/DELETE `/api/grade-formula`) swallowed every per-run `recompute_grades` error and returned only a rescored count. Because the params are saved *before* the apply and the persistent score cache keys on the params fingerprint, a run that errored during the apply — a momentarily-locked `evaluation.db` (a background scoring thread writing), a corrupt db, an `OSError` — **permanently** served its old-formula grades: after a formula change the cache always misses and re-derives from that run's stale SQL grade tables, which the failed apply never rewrote. So one run showed the old formula while its siblings showed the new one, across trend / history / card / overview, and the endpoint reported a clean success.

## Fix

- `apply_to_all_runs` retries each run's recompute (2 retries, short backoff) so a transient DB lock recovers, and returns an `ApplyResult(rescored, failed)` — `failed` being the run-dir names that still couldn't be rescored.
- The PUT/DELETE responses now include a `failed` count.
- The grade-formula page surfaces a partial apply: *"Applied, but N runs could not be rescored and still show the old formula. Try applying again."* — visible and recoverable instead of a silent mismatch.

Not included (noted as a deeper follow-up): a params-fingerprint self-heal on the read path so a stale run auto-corrects on next read. This PR makes the partial apply honest and retryable, which addresses the "silent wrong numbers" harm.

## Testing

- TDD: `apply_to_all_runs` reports failed runs and still rescoring siblings + clearing the cache; the API surfaces `failed` on both full and partial applies. Full suites: backend 4489, UI 895.

Independent of the other 1.6.1 audit PRs (#798–#801).

🤖 Generated with [Claude Code](https://claude.com/claude-code)