### PR TITLE
fix(assistant): GC leaked write worktrees + branches, prune old sessions

### DIFF
--- a/src/quodeq/api/_assistant_helpers.py
+++ b/src/quodeq/api/_assistant_helpers.py
@@ -1,6 +1,8 @@
 """Request plumbing for assistant routes: repo/context construction, busy check."""
 from __future__ import annotations
 
+import logging
+import os
 import time
 from pathlib import Path
 
@@ -11,6 +13,44 @@ from quodeq.assistant.tools import ToolContext
 from quodeq.assistant import LOCAL_PROVIDERS as _LOCAL_PROVIDERS
 from quodeq.services._fs_projects import get_project_info
 from quodeq.shared._env import get_evaluations_dir
+
+_logger = logging.getLogger(__name__)
+
+# ~/.quodeq/assistant.db is never pruned otherwise; a session older than this
+# is effectively dead (its worktree, if any, was reaped long before). 0
+# disables. Whole-session delete cascades to its messages/events/actions.
+_DEFAULT_SESSION_TTL_DAYS = 90
+
+
+def _session_ttl_days() -> int:
+    raw = os.environ.get("QUODEQ_ASSISTANT_SESSION_TTL_DAYS")
+    if raw is None:
+        return _DEFAULT_SESSION_TTL_DAYS
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return _DEFAULT_SESSION_TTL_DAYS
+
+
+def run_assistant_hygiene(app: Flask) -> None:
+    """One-shot-per-process cleanup: reap leaked worktrees, prune old sessions.
+
+    Runs on the first assistant request. Worktrees are GC'd BEFORE the session
+    prune so a pruned session's on-disk worktree/branch is already gone.
+    Never raises — hygiene must not break the request that triggered it.
+    """
+    if getattr(app, "_assistant_hygiene_done", False):
+        return
+    app._assistant_hygiene_done = True
+    from quodeq.assistant.worktree import gc_worktrees  # noqa: PLC0415
+    repo = get_repository(app)
+    try:
+        gc_worktrees(repo)
+        removed = repo.prune_sessions_older_than(_session_ttl_days())
+        if removed:
+            _logger.info("Pruned %d old assistant session(s)", removed)
+    except Exception:  # noqa: BLE001 — hygiene is best-effort
+        _logger.warning("assistant hygiene failed", exc_info=True)
 
 _POLL_SECONDS = 0.25
 _IDLE_LIMIT = 2400  # 2400 * 0.25s = 600s idle backstop. The stream now stays

--- a/src/quodeq/api/assistant_routes.py
+++ b/src/quodeq/api/assistant_routes.py
@@ -69,6 +69,9 @@ def register_assistant_routes(app: Flask) -> None:
 
     @app.post("/api/assistant/sessions")
     def create_assistant_session():
+        # First assistant request of the process: reap leaked worktrees +
+        # prune stale sessions before minting a new one (one-shot, best-effort).
+        _assistant_helpers.run_assistant_hygiene(app)
         body = request.get_json(silent=True) or {}
         provider_cfg = _known_provider(str(body.get("provider", "")))
         if provider_cfg is None:

--- a/src/quodeq/api/assistant_workspace_routes.py
+++ b/src/quodeq/api/assistant_workspace_routes.py
@@ -10,9 +10,9 @@ from pathlib import Path
 
 from flask import Flask, jsonify, request
 
-from quodeq.api._assistant_helpers import get_repository
+from quodeq.api._assistant_helpers import get_repository, run_assistant_hygiene
 from quodeq.assistant.worktree import (
-    WorktreeError, WorktreeManager, diff_stats, diff_text, gc_stale_worktrees)
+    WorktreeError, WorktreeManager, diff_stats, diff_text)
 
 _logger = logging.getLogger(__name__)
 
@@ -24,13 +24,11 @@ def _manager(row: dict) -> WorktreeManager:
 
 def register_assistant_workspace_routes(app: Flask) -> None:
     def _lookup(sid: str):
-        """(repo, row, error_response); runs the one-shot stale GC first."""
+        """(repo, row, error_response); runs one-shot worktree/db hygiene first."""
         repo = get_repository(app)
         if repo.get_session(sid) is None:
             return None, None, (jsonify({"error": "unknown session"}), 404)
-        if not getattr(app, "_worktree_gc_done", False):
-            gc_stale_worktrees(repo)
-            app._worktree_gc_done = True
+        run_assistant_hygiene(app)
         return repo, repo.get_worktree(sid), None
 
     @app.get("/api/assistant/sessions/<sid>/workspace")

--- a/src/quodeq/assistant/worktree.py
+++ b/src/quodeq/assistant/worktree.py
@@ -5,17 +5,37 @@ All git/gh invocations are argv lists (never shell strings) with explicit
 """
 from __future__ import annotations
 
+import logging
 import os
 import re
 import shutil
 import subprocess
 import tempfile
+from datetime import datetime, timezone
 from dataclasses import dataclass
 from pathlib import Path
+
+_logger = logging.getLogger(__name__)
 
 _GIT_TIMEOUT_S = 120
 _BRANCH_PREFIX = "quodeq/fix-"
 _MAX_BRANCH_TRIES = 5
+
+# How long an unresolved (never applied/pr'd/discarded) write worktree may
+# live before GC reaps it and its quodeq/fix-* branch from the user's repo.
+# Generous by default so an in-use worktree is never yanked mid-session; a
+# reaped one is recreated on the next write turn. 0 disables reaping.
+_DEFAULT_WORKTREE_TTL_H = 72
+
+
+def _worktree_ttl_hours() -> int:
+    raw = os.environ.get("QUODEQ_ASSISTANT_WORKTREE_TTL_H")
+    if raw is None:
+        return _DEFAULT_WORKTREE_TTL_H
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return _DEFAULT_WORKTREE_TTL_H
 
 
 class WorktreeError(Exception):
@@ -228,8 +248,72 @@ def ensure_session_worktree(repository, *, repo_root: Path, project_id: str | No
     return manager
 
 
+def _row_age_hours(created_at: str | None, now: datetime) -> float | None:
+    """Hours since *created_at* (a SQLite datetime string), or None if unparsable."""
+    if not created_at:
+        return None
+    text = str(created_at).strip().replace("T", " ")
+    for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"):
+        try:
+            dt = datetime.strptime(text, fmt).replace(tzinfo=timezone.utc)
+            return (now - dt).total_seconds() / 3600.0
+        except ValueError:
+            continue
+    return None
+
+
+def _remove_worktree_row(row: dict) -> None:
+    """Best-effort remove of a worktree dir + its branch from the row data."""
+    try:
+        WorktreeManager(
+            repo_root=Path(row["repo_root"]), path=Path(row["path"]),
+            branch=row["branch"],
+        ).remove()
+    except WorktreeError as exc:
+        _logger.warning("GC could not remove worktree %s: %s", row["path"], exc)
+
+
+def gc_worktrees(repository, ttl_hours: int | None = None) -> None:
+    """Reap leaked assistant worktrees + their ``quodeq/fix-*`` branches.
+
+    Cleanup only happened on explicit apply/pr/discard, so a write session the
+    user never resolved (a new session is minted per context switch / "New
+    conversation") left its worktree and branch in the real repo forever, and
+    a failed ``remove`` left a terminal row whose worktree the old GC never
+    revisited. This reaps three cases:
+
+      * ``active`` row, dir vanished  -> mark ``stale`` (crash cleanup).
+      * ``active`` row older than the TTL, dir exists -> abandoned: remove
+        the worktree + branch, mark ``discarded``.
+      * terminal row (applied/pr_created/discarded/stale), dir still exists
+        -> a prior ``remove`` failed: retry the removal.
+
+    ``ttl_hours=0`` treats every active worktree as reapable (used by tests);
+    a young active worktree is otherwise left untouched so an in-use session
+    is never yanked mid-edit.
+    """
+    ttl = _worktree_ttl_hours() if ttl_hours is None else ttl_hours
+    now = datetime.now(timezone.utc)
+    try:
+        rows = repository.list_all_worktrees()
+    except AttributeError:  # older repository without the new method
+        rows = repository.list_worktrees("active")
+    for row in rows:
+        dir_exists = Path(row["path"]).is_dir()
+        if row["status"] == "active":
+            if not dir_exists:
+                repository.set_worktree_status(row["session_id"], "stale")
+                continue
+            age = _row_age_hours(row["created_at"], now)
+            if ttl <= 0 or (age is not None and age >= ttl):
+                _remove_worktree_row(row)
+                repository.set_worktree_status(row["session_id"], "discarded")
+        elif dir_exists:
+            # Terminal row whose worktree a failed remove left behind: retry.
+            _remove_worktree_row(row)
+
+
+# Back-compat alias: the workspace route's one-shot GC calls this name.
 def gc_stale_worktrees(repository) -> None:
-    """Mark active rows whose worktree directory vanished (crash cleanup)."""
-    for row in repository.list_worktrees("active"):
-        if not Path(row["path"]).is_dir():
-            repository.set_worktree_status(row["session_id"], "stale")
+    """Deprecated name for :func:`gc_worktrees` (kept for existing callers)."""
+    gc_worktrees(repository)

--- a/src/quodeq/data/sqlite/assistant_repository.py
+++ b/src/quodeq/data/sqlite/assistant_repository.py
@@ -194,3 +194,26 @@ class AssistantRepository:
                 "SELECT * FROM worktrees WHERE status = ? AND project_id = ?",
                 (status, project_id),
             ).fetchall()
+
+    def list_all_worktrees(self) -> list[dict]:
+        """Every worktree row regardless of status — the GC needs to revisit
+        terminal rows whose on-disk worktree a failed ``remove`` left behind."""
+        with self._connect() as conn:
+            return conn.execute("SELECT * FROM worktrees").fetchall()
+
+    def prune_sessions_older_than(self, days: int) -> int:
+        """Delete sessions created more than *days* ago; return the count.
+
+        Bounds unbounded ~/.quodeq/assistant.db growth. FK cascades remove the
+        session's messages, actions, events, and worktree row. ``days <= 0``
+        disables pruning (no-op). Callers must GC worktrees first so a pruned
+        session's on-disk worktree/branch is already cleaned up.
+        """
+        if days <= 0:
+            return 0
+        with self._connect() as conn:
+            cur = conn.execute(
+                "DELETE FROM sessions WHERE created_at < datetime('now', ?)",
+                (f"-{int(days)} days",),
+            )
+            return cur.rowcount

--- a/tests/api/test_assistant_workspace_routes.py
+++ b/tests/api/test_assistant_workspace_routes.py
@@ -204,3 +204,55 @@ def test_workspace_apply_requires_csrf_origin(tmp_path, monkeypatch):
     resp = client.post("/api/assistant/sessions/x/workspace/apply",
                        headers={"Origin": "http://evil.example"})
     assert resp.status_code == 403
+
+
+def _branch_exists(repo, branch):
+    from quodeq.assistant.worktree import _run
+    out = _run(["git", "-C", str(repo), "branch", "--list", branch])
+    return bool(out.strip())
+
+
+def test_gc_removes_abandoned_active_worktree_and_branch(app, client, repo):
+    # A write session the user never resolved leaks a worktree + quodeq/fix-*
+    # branch in their real repo. GC with an elapsed TTL must remove both and
+    # mark the row, not just flip status when the dir already vanished.
+    from quodeq.assistant.worktree import gc_worktrees
+    sid, store, manager = _session_with_worktree(app, client, repo)
+    assert manager.path.exists()
+    assert _branch_exists(repo, manager.branch)
+
+    gc_worktrees(store, ttl_hours=0)  # ttl=0 => any active worktree is abandoned
+
+    assert not manager.path.exists(), "abandoned worktree dir must be removed"
+    assert not _branch_exists(repo, manager.branch), "fix branch must be deleted"
+    assert store.get_worktree(sid)["status"] == "discarded"
+
+
+def test_gc_keeps_recent_active_worktree(app, client, repo):
+    from quodeq.assistant.worktree import gc_worktrees
+    sid, store, manager = _session_with_worktree(app, client, repo)
+    gc_worktrees(store, ttl_hours=72)  # created just now => under the TTL
+    assert manager.path.exists()
+    assert store.get_worktree(sid)["status"] == "active"
+
+
+def test_gc_retries_a_failed_remove_on_a_terminal_row(app, client, repo):
+    # apply/pr set the row terminal then remove(); if remove() failed the dir
+    # lingers with a non-active row the old GC never revisited. GC must retry.
+    from quodeq.assistant.worktree import gc_worktrees
+    sid, store, manager = _session_with_worktree(app, client, repo)
+    store.set_worktree_status(sid, "applied")  # terminal, but dir still exists
+    assert manager.path.exists()
+
+    gc_worktrees(store, ttl_hours=72)
+
+    assert not manager.path.exists(), "leftover worktree of a terminal row must be removed"
+
+
+def test_gc_marks_active_row_stale_when_dir_vanished(app, client, repo):
+    from quodeq.assistant.worktree import gc_worktrees
+    import shutil
+    sid, store, manager = _session_with_worktree(app, client, repo)
+    shutil.rmtree(manager.path)  # crash / external removal
+    gc_worktrees(store, ttl_hours=72)
+    assert store.get_worktree(sid)["status"] == "stale"

--- a/tests/data/sqlite/test_assistant_repository.py
+++ b/tests/data/sqlite/test_assistant_repository.py
@@ -100,3 +100,49 @@ def test_set_action_status_unconditional_still_works(tmp_path):
     )
     assert repo.set_action_status("a1", "applied") is True
     assert repo.get_action("a1")["status"] == "applied"
+
+
+def test_list_all_worktrees_returns_every_status(tmp_path):
+    repo = _repo(tmp_path)
+    for sid, status in [("s1", "active"), ("s2", "applied"), ("s3", "discarded")]:
+        repo.create_session(session_id=sid, provider="ollama")
+        repo.upsert_worktree(session_id=sid, project_id="p", repo_root="/r",
+                             path=f"/w/{sid}", branch=f"b-{sid}")
+        if status != "active":
+            repo.set_worktree_status(sid, status)
+    rows = repo.list_all_worktrees()
+    assert {r["session_id"]: r["status"] for r in rows} == {
+        "s1": "active", "s2": "applied", "s3": "discarded",
+    }
+
+
+def test_prune_sessions_older_than_cascades(tmp_path):
+    import sqlite3
+    repo = _repo(tmp_path)
+    repo.create_session(session_id="old", provider="ollama")
+    repo.add_message("old", "user", "hi")
+    repo.append_event("old", {"type": "token", "text": "x"})
+    repo.create_session(session_id="new", provider="ollama")
+    repo.add_message("new", "user", "yo")
+
+    # Backdate the old session well past any TTL.
+    conn = sqlite3.connect(tmp_path / "assistant.db")
+    conn.execute("UPDATE sessions SET created_at = '2020-01-01 00:00:00' WHERE id = 'old'")
+    conn.commit()
+    conn.close()
+
+    removed = repo.prune_sessions_older_than(days=30)
+    assert removed == 1
+    assert repo.get_session("old") is None
+    assert repo.get_session("new") is not None
+    # Cascade: the old session's messages and events are gone too.
+    assert repo.list_messages("old") == []
+    assert repo.events_after("old", after_seq=0) == []
+    assert [(m["role"], m["content"]) for m in repo.list_messages("new")] == [("user", "yo")]
+
+
+def test_prune_sessions_ttl_zero_is_a_noop(tmp_path):
+    repo = _repo(tmp_path)
+    repo.create_session(session_id="s1", provider="ollama")
+    assert repo.prune_sessions_older_than(days=0) == 0
+    assert repo.get_session("s1") is not None


### PR DESCRIPTION
Assistant hygiene findings C2/C4 from the 1.6.1 flagship audit.

## C2 — write worktrees + `quodeq/fix-*` branches leak into the user's real repo

A write session creates a git worktree and a `quodeq/fix-<short>` branch **in the user's actual repo**, cleaned up only on explicit Apply / PR / Discard. But the UI mints a new session on every context switch and "New conversation", orphaning the old one — and `gc_stale_worktrees` only flipped a row to `stale` when its directory had *already vanished*; it never removed a live abandoned worktree or its branch, and a failed `remove` left a terminal row the GC never revisited. Over time `git branch` fills with `quodeq/fix-*` entries and `.git/worktrees` + `~/.quodeq/worktrees` accumulate.

`gc_worktrees` now reaps three cases:
- active row, dir vanished → mark `stale` (crash cleanup, unchanged);
- active row older than `QUODEQ_ASSISTANT_WORKTREE_TTL_H` (default **72h**), dir exists → abandoned: remove the worktree **and** the branch, mark `discarded`;
- terminal row (applied/pr_created/discarded/stale), dir still exists → a prior `remove` failed: retry it.

A young active worktree is never touched (an in-use session isn't yanked mid-edit); a reaped one is recreated on the next write turn.

## C4 — `assistant.db` grew unbounded

`prune_sessions_older_than` deletes sessions past `QUODEQ_ASSISTANT_SESSION_TTL_DAYS` (default **90**), cascading to their messages / events / actions / worktree rows.

*Deferred:* the audit also flagged the full event-frame replay on every drawer reopen. The client currently rebuilds the conversation **from** that event stream (not from persisted `messages`), so capping the replay would drop history rendering — that needs a client redesign (load `list_messages` for history, use events only for the live turn) and is out of scope here.

## Wiring

Both run once per process via `run_assistant_hygiene`, invoked on the first assistant request (session create / workspace lookup). Worktrees are GC'd **before** the session prune so a pruned session's on-disk worktree/branch is already gone. Best-effort — hygiene never raises into the triggering request.

## Testing

TDD, real-git end-to-end (the fixture does a real `git worktree add` + branch): GC removes an abandoned worktree **and its branch** and marks the row; keeps a recent one; retries a failed remove on a terminal row; still marks a vanished-dir row stale. Repository tests for `list_all_worktrees` and cascading `prune_sessions_older_than` (incl. `days=0` no-op). Full suite: 4507 passed.

Last remaining item from the 1.6.1 flagship audit's high/medium tier; independent of #798–#802.

🤖 Generated with [Claude Code](https://claude.com/claude-code)