### PR TITLE
docs: update demo link to the new presentation video

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.youtube.com/watch?v=C9feqpR5BMI&list=PLJjpl8sE7W-U1HMePWdGis7w834NPYD3R">Watch the 2-min demo</a> · <a href="https://quodeq.ai">Website</a> · <a href="https://quodeq.ai/blog/">Blog</a> · <a href="https://github.com/quodeq/quodeq/releases/latest">Releases</a>
+  <a href="https://www.youtube.com/watch?v=hMgwULdorNk&list=PLJjpl8sE7W-U1HMePWdGis7w834NPYD3R&index=1">Watch the demo</a> · <a href="https://quodeq.ai">Website</a> · <a href="https://quodeq.ai/blog/">Blog</a> · <a href="https://github.com/quodeq/quodeq/releases/latest">Releases</a>
 </p>
 
 ---


### PR DESCRIPTION
Points the README demo link at the new 5-minute presentation video (`hMgwULdorNk`), replacing the old 2-minute demo (`C9feqpR5BMI`). Keeps the playlist form so the link opens within the Quodeq playlist. Also updates the link text from "Watch the 2-min demo" to "Watch the demo" since the new video is a full walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)