### PR TITLE
feat: shared results repo core (settings, clone, publish)

### DIFF
--- a/src/quodeq/api/routes_registry.py
+++ b/src/quodeq/api/routes_registry.py
@@ -29,6 +29,7 @@ from quodeq.api.routes_rescore import register_rescore_routes
 from quodeq.api.routes_update import register_update_routes
 from quodeq.api._scores_routes import register_scores_routes
 from quodeq.api.routes_runs import register_runs_routes
+from quodeq.api.routes_shared import register_shared_routes
 from quodeq.api._grade_formula_routes import register_grade_formula_routes
 from quodeq.services.base import ActionProvider
 
@@ -62,6 +63,7 @@ def register_all_routes(
     register_rescore_routes(app)
     register_scores_routes(app)
     register_runs_routes(app)
+    register_shared_routes(app)
     register_grade_formula_routes(app)
     register_llm_bridge_routes(app)
     if log_buffer:

--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -21,6 +21,7 @@ from quodeq.services.shared_settings import (
     read_settings,
     write_settings,
 )
+from quodeq.shared.validation import validate_path_segment
 
 from .routes_common import reports_dir
 
@@ -79,6 +80,10 @@ def register_shared_routes(app: Flask) -> None:
 
     @app.post("/api/projects/<project>/publish")
     def shared_publish_start(project: str) -> tuple[Response, int]:
+        try:
+            validate_path_segment(project)
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
         settings = read_settings()
         if not settings.url:
             return jsonify({"error": "no shared repository configured"}), 400

--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -43,7 +43,7 @@ def register_shared_routes(app: Flask) -> None:
     @app.put("/api/shared/config")
     def shared_config_put() -> Response | tuple[Response, int]:
         body = request.get_json(silent=True) or {}
-        url = (body.get("url") or "").strip()
+        url = str(body.get("url") or "").strip()
         if not url:
             return jsonify({"error": "url is required"}), 400
         try:

--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -1,0 +1,90 @@
+"""Routes for the shared results repository (config, status, refresh, publish).
+
+Read-only invariant: no finding-mutation routes exist in this module or
+anywhere under /api/shared/*.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from flask import Flask, Response, jsonify, request
+
+from quodeq.services.shared_publish import get_publish_status, start_publish
+from quodeq.services.shared_repo import (
+    ensure_shared_clone,
+    last_synced_at,
+    refresh_shared_clone,
+    validate_remote_url,
+)
+from quodeq.services.shared_settings import (
+    SharedSettings,
+    read_settings,
+    write_settings,
+)
+
+from .routes_common import reports_dir
+
+
+def register_shared_routes(app: Flask) -> None:
+    @app.get("/api/shared/status")
+    def shared_status() -> Response:
+        settings = read_settings()
+        synced = last_synced_at(settings.url) if settings.url else None
+        return jsonify(
+            {
+                "configured": settings.url is not None,
+                "url": settings.url,
+                "lastSynced": synced,
+                "syncing": False,
+                "publish": get_publish_status(),
+            }
+        )
+
+    @app.put("/api/shared/config")
+    def shared_config_put() -> Response | tuple[Response, int]:
+        body = request.get_json(silent=True) or {}
+        url = (body.get("url") or "").strip()
+        if not url:
+            return jsonify({"error": "url is required"}), 400
+        try:
+            validate_remote_url(url)
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+        if ensure_shared_clone(url) is None:
+            return (
+                jsonify(
+                    {"error": f"could not clone the repository, check that git can access {url}"}
+                ),
+                502,
+            )
+        write_settings(SharedSettings(url=url))
+        return jsonify({"configured": True, "url": url})
+
+    @app.delete("/api/shared/config")
+    def shared_config_delete() -> Response:
+        write_settings(SharedSettings(url=None))
+        return jsonify({"configured": False})
+
+    @app.post("/api/shared/refresh")
+    def shared_refresh() -> Response | tuple[Response, int]:
+        settings = read_settings()
+        if not settings.url:
+            return jsonify({"error": "no shared repository configured"}), 400
+        if not refresh_shared_clone(settings.url):
+            return (
+                jsonify({"stale": True, "lastSynced": last_synced_at(settings.url)}),
+                502,
+            )
+        return jsonify({"stale": False, "lastSynced": last_synced_at(settings.url)})
+
+    @app.post("/api/projects/<project>/publish")
+    def shared_publish_start(project: str) -> tuple[Response, int]:
+        settings = read_settings()
+        if not settings.url:
+            return jsonify({"error": "no shared repository configured"}), 400
+        started = start_publish(
+            project, settings.url, evaluations_root=Path(reports_dir())
+        )
+        if not started:
+            return jsonify({"error": "a publish is already running"}), 409
+        return jsonify({"started": True}), 202

--- a/src/quodeq/services/shared_publish.py
+++ b/src/quodeq/services/shared_publish.py
@@ -258,8 +258,14 @@ def start_publish(project_id: str, url: str, *, evaluations_root: Path) -> bool:
         _STATUS.update(
             state="running", project=project_id, runs=None, error=None, finished_at=None
         )
-    thread = threading.Thread(
-        target=_run_publish, args=(project_id, url, evaluations_root), daemon=True
-    )
-    thread.start()
+    try:
+        thread = threading.Thread(
+            target=_run_publish, args=(project_id, url, evaluations_root), daemon=True
+        )
+        thread.start()
+    except Exception as exc:
+        with _STATUS_LOCK:
+            _STATUS.update(state="error", error=str(exc), finished_at=time.time())
+        logger.exception("failed to start publish thread")
+        return False
     return True

--- a/src/quodeq/services/shared_publish.py
+++ b/src/quodeq/services/shared_publish.py
@@ -1,0 +1,91 @@
+"""Staging logic for publishing a project into the shared results repo.
+
+Pure file operations, no git. Invariants (spec):
+- only completed runs (state == "done") are published
+- explicit allowlist of source-of-truth files, never derived artifacts
+- actions.jsonl is union-merged with the remote copy, never overwritten
+"""
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from quodeq.shared.run_status import UnsupportedSchemaError, read_status
+
+_RUN_FILES = ("status.json", "dimensions.json", "events.jsonl")
+_EVIDENCE_DIR = "evidence"
+
+
+def list_completed_runs(project_dir: Path) -> list[Path]:
+    runs: list[Path] = []
+    for entry in sorted(project_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        try:
+            status = read_status(entry)
+        except UnsupportedSchemaError:
+            # Skip runs with unsupported schema versions
+            continue
+        if status and status.get("state") == "done":
+            runs.append(entry)
+    return runs
+
+
+def copy_run(run_dir: Path, dest_run_dir: Path) -> None:
+    dest_run_dir.mkdir(parents=True, exist_ok=True)
+    for name in _RUN_FILES:
+        src = run_dir / name
+        if src.exists():
+            shutil.copy2(src, dest_run_dir / name)
+    evidence = run_dir / _EVIDENCE_DIR
+    if evidence.is_dir():
+        dest_evidence = dest_run_dir / _EVIDENCE_DIR
+        dest_evidence.mkdir(exist_ok=True)
+        manifest = evidence / "manifest.json"
+        if manifest.exists():
+            shutil.copy2(manifest, dest_evidence / "manifest.json")
+        for src in sorted(evidence.glob("*_evidence.jsonl")):
+            shutil.copy2(src, dest_evidence / src.name)
+
+
+def _timestamp_key(line: str) -> tuple[int, str]:
+    try:
+        ts = json.loads(line).get("timestamp") or ""
+        return (0, str(ts))
+    except (json.JSONDecodeError, AttributeError):
+        return (1, "")
+
+
+def merge_actions_log(ours: Path, theirs: Path, dest: Path) -> None:
+    seen: set[str] = set()
+    lines: list[str] = []
+    for source in (ours, theirs):
+        if not source.exists():
+            continue
+        for raw in source.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if line and line not in seen:
+                seen.add(line)
+                lines.append(line)
+    if not lines:
+        return
+    lines.sort(key=_timestamp_key)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def stage_project(project_dir: Path, dest_project_dir: Path) -> int:
+    dest_project_dir.mkdir(parents=True, exist_ok=True)
+    info = project_dir / "repository_info.json"
+    if info.exists():
+        shutil.copy2(info, dest_project_dir / "repository_info.json")
+    merge_actions_log(
+        project_dir / "actions.jsonl",
+        dest_project_dir / "actions.jsonl",
+        dest_project_dir / "actions.jsonl",
+    )
+    runs = list_completed_runs(project_dir)
+    for run_dir in runs:
+        copy_run(run_dir, dest_project_dir / run_dir.name)
+    return len(runs)

--- a/src/quodeq/services/shared_publish.py
+++ b/src/quodeq/services/shared_publish.py
@@ -12,6 +12,14 @@ import shutil
 from pathlib import Path
 
 from quodeq.data.actions_log import ACTIONS_LOG_FILENAME
+from quodeq.services.shared_repo import (
+    MARKER_FILENAME,
+    bootstrap_repo_layout,
+    check_repo_format,
+    ensure_shared_clone,
+    refresh_shared_clone,
+    run_git,
+)
 from quodeq.shared.dimensions_state import FILENAME as DIMENSIONS_FILENAME
 from quodeq.shared.run_status import STATUS_FILENAME, UnsupportedSchemaError, read_status
 
@@ -93,3 +101,108 @@ def stage_project(project_dir: Path, dest_project_dir: Path) -> int:
     for run_dir in runs:
         copy_run(run_dir, dest_project_dir / run_dir.name)
     return len(runs)
+
+
+class PublishError(Exception):
+    """User-facing publish failure."""
+
+
+def _app_version() -> str:
+    from quodeq import __version__
+
+    return __version__ or "0.0.0+dev"
+
+
+def publish_project(
+    project_id: str, url: str, *, evaluations_root: Path, env: dict | None = None
+) -> int:
+    project_dir = evaluations_root / project_id
+    if not project_dir.is_dir():
+        raise PublishError(f"project {project_id} not found in local evaluations")
+
+    repo = ensure_shared_clone(url, env)
+    if repo is None:
+        raise PublishError(
+            f"could not reach the shared repository, check that git can access {url}"
+        )
+    refresh_shared_clone(url, env)  # best effort, publish is still guarded by push
+
+    fmt = check_repo_format(repo)
+    if fmt == "unsupported_version":
+        raise PublishError("this shared repository requires a newer version of quodeq")
+    if fmt == "foreign":
+        raise PublishError(
+            "the configured repository does not look like a quodeq results repository, "
+            "refusing to publish into it"
+        )
+    if fmt == "empty":
+        bootstrap_repo_layout(repo)
+
+    count = stage_project(project_dir, repo / "evaluations" / project_id)
+
+    add_paths = [MARKER_FILENAME, ".gitignore", f"evaluations/{project_id}"]
+    if (repo / "evaluations" / ".gitkeep").exists():
+        add_paths.append("evaluations/.gitkeep")
+    ok, out = run_git(["add", "--", *add_paths], cwd=repo)
+    if not ok:
+        raise PublishError(f"git add failed, {out.strip()[:300]}")
+
+    ok, _ = run_git(["diff", "--cached", "--quiet"], cwd=repo)
+    if ok:
+        return count  # nothing new to publish
+
+    message = f"Publish {project_id} ({count} runs) via quodeq {_app_version()}"
+    ok, out = run_git(["commit", "-m", message], cwd=repo)
+    if not ok:
+        raise PublishError(f"git commit failed, {out.strip()[:300]}")
+
+    ok, out = _push(repo)
+    if not ok:
+        ok_rebase, out_rebase = run_git(["pull", "--rebase", "origin", "HEAD"], cwd=repo)
+        if ok_rebase:
+            ok, out = _push(repo)
+        else:
+            out = out_rebase
+    if not ok:
+        raise PublishError(
+            f"push to the shared repository failed, try again. {out.strip()[:300]}"
+        )
+    return count
+
+
+def _push(repo: Path) -> tuple[bool, str]:
+    """Push HEAD to the remote's default branch.
+
+    A fresh --depth 1 clone of a brand-new empty bare repo has no commits
+    and no origin/HEAD symref yet, so plain ``push origin HEAD`` has nothing
+    to compare against. Detect that case and push with an explicit refspec
+    instead, deriving the target branch name from the remote's symref (or
+    falling back to the local clone's current branch name).
+    """
+    ok, out = run_git(["push", "origin", "HEAD"], cwd=repo)
+    if ok:
+        return ok, out
+
+    # Fall back for a still-unborn remote default branch: push HEAD to an
+    # explicit ref name rather than relying on origin/HEAD resolution.
+    branch = _remote_default_branch(repo) or _local_branch_name(repo)
+    return run_git(["push", "origin", f"HEAD:refs/heads/{branch}"], cwd=repo)
+
+
+def _remote_default_branch(repo: Path) -> str | None:
+    ok, out = run_git(["ls-remote", "--symref", "origin", "HEAD"], cwd=repo)
+    if not ok:
+        return None
+    for line in out.splitlines():
+        if line.startswith("ref:"):
+            # "ref: refs/heads/main\tHEAD"
+            ref = line.split()[1]
+            if ref.startswith("refs/heads/"):
+                return ref[len("refs/heads/") :]
+    return None
+
+
+def _local_branch_name(repo: Path) -> str:
+    ok, out = run_git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=repo)
+    name = out.strip()
+    return name if ok and name and name != "HEAD" else "main"

--- a/src/quodeq/services/shared_publish.py
+++ b/src/quodeq/services/shared_publish.py
@@ -8,7 +8,10 @@ Pure file operations, no git. Invariants (spec):
 from __future__ import annotations
 
 import json
+import logging
 import shutil
+import threading
+import time
 from pathlib import Path
 
 from quodeq.data.actions_log import ACTIONS_LOG_FILENAME
@@ -22,6 +25,8 @@ from quodeq.services.shared_repo import (
 )
 from quodeq.shared.dimensions_state import FILENAME as DIMENSIONS_FILENAME
 from quodeq.shared.run_status import STATUS_FILENAME, UnsupportedSchemaError, read_status
+
+logger = logging.getLogger(__name__)
 
 _RUN_FILES = (STATUS_FILENAME, DIMENSIONS_FILENAME, "events.jsonl")
 _EVIDENCE_DIR = "evidence"
@@ -213,3 +218,48 @@ def _local_branch_name(repo: Path) -> str:
     ok, out = run_git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=repo)
     name = out.strip()
     return name if ok and name and name != "HEAD" else "main"
+
+
+_STATUS_LOCK = threading.Lock()
+_STATUS: dict = {
+    "state": "idle",
+    "project": None,
+    "runs": None,
+    "error": None,
+    "finished_at": None,
+}
+
+
+def get_publish_status() -> dict:
+    with _STATUS_LOCK:
+        return dict(_STATUS)
+
+
+def _run_publish(project_id: str, url: str, evaluations_root: Path) -> None:
+    try:
+        count = publish_project(project_id, url, evaluations_root=evaluations_root)
+        with _STATUS_LOCK:
+            _STATUS.update(
+                state="done", runs=count, error=None, finished_at=time.time()
+            )
+    except PublishError as exc:
+        with _STATUS_LOCK:
+            _STATUS.update(state="error", error=str(exc), finished_at=time.time())
+    except Exception as exc:  # never leave the job stuck in "running"
+        logger.exception("unexpected publish failure")
+        with _STATUS_LOCK:
+            _STATUS.update(state="error", error=str(exc), finished_at=time.time())
+
+
+def start_publish(project_id: str, url: str, *, evaluations_root: Path) -> bool:
+    with _STATUS_LOCK:
+        if _STATUS["state"] == "running":
+            return False
+        _STATUS.update(
+            state="running", project=project_id, runs=None, error=None, finished_at=None
+        )
+    thread = threading.Thread(
+        target=_run_publish, args=(project_id, url, evaluations_root), daemon=True
+    )
+    thread.start()
+    return True

--- a/src/quodeq/services/shared_publish.py
+++ b/src/quodeq/services/shared_publish.py
@@ -135,10 +135,13 @@ def publish_project(
             "the configured repository does not look like a quodeq results repository, "
             "refusing to publish into it"
         )
-    if fmt == "empty":
-        bootstrap_repo_layout(repo)
+    try:
+        if fmt == "empty":
+            bootstrap_repo_layout(repo)
 
-    count = stage_project(project_dir, repo / "evaluations" / project_id)
+        count = stage_project(project_dir, repo / "evaluations" / project_id)
+    except OSError as exc:
+        raise PublishError(f"failed to stage project files, {exc}") from exc
 
     add_paths = [MARKER_FILENAME, ".gitignore", f"evaluations/{project_id}"]
     if (repo / "evaluations" / ".gitkeep").exists():
@@ -162,6 +165,10 @@ def publish_project(
         if ok_rebase:
             ok, out = _push(repo)
         else:
+            # A real conflict wedges the persistent clone with a lingering
+            # .git/rebase-merge directory, breaking every future publish.
+            # The clone is reused across calls, so always leave it clean.
+            run_git(["rebase", "--abort"], cwd=repo)
             out = out_rebase
     if not ok:
         raise PublishError(

--- a/src/quodeq/services/shared_publish.py
+++ b/src/quodeq/services/shared_publish.py
@@ -145,7 +145,7 @@ def publish_project(
             bootstrap_repo_layout(repo)
 
         count = stage_project(project_dir, repo / "evaluations" / project_id)
-    except OSError as exc:
+    except (OSError, ValueError) as exc:
         raise PublishError(f"failed to stage project files, {exc}") from exc
 
     add_paths = [MARKER_FILENAME, ".gitignore", f"evaluations/{project_id}"]
@@ -155,14 +155,20 @@ def publish_project(
     if not ok:
         raise PublishError(f"git add failed, {out.strip()[:300]}")
 
-    ok, _ = run_git(["diff", "--cached", "--quiet"], cwd=repo)
-    if ok:
-        return count  # nothing new to publish
-
-    message = f"Publish {project_id} ({count} runs) via quodeq {_app_version()}"
-    ok, out = run_git(["commit", "-m", message], cwd=repo)
-    if not ok:
-        raise PublishError(f"git commit failed, {out.strip()[:300]}")
+    # A clean `diff --cached` only means nothing NEW was staged this call; it
+    # does not mean the remote already has our commits. A prior publish can
+    # have committed locally and then failed to push (transient network
+    # error), leaving a local commit the remote never received. Retrying
+    # with unchanged project files hits this exact "nothing staged" state,
+    # so we must still fall through to the push below rather than returning
+    # early. A push with nothing new to send exits 0 ("Everything
+    # up-to-date"), so this stays a no-op for the true idempotent case.
+    nothing_staged, _ = run_git(["diff", "--cached", "--quiet"], cwd=repo)
+    if not nothing_staged:
+        message = f"Publish {project_id} ({count} runs) via quodeq {_app_version()}"
+        ok, out = run_git(["commit", "-m", message], cwd=repo)
+        if not ok:
+            raise PublishError(f"git commit failed, {out.strip()[:300]}")
 
     ok, out = _push(repo)
     if not ok:

--- a/src/quodeq/services/shared_publish.py
+++ b/src/quodeq/services/shared_publish.py
@@ -11,9 +11,11 @@ import json
 import shutil
 from pathlib import Path
 
-from quodeq.shared.run_status import UnsupportedSchemaError, read_status
+from quodeq.data.actions_log import ACTIONS_LOG_FILENAME
+from quodeq.shared.dimensions_state import FILENAME as DIMENSIONS_FILENAME
+from quodeq.shared.run_status import STATUS_FILENAME, UnsupportedSchemaError, read_status
 
-_RUN_FILES = ("status.json", "dimensions.json", "events.jsonl")
+_RUN_FILES = (STATUS_FILENAME, DIMENSIONS_FILENAME, "events.jsonl")
 _EVIDENCE_DIR = "evidence"
 
 
@@ -51,10 +53,12 @@ def copy_run(run_dir: Path, dest_run_dir: Path) -> None:
 
 def _timestamp_key(line: str) -> tuple[int, str]:
     try:
-        ts = json.loads(line).get("timestamp") or ""
-        return (0, str(ts))
-    except (json.JSONDecodeError, AttributeError):
+        ts = json.loads(line).get("timestamp")
+    except (json.JSONDecodeError, AttributeError, TypeError):
         return (1, "")
+    if not ts:
+        return (1, "")
+    return (0, str(ts))
 
 
 def merge_actions_log(ours: Path, theirs: Path, dest: Path) -> None:
@@ -81,9 +85,9 @@ def stage_project(project_dir: Path, dest_project_dir: Path) -> int:
     if info.exists():
         shutil.copy2(info, dest_project_dir / "repository_info.json")
     merge_actions_log(
-        project_dir / "actions.jsonl",
-        dest_project_dir / "actions.jsonl",
-        dest_project_dir / "actions.jsonl",
+        project_dir / ACTIONS_LOG_FILENAME,
+        dest_project_dir / ACTIONS_LOG_FILENAME,
+        dest_project_dir / ACTIONS_LOG_FILENAME,
     )
     runs = list_completed_runs(project_dir)
     for run_dir in runs:

--- a/src/quodeq/services/shared_repo.py
+++ b/src/quodeq/services/shared_repo.py
@@ -30,6 +30,7 @@ def run_git(
             capture_output=True,
             text=True,
             encoding="utf-8",
+            errors="replace",
             timeout=timeout,
         )
         return proc.returncode == 0, (proc.stdout or "") + (proc.stderr or "")

--- a/src/quodeq/services/shared_repo.py
+++ b/src/quodeq/services/shared_repo.py
@@ -7,6 +7,7 @@ layout as the local evaluations dir. We keep a shallow clone under
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import shutil
@@ -91,3 +92,35 @@ def last_synced_at(url: str, env: dict | None = None) -> float | None:
         except OSError:
             continue
     return None
+
+
+MARKER_FILENAME = "quodeq.json"
+FORMAT_NAME = "quodeq-shared-evaluations"
+FORMAT_VERSION = 1
+
+_GITIGNORE_CONTENT = "**/evaluation.db\n*.log\n"
+
+
+def check_repo_format(repo_root: Path) -> str:
+    marker = repo_root / MARKER_FILENAME
+    if marker.exists():
+        try:
+            data = json.loads(marker.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return "foreign"
+        if data.get("format") != FORMAT_NAME:
+            return "foreign"
+        if int(data.get("version", 0)) > FORMAT_VERSION:
+            return "unsupported_version"
+        return "ok"
+    entries = [p for p in repo_root.iterdir() if p.name != ".git"]
+    return "empty" if not entries else "foreign"
+
+
+def bootstrap_repo_layout(repo_root: Path) -> None:
+    marker_content = json.dumps({"format": FORMAT_NAME, "version": FORMAT_VERSION}) + "\n"
+    (repo_root / MARKER_FILENAME).write_text(marker_content, encoding="utf-8")
+    (repo_root / ".gitignore").write_text(_GITIGNORE_CONTENT, encoding="utf-8")
+    evaluations = repo_root / "evaluations"
+    evaluations.mkdir(exist_ok=True)
+    (evaluations / ".gitkeep").write_text("", encoding="utf-8")

--- a/src/quodeq/services/shared_repo.py
+++ b/src/quodeq/services/shared_repo.py
@@ -27,6 +27,16 @@ _CACHE_ENV = "QUODEQ_CACHE_ROOT"
 _DEFAULT_GIT_TIMEOUT_S = 300
 
 
+def _git_env() -> dict[str, str]:
+    """Environment for git subprocess calls.
+
+    GIT_LFS_SKIP_SMUDGE avoids pulling LFS blobs we don't need. GIT_TERMINAL_PROMPT=0
+    stops git from blocking on an interactive credential or passphrase prompt, since
+    these subprocess calls have stdin closed (see run_git) and nobody is there to answer.
+    """
+    return {**os.environ, "GIT_LFS_SKIP_SMUDGE": "1", "GIT_TERMINAL_PROMPT": "0"}
+
+
 def run_git(
     args: list[str], *, cwd: Path | None = None, timeout: int = _DEFAULT_GIT_TIMEOUT_S
 ) -> tuple[bool, str]:
@@ -34,7 +44,8 @@ def run_git(
         proc = subprocess.run(
             ["git", *args],
             cwd=str(cwd) if cwd else None,
-            env={**os.environ, "GIT_LFS_SKIP_SMUDGE": "1"},
+            env=_git_env(),
+            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,
             encoding="utf-8",

--- a/src/quodeq/services/shared_repo.py
+++ b/src/quodeq/services/shared_repo.py
@@ -1,0 +1,92 @@
+"""Shared results repository: clone, refresh, and path management.
+
+The shared repo is a git remote holding an evaluations/ tree in the same
+layout as the local evaluations dir. We keep a shallow clone under
+~/.quodeq/cache/shared/<url-hash>/repo (QUODEQ_CACHE_ROOT overrides the base).
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_CACHE_ENV = "QUODEQ_CACHE_ROOT"
+_DEFAULT_GIT_TIMEOUT_S = 300
+
+
+def run_git(
+    args: list[str], *, cwd: Path | None = None, timeout: int = _DEFAULT_GIT_TIMEOUT_S
+) -> tuple[bool, str]:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd) if cwd else None,
+            env={**os.environ, "GIT_LFS_SKIP_SMUDGE": "1"},
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=timeout,
+        )
+        return proc.returncode == 0, (proc.stdout or "") + (proc.stderr or "")
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, str(exc)
+
+
+def _cache_base(env: dict | None = None) -> Path:
+    e = env if env is not None else os.environ
+    base = e.get(_CACHE_ENV)
+    root = Path(base) if base else Path.home() / ".quodeq" / "cache"
+    return root / "shared"
+
+
+def shared_cache_dir(url: str, env: dict | None = None) -> Path:
+    digest = hashlib.sha256(url.strip().encode("utf-8")).hexdigest()[:16]
+    return _cache_base(env) / digest
+
+
+def shared_repo_path(url: str, env: dict | None = None) -> Path:
+    return shared_cache_dir(url, env) / "repo"
+
+
+def shared_evaluations_root(url: str, env: dict | None = None) -> Path:
+    return shared_repo_path(url, env) / "evaluations"
+
+
+def ensure_shared_clone(url: str, env: dict | None = None) -> Path | None:
+    repo = shared_repo_path(url, env)
+    if (repo / ".git").exists():
+        return repo
+    repo.parent.mkdir(parents=True, exist_ok=True)
+    ok, out = run_git(["clone", "--depth", "1", "--", url, str(repo)])
+    if not ok:
+        logger.warning("shared clone failed for %s: %s", url, out.strip()[:500])
+        shutil.rmtree(repo, ignore_errors=True)
+        return None
+    return repo
+
+
+def refresh_shared_clone(url: str, env: dict | None = None) -> bool:
+    repo = shared_repo_path(url, env)
+    if not (repo / ".git").exists():
+        return ensure_shared_clone(url, env) is not None
+    ok, _ = run_git(["fetch", "--depth", "1", "origin", "HEAD"], cwd=repo)
+    if not ok:
+        return False
+    ok, _ = run_git(["reset", "--hard", "FETCH_HEAD"], cwd=repo)
+    return ok
+
+
+def last_synced_at(url: str, env: dict | None = None) -> float | None:
+    repo = shared_repo_path(url, env)
+    for name in ("FETCH_HEAD", "HEAD"):
+        candidate = repo / ".git" / name
+        try:
+            return candidate.stat().st_mtime
+        except OSError:
+            continue
+    return None

--- a/src/quodeq/services/shared_repo.py
+++ b/src/quodeq/services/shared_repo.py
@@ -14,6 +14,13 @@ import shutil
 import subprocess
 from pathlib import Path
 
+# Re-exported so the api layer can validate a shared-repo URL without
+# importing quodeq.data directly (the import-layer gate in
+# tools/check_imports.py allows api -> services and services -> data, but
+# not api -> data). services/evaluation_mixin.py imports the same function
+# straight from quodeq.data.fs.repo_validation for the same reason.
+from quodeq.data.fs.repo_validation import validate_remote_url  # noqa: F401
+
 logger = logging.getLogger(__name__)
 
 _CACHE_ENV = "QUODEQ_CACHE_ROOT"

--- a/src/quodeq/services/shared_repo.py
+++ b/src/quodeq/services/shared_repo.py
@@ -106,14 +106,30 @@ def check_repo_format(repo_root: Path) -> str:
     if marker.exists():
         try:
             data = json.loads(marker.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
             return "foreign"
+
+        # Marker JSON must be a dict; if not, it's foreign.
+        if not isinstance(data, dict):
+            return "foreign"
+
         if data.get("format") != FORMAT_NAME:
             return "foreign"
-        if int(data.get("version", 0)) > FORMAT_VERSION:
+
+        # Try to parse version as int; if it fails or is non-numeric, unsupported.
+        try:
+            version = int(data.get("version", 0))
+        except (ValueError, TypeError):
+            return "unsupported_version"
+
+        if version > FORMAT_VERSION:
             return "unsupported_version"
         return "ok"
-    entries = [p for p in repo_root.iterdir() if p.name != ".git"]
+
+    try:
+        entries = [p for p in repo_root.iterdir() if p.name != ".git"]
+    except OSError:
+        return "foreign"
     return "empty" if not entries else "foreign"
 
 

--- a/src/quodeq/services/shared_settings.py
+++ b/src/quodeq/services/shared_settings.py
@@ -1,0 +1,55 @@
+"""Persisted settings for the shared results repository.
+
+One JSON file at ~/.quodeq/shared.json (QUODEQ_DIR overrides the directory),
+following the update/state.py pattern: dataclass, atomic replace, fail-soft reads.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+_FILENAME = "shared.json"
+
+
+@dataclass
+class SharedSettings:
+    url: str | None = None
+
+
+def shared_settings_path(env: dict | None = None) -> Path:
+    """Resolve the path to the shared settings file.
+
+    Honors QUODEQ_DIR environment variable if set, otherwise uses ~/.quodeq.
+    """
+    e = env if env is not None else os.environ
+    base = e.get("QUODEQ_DIR")
+    root = Path(base) if base else Path.home() / ".quodeq"
+    return root / _FILENAME
+
+
+def read_settings(env: dict | None = None) -> SharedSettings:
+    """Read the shared settings file, returning empty settings if missing or corrupt."""
+    path = shared_settings_path(env=env)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return SharedSettings()
+    if not isinstance(data, dict):
+        return SharedSettings()
+    known = {f for f in SharedSettings().__dict__}
+    return SharedSettings(**{k: v for k, v in data.items() if k in known})
+
+
+def write_settings(settings: SharedSettings, env: dict | None = None) -> None:
+    """Write shared settings atomically to disk, fail-silent on error."""
+    path = shared_settings_path(env=env)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(asdict(settings)), encoding="utf-8")
+        os.replace(tmp, path)
+    except OSError:
+        pass  # fail-silent: a notice is never worth crashing over

--- a/src/quodeq/shared/run_status.py
+++ b/src/quodeq/shared/run_status.py
@@ -142,6 +142,9 @@ def read_status(run_dir: Path) -> dict[str, Any] | None:
     except (json.JSONDecodeError, ValueError):
         _logger.warning("corrupt status.json at %s", path)
         return None
+    if not isinstance(data, dict):
+        _logger.warning("status.json contains non-dict JSON at %s", path)
+        return None
     schema = data.get("schema_version", 0)
     if isinstance(schema, int) and schema > SCHEMA_VERSION:
         raise UnsupportedSchemaError(f"status.json schema_version={schema} newer than supported ({SCHEMA_VERSION})")

--- a/tests/api/test_routes_shared.py
+++ b/tests/api/test_routes_shared.py
@@ -179,3 +179,20 @@ def test_publish_started_returns_202(client, tmp_path, monkeypatch):
     resp = client.post("/api/projects/some-proj/publish", headers=_ORIGIN)
     assert resp.status_code == 202
     assert resp.get_json()["started"] is True
+
+
+def test_publish_rejects_path_traversal_project_segment(client, tmp_path, monkeypatch):
+    """POST /api/projects/../publish must not reach start_publish with a
+    project id that can escape the evaluations root.
+    """
+    (tmp_path / "shared.json").write_text(json.dumps({"url": "git@github.com:t/r.git"}))
+    called = {"n": 0}
+    monkeypatch.setattr(
+        "quodeq.api.routes_shared.start_publish",
+        lambda *a, **kw: called.__setitem__("n", called["n"] + 1) or True,
+    )
+
+    resp = client.post("/api/projects/%2e%2e/publish", headers=_ORIGIN)
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+    assert called["n"] == 0

--- a/tests/api/test_routes_shared.py
+++ b/tests/api/test_routes_shared.py
@@ -84,6 +84,13 @@ def test_put_config_requires_url(client):
     assert resp.status_code == 400
 
 
+def test_put_config_rejects_non_string_url(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("QUODEQ_DIR", str(tmp_path))
+    resp = client.put("/api/shared/config", json={"url": 123}, headers=_ORIGIN)
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
 def test_put_config_clone_failure_returns_502(client, monkeypatch):
     monkeypatch.setattr("quodeq.api.routes_shared.validate_remote_url", lambda url: None)
     monkeypatch.setattr("quodeq.api.routes_shared.ensure_shared_clone", lambda url: None)

--- a/tests/api/test_routes_shared.py
+++ b/tests/api/test_routes_shared.py
@@ -1,0 +1,174 @@
+"""Tests for the shared results repository API routes: config, status,
+refresh, publish. Read-only invariant: no finding-mutation routes exist
+under /api/shared/* or /api/projects/<project>/publish.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from quodeq.api.app import create_app
+from quodeq.services import shared_publish
+
+_ORIGIN = {"Origin": "http://localhost"}
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_DIR", str(tmp_path))
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(tmp_path / "evaluations"))
+    app = create_app(test_config={"TESTING": True})
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def _clean_publish_status():
+    """Snapshot and restore the module-level publish status dict.
+
+    ``shared_publish._STATUS`` is a process-global mutated by the real
+    publish job (tests/services/test_shared_publish_job.py) and by the
+    monkeypatched routes below, so each test here must start and end from
+    a clean slate to stay hermetic across the whole suite.
+    """
+    with shared_publish._STATUS_LOCK:
+        snapshot = dict(shared_publish._STATUS)
+    yield
+    with shared_publish._STATUS_LOCK:
+        shared_publish._STATUS.clear()
+        shared_publish._STATUS.update(snapshot)
+
+
+# --- GET /api/shared/status --------------------------------------------------
+
+def test_shared_status_unconfigured(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("QUODEQ_DIR", str(tmp_path))
+    resp = client.get("/api/shared/status")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["configured"] is False
+    assert body["url"] is None
+    assert body["lastSynced"] is None
+    assert "publish" in body
+
+
+def test_shared_status_configured(client, tmp_path):
+    (tmp_path / "shared.json").write_text(json.dumps({"url": "git@github.com:t/r.git"}))
+    resp = client.get("/api/shared/status")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["configured"] is True
+    assert body["url"] == "git@github.com:t/r.git"
+
+
+# --- PUT /api/shared/config ---------------------------------------------------
+
+def test_put_config_rejects_invalid_url(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("QUODEQ_DIR", str(tmp_path))
+    resp = client.put("/api/shared/config", json={"url": "not a url"}, headers=_ORIGIN)
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+
+
+def test_put_config_rejects_private_host(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("QUODEQ_DIR", str(tmp_path))
+    resp = client.put(
+        "/api/shared/config", json={"url": "https://127.0.0.1/x/y.git"}, headers=_ORIGIN
+    )
+    assert resp.status_code == 400
+
+
+def test_put_config_requires_url(client):
+    resp = client.put("/api/shared/config", json={}, headers=_ORIGIN)
+    assert resp.status_code == 400
+
+
+def test_put_config_clone_failure_returns_502(client, monkeypatch):
+    monkeypatch.setattr("quodeq.api.routes_shared.validate_remote_url", lambda url: None)
+    monkeypatch.setattr("quodeq.api.routes_shared.ensure_shared_clone", lambda url: None)
+    resp = client.put(
+        "/api/shared/config",
+        json={"url": "https://github.com/example/repo.git"},
+        headers=_ORIGIN,
+    )
+    assert resp.status_code == 502
+    assert "error" in resp.get_json()
+
+
+def test_put_config_happy_path(client, monkeypatch, tmp_path):
+    fake_repo = tmp_path / "fake-clone"
+    fake_repo.mkdir()
+    monkeypatch.setattr("quodeq.api.routes_shared.validate_remote_url", lambda url: None)
+    monkeypatch.setattr("quodeq.api.routes_shared.ensure_shared_clone", lambda url: fake_repo)
+    resp = client.put(
+        "/api/shared/config",
+        json={"url": "https://github.com/example/repo.git"},
+        headers=_ORIGIN,
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["configured"] is True
+    assert body["url"] == "https://github.com/example/repo.git"
+
+    status = client.get("/api/shared/status").get_json()
+    assert status["configured"] is True
+    assert status["url"] == "https://github.com/example/repo.git"
+
+
+# --- DELETE /api/shared/config -----------------------------------------------
+
+def test_delete_config_clears(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("QUODEQ_DIR", str(tmp_path))
+    (tmp_path / "shared.json").write_text(json.dumps({"url": "git@github.com:t/r.git"}))
+    resp = client.delete("/api/shared/config", headers=_ORIGIN)
+    assert resp.status_code == 200
+    assert client.get("/api/shared/status").get_json()["configured"] is False
+
+
+# --- POST /api/shared/refresh -------------------------------------------------
+
+def test_refresh_without_config_400(client):
+    resp = client.post("/api/shared/refresh", headers=_ORIGIN)
+    assert resp.status_code == 400
+
+
+def test_refresh_failure_returns_502(client, tmp_path, monkeypatch):
+    (tmp_path / "shared.json").write_text(json.dumps({"url": "git@github.com:t/r.git"}))
+    monkeypatch.setattr("quodeq.api.routes_shared.refresh_shared_clone", lambda url: False)
+    resp = client.post("/api/shared/refresh", headers=_ORIGIN)
+    assert resp.status_code == 502
+    body = resp.get_json()
+    assert body["stale"] is True
+
+
+def test_refresh_success_200(client, tmp_path, monkeypatch):
+    (tmp_path / "shared.json").write_text(json.dumps({"url": "git@github.com:t/r.git"}))
+    monkeypatch.setattr("quodeq.api.routes_shared.refresh_shared_clone", lambda url: True)
+    resp = client.post("/api/shared/refresh", headers=_ORIGIN)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["stale"] is False
+
+
+# --- POST /api/projects/<project>/publish -------------------------------------
+
+def test_publish_without_config_400(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("QUODEQ_DIR", str(tmp_path))
+    resp = client.post("/api/projects/some-proj/publish", headers=_ORIGIN)
+    assert resp.status_code == 400
+
+
+def test_publish_conflict_returns_409(client, tmp_path, monkeypatch):
+    (tmp_path / "shared.json").write_text(json.dumps({"url": "git@github.com:t/r.git"}))
+    monkeypatch.setattr("quodeq.api.routes_shared.start_publish", lambda *a, **kw: False)
+    resp = client.post("/api/projects/some-proj/publish", headers=_ORIGIN)
+    assert resp.status_code == 409
+
+
+def test_publish_started_returns_202(client, tmp_path, monkeypatch):
+    (tmp_path / "shared.json").write_text(json.dumps({"url": "git@github.com:t/r.git"}))
+    monkeypatch.setattr("quodeq.api.routes_shared.start_publish", lambda *a, **kw: True)
+    resp = client.post("/api/projects/some-proj/publish", headers=_ORIGIN)
+    assert resp.status_code == 202
+    assert resp.get_json()["started"] is True

--- a/tests/services/test_shared_publish.py
+++ b/tests/services/test_shared_publish.py
@@ -89,3 +89,20 @@ def test_list_completed_runs_skips_unsupported_schema_version(tmp_path):
     runs = list_completed_runs(tmp_path)
     # Only the valid "done" run should be included; the unsupported one should be skipped
     assert [r.name for r in runs] == ["r-done"]
+
+
+def test_merge_actions_log_missing_timestamp_sorts_last(tmp_path):
+    """Lines missing timestamp should sort last; timestamped lines sort first in order."""
+    a = tmp_path / "a.jsonl"
+    b = tmp_path / "b.jsonl"
+    dest = tmp_path / "merged.jsonl"
+    line_ts_2 = '{"event_id":"2","timestamp":"2026-07-02T10:00:00Z","event_type":"FINDING_DISMISSED","payload":{}}'
+    line_ts_1 = '{"event_id":"1","timestamp":"2026-07-01T10:00:00Z","event_type":"FINDING_DISMISSED","payload":{}}'
+    line_no_ts = '{"event_id":"3","event_type":"FINDING_DISMISSED","payload":{}}'
+    line_invalid = "not-valid-json"
+    a.write_text(line_invalid + "\n" + line_ts_2 + "\n" + line_ts_1 + "\n")
+    b.write_text(line_no_ts + "\n")
+    merge_actions_log(a, b, dest)
+    lines = dest.read_text().splitlines()
+    # Timestamped lines come first, sorted by timestamp; non-timestamped come last in original order
+    assert lines == [line_ts_1, line_ts_2, line_invalid, line_no_ts]

--- a/tests/services/test_shared_publish.py
+++ b/tests/services/test_shared_publish.py
@@ -1,0 +1,91 @@
+"""Tests for the publish staging logic (pure file operations)."""
+import json
+from pathlib import Path
+
+from quodeq.services.shared_publish import (
+    copy_run,
+    list_completed_runs,
+    merge_actions_log,
+    stage_project,
+)
+
+
+def _make_run(project_dir: Path, run_id: str, state: str) -> Path:
+    run = project_dir / run_id
+    (run / "evidence").mkdir(parents=True)
+    (run / "status.json").write_text(json.dumps({"state": state, "schema_version": 2}))
+    (run / "dimensions.json").write_text("{}")
+    (run / "events.jsonl").write_text('{"event_type":"RUN_STARTED"}\n')
+    (run / "evidence" / "manifest.json").write_text("{}")
+    (run / "evidence" / "security_evidence.jsonl").write_text("{}\n")
+    (run / "run.log").write_text("noise")            # must NOT be copied
+    (run / "evaluation.db").write_text("derived")     # must NOT be copied
+    return run
+
+
+def test_list_completed_runs_filters_terminal_done_only(tmp_path):
+    _make_run(tmp_path, "r-done", "done")
+    _make_run(tmp_path, "r-running", "running")
+    _make_run(tmp_path, "r-failed", "failed")
+    (tmp_path / "not-a-run").mkdir()  # no status.json
+    runs = list_completed_runs(tmp_path)
+    assert [r.name for r in runs] == ["r-done"]
+
+
+def test_copy_run_applies_allowlist(tmp_path):
+    src = _make_run(tmp_path / "src", "r1", "done")
+    dest = tmp_path / "dest" / "r1"
+    copy_run(src, dest)
+    assert (dest / "status.json").exists()
+    assert (dest / "dimensions.json").exists()
+    assert (dest / "events.jsonl").exists()
+    assert (dest / "evidence" / "manifest.json").exists()
+    assert (dest / "evidence" / "security_evidence.jsonl").exists()
+    assert not (dest / "run.log").exists()
+    assert not (dest / "evaluation.db").exists()
+
+
+def test_merge_actions_log_unions_and_sorts(tmp_path):
+    a = tmp_path / "a.jsonl"
+    b = tmp_path / "b.jsonl"
+    dest = tmp_path / "merged.jsonl"
+    line1 = '{"event_id":"1","timestamp":"2026-07-01T10:00:00Z","event_type":"FINDING_DISMISSED","payload":{}}'
+    line2 = '{"event_id":"2","timestamp":"2026-07-02T10:00:00Z","event_type":"FINDING_DISMISSED","payload":{}}'
+    a.write_text(line2 + "\n" + line1 + "\n")
+    b.write_text(line1 + "\n")  # duplicate of line1
+    merge_actions_log(a, b, dest)
+    lines = dest.read_text().splitlines()
+    assert lines == [line1, line2]
+
+
+def test_merge_actions_log_missing_inputs(tmp_path):
+    dest = tmp_path / "merged.jsonl"
+    merge_actions_log(tmp_path / "none1", tmp_path / "none2", dest)
+    assert not dest.exists() or dest.read_text() == ""
+
+
+def test_stage_project_copies_info_actions_and_done_runs(tmp_path):
+    project = tmp_path / "local" / "proj-uuid"
+    project.mkdir(parents=True)
+    (project / "repository_info.json").write_text('{"name":"x"}')
+    (project / "actions.jsonl").write_text('{"event_id":"1","timestamp":"t"}\n')
+    _make_run(project, "r-done", "done")
+    _make_run(project, "r-live", "running")
+    dest = tmp_path / "clone" / "evaluations" / "proj-uuid"
+    count = stage_project(project, dest)
+    assert count == 1
+    assert (dest / "repository_info.json").exists()
+    assert (dest / "actions.jsonl").exists()
+    assert (dest / "r-done" / "status.json").exists()
+    assert not (dest / "r-live").exists()
+
+
+def test_list_completed_runs_skips_unsupported_schema_version(tmp_path):
+    """A run with schema_version > supported should be skipped, not crash."""
+    run = tmp_path / "r-unsupported"
+    (run / "evidence").mkdir(parents=True)
+    (run / "status.json").write_text(json.dumps({"state": "done", "schema_version": 99}))
+    _make_run(tmp_path, "r-done", "done")
+    runs = list_completed_runs(tmp_path)
+    # Only the valid "done" run should be included; the unsupported one should be skipped
+    assert [r.name for r in runs] == ["r-done"]

--- a/tests/services/test_shared_publish_git.py
+++ b/tests/services/test_shared_publish_git.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 import quodeq.services.shared_publish as shared_publish
+from quodeq.data.actions_log import ACTIONS_LOG_FILENAME
 from quodeq.services.shared_publish import PublishError, publish_project
 from quodeq.services.shared_repo import ensure_shared_clone, shared_repo_path
 
@@ -186,6 +187,86 @@ def test_stage_failure_raises_publish_error_not_oserror(tmp_path):
         assert "failed to stage project files" in str(excinfo.value)
     finally:
         repo.chmod(0o755)
+
+
+def test_retry_after_push_failure_still_reaches_remote(tmp_path, monkeypatch):
+    """A publish whose commit succeeds but whose push fails must not report
+    success on the next retry without actually pushing.
+
+    The second call re-stages identical project files, so `git diff --cached
+    --quiet` comes back clean (nothing NEW to stage) even though the first
+    call's commit is still sitting unpushed in the local clone. The old code
+    read that clean diff as "nothing to publish" and returned success
+    without ever attempting a push, so the remote never received the data.
+    """
+    url = _bare_origin(tmp_path)
+    root = _local_project(tmp_path)
+
+    real_run_git = shared_publish.run_git
+
+    def failing_push(args, *, cwd=None, timeout=300):
+        # Fail every push attempt: both the plain "push origin HEAD" and
+        # the explicit-refspec fallback start with ["push", "origin", ...].
+        if args[:2] == ["push", "origin"]:
+            return False, "simulated network error"
+        return real_run_git(args, cwd=cwd, timeout=timeout)
+
+    monkeypatch.setattr(shared_publish, "run_git", failing_push)
+
+    with pytest.raises(PublishError):
+        publish_project("proj-uuid-1", url, evaluations_root=root)
+
+    # Restore the healthy git wrapper for the retry.
+    monkeypatch.setattr(shared_publish, "run_git", real_run_git)
+
+    count = publish_project("proj-uuid-1", url, evaluations_root=root)
+    assert count == 1
+
+    # The regression: without the fix, this second call would return
+    # success while the remote still has none of the project's data.
+    verify = tmp_path / "verify-retry"
+    subprocess.run(["git", "clone", url, str(verify)], check=True, capture_output=True)
+    assert (verify / "quodeq.json").exists()
+    assert (verify / "evaluations" / "proj-uuid-1" / "run-1" / "status.json").exists()
+
+
+def test_non_utf8_remote_actions_log_raises_publish_error_not_unicode_error(tmp_path):
+    """merge_actions_log reads the remote's actions.jsonl via Path.read_text
+    (encoding='utf-8'). A non-UTF8 remote file raises UnicodeDecodeError,
+    a ValueError, which must surface through the documented PublishError
+    contract rather than leak out of publish_project as a raw exception.
+    """
+    url = _bare_origin(tmp_path)
+    root = _local_project(tmp_path)
+    publish_project("proj-uuid-1", url, evaluations_root=root)
+
+    # Push a genuinely corrupted actions.jsonl to the remote from a second
+    # clone. publish_project's own refresh_shared_clone does `git reset
+    # --hard FETCH_HEAD`, which would wipe an uncommitted edit made
+    # directly in the persistent clone before staging ever ran, so the
+    # corruption has to actually be committed and pushed to survive that.
+    other = tmp_path / "other-corrupt"
+    subprocess.run(["git", "clone", url, str(other)], check=True, capture_output=True)
+    (other / "evaluations" / "proj-uuid-1" / ACTIONS_LOG_FILENAME).write_bytes(
+        b"\xff\xfe not valid utf-8\n"
+    )
+    for cmd in (
+        ["git", "add", "."],
+        ["git", "commit", "-m", "corrupt actions log"],
+        ["git", "push", "origin", "HEAD"],
+    ):
+        subprocess.run(cmd, cwd=other, check=True, capture_output=True)
+
+    # A local actions.jsonl must also exist so merge_actions_log actually
+    # reaches the read of the (now corrupted) remote copy in the same
+    # code path a real merge takes.
+    (root / "proj-uuid-1" / ACTIONS_LOG_FILENAME).write_text(
+        json.dumps({"timestamp": "1", "type": "note"}) + "\n", encoding="utf-8"
+    )
+
+    with pytest.raises(PublishError) as excinfo:
+        publish_project("proj-uuid-1", url, evaluations_root=root)
+    assert "failed to stage project files" in str(excinfo.value)
 
 
 def test_push_falls_back_to_explicit_refspec_when_origin_head_push_fails(tmp_path, monkeypatch):

--- a/tests/services/test_shared_publish_git.py
+++ b/tests/services/test_shared_publish_git.py
@@ -1,0 +1,98 @@
+"""End-to-end publish flow against a local bare repo."""
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from quodeq.services.shared_publish import PublishError, publish_project
+from quodeq.services.shared_repo import shared_repo_path
+
+
+def _bare_origin(tmp_path: Path) -> str:
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    return f"file://{origin}"
+
+
+def _local_project(tmp_path: Path) -> Path:
+    root = tmp_path / "evaluations"
+    project = root / "proj-uuid-1"
+    run = project / "run-1"
+    (run / "evidence").mkdir(parents=True)
+    (project / "repository_info.json").write_text('{"name":"demo"}')
+    (run / "status.json").write_text(json.dumps({"state": "done", "schema_version": 2}))
+    (run / "dimensions.json").write_text("{}")
+    (run / "events.jsonl").write_text("{}\n")
+    (run / "evidence" / "manifest.json").write_text("{}")
+    return root
+
+
+@pytest.fixture(autouse=True)
+def _git_identity(monkeypatch, tmp_path):
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "tester")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "t@t")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "tester")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "t@t")
+
+
+def test_publish_bootstraps_and_pushes(tmp_path):
+    url = _bare_origin(tmp_path)
+    root = _local_project(tmp_path)
+    count = publish_project("proj-uuid-1", url, evaluations_root=root)
+    assert count == 1
+    # verify the remote actually received the content
+    verify = tmp_path / "verify"
+    subprocess.run(["git", "clone", url, str(verify)], check=True, capture_output=True)
+    assert (verify / "quodeq.json").exists()
+    assert (verify / "evaluations" / "proj-uuid-1" / "run-1" / "status.json").exists()
+
+
+def test_publish_is_idempotent_no_empty_commit(tmp_path):
+    url = _bare_origin(tmp_path)
+    root = _local_project(tmp_path)
+    publish_project("proj-uuid-1", url, evaluations_root=root)
+    publish_project("proj-uuid-1", url, evaluations_root=root)  # must not raise
+    repo = shared_repo_path(url)
+    log = subprocess.run(
+        ["git", "log", "--oneline"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip().splitlines()
+    assert len(log) == 1  # second publish added no commit
+
+
+def test_publish_into_foreign_repo_refused(tmp_path):
+    url = _bare_origin(tmp_path)
+    seed = tmp_path / "seed"
+    subprocess.run(["git", "clone", url, str(seed)], check=True, capture_output=True)
+    (seed / "README.md").write_text("existing project")
+    for cmd in (["git", "add", "."], ["git", "commit", "-m", "x"], ["git", "push", "origin", "HEAD"]):
+        subprocess.run(cmd, cwd=seed, check=True, capture_output=True)
+    root = _local_project(tmp_path)
+    with pytest.raises(PublishError):
+        publish_project("proj-uuid-1", url, evaluations_root=root)
+
+
+def test_publish_race_rebase_retry(tmp_path):
+    url = _bare_origin(tmp_path)
+    root = _local_project(tmp_path)
+    publish_project("proj-uuid-1", url, evaluations_root=root)
+    # someone else pushes meanwhile
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", url, str(other)], check=True, capture_output=True)
+    (other / "evaluations" / "other-proj").mkdir(parents=True)
+    (other / "evaluations" / "other-proj" / "repository_info.json").write_text("{}")
+    for cmd in (["git", "add", "."], ["git", "commit", "-m", "other"], ["git", "push", "origin", "HEAD"]):
+        subprocess.run(cmd, cwd=other, check=True, capture_output=True)
+    # our clone is now behind; a new run appears locally
+    run2 = root / "proj-uuid-1" / "run-2"
+    (run2 / "evidence").mkdir(parents=True)
+    (run2 / "status.json").write_text(json.dumps({"state": "done", "schema_version": 2}))
+    (run2 / "dimensions.json").write_text("{}")
+    (run2 / "events.jsonl").write_text("{}\n")
+    # publish must succeed via rebase retry, and the other project must survive (additive)
+    publish_project("proj-uuid-1", url, evaluations_root=root)
+    verify = tmp_path / "verify2"
+    subprocess.run(["git", "clone", url, str(verify)], check=True, capture_output=True)
+    assert (verify / "evaluations" / "proj-uuid-1" / "run-2").exists()
+    assert (verify / "evaluations" / "other-proj").exists()

--- a/tests/services/test_shared_publish_git.py
+++ b/tests/services/test_shared_publish_git.py
@@ -1,12 +1,14 @@
 """End-to-end publish flow against a local bare repo."""
 import json
+import os
 import subprocess
 from pathlib import Path
 
 import pytest
 
+import quodeq.services.shared_publish as shared_publish
 from quodeq.services.shared_publish import PublishError, publish_project
-from quodeq.services.shared_repo import shared_repo_path
+from quodeq.services.shared_repo import ensure_shared_clone, shared_repo_path
 
 
 def _bare_origin(tmp_path: Path) -> str:
@@ -96,3 +98,122 @@ def test_publish_race_rebase_retry(tmp_path):
     subprocess.run(["git", "clone", url, str(verify)], check=True, capture_output=True)
     assert (verify / "evaluations" / "proj-uuid-1" / "run-2").exists()
     assert (verify / "evaluations" / "other-proj").exists()
+
+
+def test_failed_rebase_conflict_is_aborted_and_clone_recovers(tmp_path, monkeypatch):
+    """A real rebase conflict must not wedge the persistent clone.
+
+    The clone under QUODEQ_CACHE_ROOT is reused across publishes, so a
+    failed rebase that leaves .git/rebase-merge on disk breaks every
+    subsequent publish with git's "already a rebase-merge directory"
+    error instead of a clean PublishError.
+    """
+    url = _bare_origin(tmp_path)
+    root = _local_project(tmp_path)
+    publish_project("proj-uuid-1", url, evaluations_root=root)
+
+    # A change we will try to publish next, conflicting with a racing push.
+    (root / "proj-uuid-1" / "repository_info.json").write_text('{"name":"local-change"}')
+
+    other_counter = {"n": 0}
+
+    def push_conflicting_change() -> None:
+        # Real git operations from a second clone, racing our own publish:
+        # it modifies the SAME file our pending commit touches, so the
+        # rebase that follows a rejected push hits a genuine conflict.
+        other_counter["n"] += 1
+        other = tmp_path / f"other-{other_counter['n']}"
+        subprocess.run(["git", "clone", url, str(other)], check=True, capture_output=True)
+        (other / "evaluations" / "proj-uuid-1" / "repository_info.json").write_text(
+            json.dumps({"name": f"remote-change-{other_counter['n']}"})
+        )
+        for cmd in (
+            ["git", "add", "."],
+            ["git", "commit", "-m", f"remote edit {other_counter['n']}"],
+            ["git", "push", "origin", "HEAD"],
+        ):
+            subprocess.run(cmd, cwd=other, check=True, capture_output=True)
+
+    real_run_git = shared_publish.run_git
+
+    def racing_run_git(args, *, cwd=None, timeout=300):
+        # Only the plain "push origin HEAD" attempt races; explicit-refspec
+        # pushes and everything else go straight to the real implementation.
+        if args == ["push", "origin", "HEAD"]:
+            push_conflicting_change()
+        return real_run_git(args, cwd=cwd, timeout=timeout)
+
+    monkeypatch.setattr(shared_publish, "run_git", racing_run_git)
+
+    repo = shared_repo_path(url)
+
+    with pytest.raises(PublishError) as excinfo_2:
+        publish_project("proj-uuid-1", url, evaluations_root=root)
+    assert not (repo / ".git" / "rebase-merge").exists()
+
+    # Without the fix, the clone above would still carry a wedged
+    # .git/rebase-merge, and this next call would fail with git's own
+    # "already a rebase-merge directory" error rather than a clean,
+    # push-rejected PublishError.
+    with pytest.raises(PublishError) as excinfo_3:
+        publish_project("proj-uuid-1", url, evaluations_root=root)
+    assert not (repo / ".git" / "rebase-merge").exists()
+    assert "already a rebase-merge directory" not in str(excinfo_3.value)
+    assert "already a rebase-merge directory" not in str(excinfo_2.value)
+
+
+@pytest.mark.skipif(
+    os.name == "nt" or (hasattr(os, "geteuid") and os.geteuid() == 0),
+    reason="chmod-based permission denial is ineffective as root or on Windows",
+)
+def test_stage_failure_raises_publish_error_not_oserror(tmp_path):
+    """An OSError from bootstrap/stage (disk full, permissions) must
+    surface as PublishError, matching the documented "raises PublishError
+    on any failure" contract, not leak as a raw OSError.
+    """
+    url = _bare_origin(tmp_path)
+    root = _local_project(tmp_path)
+
+    # Pre-create the persistent clone (same call publish_project would
+    # make), then make its directory unwritable so bootstrap_repo_layout's
+    # write_text calls fail with a real PermissionError.
+    repo = ensure_shared_clone(url, None)
+    assert repo is not None
+    repo.chmod(0o555)
+    try:
+        with pytest.raises(PublishError) as excinfo:
+            publish_project("proj-uuid-1", url, evaluations_root=root)
+        assert "failed to stage project files" in str(excinfo.value)
+    finally:
+        repo.chmod(0o755)
+
+
+def test_push_falls_back_to_explicit_refspec_when_origin_head_push_fails(tmp_path, monkeypatch):
+    """_push falls back to an explicit refspec push when a plain
+    ``push origin HEAD`` fails. The empty-remote condition this fallback
+    targets cannot be reproduced deterministically with this git version,
+    so the first push call is forced to fail; everything else runs for
+    real.
+    """
+    url = _bare_origin(tmp_path)
+    root = _local_project(tmp_path)
+
+    real_run_git = shared_publish.run_git
+    state = {"failed_once": False}
+
+    def flaky_first_push(args, *, cwd=None, timeout=300):
+        if not state["failed_once"] and args == ["push", "origin", "HEAD"]:
+            state["failed_once"] = True
+            return False, "simulated"
+        return real_run_git(args, cwd=cwd, timeout=timeout)
+
+    monkeypatch.setattr(shared_publish, "run_git", flaky_first_push)
+
+    count = publish_project("proj-uuid-1", url, evaluations_root=root)
+    assert count == 1
+    assert state["failed_once"]  # the fallback branch was actually exercised
+
+    verify = tmp_path / "verify-fallback"
+    subprocess.run(["git", "clone", url, str(verify)], check=True, capture_output=True)
+    assert (verify / "quodeq.json").exists()
+    assert (verify / "evaluations" / "proj-uuid-1" / "run-1" / "status.json").exists()

--- a/tests/services/test_shared_publish_job.py
+++ b/tests/services/test_shared_publish_job.py
@@ -1,12 +1,25 @@
 """Publish job state machine (synchronous worker invocation, no sleeps)."""
 from unittest.mock import patch
 
+import pytest
+
 from quodeq.services import shared_publish
 from quodeq.services.shared_publish import (
     PublishError,
     get_publish_status,
     start_publish,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clean_status():
+    """Snapshot and restore _STATUS dict before/after each test."""
+    with shared_publish._STATUS_LOCK:
+        snapshot = dict(shared_publish._STATUS)
+    yield
+    with shared_publish._STATUS_LOCK:
+        shared_publish._STATUS.clear()
+        shared_publish._STATUS.update(snapshot)
 
 
 def _run_inline(monkeypatch):
@@ -43,8 +56,24 @@ def test_publish_job_error_captured(tmp_path, monkeypatch):
 def test_publish_rejected_while_running(tmp_path):
     with shared_publish._STATUS_LOCK:
         shared_publish._STATUS.update({"state": "running", "project": "p0"})
-    try:
-        assert start_publish("p1", "u", evaluations_root=tmp_path) is False
-    finally:
-        with shared_publish._STATUS_LOCK:
-            shared_publish._STATUS.update({"state": "idle", "project": None})
+    assert start_publish("p1", "u", evaluations_root=tmp_path) is False
+
+
+def test_publish_thread_start_failure(tmp_path, monkeypatch):
+    """Thread creation failure leaves state as error, not stuck at running."""
+
+    class FailingThread:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("thread creation failed")
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(shared_publish.threading, "Thread", FailingThread)
+
+    result = start_publish("p1", "u", evaluations_root=tmp_path)
+
+    assert result is False
+    status = get_publish_status()
+    assert status["state"] == "error"
+    assert "thread creation failed" in status["error"]

--- a/tests/services/test_shared_publish_job.py
+++ b/tests/services/test_shared_publish_job.py
@@ -1,0 +1,50 @@
+"""Publish job state machine (synchronous worker invocation, no sleeps)."""
+from unittest.mock import patch
+
+from quodeq.services import shared_publish
+from quodeq.services.shared_publish import (
+    PublishError,
+    get_publish_status,
+    start_publish,
+)
+
+
+def _run_inline(monkeypatch):
+    """Make the thread run synchronously for deterministic tests."""
+    class InlineThread:
+        def __init__(self, target=None, args=(), daemon=None):
+            self._target, self._args = target, args
+
+        def start(self):
+            self._target(*self._args)
+
+    monkeypatch.setattr(shared_publish.threading, "Thread", InlineThread)
+
+
+def test_publish_job_success(tmp_path, monkeypatch):
+    _run_inline(monkeypatch)
+    with patch.object(shared_publish, "publish_project", return_value=3) as pub:
+        assert start_publish("p1", "u", evaluations_root=tmp_path) is True
+    status = get_publish_status()
+    assert status["state"] == "done"
+    assert status["runs"] == 3
+    pub.assert_called_once()
+
+
+def test_publish_job_error_captured(tmp_path, monkeypatch):
+    _run_inline(monkeypatch)
+    with patch.object(shared_publish, "publish_project", side_effect=PublishError("boom")):
+        start_publish("p1", "u", evaluations_root=tmp_path)
+    status = get_publish_status()
+    assert status["state"] == "error"
+    assert status["error"] == "boom"
+
+
+def test_publish_rejected_while_running(tmp_path):
+    with shared_publish._STATUS_LOCK:
+        shared_publish._STATUS.update({"state": "running", "project": "p0"})
+    try:
+        assert start_publish("p1", "u", evaluations_root=tmp_path) is False
+    finally:
+        with shared_publish._STATUS_LOCK:
+            shared_publish._STATUS.update({"state": "idle", "project": None})

--- a/tests/services/test_shared_repo.py
+++ b/tests/services/test_shared_repo.py
@@ -1,0 +1,60 @@
+"""Tests for shared repo clone management."""
+import subprocess
+from pathlib import Path
+
+from quodeq.services.shared_repo import (
+    ensure_shared_clone,
+    refresh_shared_clone,
+    run_git,
+    shared_cache_dir,
+    shared_repo_path,
+)
+
+
+def _make_origin(tmp_path: Path) -> str:
+    """Create a bare repo with one commit; return its file:// URL."""
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    work = tmp_path / "seed"
+    subprocess.run(["git", "clone", str(origin), str(work)], check=True, capture_output=True)
+    (work / "hello.txt").write_text("hi", encoding="utf-8")
+    for cmd in (
+        ["git", "add", "."],
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "seed"],
+        ["git", "push", "origin", "HEAD"],
+    ):
+        subprocess.run(cmd, cwd=work, check=True, capture_output=True)
+    return f"file://{origin}"
+
+
+def test_run_git_success_and_failure(tmp_path):
+    ok, _ = run_git(["init", str(tmp_path / "x")])
+    assert ok
+    ok, out = run_git(["rev-parse", "HEAD"], cwd=tmp_path)
+    assert not ok
+    assert out  # error text captured
+
+
+def test_cache_dir_is_stable_hash(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path))
+    d1 = shared_cache_dir("git@github.com:team/r.git")
+    d2 = shared_cache_dir("git@github.com:team/r.git")
+    assert d1 == d2
+    assert d1.parent == tmp_path / "shared"
+
+
+def test_ensure_clone_and_refresh(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    url = _make_origin(tmp_path)
+    repo = ensure_shared_clone(url)
+    assert repo is not None
+    assert (repo / "hello.txt").exists()
+    # second call reuses without error
+    assert ensure_shared_clone(url) == repo
+    assert refresh_shared_clone(url) is True
+
+
+def test_ensure_clone_bad_url_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    assert ensure_shared_clone(f"file://{tmp_path}/nonexistent.git") is None
+    assert not shared_repo_path(f"file://{tmp_path}/nonexistent.git").exists()

--- a/tests/services/test_shared_repo.py
+++ b/tests/services/test_shared_repo.py
@@ -3,6 +3,10 @@ import subprocess
 from pathlib import Path
 
 from quodeq.services.shared_repo import (
+    FORMAT_NAME,
+    MARKER_FILENAME,
+    bootstrap_repo_layout,
+    check_repo_format,
     ensure_shared_clone,
     refresh_shared_clone,
     run_git,
@@ -85,3 +89,31 @@ def test_run_git_survives_non_utf8_output(tmp_path):
     # The invalid bytes should be replaced with U+FFFD (replacement character)
     # Output may contain the replacement character or simply be non-empty
     assert output is not None
+
+
+def test_check_format_empty_then_bootstrap_then_ok(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    assert check_repo_format(repo) == "empty"
+    bootstrap_repo_layout(repo)
+    assert check_repo_format(repo) == "ok"
+    gitignore = (repo / ".gitignore").read_text(encoding="utf-8")
+    assert "**/evaluation.db" in gitignore
+    assert "*.log" in gitignore
+    assert (repo / "evaluations").is_dir()
+
+
+def test_check_format_newer_version_unsupported(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    (repo / MARKER_FILENAME).write_text(
+        '{"format": "%s", "version": 99}' % FORMAT_NAME, encoding="utf-8"
+    )
+    assert check_repo_format(repo) == "unsupported_version"
+
+
+def test_check_format_foreign_repo(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    (repo / "README.md").write_text("some other project", encoding="utf-8")
+    assert check_repo_format(repo) == "foreign"

--- a/tests/services/test_shared_repo.py
+++ b/tests/services/test_shared_repo.py
@@ -58,3 +58,30 @@ def test_ensure_clone_bad_url_returns_none(tmp_path, monkeypatch):
     monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
     assert ensure_shared_clone(f"file://{tmp_path}/nonexistent.git") is None
     assert not shared_repo_path(f"file://{tmp_path}/nonexistent.git").exists()
+
+
+def test_run_git_survives_non_utf8_output(tmp_path):
+    """Verify run_git handles non-UTF8 git output without raising UnicodeDecodeError."""
+    # Initialize a git repo
+    repo = tmp_path / "test_repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "test"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+    # Use git alias to output invalid UTF-8 bytes; git will echo them in its output
+    ok, output = run_git(
+        ["-c", "alias.x=!printf '\\xff\\xfe'", "x"],
+        cwd=repo,
+    )
+
+    # Must return a tuple (bool, str) without raising UnicodeDecodeError
+    assert isinstance(ok, bool)
+    assert isinstance(output, str)
+    # The invalid bytes should be replaced with U+FFFD (replacement character)
+    # Output may contain the replacement character or simply be non-empty
+    assert output is not None

--- a/tests/services/test_shared_repo.py
+++ b/tests/services/test_shared_repo.py
@@ -117,3 +117,47 @@ def test_check_format_foreign_repo(tmp_path):
     (repo / ".git").mkdir(parents=True)
     (repo / "README.md").write_text("some other project", encoding="utf-8")
     assert check_repo_format(repo) == "foreign"
+
+
+def test_check_format_marker_not_dict(tmp_path):
+    """Marker JSON that parses but is not a dict (e.g. list) returns 'foreign'."""
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    (repo / MARKER_FILENAME).write_text("[1, 2, 3]", encoding="utf-8")
+    assert check_repo_format(repo) == "foreign"
+
+
+def test_check_format_version_not_int_parseable(tmp_path):
+    """Version field that cannot be parsed as int returns 'unsupported_version'."""
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    (repo / MARKER_FILENAME).write_text(
+        '{"format": "%s", "version": "1.0"}' % FORMAT_NAME, encoding="utf-8"
+    )
+    assert check_repo_format(repo) == "unsupported_version"
+
+
+def test_check_format_invalid_utf8_marker(tmp_path):
+    """Marker file with invalid UTF-8 bytes returns 'foreign'."""
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    # Write raw bytes that are invalid UTF-8
+    (repo / MARKER_FILENAME).write_bytes(b"\xff\xfe invalid json")
+    assert check_repo_format(repo) == "foreign"
+
+
+def test_check_format_missing_repo_root(tmp_path):
+    """Missing repo_root directory returns 'foreign' (not FileNotFoundError)."""
+    repo = tmp_path / "nonexistent" / "repo"
+    # repo does not exist; iterdir() would raise FileNotFoundError
+    assert check_repo_format(repo) == "foreign"
+
+
+def test_check_format_wrong_format_string(tmp_path):
+    """Marker with wrong format string returns 'foreign'."""
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    (repo / MARKER_FILENAME).write_text(
+        '{"format": "something-else", "version": 1}', encoding="utf-8"
+    )
+    assert check_repo_format(repo) == "foreign"

--- a/tests/services/test_shared_repo.py
+++ b/tests/services/test_shared_repo.py
@@ -1,10 +1,12 @@
 """Tests for shared repo clone management."""
 import subprocess
+import time
 from pathlib import Path
 
 from quodeq.services.shared_repo import (
     FORMAT_NAME,
     MARKER_FILENAME,
+    _git_env,
     bootstrap_repo_layout,
     check_repo_format,
     ensure_shared_clone,
@@ -161,3 +163,34 @@ def test_check_format_wrong_format_string(tmp_path):
         '{"format": "something-else", "version": 1}', encoding="utf-8"
     )
     assert check_repo_format(repo) == "foreign"
+
+
+def test_git_env_disables_terminal_prompt_and_keeps_lfs_skip():
+    """run_git's subprocess env must never block on an interactive git
+    credential/passphrase prompt: GIT_TERMINAL_PROMPT=0 tells git to fail
+    fast instead of trying to read a prompt from a terminal that (with
+    stdin=DEVNULL) no longer exists.
+    """
+    env = _git_env()
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+    assert env["GIT_LFS_SKIP_SMUDGE"] == "1"
+    # GIT_SSH_COMMAND must NOT be set here: overriding it would silently
+    # discard the user's own ssh config (identity files, host aliases, etc).
+    assert "GIT_SSH_COMMAND" not in env
+
+
+def test_run_git_does_not_hang_on_credential_prompt(tmp_path):
+    """Without stdin=DEVNULL, a git subcommand that reads from stdin (like
+    `credential fill`) can block waiting for input that will never come.
+    With stdin closed, git gets an immediate EOF and fails fast instead.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+
+    start = time.monotonic()
+    ok, _out = run_git(["credential", "fill"], cwd=repo, timeout=5)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 5  # never hit the timeout path
+    assert isinstance(ok, bool)

--- a/tests/services/test_shared_settings.py
+++ b/tests/services/test_shared_settings.py
@@ -1,0 +1,26 @@
+"""Tests for the shared-repo settings store."""
+from quodeq.services.shared_settings import (
+    SharedSettings,
+    read_settings,
+    shared_settings_path,
+    write_settings,
+)
+
+
+def test_read_settings_missing_file_returns_empty(tmp_path):
+    env = {"QUODEQ_DIR": str(tmp_path)}
+    settings = read_settings(env=env)
+    assert settings.url is None
+
+
+def test_write_then_read_round_trip(tmp_path):
+    env = {"QUODEQ_DIR": str(tmp_path)}
+    write_settings(SharedSettings(url="git@github.com:team/results.git"), env=env)
+    assert read_settings(env=env).url == "git@github.com:team/results.git"
+    assert shared_settings_path(env=env) == tmp_path / "shared.json"
+
+
+def test_read_settings_corrupt_file_returns_empty(tmp_path):
+    env = {"QUODEQ_DIR": str(tmp_path)}
+    (tmp_path / "shared.json").write_text("{not json", encoding="utf-8")
+    assert read_settings(env=env).url is None

--- a/tests/shared/test_run_status.py
+++ b/tests/shared/test_run_status.py
@@ -87,6 +87,12 @@ def test_read_unsupported_schema_raises(tmp_path: Path) -> None:
         read_status(tmp_path)
 
 
+def test_read_non_dict_json_returns_none(tmp_path: Path) -> None:
+    """status.json containing non-dict JSON (array, string, null) returns None."""
+    (tmp_path / "status.json").write_text("[1, 2, 3]")
+    assert read_status(tmp_path) is None
+
+
 def test_write_status_persists_provider_and_model(tmp_path: Path) -> None:
     write_status(
         tmp_path,


### PR DESCRIPTION
Phase 1 of the online shared evaluations feature (spec: local docs).

- Persisted shared repo URL at ~/.quodeq/shared.json
- Shallow clone management under ~/.quodeq/cache/shared/<url-hash>/repo
- Repo format marker (quodeq.json v1), bootstrap, generated .gitignore
- Publish: completed runs only, explicit file allowlist, actions.jsonl union-merge, additive (never deletes remote runs), commit+push with one rebase retry, rebase --abort recovery
- Background publish job + /api/shared/* config/status/refresh routes and POST /api/projects/<id>/publish
- Hardening from review: push-after-quiet-diff (no false success on retry), PublishError contract covers decode errors, project-id path validation, non-interactive git (GIT_TERMINAL_PROMPT=0 + stdin DEVNULL), root fix for read_status non-dict JSON crash

No UI yet; no read endpoints yet (phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)