### PR TITLE
feat: read-only shared evaluation endpoints

### DIFF
--- a/src/quodeq/api/import_project.py
+++ b/src/quodeq/api/import_project.py
@@ -318,6 +318,10 @@ def import_project(reports_dir: str) -> Response | tuple[Response, int]:
         - ``file``: the project zip (required)
         - ``action``: optional, ``"replace"`` or ``"copy"`` to resolve a 409
           collision returned from a previous attempt.
+
+    Parses the multipart request, then delegates everything else (the
+    hardened validation and extraction) to ``import_zip_stream``, which has
+    no dependency on ``request`` and can be called with any zip bytes.
     """
     upload = request.files.get("file")
     if upload is None or not upload.filename:
@@ -325,6 +329,23 @@ def import_project(reports_dir: str) -> Response | tuple[Response, int]:
         return jsonify(body), status
 
     action = (request.form.get("action") or "").strip().lower() or None
+    return import_zip_stream(upload, reports_dir, action)
+
+
+def import_zip_stream(stream: Any, reports_dir: str, action: str | None) -> Response | tuple[Response, int]:
+    """Validate and materialize a project zip *stream* into *reports_dir*.
+
+    Contains all the hardened validation (path traversal, zip-bomb ratio,
+    symlinks, member limits, collision handling) that used to live directly
+    in ``import_project``. *stream* is anything with a ``.read(n)`` method
+    (a Werkzeug ``FileStorage``, an ``io.BytesIO``, or a plain file handle) —
+    this function never touches ``flask.request.files``, so it is callable
+    from any caller that already has zip bytes, such as the shared-repo
+    "pull local copy" route.
+
+    *action* is optional, ``"replace"`` or ``"copy"`` to resolve a 409
+    collision returned from a previous attempt.
+    """
     if action is not None and action not in _ALLOWED_ACTIONS:
         body, status = error_response(
             f"Invalid action; expected one of {sorted(_ALLOWED_ACTIONS)}.",
@@ -333,7 +354,7 @@ def import_project(reports_dir: str) -> Response | tuple[Response, int]:
         return jsonify(body), status
 
     size_limit = _max_zip_size_bytes()
-    raw = upload.read(size_limit + 1)
+    raw = stream.read(size_limit + 1)
     if len(raw) > size_limit:
         body, status = error_response(
             f"Archive exceeds the {size_limit // (1024 * 1024)} MB import limit.",
@@ -460,4 +481,4 @@ def import_project(reports_dir: str) -> Response | tuple[Response, int]:
 
 
 # Re-export for routing module.
-__all__ = ["import_project"]
+__all__ = ["import_project", "import_zip_stream"]

--- a/src/quodeq/api/import_project.py
+++ b/src/quodeq/api/import_project.py
@@ -319,9 +319,11 @@ def import_project(reports_dir: str) -> Response | tuple[Response, int]:
         - ``action``: optional, ``"replace"`` or ``"copy"`` to resolve a 409
           collision returned from a previous attempt.
 
-    Parses the multipart request, then delegates everything else (the
-    hardened validation and extraction) to ``import_zip_stream``, which has
-    no dependency on ``request`` and can be called with any zip bytes.
+    Parses the multipart request for file and action parameters, then
+    delegates validation and extraction to ``import_zip_stream``. The zip
+    stream itself has no dependency on request.files/request.form, but this
+    handler must run inside a Flask request context to access request.form
+    and request.remote_addr for logging.
     """
     upload = request.files.get("file")
     if upload is None or not upload.filename:

--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -33,6 +33,7 @@ from quodeq.services.shared_repo import (
     shared_evaluations_root,
     shared_index_db_path,
     shared_score_cache_path,
+    sync_shared_index,
     validate_remote_url,
 )
 from quodeq.services.shared_settings import (
@@ -189,6 +190,20 @@ def register_shared_routes(app: Flask) -> None:
     @app.get("/api/shared/projects")
     @_with_shared_root
     def shared_projects(eval_root: Path, url: str):
+        stale = None
+        if request.args.get("refresh") == "1":
+            # Refresh-on-read: the UI calls this on tab entry to force the
+            # clone up to date before listing, rather than showing whatever
+            # was last fetched. A failed refresh (host unreachable) is not
+            # fatal -- fall through and serve the existing (now-stale)
+            # clone contents, just flag it. The index is only re-synced
+            # after a successful refresh; there is nothing new to index
+            # when the fetch itself failed.
+            if refresh_shared_clone(url):
+                sync_shared_index(url)
+                stale = False
+            else:
+                stale = True
         projects = _fs_projects.build_project_list(eval_root)
         listing = {"projects": [to_camel_dict(p) for p in projects]}
         meta = published_meta(url)
@@ -197,6 +212,8 @@ def register_shared_routes(app: Flask) -> None:
             project.update(meta.get(key, {}))
             project["source"] = "shared"
         listing["lastSynced"] = last_synced_at(url)
+        if stale is not None:
+            listing["stale"] = stale
         return jsonify(listing)
 
     @app.get("/api/shared/projects/<project>/info")

--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -33,7 +33,6 @@ from quodeq.services.shared_repo import (
     shared_evaluations_root,
     shared_index_db_path,
     shared_score_cache_path,
-    sync_shared_index,
     validate_remote_url,
 )
 from quodeq.services.shared_settings import (
@@ -218,7 +217,6 @@ def register_shared_routes(app: Flask) -> None:
         err = _validate_segment(project)
         if err:
             return err
-        sync_shared_index(url)
         try:
             runs = build_runs_unit(eval_root, shared_index_db_path(url), project)
         except Exception:

--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -10,13 +10,17 @@ root (via ``_with_shared_root``) instead of the local reports directory.
 from __future__ import annotations
 
 import functools
+import io
 import logging
+import zipfile
 from http import HTTPStatus
 from pathlib import Path
 
 from flask import Flask, Response, jsonify, request
 
 from quodeq.api.helpers import error_response
+from quodeq.api.import_project import import_zip_stream
+from quodeq.api.zip import _build_project_zip
 from quodeq.core.types import to_camel_dict
 from quodeq.services import _fs_projects, _fs_reports
 from quodeq.services._runs_unit import build_runs_unit
@@ -177,6 +181,69 @@ def register_shared_routes(app: Flask) -> None:
         if not started:
             return jsonify({"error": "a publish is already running"}), 409
         return jsonify({"started": True}), 202
+
+    # -- pull a shared project into local evaluations -----------------------
+    #
+    # This is a deliberate, spec-approved exception to the read-only
+    # invariant documented at the top of this module: it mutates LOCAL
+    # state (the local reports directory, via import_zip_stream), not the
+    # shared repository clone itself. The clone is only read from to build
+    # the in-memory zip. It is therefore intentionally included in the
+    # allowed-mutations set of the read-only sweep test
+    # (tests/api/test_routes_shared_read.py::test_no_mutating_routes_under_shared).
+    @app.post("/api/shared/projects/<project>/pull")
+    @_with_shared_root
+    def shared_pull(project: str, eval_root: Path, url: str) -> Response | tuple[Response, int]:
+        """Materialize a shared project as a local copy.
+
+        Body: optional JSON ``{"action": "copy"|"replace"}`` to resolve a 409
+        collision returned from a previous attempt -- same semantics as the
+        manual ``POST /api/projects/import`` route, since both funnel through
+        ``import_zip_stream``.
+        """
+        err = _validate_segment(project)
+        if err:
+            return err
+        project_path = _shared_project_dir(eval_root, project)
+        if project_path is None:
+            body, status = error_response("Invalid parameter", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+            return jsonify(body), status
+        if not project_path.is_dir():
+            body, status = error_response(
+                "Project not found in the shared repository", HTTPStatus.NOT_FOUND, "NOT_FOUND",
+            )
+            return jsonify(body), status
+
+        payload = request.get_json(silent=True) or {}
+        action = payload.get("action")
+        if action is not None and not isinstance(action, str):
+            body, status = error_response("action must be a string", HTTPStatus.BAD_REQUEST, "INVALID_ACTION")
+            return jsonify(body), status
+
+        try:
+            zip_path = _build_project_zip(project_path)
+        except ValueError:
+            body, status = error_response(
+                "Project too large to pull", HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "TOO_LARGE",
+            )
+            return jsonify(body), status
+        except (OSError, zipfile.BadZipFile):
+            _logger.exception("Failed to build zip for shared pull of %s", project)
+            body, status = error_response(
+                "Failed to build project archive from the shared repository",
+                HTTPStatus.INTERNAL_SERVER_ERROR, "EXPORT_ERROR",
+            )
+            return jsonify(body), status
+
+        try:
+            zip_bytes = zip_path.read_bytes()
+        finally:
+            try:
+                zip_path.unlink()
+            except OSError as exc:
+                _logger.warning("Failed to remove temp zip %s: %s", zip_path, exc)
+
+        return import_zip_stream(io.BytesIO(zip_bytes), reports_dir(), action)
 
     # -- read-only mirrors of the project read endpoints -------------------
     #

--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -236,14 +236,20 @@ def register_shared_routes(app: Flask) -> None:
             return jsonify(body), status
 
         try:
-            zip_bytes = zip_path.read_bytes()
+            with zip_path.open("rb") as stream:
+                return import_zip_stream(stream, reports_dir(), action)
+        except OSError:
+            _logger.exception("Failed to read zip for shared pull of %s", project)
+            body, status = error_response(
+                "Failed to read project archive from the shared repository",
+                HTTPStatus.INTERNAL_SERVER_ERROR, "EXPORT_ERROR",
+            )
+            return jsonify(body), status
         finally:
             try:
                 zip_path.unlink()
             except OSError as exc:
                 _logger.warning("Failed to remove temp zip %s: %s", zip_path, exc)
-
-        return import_zip_stream(io.BytesIO(zip_bytes), reports_dir(), action)
 
     # -- read-only mirrors of the project read endpoints -------------------
     #

--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -10,7 +10,6 @@ root (via ``_with_shared_root``) instead of the local reports directory.
 from __future__ import annotations
 
 import functools
-import io
 import logging
 import zipfile
 from http import HTTPStatus

--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -276,7 +276,12 @@ def register_shared_routes(app: Flask) -> None:
                 stale = False
             else:
                 stale = True
-        projects = _fs_projects.build_project_list(eval_root)
+        # backfill=False: the shared clone is a git worktree, not a local
+        # evaluations dir -- writing onboardingCompletedAt into
+        # repository_info.json here would dirty it, and a dirty worktree can
+        # make publish's `pull --rebase` refuse (confusing wedge) the next
+        # time someone publishes into this clone.
+        projects = _fs_projects.build_project_list(eval_root, backfill=False)
         listing = {"projects": [to_camel_dict(p) for p in projects]}
         meta = published_meta(url)
         for project in listing["projects"]:

--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -1,19 +1,39 @@
-"""Routes for the shared results repository (config, status, refresh, publish).
+"""Routes for the shared results repository (config, status, refresh, publish),
+plus read-only mirrors of the project read endpoints scoped to the shared clone.
 
 Read-only invariant: no finding-mutation routes exist in this module or
-anywhere under /api/shared/*.
+anywhere under /api/shared/*. Every ``/api/shared/projects/...`` route is a
+thin GET-only delegation to the same service functions the local
+``/api/projects/...`` routes use, pointed at the shared clone's evaluations
+root (via ``_with_shared_root``) instead of the local reports directory.
 """
 from __future__ import annotations
 
+import functools
+import logging
+from http import HTTPStatus
 from pathlib import Path
 
 from flask import Flask, Response, jsonify, request
 
+from quodeq.api.helpers import error_response
+from quodeq.core.types import to_camel_dict
+from quodeq.services import _fs_projects, _fs_reports
+from quodeq.services._runs_unit import build_runs_unit
+from quodeq.services.dismissed import load_dismissed
+from quodeq.services.score_cache import score_cache_path_override
+from quodeq.services.scoring import get_project_scores, get_scores_slim
 from quodeq.services.shared_publish import get_publish_status, start_publish
 from quodeq.services.shared_repo import (
     ensure_shared_clone,
     last_synced_at,
+    published_meta,
+    read_state,
     refresh_shared_clone,
+    shared_evaluations_root,
+    shared_index_db_path,
+    shared_score_cache_path,
+    sync_shared_index,
     validate_remote_url,
 )
 from quodeq.services.shared_settings import (
@@ -21,9 +41,73 @@ from quodeq.services.shared_settings import (
     read_settings,
     write_settings,
 )
+from quodeq.services.verified import verified_entries
 from quodeq.shared.validation import validate_path_segment
 
 from .routes_common import reports_dir
+
+_logger = logging.getLogger(__name__)
+
+# Mirrors quodeq.api.routes_findings._MAX_DISMISSED_LIMIT — the shared
+# dismissed-findings mirror clamps to the same hard cap as the local route.
+_MAX_DISMISSED_LIMIT = 5000
+
+
+def _with_shared_root(fn):
+    """Resolve the configured clone; inject eval_root; scope the score cache.
+
+    Every decorated route becomes: 409 when unconfigured, 409 when the clone's
+    format is newer than this build understands, 503 when the clone hasn't
+    been fetched yet (or is otherwise unreadable), else the wrapped view runs
+    with ``eval_root`` (the shared clone's evaluations directory) and ``url``
+    (the configured remote) injected as keyword arguments, with the score
+    cache transparently scoped to this clone's own cache DB (Task 9) so its
+    rows never mix with the local clone's cache.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        settings = read_settings()
+        if not settings.url:
+            return jsonify({"error": "no shared repository configured"}), 409
+        state = read_state(settings.url)
+        if state == "unsupported_version":
+            return (
+                jsonify({"error": "this shared repository requires a newer version of quodeq"}),
+                409,
+            )
+        if state != "ok":
+            return jsonify({"error": "shared repository has not been cloned yet"}), 503
+        root = shared_evaluations_root(settings.url)
+        with score_cache_path_override(shared_score_cache_path(settings.url)):
+            return fn(*args, eval_root=root, url=settings.url, **kwargs)
+
+    return wrapper
+
+
+def _validate_segment(*segments: str) -> tuple[Response, int] | None:
+    """Shared-route path-segment guard (Task 7 precedent).
+
+    Every shared mirror that takes a project/run/dimension segment validates
+    it here, even where the local route it mirrors relies solely on the
+    service layer's own traversal check — defense in depth for a surface
+    that serves a second, independently-controlled clone.
+    """
+    try:
+        validate_path_segment(*segments)
+    except ValueError:
+        body, status = error_response("Invalid parameter", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+        return jsonify(body), status
+    return None
+
+
+def _shared_project_dir(eval_root: Path, project: str) -> Path | None:
+    """Resolve *project* under *eval_root*; None if it would escape the root."""
+    base = eval_root.resolve()
+    resolved = (base / project).resolve()
+    if not resolved.is_relative_to(base):
+        return None
+    return resolved
 
 
 def register_shared_routes(app: Flask) -> None:
@@ -93,3 +177,173 @@ def register_shared_routes(app: Flask) -> None:
         if not started:
             return jsonify({"error": "a publish is already running"}), 409
         return jsonify({"started": True}), 202
+
+    # -- read-only mirrors of the project read endpoints -------------------
+    #
+    # Each route below delegates to the SAME service function its local
+    # counterpart uses (see api/routes_project_list.py, routes_project_data.py,
+    # _scores_routes.py, routes_runs.py, routes_findings.py), with the shared
+    # clone's evaluations root standing in for the local reports directory.
+    # The response shape is therefore identical to the local route's; only the
+    # data source differs.
+
+    @app.get("/api/shared/projects")
+    @_with_shared_root
+    def shared_projects(eval_root: Path, url: str):
+        projects = _fs_projects.build_project_list(eval_root)
+        listing = {"projects": [to_camel_dict(p) for p in projects]}
+        meta = published_meta(url)
+        for project in listing["projects"]:
+            key = project.get("id") or project.get("name")
+            project.update(meta.get(key, {}))
+            project["source"] = "shared"
+        listing["lastSynced"] = last_synced_at(url)
+        return jsonify(listing)
+
+    @app.get("/api/shared/projects/<project>/info")
+    @_with_shared_root
+    def shared_project_info(project: str, eval_root: Path, url: str):
+        err = _validate_segment(project)
+        if err:
+            return err
+        info = _fs_projects.get_project_info(str(eval_root), project)
+        if not info:
+            body, status = error_response("Project info not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+        return jsonify(info)
+
+    @app.get("/api/shared/projects/<project>/runs")
+    @_with_shared_root
+    def shared_runs(project: str, eval_root: Path, url: str):
+        err = _validate_segment(project)
+        if err:
+            return err
+        sync_shared_index(url)
+        try:
+            runs = build_runs_unit(eval_root, shared_index_db_path(url), project)
+        except Exception:
+            _logger.exception("Failed to build shared runs unit for %s", project)
+            body, status = error_response("Failed to load runs", HTTPStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR")
+            return jsonify(body), status
+        return jsonify({"runs": runs})
+
+    @app.get("/api/shared/projects/<project>/dashboard")
+    @_with_shared_root
+    def shared_dashboard(project: str, eval_root: Path, url: str):
+        err = _validate_segment(project)
+        if err:
+            return err
+        run = request.args.get("run", "latest")
+        try:
+            payload = _fs_reports.get_dashboard(str(eval_root), project, run)
+        except FileNotFoundError:
+            body, status = error_response("Dashboard data not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+        return jsonify(payload)
+
+    @app.get("/api/shared/projects/<project>/accumulated")
+    @_with_shared_root
+    def shared_accumulated(project: str, eval_root: Path, url: str):
+        err = _validate_segment(project)
+        if err:
+            return err
+        as_of = request.args.get("asOf")
+        payload = _fs_reports.get_accumulated(str(eval_root), project, as_of)
+        if payload is None:
+            body, status = error_response("Project not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+        return jsonify(payload)
+
+    @app.get("/api/shared/projects/<project>/scores")
+    @_with_shared_root
+    def shared_scores(project: str, eval_root: Path, url: str):
+        err = _validate_segment(project)
+        if err:
+            return err
+        as_of = request.args.get("asOf")
+        try:
+            result = get_project_scores(eval_root, project, as_of)
+        except Exception:
+            _logger.exception("Unexpected error fetching shared scores for project %s", project)
+            body, status = error_response("Failed to load scores", HTTPStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR")
+            return jsonify(body), status
+        if result is None:
+            body, status = error_response("Project not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+        return jsonify(result)
+
+    @app.get("/api/shared/projects/<project>/scores/<run_id>")
+    @_with_shared_root
+    def shared_run_scores(project: str, run_id: str, eval_root: Path, url: str):
+        err = _validate_segment(project, run_id)
+        if err:
+            return err
+        try:
+            result = get_scores_slim(eval_root, project, run_id)
+        except FileNotFoundError:
+            body, status = error_response("Run not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+        return jsonify(result)
+
+    @app.get("/api/shared/projects/<project>/dimensions/<dim>/eval")
+    @_with_shared_root
+    def shared_dimension_eval(project: str, dim: str, eval_root: Path, url: str):
+        run_id = request.args.get("run", "latest")
+        err = _validate_segment(project, dim, run_id)
+        if err:
+            return err
+        payload = _fs_reports.get_dimension_eval(str(eval_root), project, run_id, dim)
+        if payload is None:
+            body, status = error_response("Eval file not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+        if payload.get("waiting"):
+            return jsonify(payload), HTTPStatus.ACCEPTED
+        return jsonify(payload)
+
+    @app.get("/api/shared/projects/<project>/violations")
+    @_with_shared_root
+    def shared_violations(project: str, eval_root: Path, url: str):
+        run_id = request.args.get("run", "latest")
+        err = _validate_segment(project, run_id)
+        if err:
+            return err
+        try:
+            payload = _fs_reports.get_violations(str(eval_root), project, run_id)
+        except FileNotFoundError:
+            body, status = error_response("Violation data not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+        return jsonify(to_camel_dict(payload))
+
+    # The local routes take ``project`` as a query param
+    # (``/api/findings/dismissed?project=``) since /api/findings/* is a flat
+    # namespace shared by mutation routes too. Every other shared mirror
+    # nests ``project`` as a URL path segment, so these two follow that
+    # convention instead of the local route's exact URL shape -- the response
+    # bodies (bare JSON array, same item shape) are unchanged.
+    @app.get("/api/shared/projects/<project>/findings/dismissed")
+    @_with_shared_root
+    def shared_dismissed_findings(project: str, eval_root: Path, url: str):
+        err = _validate_segment(project)
+        if err:
+            return err
+        project_dir = _shared_project_dir(eval_root, project)
+        if project_dir is None:
+            body, status = error_response("Invalid parameter", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+            return jsonify(body), status
+        raw_limit = request.args.get("limit", _MAX_DISMISSED_LIMIT, type=int)
+        limit = max(1, min(raw_limit, _MAX_DISMISSED_LIMIT))
+        offset = max(0, request.args.get("offset", 0, type=int))
+        items = load_dismissed(project_dir, offset=offset, limit=limit)
+        return jsonify(items)
+
+    @app.get("/api/shared/projects/<project>/findings/verified")
+    @_with_shared_root
+    def shared_verified_findings(project: str, eval_root: Path, url: str):
+        err = _validate_segment(project)
+        if err:
+            return err
+        project_dir = _shared_project_dir(eval_root, project)
+        if project_dir is None:
+            body, status = error_response("Invalid parameter", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+            return jsonify(body), status
+        return jsonify(verified_entries(project_dir))

--- a/src/quodeq/services/_fs_project_helpers.py
+++ b/src/quodeq/services/_fs_project_helpers.py
@@ -44,14 +44,21 @@ def _backfill_onboarding_field(project_dir: Path) -> dict | None:
     return data
 
 
-def _build_project_entry(reports_root: Path, entry_name: str, runs: list[RunInfo]) -> ProjectEntry:
-    """Build a frozen ProjectEntry from its directory and run list."""
+def _build_project_entry(
+    reports_root: Path, entry_name: str, runs: list[RunInfo], *, backfill: bool = True,
+) -> ProjectEntry:
+    """Build a frozen ProjectEntry from its directory and run list.
+
+    *backfill* mirrors ``build_project_list``'s parameter of the same name:
+    when False, the record is read read-only and never rewritten (used by
+    the shared-repo route so listing a clone never dirties its worktree).
+    """
     # Lazy backfill: ensure legacy project records have an
     # ``onboardingCompletedAt`` field so the wizard never auto-opens for
     # already-onboarded projects. Returns the (possibly updated) info dict
     # so we can pass the field through to the entry without re-reading.
     project_dir = reports_root / entry_name
-    backfilled = _backfill_onboarding_field(project_dir)
+    backfilled = _backfill_onboarding_field(project_dir) if backfill else None
     info = backfilled if backfilled is not None else _read_repo_info(reports_root, entry_name)
     meta = _extract_project_metadata(info, entry_name)
     latest_grade, latest_score, files_count = _read_accumulated_summary(

--- a/src/quodeq/services/_fs_projects.py
+++ b/src/quodeq/services/_fs_projects.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextvars
 import json
 import shutil
 from concurrent.futures import ThreadPoolExecutor
@@ -112,8 +113,21 @@ def build_project_list(reports_root: Path) -> list[ProjectEntry]:
             return None
         return _build_project_entry(reports_root, name, runs)
 
+    # contextvars do NOT propagate into ThreadPoolExecutor worker threads --
+    # each worker runs with its own default Context, so a caller-side
+    # score_cache_path_override (e.g. from _with_shared_root) would be
+    # invisible inside _build_one and per-project summaries would read/write
+    # the LOCAL score cache DB instead of the scoped one. Copy the calling
+    # context once per task -- a single Context object cannot be entered by
+    # more than one thread concurrently -- so each worker sees the same
+    # contextvar values (including the override, when active) as the caller.
+    # When no override is active this is a no-op: copy_context().run just
+    # calls _build_one with the same (empty) contextvar state.
+    ctxs = [contextvars.copy_context() for _ in dir_names]
     with ThreadPoolExecutor(max_workers=min(_MAX_PROJECT_BUILD_WORKERS, len(dir_names) or 1)) as pool:
-        results = pool.map(_build_one, dir_names)
+        results = pool.map(
+            lambda pair: pair[0].run(_build_one, pair[1]), zip(ctxs, dir_names),
+        )
     projects = [p for p in results if p is not None]
     projects.sort(key=lambda p: p.name)
     return _auto_detect_parents(projects)

--- a/src/quodeq/services/_fs_projects.py
+++ b/src/quodeq/services/_fs_projects.py
@@ -87,8 +87,15 @@ def _build_parent_child_sets(reports_root: Path, dir_names: list[str]) -> tuple[
     return parent_ids, subproject_ids
 
 
-def build_project_list(reports_root: Path) -> list[ProjectEntry]:
-    """Collect eligible project dirs and build entries in parallel."""
+def build_project_list(reports_root: Path, *, backfill: bool = True) -> list[ProjectEntry]:
+    """Collect eligible project dirs and build entries in parallel.
+
+    *backfill* controls the lazy ``onboardingCompletedAt`` backfill below (and
+    the equivalent one inside ``_build_project_entry``): when False, records
+    are read as-is and never rewritten. Local callers keep the default
+    (True); the shared-repo route passes False so listing a clone's projects
+    never dirties its git worktree (see routes_shared.py shared_projects).
+    """
     max_listed = _max_projects_listed()
     dir_names: list[str] = []
     for entry in safe_read_dir(reports_root):
@@ -102,8 +109,9 @@ def build_project_list(reports_root: Path) -> list[ProjectEntry]:
     # ``onboardingCompletedAt`` field. Run before the parent/child sweep so
     # any subsequent reads see the updated file. Idempotent — no-op for
     # records that already have the field. Failures are silently ignored.
-    for name in dir_names:
-        _backfill_onboarding_field(reports_root / name)
+    if backfill:
+        for name in dir_names:
+            _backfill_onboarding_field(reports_root / name)
 
     parent_ids, subproject_ids = _build_parent_child_sets(reports_root, dir_names)
 
@@ -111,7 +119,7 @@ def build_project_list(reports_root: Path) -> list[ProjectEntry]:
         runs = list_runs(reports_root, name)
         if not runs and name not in parent_ids and name not in subproject_ids:
             return None
-        return _build_project_entry(reports_root, name, runs)
+        return _build_project_entry(reports_root, name, runs, backfill=backfill)
 
     # contextvars do NOT propagate into ThreadPoolExecutor worker threads --
     # each worker runs with its own default Context, so a caller-side

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -11,6 +11,7 @@ import json
 import logging
 import sqlite3
 from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Callable, Iterator
 
@@ -37,6 +38,31 @@ _BUSY_TIMEOUT_MS = 5000
 # forever; the gate now persists only terminal runs, and this bump purges the
 # non-version-keyed run_keys table once so stranded partial snapshots rebuild.
 _CACHE_WRITER_EPOCH = "4"
+
+# Shared-root isolation seam (Phase 2): when serving read endpoints from a
+# second (shared) clone, the score cache must not mix rows with the local
+# clone's cache. Unset (None) in every normal code path, so the default
+# behavior below is byte-identical to before this seam existed.
+_CACHE_PATH_OVERRIDE: ContextVar[str | None] = ContextVar(
+    "score_cache_path_override", default=None
+)
+
+
+@contextmanager
+def score_cache_path_override(path: str | Path) -> Iterator[None]:
+    """Route score-cache reads/writes to *path* instead of the default DB.
+
+    Active only for the duration of the ``with`` block (and any code it
+    calls, via contextvars' task-local propagation); always restored,
+    including when the block raises.
+    """
+    token = _CACHE_PATH_OVERRIDE.set(str(path))
+    try:
+        yield
+    finally:
+        _CACHE_PATH_OVERRIDE.reset(token)
+
+
 _SCHEMA = (
     "CREATE TABLE IF NOT EXISTS run_scalars ("
     " project TEXT NOT NULL, run_id TEXT NOT NULL, version TEXT NOT NULL,"
@@ -101,7 +127,8 @@ def _init(path: Path) -> sqlite3.Connection:
 @contextmanager
 def open_score_cache() -> Iterator[sqlite3.Connection]:
     """Open the score cache DB (WAL). Rebuilds from scratch if corrupt/older-schema."""
-    path = Path(get_score_cache_path())
+    override = _CACHE_PATH_OVERRIDE.get()
+    path = Path(override) if override else Path(get_score_cache_path())
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
         conn = _init(path)

--- a/src/quodeq/services/shared_publish.py
+++ b/src/quodeq/services/shared_publish.py
@@ -104,11 +104,22 @@ def merge_actions_log(ours: Path, theirs: Path, dest: Path) -> None:
     dest.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
+_SCAN_FILENAME = "scan.json"
+
+
 def stage_project(project_dir: Path, dest_project_dir: Path) -> int:
     dest_project_dir.mkdir(parents=True, exist_ok=True)
     info = project_dir / "repository_info.json"
     if info.exists():
         shutil.copy2(info, dest_project_dir / "repository_info.json")
+    # Project-level scan.json (quick-scan coverage metadata: total_files etc.)
+    # is consumed by _fs_reports._enrich_with_coverage and the project-card
+    # coverage reader -- without it, a published clone's dashboard/card never
+    # shows a coverage header. Copied only when present; a project scanned
+    # before this field existed simply stays absent on the clone too.
+    scan = project_dir / _SCAN_FILENAME
+    if scan.exists():
+        shutil.copy2(scan, dest_project_dir / _SCAN_FILENAME)
     merge_actions_log(
         project_dir / ACTIONS_LOG_FILENAME,
         dest_project_dir / ACTIONS_LOG_FILENAME,

--- a/src/quodeq/services/shared_publish.py
+++ b/src/quodeq/services/shared_publish.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 _RUN_FILES = (STATUS_FILENAME, DIMENSIONS_FILENAME, "events.jsonl")
 _EVIDENCE_DIR = "evidence"
+_EVALUATION_DIR = "evaluation"
 
 
 def list_completed_runs(project_dir: Path) -> list[Path]:
@@ -62,6 +63,17 @@ def copy_run(run_dir: Path, dest_run_dir: Path) -> None:
             shutil.copy2(manifest, dest_evidence / "manifest.json")
         for src in sorted(evidence.glob("*_evidence.jsonl")):
             shutil.copy2(src, dest_evidence / src.name)
+    evaluation = run_dir / _EVALUATION_DIR
+    if evaluation.is_dir():
+        dest_evaluation = dest_run_dir / _EVALUATION_DIR
+        dest_evaluation.mkdir(exist_ok=True)
+        # Frozen eval-time per-dimension scores (e.g. security.json) are the
+        # source of truth read_run_data() needs to render a dashboard at
+        # all -- without them a published clone renders an EMPTY dashboard.
+        # Pattern-bounded like the evidence glob above: only .json files,
+        # nothing else (markdown companions, stray files) from that dir.
+        for src in sorted(evaluation.glob("*.json")):
+            shutil.copy2(src, dest_evaluation / src.name)
 
 
 def _timestamp_key(line: str) -> tuple[int, str]:

--- a/src/quodeq/services/shared_repo.py
+++ b/src/quodeq/services/shared_repo.py
@@ -207,7 +207,7 @@ def published_meta(url: str, env: dict | None = None) -> dict[str, dict]:
             cwd=repo,
         )
         if ok and "|" in out:
-            author, _, ts = out.strip().partition("|")
+            author, _, ts = out.strip().rpartition("|")
             try:
                 result[entry.name] = {"publishedBy": author, "publishedAt": int(ts)}
             except ValueError:

--- a/src/quodeq/services/shared_repo.py
+++ b/src/quodeq/services/shared_repo.py
@@ -158,3 +158,58 @@ def bootstrap_repo_layout(repo_root: Path) -> None:
     evaluations = repo_root / "evaluations"
     evaluations.mkdir(exist_ok=True)
     (evaluations / ".gitkeep").write_text("", encoding="utf-8")
+
+
+def shared_index_db_path(url: str, env: dict | None = None) -> Path:
+    return shared_cache_dir(url, env) / "index.db"
+
+
+def shared_score_cache_path(url: str, env: dict | None = None) -> Path:
+    return shared_cache_dir(url, env) / "score_cache.db"
+
+
+def sync_shared_index(url: str, env: dict | None = None) -> None:
+    from quodeq.services.run_index import open_index, sync_index
+
+    root = shared_evaluations_root(url, env)
+    if not root.is_dir():
+        return
+    db = open_index(shared_index_db_path(url, env))
+    try:
+        sync_index(db, root)
+    finally:
+        db.close()
+
+
+def read_state(url: str, env: dict | None = None) -> str:
+    repo = shared_repo_path(url, env)
+    if not (repo / ".git").exists():
+        return "missing"
+    fmt = check_repo_format(repo)
+    if fmt == "unsupported_version":
+        return "unsupported_version"
+    if fmt == "ok" or shared_evaluations_root(url, env).is_dir():
+        return "ok"
+    return "missing"
+
+
+def published_meta(url: str, env: dict | None = None) -> dict[str, dict]:
+    repo = shared_repo_path(url, env)
+    root = shared_evaluations_root(url, env)
+    result: dict[str, dict] = {}
+    if not root.is_dir():
+        return result
+    for entry in sorted(root.iterdir()):
+        if not entry.is_dir():
+            continue
+        ok, out = run_git(
+            ["log", "-1", "--format=%an|%ct", "--", f"evaluations/{entry.name}"],
+            cwd=repo,
+        )
+        if ok and "|" in out:
+            author, _, ts = out.strip().partition("|")
+            try:
+                result[entry.name] = {"publishedBy": author, "publishedAt": int(ts)}
+            except ValueError:
+                continue
+    return result

--- a/src/quodeq/services/shared_repo.py
+++ b/src/quodeq/services/shared_repo.py
@@ -90,14 +90,28 @@ def ensure_shared_clone(url: str, env: dict | None = None) -> Path | None:
     return repo
 
 
-def refresh_shared_clone(url: str, env: dict | None = None) -> bool:
+_DEFAULT_REFRESH_TIMEOUT_S = 30
+
+
+def refresh_shared_clone(url: str, env: dict | None = None, *, timeout: int = _DEFAULT_REFRESH_TIMEOUT_S) -> bool:
+    """Fetch + hard-reset the clone to the remote's HEAD.
+
+    Called in-request (GET /api/shared/projects?refresh=1, POST
+    /api/shared/refresh), so it must not inherit run_git's 300s default --
+    a black-holed connection would otherwise hang the request for up to 5
+    minutes. *timeout* bounds both the fetch (the network call) and the
+    reset (local but kept consistent); a black-holed connection now turns
+    into a stale=true response in ~*timeout* seconds instead. Does not
+    affect ensure_shared_clone's own (still 300s) clone timeout -- an
+    initial clone can legitimately take much longer than a refresh.
+    """
     repo = shared_repo_path(url, env)
     if not (repo / ".git").exists():
         return ensure_shared_clone(url, env) is not None
-    ok, _ = run_git(["fetch", "--depth", "1", "origin", "HEAD"], cwd=repo)
+    ok, _ = run_git(["fetch", "--depth", "1", "origin", "HEAD"], cwd=repo, timeout=timeout)
     if not ok:
         return False
-    ok, _ = run_git(["reset", "--hard", "FETCH_HEAD"], cwd=repo)
+    ok, _ = run_git(["reset", "--hard", "FETCH_HEAD"], cwd=repo, timeout=timeout)
     return ok
 
 

--- a/tests/api/test_routes_shared_read.py
+++ b/tests/api/test_routes_shared_read.py
@@ -255,6 +255,31 @@ def test_shared_projects_refresh_stale_when_origin_unreachable(
     assert "proj-a" in ids
 
 
+def test_shared_projects_score_cache_override_propagates_into_pool(
+    client, shared_clone_fixture,
+):
+    """Finding 1 regression: build_project_list runs _build_one (which
+    ultimately calls cached_project_summary) inside a ThreadPoolExecutor.
+    contextvars do NOT propagate into pool worker threads by default, so the
+    score_cache_path_override set by _with_shared_root would be invisible
+    there and per-project summaries would read/write the LOCAL score cache
+    DB instead of this clone's own one. Both must hold: the per-clone cache
+    gets written, and the local (sandboxed-default) cache never does."""
+    from quodeq.services.shared_repo import shared_score_cache_path
+    from quodeq.shared._env import get_score_cache_path
+
+    clone_cache_path = shared_score_cache_path(shared_clone_fixture)
+    local_cache_path = Path(get_score_cache_path())
+    assert not clone_cache_path.exists()
+    assert not local_cache_path.exists()
+
+    resp = client.get("/api/shared/projects")
+    assert resp.status_code == 200
+
+    assert clone_cache_path.exists()
+    assert not local_cache_path.exists()
+
+
 # --- GET /api/shared/projects/<project>/info ----------------------------------
 
 def test_shared_project_info(client, shared_clone_fixture):

--- a/tests/api/test_routes_shared_read.py
+++ b/tests/api/test_routes_shared_read.py
@@ -186,6 +186,69 @@ def test_shared_projects_lists_published(client, shared_clone_fixture):
     assert "lastSynced" in body
 
 
+def test_shared_projects_without_refresh_param_omits_stale(client, shared_clone_fixture):
+    """Backward compat: a plain GET (no ?refresh=1) never forces a fetch and
+    never gains a "stale" key -- the refresh-on-read behaviour is opt-in."""
+    resp = client.get("/api/shared/projects")
+    assert resp.status_code == 200
+    assert "stale" not in resp.get_json()
+
+
+def test_shared_projects_refresh_success_reports_fresh_and_syncs_index(
+    client, shared_clone_fixture, monkeypatch
+):
+    """?refresh=1 calls refresh_shared_clone first; on success it also calls
+    sync_shared_index and the response gains "stale": False."""
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "quodeq.api.routes_shared.refresh_shared_clone",
+        lambda url: calls.append(f"refresh:{url}") or True,
+    )
+    monkeypatch.setattr(
+        "quodeq.api.routes_shared.sync_shared_index",
+        lambda url: calls.append(f"sync:{url}"),
+    )
+    resp = client.get("/api/shared/projects?refresh=1")
+    assert resp.status_code == 200
+    assert resp.get_json()["stale"] is False
+    assert calls == [f"refresh:{shared_clone_fixture}", f"sync:{shared_clone_fixture}"]
+
+
+def test_shared_projects_refresh_failure_reports_stale_and_skips_sync(
+    client, shared_clone_fixture, monkeypatch
+):
+    """When refresh_shared_clone fails, the response gains "stale": True and
+    sync_shared_index is never called (nothing new was fetched to index)."""
+    sync_calls: list[str] = []
+    monkeypatch.setattr("quodeq.api.routes_shared.refresh_shared_clone", lambda url: False)
+    monkeypatch.setattr(
+        "quodeq.api.routes_shared.sync_shared_index",
+        lambda url: sync_calls.append(url),
+    )
+    resp = client.get("/api/shared/projects?refresh=1")
+    assert resp.status_code == 200
+    assert resp.get_json()["stale"] is True
+    assert sync_calls == []
+
+
+def test_shared_projects_refresh_stale_when_origin_unreachable(
+    client, shared_clone_fixture, tmp_path
+):
+    """End-to-end: the origin bare repo becomes unreachable (e.g. renamed
+    away/deleted), so `git fetch` fails and the forced refresh reports
+    stale, while the already-cloned (now-stale) project listing still
+    renders from the local cache instead of erroring out."""
+    origin_path = Path(shared_clone_fixture.removeprefix("file://"))
+    origin_path.rename(tmp_path / "origin-moved.git")
+
+    resp = client.get("/api/shared/projects?refresh=1")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["stale"] is True
+    ids = [p.get("id") or p.get("name") for p in body["projects"]]
+    assert "proj-a" in ids
+
+
 # --- GET /api/shared/projects/<project>/info ----------------------------------
 
 def test_shared_project_info(client, shared_clone_fixture):

--- a/tests/api/test_routes_shared_read.py
+++ b/tests/api/test_routes_shared_read.py
@@ -255,6 +255,43 @@ def test_shared_projects_refresh_stale_when_origin_unreachable(
     assert "proj-a" in ids
 
 
+def _git_porcelain(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "status", "--porcelain"], cwd=repo, check=True, capture_output=True, text=True,
+    ).stdout
+
+
+def test_shared_projects_listing_does_not_dirty_clone_worktree(client, shared_clone_fixture):
+    """Finding 2 regression: build_project_list's lazy onboarding backfill
+    writes onboardingCompletedAt into repository_info.json when missing --
+    the shared route must skip that write (backfill=False), or listing
+    dirties the clone's git worktree and a subsequent publish's
+    `pull --rebase` can refuse (offline refresh) with a confusing wedge.
+
+    shared_clone_fixture already publishes a repository_info.json without
+    onboardingCompletedAt (just {"name": "proj-a"}), so no extra fixture
+    crafting is needed to exercise the missing-field path. The fixture also
+    writes an evaluation/Security.json straight into the clone's working
+    tree without `git add`ing it (see its docstring), which is pre-existing
+    untracked noise unrelated to this bug -- so this test compares the
+    worktree's git status BEFORE and AFTER the request instead of asserting
+    a blanket-clean tree, to isolate exactly what the route call itself does.
+    """
+    repo = shared_repo_path(shared_clone_fixture)
+    info_path = shared_evaluations_root(shared_clone_fixture) / "proj-a" / "repository_info.json"
+    info_before = json.loads(info_path.read_text(encoding="utf-8"))
+    assert "onboardingCompletedAt" not in info_before
+    status_before = _git_porcelain(repo)
+
+    resp = client.get("/api/shared/projects")
+    assert resp.status_code == 200
+
+    status_after = _git_porcelain(repo)
+    assert status_after == status_before
+    info_after = json.loads(info_path.read_text(encoding="utf-8"))
+    assert "onboardingCompletedAt" not in info_after
+
+
 def test_shared_projects_score_cache_override_propagates_into_pool(
     client, shared_clone_fixture,
 ):

--- a/tests/api/test_routes_shared_read.py
+++ b/tests/api/test_routes_shared_read.py
@@ -159,11 +159,17 @@ def test_shared_routes_409_when_unsupported_version(client):
 # --- read-only sweep ----------------------------------------------------------
 
 def test_no_mutating_routes_under_shared(app):
-    """Read-only invariant: /api/shared/* accepts only GET plus the three control POST/PUT/DELETE."""
+    """Read-only invariant: /api/shared/* accepts only GET plus the four control POST/PUT/DELETE."""
     allowed_mutations = {
         ("/api/shared/config", "PUT"),
         ("/api/shared/config", "DELETE"),
         ("/api/shared/refresh", "POST"),
+        # Deliberate, spec-approved exception: this mutates LOCAL state (the
+        # local reports directory, via import_zip_stream) to materialize a
+        # copy of a shared project -- it does not mutate the shared
+        # repository clone itself, so it does not violate the read-only
+        # invariant this test enforces for the shared repo.
+        ("/api/shared/projects/<project>/pull", "POST"),
     }
     for rule in app.url_map.iter_rules():
         if not str(rule).startswith("/api/shared"):

--- a/tests/api/test_routes_shared_read.py
+++ b/tests/api/test_routes_shared_read.py
@@ -1,0 +1,357 @@
+"""Tests for the read-only mirrors of project read endpoints under /api/shared/*.
+
+Read-only invariant: every route under /api/shared/projects/... is a thin GET
+delegation to the same service functions the local /api/projects/... routes
+use, pointed at the shared clone's evaluations root instead of the local
+reports directory. This module covers:
+
+  * the ``_with_shared_root`` decorator's three failure branches (409
+    unconfigured, 409 unsupported clone format, 503 clone not cloned yet)
+  * the durable read-only sweep test (no mutating routes under /api/shared
+    beyond the three already-established control endpoints)
+  * one smoke test per mirror route, built against a REAL published clone
+    (bare origin + publish_project + sync_shared_index, same recipe as
+    tests/services/test_shared_repo.py) driven through the Flask test client
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from quodeq.api.app import create_app
+from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.writer import EventLogWriter
+from quodeq.services.shared_publish import publish_project
+from quodeq.services.shared_repo import (
+    FORMAT_NAME,
+    MARKER_FILENAME,
+    shared_evaluations_root,
+    shared_repo_path,
+    sync_shared_index,
+)
+from quodeq.services.shared_settings import SharedSettings, write_settings
+
+_VIOLATION = dict(
+    practice_id="P1", verdict="violation", dimension="Security",
+    file="a.py", line=10, reason="weak hash", req="R1", severity="high",
+)
+
+_EVAL_JSON = {
+    "schema_version": 1,
+    "dimension": "Security",
+    "project": "proj-a",
+    "runId": "run-1",
+    "overallScore": "7.0/10",
+    "overallGrade": "Good",
+    "principles": [{"name": "Integrity", "score": "7.0/10", "grade": "Good", "violations": [], "compliance": []}],
+    "violations": [{
+        "principle": "Integrity", "req": "R1", "file": "a.py", "line": 10,
+        "severity": "major", "reason": "bad", "title": "Bad",
+    }],
+    "compliance": [],
+}
+
+
+def _make_origin(tmp_path: Path) -> str:
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    return f"file://{origin}"
+
+
+@pytest.fixture()
+def app():
+    return create_app(test_config={"TESTING": True})
+
+
+@pytest.fixture()
+def client(app):
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture()
+def shared_clone_fixture(tmp_path, monkeypatch):
+    """Build a real published shared-repo clone and point settings at it.
+
+    Follows the same recipe as
+    tests/services/test_shared_repo.py::test_readable_and_index_sync_on_published_clone:
+    bare origin + publish_project + sync_shared_index. ``publish_project``'s
+    staging allowlist (source-of-truth files only) never carries
+    ``evaluation/<dim>.json`` — a real published run always has that
+    directory empty — so a per-dimension eval file is written directly into
+    the clone afterwards to exercise the dashboard/accumulated/dimension-eval/
+    violations read paths (this task's job) against real content, without
+    relitigating the publish allowlist (a prior task's decision).
+    """
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "tester")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "t@t")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "tester")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "t@t")
+
+    url = _make_origin(tmp_path)
+    local_root = tmp_path / "local-evaluations"
+    project_dir = local_root / "proj-a"
+    run_dir = project_dir / "run-1"
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "evidence" / "manifest.json").write_text("{}", encoding="utf-8")
+    (project_dir / "repository_info.json").write_text(
+        json.dumps({"name": "proj-a"}), encoding="utf-8",
+    )
+    (run_dir / "status.json").write_text(
+        json.dumps({"state": "done", "schema_version": 2}), encoding="utf-8",
+    )
+    (run_dir / "dimensions.json").write_text("{}", encoding="utf-8")
+
+    writer = EventLogWriter(run_dir / "events.jsonl")
+    writer.emit(JudgmentCreatedEvent(payload=JudgmentPayload(**_VIOLATION)))
+
+    publish_project("proj-a", url, evaluations_root=local_root)
+    sync_shared_index(url)
+
+    repo_run_dir = shared_evaluations_root(url) / "proj-a" / "run-1"
+    (repo_run_dir / "evaluation").mkdir(parents=True, exist_ok=True)
+    (repo_run_dir / "evaluation" / "Security.json").write_text(
+        json.dumps(_EVAL_JSON), encoding="utf-8",
+    )
+
+    write_settings(SharedSettings(url=url))
+    return url
+
+
+# --- _with_shared_root decorator ---------------------------------------------
+
+def test_shared_routes_409_when_unconfigured(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("QUODEQ_DIR", str(tmp_path))
+    for path in (
+        "/api/shared/projects",
+        "/api/shared/projects/x/runs",
+        "/api/shared/projects/x/dashboard",
+    ):
+        resp = client.get(path)
+        assert resp.status_code == 409
+        assert resp.get_json()["error"] == "no shared repository configured"
+
+
+def test_shared_routes_503_when_clone_missing(client):
+    write_settings(SharedSettings(url="file:///nonexistent/repo.git"))
+    resp = client.get("/api/shared/projects")
+    assert resp.status_code == 503
+    assert resp.get_json()["error"] == "shared repository has not been cloned yet"
+
+
+def test_shared_routes_409_when_unsupported_version(client):
+    url = "file:///dummy/unsupported.git"
+    repo = shared_repo_path(url)
+    repo.mkdir(parents=True)
+    (repo / ".git").mkdir()
+    (repo / MARKER_FILENAME).write_text(
+        json.dumps({"format": FORMAT_NAME, "version": 99}), encoding="utf-8",
+    )
+    write_settings(SharedSettings(url=url))
+    resp = client.get("/api/shared/projects")
+    assert resp.status_code == 409
+    assert "newer version" in resp.get_json()["error"]
+
+
+# --- read-only sweep ----------------------------------------------------------
+
+def test_no_mutating_routes_under_shared(app):
+    """Read-only invariant: /api/shared/* accepts only GET plus the three control POST/PUT/DELETE."""
+    allowed_mutations = {
+        ("/api/shared/config", "PUT"),
+        ("/api/shared/config", "DELETE"),
+        ("/api/shared/refresh", "POST"),
+    }
+    for rule in app.url_map.iter_rules():
+        if not str(rule).startswith("/api/shared"):
+            continue
+        for method in rule.methods - {"HEAD", "OPTIONS", "GET"}:
+            assert (str(rule), method) in allowed_mutations, f"unexpected {method} {rule}"
+
+
+# --- GET /api/shared/projects -------------------------------------------------
+
+def test_shared_projects_lists_published(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    ids = [p.get("id") or p.get("name") for p in body["projects"]]
+    assert "proj-a" in ids
+    proj = next(p for p in body["projects"] if (p.get("id") or p.get("name")) == "proj-a")
+    assert proj.get("publishedBy") == "tester"
+    assert proj.get("source") == "shared"
+    assert "lastSynced" in body
+
+
+# --- GET /api/shared/projects/<project>/info ----------------------------------
+
+def test_shared_project_info(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/proj-a/info")
+    assert resp.status_code == 200
+
+
+def test_shared_project_info_not_found(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/does-not-exist/info")
+    assert resp.status_code == 404
+
+
+def test_shared_project_info_invalid_segment(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/%2e%2e/info")
+    assert resp.status_code == 400
+
+
+# --- GET /api/shared/projects/<project>/runs ----------------------------------
+
+def test_shared_runs(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/proj-a/runs")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "runs" in body
+    run_ids = [r.get("runId") for r in body["runs"]]
+    assert "run-1" in run_ids
+
+
+# --- GET /api/shared/projects/<project>/dashboard -----------------------------
+
+def test_shared_dashboard(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/proj-a/dashboard")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body.get("project") == "proj-a"
+    dims = body.get("dimensions", [])
+    assert any(d.get("dimension") == "Security" for d in dims)
+
+
+def test_shared_dashboard_with_run_param(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/proj-a/dashboard?run=run-1")
+    assert resp.status_code == 200
+
+
+def test_shared_dashboard_invalid_segment(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/%2e%2e/dashboard")
+    assert resp.status_code == 400
+
+
+# --- GET /api/shared/projects/<project>/accumulated ---------------------------
+
+def test_shared_accumulated(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/proj-a/accumulated")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "dimensions" in body
+
+
+def test_shared_accumulated_not_found(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/does-not-exist/accumulated")
+    assert resp.status_code == 404
+
+
+# --- GET /api/shared/projects/<project>/scores --------------------------------
+
+def test_shared_scores(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/proj-a/scores")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "accumulated" in body
+    assert "trend" in body
+    assert "availableRuns" in body
+
+
+def test_shared_scores_not_found(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/does-not-exist/scores")
+    assert resp.status_code == 404
+
+
+def test_shared_scores_uses_isolated_score_cache(client, shared_clone_fixture):
+    """Task 9 integration: the shared clone's own score_cache.db is touched,
+    not the local (unconfigured, in this test) default score cache path."""
+    from quodeq.services.shared_repo import shared_score_cache_path
+
+    cache_path = shared_score_cache_path(shared_clone_fixture)
+    assert not cache_path.exists()
+    resp = client.get("/api/shared/projects/proj-a/scores")
+    assert resp.status_code == 200
+    assert cache_path.exists()
+
+
+# --- GET /api/shared/projects/<project>/scores/<run_id> -----------------------
+
+def test_shared_run_scores(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/proj-a/scores/run-1")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "dimensions" in body
+    for dim in body["dimensions"]:
+        for v in dim.get("violations", []):
+            assert set(v.keys()) == {"req", "file", "line"}
+
+
+def test_shared_run_scores_not_found(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/proj-a/scores/nonexistent-run")
+    assert resp.status_code == 404
+
+
+# --- GET /api/shared/projects/<project>/dimensions/<dim>/eval -----------------
+
+def test_shared_dimension_eval(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/proj-a/dimensions/Security/eval?run=run-1")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body.get("dimension") == "Security"
+
+
+def test_shared_dimension_eval_waiting_when_no_eval_file(client, shared_clone_fixture):
+    """No evaluation/DoesNotExist.json (or evidence fallback) exists, but the
+    run directory does -- same as the local route, this is "waiting" (202),
+    not 404. 404 is reserved for a run directory that doesn't exist at all."""
+    resp = client.get("/api/shared/projects/proj-a/dimensions/DoesNotExist/eval?run=run-1")
+    assert resp.status_code == 202
+
+
+def test_shared_dimension_eval_not_found_when_run_missing(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/proj-a/dimensions/Security/eval?run=nonexistent-run")
+    assert resp.status_code == 404
+
+
+def test_shared_dimension_eval_invalid_run_segment(client, shared_clone_fixture):
+    """The run comes from a query param here (not a URL path segment), so it
+    must still be validated against path traversal before touching disk."""
+    resp = client.get("/api/shared/projects/proj-a/dimensions/Security/eval?run=..%2fescape")
+    assert resp.status_code == 400
+
+
+# --- GET /api/shared/projects/<project>/violations ----------------------------
+
+def test_shared_violations(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/proj-a/violations?run=run-1")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "total" in body
+    assert "files" in body
+
+
+def test_shared_violations_invalid_run_segment(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/proj-a/violations?run=..%2fescape")
+    assert resp.status_code == 400
+
+
+# --- GET /api/shared/projects/<project>/findings/dismissed & /verified --------
+
+def test_shared_dismissed_findings_empty(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/proj-a/findings/dismissed")
+    assert resp.status_code == 200
+    assert resp.get_json() == []
+
+
+def test_shared_verified_findings_empty(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/proj-a/findings/verified")
+    assert resp.status_code == 200
+    assert resp.get_json() == []
+
+
+def test_shared_dismissed_findings_invalid_segment(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/%2e%2e/findings/dismissed")
+    assert resp.status_code == 400

--- a/tests/api/test_shared_pull.py
+++ b/tests/api/test_shared_pull.py
@@ -1,0 +1,228 @@
+"""Tests for POST /api/shared/projects/<project>/pull.
+
+Pulls a project from the shared clone into the local evaluations directory
+by building an in-memory zip of the clone's project directory
+(``_build_project_zip``) and feeding it to ``import_zip_stream`` -- the same
+hardened validation/collision logic used by the manual
+``POST /api/projects/import`` route (see tests/api/test_project_import.py).
+
+Note on project naming: real local project directories under reports_dir are
+named by UUID (``import_project.py``'s ``_validate_archive`` requires the
+zip's single top-level directory to be a valid UUID), and ``publish_project``
+mirrors the source directory name as-is into the shared repo -- so a
+realistic pull target is UUID-named too. This intentionally differs from
+``tests/api/test_routes_shared_read.py``'s ``shared_clone_fixture``, which
+publishes under the human-friendly slug ``"proj-a"`` purely for readability
+across its read-endpoint tests; that slug is not a valid zip top-level
+directory name for ``import_zip_stream`` (it fails the UUID check with
+``BAD_LAYOUT``), so these pull tests use their own UUID-named fixture to
+exercise the real success and collision paths.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import uuid as _uuid
+from pathlib import Path
+
+import pytest
+
+from quodeq.api.app import create_app
+from quodeq.services.shared_publish import publish_project
+from quodeq.services.shared_settings import SharedSettings, write_settings
+
+_ORIGIN = {"Origin": "http://localhost"}
+
+
+def _make_origin(tmp_path: Path) -> str:
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    return f"file://{origin}"
+
+
+@pytest.fixture()
+def app():
+    return create_app(test_config={"TESTING": True})
+
+
+@pytest.fixture()
+def client(app):
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture()
+def local_eval_dir(tmp_path, monkeypatch) -> Path:
+    """The LOCAL evaluations directory the pull route writes into."""
+    d = tmp_path / "local-evaluations"
+    d.mkdir()
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(d))
+    return d
+
+
+@pytest.fixture()
+def shared_clone_fixture(tmp_path, monkeypatch):
+    """A real published shared-repo clone containing one UUID-named project.
+
+    Follows the same bare-origin + publish_project recipe as
+    tests/services/test_shared_repo.py and
+    tests/api/test_routes_shared_read.py, but publishes a UUID-named project
+    (see module docstring) with a complete repository_info.json so the
+    import-side validation (_validate_repository_info requires 'name' and
+    'path') succeeds.
+
+    Returns (url, project_uuid).
+    """
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "tester")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "t@t")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "tester")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "t@t")
+
+    url = _make_origin(tmp_path)
+    publish_source = tmp_path / "publish-source"
+    project_uuid = str(_uuid.uuid4())
+    project_dir = publish_source / project_uuid
+    project_dir.mkdir(parents=True)
+    (project_dir / "repository_info.json").write_text(
+        json.dumps({
+            "uuid": project_uuid,
+            "name": "proj-a",
+            "location": "local",
+            "path": "/tmp/proj-a",
+        }),
+        encoding="utf-8",
+    )
+    # build_project_list() (backing GET /api/projects) skips any project dir
+    # with zero runs, so give it one minimal run -- list_runs only requires
+    # evidence/manifest.json to exist to count a run directory as a run.
+    run_dir = project_dir / "run-1"
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "evidence" / "manifest.json").write_text("{}", encoding="utf-8")
+    (run_dir / "status.json").write_text(
+        json.dumps({"state": "done", "schema_version": 2}), encoding="utf-8",
+    )
+
+    publish_project(project_uuid, url, evaluations_root=publish_source)
+    write_settings(SharedSettings(url=url))
+    return url, project_uuid
+
+
+@pytest.fixture()
+def local_eval_dir_with_collision(local_eval_dir, shared_clone_fixture) -> Path:
+    """local_eval_dir, pre-seeded with a project at the same UUID the shared
+    clone publishes -- forces the same-uuid 409 collision path."""
+    _, project_uuid = shared_clone_fixture
+    existing = local_eval_dir / project_uuid
+    existing.mkdir()
+    (existing / "repository_info.json").write_text(
+        json.dumps({
+            "uuid": project_uuid,
+            "name": "existing-local-name",
+            "location": "local",
+            "path": "/tmp/existing",
+        }),
+        encoding="utf-8",
+    )
+    return local_eval_dir
+
+
+def _pull(client, project: str, action: str | None = None):
+    body = {"action": action} if action is not None else {}
+    return client.post(
+        f"/api/shared/projects/{project}/pull",
+        json=body,
+        headers=_ORIGIN,
+    )
+
+
+# --- happy path ---------------------------------------------------------------
+
+def test_pull_materializes_local_copy(client, shared_clone_fixture, local_eval_dir):
+    _, project_uuid = shared_clone_fixture
+    resp = _pull(client, project_uuid)
+    assert resp.status_code in (200, 201), resp.get_json()
+    assert (local_eval_dir / project_uuid / "repository_info.json").exists()
+
+    listing = client.get("/api/projects").get_json()
+    ids = [p.get("id") or p.get("name") for p in listing["projects"]]
+    assert any(project_uuid in str(i) for i in ids)
+
+
+# --- collision handling --------------------------------------------------------
+
+def test_pull_collision_returns_409(client, shared_clone_fixture, local_eval_dir_with_collision):
+    _, project_uuid = shared_clone_fixture
+    resp = _pull(client, project_uuid)
+    assert resp.status_code == 409  # caller retries with {"action": "copy"}
+    body = resp.get_json()
+    assert body["code"] == "PROJECT_EXISTS"
+    assert body["kind"] == "same_uuid"
+
+
+def test_pull_collision_replace_overwrites(client, shared_clone_fixture, local_eval_dir_with_collision):
+    _, project_uuid = shared_clone_fixture
+    existing = local_eval_dir_with_collision / project_uuid
+    (existing / "old-marker.txt").write_text("stale", encoding="utf-8")
+
+    resp = _pull(client, project_uuid, action="replace")
+    assert resp.status_code == 200, resp.get_json()
+    body = resp.get_json()
+    assert body["projectId"] == project_uuid
+    assert body["renamed"] is False
+    assert not (existing / "old-marker.txt").exists()
+    info = json.loads((existing / "repository_info.json").read_text())
+    assert info["name"] == "proj-a"
+
+
+def test_pull_collision_copy_creates_new_uuid(client, shared_clone_fixture, local_eval_dir_with_collision):
+    _, project_uuid = shared_clone_fixture
+    resp = _pull(client, project_uuid, action="copy")
+    assert resp.status_code == 200, resp.get_json()
+    body = resp.get_json()
+    assert body["projectId"] != project_uuid
+    assert body["sourceProjectId"] == project_uuid
+    assert body["renamed"] is True
+    # Both the pre-existing local project and the newly copied one exist.
+    assert (local_eval_dir_with_collision / project_uuid).exists()
+    assert (local_eval_dir_with_collision / body["projectId"]).exists()
+
+
+def test_pull_invalid_action_returns_400(client, shared_clone_fixture, local_eval_dir):
+    _, project_uuid = shared_clone_fixture
+    resp = _pull(client, project_uuid, action="nuke")
+    assert resp.status_code == 400
+    assert resp.get_json()["code"] == "INVALID_ACTION"
+
+
+def test_pull_non_string_action_returns_400(client, shared_clone_fixture, local_eval_dir):
+    _, project_uuid = shared_clone_fixture
+    resp = client.post(
+        f"/api/shared/projects/{project_uuid}/pull",
+        json={"action": ["copy"]},
+        headers=_ORIGIN,
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["code"] == "INVALID_ACTION"
+
+
+# --- not-found / validation ------------------------------------------------
+
+def test_pull_project_not_found_in_shared_repo_returns_404(client, shared_clone_fixture, local_eval_dir):
+    resp = _pull(client, "does-not-exist")
+    assert resp.status_code == 404
+
+
+def test_pull_invalid_project_segment_returns_400(client, shared_clone_fixture, local_eval_dir):
+    resp = client.post(
+        "/api/shared/projects/%2e%2e/pull",
+        json={},
+        headers=_ORIGIN,
+    )
+    assert resp.status_code == 400
+
+
+def test_pull_without_body_defaults_to_no_action(client, shared_clone_fixture, local_eval_dir):
+    """A POST with no JSON body at all (not even {}) must not 400/500."""
+    _, project_uuid = shared_clone_fixture
+    resp = client.post(f"/api/shared/projects/{project_uuid}/pull", headers=_ORIGIN)
+    assert resp.status_code in (200, 201), resp.get_json()

--- a/tests/integration/test_shared_parity.py
+++ b/tests/integration/test_shared_parity.py
@@ -102,6 +102,13 @@ def real_project_fixture(tmp_path, monkeypatch):
     (project_dir / "repository_info.json").write_text(
         json.dumps({"name": _PROJECT}), encoding="utf-8",
     )
+    # Project-level scan.json (quick-scan coverage metadata). Publishing must
+    # carry it into the clone (Finding 3) so the dashboard's coverage header
+    # (totalFiles/analyzedFiles, added by _fs_reports._enrich_with_coverage)
+    # is identical on both sides instead of only appearing locally.
+    (project_dir / "scan.json").write_text(
+        json.dumps({"total_files": 42, "code_files": 30}), encoding="utf-8",
+    )
     (run_dir / "status.json").write_text(
         json.dumps({"state": "done", "schema_version": 2}), encoding="utf-8",
     )
@@ -162,6 +169,14 @@ def test_dashboard_parity_local_vs_shared(client, real_project_fixture, shared_c
     local = client.get(f"/api/projects/{_PROJECT}/dashboard?run={_RUN}").get_json()
     shared = client.get(f"/api/shared/projects/{_PROJECT}/dashboard?run={_RUN}").get_json()
     assert shared == local
+
+    # Finding 3: the published clone must carry the project-level scan.json
+    # too, so the coverage header the local dashboard derives from it
+    # (totalFiles) is present and identical on the shared side as well --
+    # not merely absent-on-both-sides, which the blanket equality above
+    # alone wouldn't distinguish from a fixed publish allowlist.
+    assert local["totalFiles"] == 42
+    assert shared["totalFiles"] == 42
 
     # The dismissed R1/a.py:10 finding must not appear on either side.
     dims = {d["dimension"]: d for d in local["dimensions"]}

--- a/tests/integration/test_shared_parity.py
+++ b/tests/integration/test_shared_parity.py
@@ -1,0 +1,190 @@
+"""Parity: a published project must render identically from the shared
+clone as it does from the local evaluations root.
+
+This is the core correctness guarantee of the shared-results feature: the
+same project, run, and dismissal state must produce the SAME numbers
+whether read through /api/projects/... (local reports_dir) or
+/api/shared/projects/... (the shared clone). Any divergence here is a real
+bug in root-threading -- either a missing publish-allowlist file, index
+drift, or score-cache contamination -- and must be fixed at the root, never
+by loosening the assertions below.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from quodeq.api.app import create_app
+from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.writer import EventLogWriter
+from quodeq.services.dismissed import dismiss_finding
+from quodeq.services.shared_publish import publish_project
+from quodeq.services.shared_repo import sync_shared_index
+from quodeq.services.shared_settings import SharedSettings, write_settings
+
+_PROJECT = "proj-a"
+_RUN = "run-1"
+
+# Two findings in Security, one in Reliability. The Security/R1 finding gets
+# dismissed via actions.jsonl so parity covers dismissal-aware scoring on
+# both the violations list and the recomputed score/grade.
+_SECURITY_VIOLATIONS = [
+    dict(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file="a.py", line=10, reason="weak hash", req="R1", severity="high",
+    ),
+    dict(
+        practice_id="P2", verdict="violation", dimension="Security",
+        file="b.py", line=20, reason="sql injection", req="R2", severity="critical",
+    ),
+]
+_RELIABILITY_VIOLATIONS = [
+    dict(
+        practice_id="P3", verdict="violation", dimension="Reliability",
+        file="c.py", line=5, reason="no retry", req="R3", severity="medium",
+    ),
+]
+
+_DISMISSED = {"req": "R1", "file": "a.py", "line": 10}
+
+
+def _eval_json(dimension: str, violations: list[dict]) -> dict:
+    return {
+        "schema_version": 1,
+        "dimension": dimension,
+        "project": _PROJECT,
+        "runId": _RUN,
+        "overallScore": "6.0/10",
+        "overallGrade": "Fair",
+        "principles": [{
+            "name": "Integrity", "score": "6.0/10", "grade": "Fair",
+            "violations": [], "compliance": [],
+        }],
+        "violations": [
+            {
+                "principle": "Integrity", "req": v["req"], "file": v["file"],
+                "line": v["line"], "severity": v["severity"], "reason": v["reason"],
+                "title": v["reason"].title(),
+            }
+            for v in violations
+        ],
+        "compliance": [],
+    }
+
+
+def _make_origin(tmp_path: Path) -> str:
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    return f"file://{origin}"
+
+
+@pytest.fixture()
+def real_project_fixture(tmp_path, monkeypatch):
+    """Build a real project under a temp evaluations root: one completed
+    run with findings across 2 dimensions (via events.jsonl), frozen
+    evaluation/<dim>.json files, evidence, dimensions.json, status.json
+    (state=done), and a project actions.jsonl dismissing one finding.
+
+    Returns the local evaluations root Path.
+    """
+    local_root = tmp_path / "local-evaluations"
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(local_root))
+
+    project_dir = local_root / _PROJECT
+    run_dir = project_dir / _RUN
+
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "evaluation").mkdir(parents=True)
+
+    (project_dir / "repository_info.json").write_text(
+        json.dumps({"name": _PROJECT}), encoding="utf-8",
+    )
+    (run_dir / "status.json").write_text(
+        json.dumps({"state": "done", "schema_version": 2}), encoding="utf-8",
+    )
+    (run_dir / "dimensions.json").write_text("{}", encoding="utf-8")
+    (run_dir / "evidence" / "manifest.json").write_text("{}", encoding="utf-8")
+
+    writer = EventLogWriter(run_dir / "events.jsonl")
+    for violation in (*_SECURITY_VIOLATIONS, *_RELIABILITY_VIOLATIONS):
+        writer.emit(JudgmentCreatedEvent(payload=JudgmentPayload(**violation)))
+
+    (run_dir / "evaluation" / "Security.json").write_text(
+        json.dumps(_eval_json("Security", _SECURITY_VIOLATIONS)), encoding="utf-8",
+    )
+    (run_dir / "evaluation" / "Reliability.json").write_text(
+        json.dumps(_eval_json("Reliability", _RELIABILITY_VIOLATIONS)), encoding="utf-8",
+    )
+
+    dismiss_finding(project_dir, _DISMISSED)
+
+    return local_root
+
+
+@pytest.fixture()
+def shared_clone_fixture(tmp_path, monkeypatch, real_project_fixture):
+    """Publish real_project_fixture into a bare origin, clone it as the
+    shared repo, and sync its index -- same recipe as
+    tests/services/test_shared_repo.py::test_readable_and_index_sync_on_published_clone
+    and tests/api/test_routes_shared_read.py::shared_clone_fixture.
+    """
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "tester")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "t@t")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "tester")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "t@t")
+
+    url = _make_origin(tmp_path)
+    publish_project(_PROJECT, url, evaluations_root=real_project_fixture)
+    sync_shared_index(url)
+    write_settings(SharedSettings(url=url))
+    return url
+
+
+@pytest.fixture()
+def client():
+    app = create_app(test_config={"TESTING": True})
+    with app.test_client() as c:
+        yield c
+
+
+def test_dashboard_parity_local_vs_shared(client, real_project_fixture, shared_clone_fixture):
+    """Publish a fixture project, then compare local vs shared responses.
+
+    No field-level normalization is needed here: neither payload encodes the
+    evaluations root path (dashboard/scores/violations carry project-relative
+    data -- run ids, dimension names, file/line/req identities -- never an
+    absolute reports_dir/eval_root string), so a plain equality check is the
+    real assertion, not a stand-in for one that had to be loosened.
+    """
+    local = client.get(f"/api/projects/{_PROJECT}/dashboard?run={_RUN}").get_json()
+    shared = client.get(f"/api/shared/projects/{_PROJECT}/dashboard?run={_RUN}").get_json()
+    assert shared == local
+
+    # The dismissed R1/a.py:10 finding must not appear on either side.
+    dims = {d["dimension"]: d for d in local["dimensions"]}
+    security_reqs = {v["req"] for v in dims["Security"]["violations"]}
+    assert "R1" not in security_reqs
+    assert "R2" in security_reqs
+
+
+def test_scores_parity_local_vs_shared(client, real_project_fixture, shared_clone_fixture):
+    local_scores = client.get(f"/api/projects/{_PROJECT}/scores").get_json()
+    shared_scores = client.get(f"/api/shared/projects/{_PROJECT}/scores").get_json()
+    assert shared_scores == local_scores
+
+
+def test_violations_parity_local_vs_shared(client, real_project_fixture, shared_clone_fixture):
+    """The dismissal must suppress the same finding on both sides.
+
+    The local route takes run_id as a URL path segment
+    (/runs/<run_id>/violations); the shared mirror takes it as a query
+    param (?run=) -- see the shared-route module docstring for why the
+    two shapes diverge. The response bodies are otherwise identical.
+    """
+    local = client.get(f"/api/projects/{_PROJECT}/runs/{_RUN}/violations").get_json()
+    shared = client.get(f"/api/shared/projects/{_PROJECT}/violations?run={_RUN}").get_json()
+    assert shared == local
+    assert local["total"] == 2  # R2 (Security) + R3 (Reliability); R1 dismissed

--- a/tests/services/test_score_cache_override.py
+++ b/tests/services/test_score_cache_override.py
@@ -1,0 +1,53 @@
+"""Score cache path override for the shared root."""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.services.score_cache import open_score_cache, score_cache_path_override
+
+
+def test_override_redirects_db_path(tmp_path, monkeypatch):
+    override_db = tmp_path / "shared" / "score_cache.db"
+    monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(tmp_path / "index.db"))
+    with score_cache_path_override(override_db):
+        with open_score_cache() as conn:
+            pass
+    assert override_db.exists()
+    # Nothing was written to the default (non-override) location.
+    assert not (tmp_path / "score_cache.db").exists()
+
+
+def test_no_override_uses_default(tmp_path, monkeypatch):
+    # Point the default location into tmp so the test never touches ~/.quodeq.
+    monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(tmp_path / "index.db"))
+    with open_score_cache() as conn:
+        pass
+    assert not (tmp_path / "shared").exists()
+    assert (tmp_path / "score_cache.db").exists()
+
+
+def test_override_restored_after_exception(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(tmp_path / "index.db"))
+    override_db = tmp_path / "shared" / "score_cache.db"
+    with pytest.raises(RuntimeError):
+        with score_cache_path_override(override_db):
+            raise RuntimeError("boom")
+    with open_score_cache() as conn:
+        pass
+    # After the exception, the override must be cleared: the default path
+    # (next to the tmp index db) is used, not the override target.
+    assert (tmp_path / "score_cache.db").exists()
+
+
+def test_nested_override_restores_outer(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(tmp_path / "index.db"))
+    outer_db = tmp_path / "outer" / "score_cache.db"
+    inner_db = tmp_path / "inner" / "score_cache.db"
+    with score_cache_path_override(outer_db):
+        with score_cache_path_override(inner_db):
+            with open_score_cache() as conn:
+                pass
+        assert inner_db.exists()
+        with open_score_cache() as conn:
+            pass
+    assert outer_db.exists()

--- a/tests/services/test_shared_publish.py
+++ b/tests/services/test_shared_publish.py
@@ -13,11 +13,14 @@ from quodeq.services.shared_publish import (
 def _make_run(project_dir: Path, run_id: str, state: str) -> Path:
     run = project_dir / run_id
     (run / "evidence").mkdir(parents=True)
+    (run / "evaluation").mkdir(parents=True)
     (run / "status.json").write_text(json.dumps({"state": state, "schema_version": 2}))
     (run / "dimensions.json").write_text("{}")
     (run / "events.jsonl").write_text('{"event_type":"RUN_STARTED"}\n')
     (run / "evidence" / "manifest.json").write_text("{}")
     (run / "evidence" / "security_evidence.jsonl").write_text("{}\n")
+    (run / "evaluation" / "security.json").write_text('{"dimension":"Security"}')
+    (run / "evaluation" / "reliability_eval.md").write_text("# noise")  # must NOT be copied
     (run / "run.log").write_text("noise")            # must NOT be copied
     (run / "evaluation.db").write_text("derived")     # must NOT be copied
     return run
@@ -43,6 +46,20 @@ def test_copy_run_applies_allowlist(tmp_path):
     assert (dest / "evidence" / "security_evidence.jsonl").exists()
     assert not (dest / "run.log").exists()
     assert not (dest / "evaluation.db").exists()
+
+
+def test_copy_run_copies_evaluation_json_only(tmp_path):
+    """The frozen eval-time per-dimension scores (evaluation/<dim>.json) are the
+    source of truth read_run_data() needs to render a dashboard at all; a
+    published clone without them renders an empty dashboard. Only .json files
+    from evaluation/ are copied -- markdown companions and any other junk in
+    that directory are not source-of-truth and must not be copied."""
+    src = _make_run(tmp_path / "src", "r1", "done")
+    dest = tmp_path / "dest" / "r1"
+    copy_run(src, dest)
+    assert (dest / "evaluation" / "security.json").exists()
+    assert (dest / "evaluation" / "security.json").read_text() == '{"dimension":"Security"}'
+    assert not (dest / "evaluation" / "reliability_eval.md").exists()
 
 
 def test_merge_actions_log_unions_and_sorts(tmp_path):

--- a/tests/services/test_shared_publish.py
+++ b/tests/services/test_shared_publish.py
@@ -97,6 +97,32 @@ def test_stage_project_copies_info_actions_and_done_runs(tmp_path):
     assert not (dest / "r-live").exists()
 
 
+def test_stage_project_copies_scan_json_when_present(tmp_path):
+    """Finding 3 regression: _fs_reports._enrich_with_coverage and the
+    project-card coverage reader consume <project>/scan.json (totalFiles
+    etc.); stage_project's allowlist previously dropped it, so a published
+    clone's dashboard/card never showed coverage data."""
+    project = tmp_path / "local" / "proj-uuid"
+    project.mkdir(parents=True)
+    (project / "repository_info.json").write_text('{"name":"x"}')
+    (project / "scan.json").write_text(json.dumps({"total_files": 42, "code_files": 30}))
+    _make_run(project, "r-done", "done")
+    dest = tmp_path / "clone" / "evaluations" / "proj-uuid"
+    stage_project(project, dest)
+    assert (dest / "scan.json").exists()
+    assert json.loads((dest / "scan.json").read_text()) == {"total_files": 42, "code_files": 30}
+
+
+def test_stage_project_leaves_scan_json_absent_when_source_has_none(tmp_path):
+    project = tmp_path / "local" / "proj-uuid"
+    project.mkdir(parents=True)
+    (project / "repository_info.json").write_text('{"name":"x"}')
+    _make_run(project, "r-done", "done")
+    dest = tmp_path / "clone" / "evaluations" / "proj-uuid"
+    stage_project(project, dest)
+    assert not (dest / "scan.json").exists()
+
+
 def test_list_completed_runs_skips_unsupported_schema_version(tmp_path):
     """A run with schema_version > supported should be skipped, not crash."""
     run = tmp_path / "r-unsupported"

--- a/tests/services/test_shared_repo.py
+++ b/tests/services/test_shared_repo.py
@@ -1,7 +1,10 @@
 """Tests for shared repo clone management."""
+import json
 import subprocess
 import time
 from pathlib import Path
+
+import pytest
 
 from quodeq.services.shared_repo import (
     FORMAT_NAME,
@@ -10,10 +13,14 @@ from quodeq.services.shared_repo import (
     bootstrap_repo_layout,
     check_repo_format,
     ensure_shared_clone,
+    published_meta,
+    read_state,
     refresh_shared_clone,
     run_git,
     shared_cache_dir,
+    shared_index_db_path,
     shared_repo_path,
+    sync_shared_index,
 )
 
 
@@ -194,3 +201,32 @@ def test_run_git_does_not_hang_on_credential_prompt(tmp_path):
 
     assert elapsed < 5  # never hit the timeout path
     assert isinstance(ok, bool)
+
+
+def test_readable_and_index_sync_on_published_clone(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    # build a real published origin using the Phase 1 publish path
+    from quodeq.services.shared_publish import publish_project
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    url = f"file://{origin}"
+    root = tmp_path / "evaluations"
+    project = root / "proj-a"
+    run = project / "run-1"
+    (run / "evidence").mkdir(parents=True)
+    (project / "repository_info.json").write_text('{"name":"demo"}')
+    (run / "status.json").write_text(json.dumps({"state": "done", "schema_version": 2}))
+    (run / "dimensions.json").write_text("{}")
+    (run / "events.jsonl").write_text("{}\n")
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "anna")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "a@a")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "anna")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "a@a")
+    publish_project("proj-a", url, evaluations_root=root)
+
+    assert read_state(url) == "ok"
+    sync_shared_index(url)
+    assert shared_index_db_path(url).exists()
+    meta = published_meta(url)
+    assert meta["proj-a"]["publishedBy"] == "anna"
+    assert meta["proj-a"]["publishedAt"] > 0

--- a/tests/services/test_shared_repo.py
+++ b/tests/services/test_shared_repo.py
@@ -4,8 +4,6 @@ import subprocess
 import time
 from pathlib import Path
 
-import pytest
-
 from quodeq.services.shared_repo import (
     FORMAT_NAME,
     MARKER_FILENAME,
@@ -230,3 +228,97 @@ def test_readable_and_index_sync_on_published_clone(tmp_path, monkeypatch):
     meta = published_meta(url)
     assert meta["proj-a"]["publishedBy"] == "anna"
     assert meta["proj-a"]["publishedAt"] > 0
+
+
+def test_published_meta_author_name_with_pipe(tmp_path, monkeypatch):
+    """Test that author names containing pipes are correctly parsed."""
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    from quodeq.services.shared_publish import publish_project
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    url = f"file://{origin}"
+    root = tmp_path / "evaluations"
+    project = root / "proj-pipe"
+    run = project / "run-1"
+    (run / "evidence").mkdir(parents=True)
+    (project / "repository_info.json").write_text('{"name":"demo"}')
+    (run / "status.json").write_text(json.dumps({"state": "done", "schema_version": 2}))
+    (run / "dimensions.json").write_text("{}")
+    (run / "events.jsonl").write_text("{}\n")
+    # Author name with pipe character
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Jane | Marketing")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "jane@example.com")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Jane | Marketing")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "jane@example.com")
+    publish_project("proj-pipe", url, evaluations_root=root)
+
+    meta = published_meta(url)
+    assert "proj-pipe" in meta
+    assert meta["proj-pipe"]["publishedBy"] == "Jane | Marketing"
+    assert isinstance(meta["proj-pipe"]["publishedAt"], int)
+    assert meta["proj-pipe"]["publishedAt"] > 0
+
+
+def test_read_state_missing_clone(tmp_path, monkeypatch):
+    """read_state returns 'missing' when clone does not exist."""
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    url = "file:///nonexistent/repo.git"
+    assert read_state(url) == "missing"
+
+
+def test_read_state_unsupported_version(tmp_path, monkeypatch):
+    """read_state returns 'unsupported_version' when quodeq.json has version > FORMAT_VERSION."""
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    url = "file:///dummy/url"
+    repo = shared_repo_path(url, {"QUODEQ_CACHE_ROOT": str(tmp_path / "cache")})
+    repo.mkdir(parents=True)
+    (repo / ".git").mkdir()
+    (repo / MARKER_FILENAME).write_text(
+        json.dumps({"format": FORMAT_NAME, "version": 99}), encoding="utf-8"
+    )
+    assert read_state(url) == "unsupported_version"
+
+
+def test_read_state_foreign_with_evaluations_dir_ok(tmp_path, monkeypatch):
+    """read_state returns 'ok' when evaluations/ dir exists even if format is foreign."""
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    url = "file:///dummy/url"
+    repo = shared_repo_path(url, {"QUODEQ_CACHE_ROOT": str(tmp_path / "cache")})
+    repo.mkdir(parents=True)
+    (repo / ".git").mkdir()
+    (repo / "README.md").write_text("Some other project")
+    (repo / "evaluations").mkdir()
+    assert read_state(url) == "ok"
+
+
+def test_published_meta_skips_uncommitted_project_dir(tmp_path, monkeypatch):
+    """published_meta skips a project dir with no committed history."""
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    from quodeq.services.shared_publish import publish_project
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    url = f"file://{origin}"
+    root = tmp_path / "evaluations"
+
+    # Create and publish proj-committed
+    project_committed = root / "proj-committed"
+    run = project_committed / "run-1"
+    (run / "evidence").mkdir(parents=True)
+    (project_committed / "repository_info.json").write_text('{"name":"demo"}')
+    (run / "status.json").write_text(json.dumps({"state": "done", "schema_version": 2}))
+    (run / "dimensions.json").write_text("{}")
+    (run / "events.jsonl").write_text("{}\n")
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "alice")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "a@a")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "alice")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "a@a")
+    publish_project("proj-committed", url, evaluations_root=root)
+
+    # Create proj-uncommitted dir locally (not committed)
+    project_uncommitted = root / "proj-uncommitted"
+    (project_uncommitted / "run-1").mkdir(parents=True)
+    (project_uncommitted / "repository_info.json").write_text('{"name":"demo"}')
+
+    meta = published_meta(url)
+    assert "proj-committed" in meta
+    assert "proj-uncommitted" not in meta

--- a/tests/services/test_shared_repo.py
+++ b/tests/services/test_shared_repo.py
@@ -65,6 +65,49 @@ def test_ensure_clone_and_refresh(tmp_path, monkeypatch):
     assert refresh_shared_clone(url) is True
 
 
+def test_refresh_shared_clone_passes_explicit_timeout_to_both_git_calls(tmp_path, monkeypatch):
+    """Finding 4 regression: refresh_shared_clone must not inherit run_git's
+    300s default -- it's called in-request (GET /api/shared/projects?refresh=1,
+    POST /api/shared/refresh) and a black-holed connection would otherwise
+    hang the request for up to 5 minutes. A tiny explicit *timeout* must
+    reach BOTH the fetch (network) and reset (local) run_git calls."""
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    url = _make_origin(tmp_path)
+    assert ensure_shared_clone(url) is not None
+
+    seen_timeouts: list[int] = []
+    real_run_git = run_git
+
+    def _spy(args, *, cwd=None, timeout=None):
+        seen_timeouts.append(timeout)
+        return real_run_git(args, cwd=cwd, timeout=timeout)
+
+    monkeypatch.setattr("quodeq.services.shared_repo.run_git", _spy)
+
+    assert refresh_shared_clone(url, timeout=7) is True
+    assert seen_timeouts == [7, 7]
+
+
+def test_refresh_shared_clone_default_timeout_is_bounded_not_300s(tmp_path, monkeypatch):
+    """Without an explicit timeout, refresh_shared_clone must still use a
+    short bounded default (not run_git's 300s general-purpose default)."""
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    url = _make_origin(tmp_path)
+    assert ensure_shared_clone(url) is not None
+
+    seen_timeouts: list[int] = []
+    real_run_git = run_git
+
+    def _spy(args, *, cwd=None, timeout=None):
+        seen_timeouts.append(timeout)
+        return real_run_git(args, cwd=cwd, timeout=timeout)
+
+    monkeypatch.setattr("quodeq.services.shared_repo.run_git", _spy)
+
+    assert refresh_shared_clone(url) is True
+    assert seen_timeouts == [30, 30]
+
+
 def test_ensure_clone_bad_url_returns_none(tmp_path, monkeypatch):
     monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
     assert ensure_shared_clone(f"file://{tmp_path}/nonexistent.git") is None


### PR DESCRIPTION
Phase 2 of the online shared evaluations feature (Phase 1: #814).

- GET /api/shared/projects (+info/runs/dashboard/accumulated/scores/dimensions/violations/dismissed/verified mirrors), fed from the shared clone via a _with_shared_root decorator (409 unconfigured / 409 needs-newer-quodeq / 503 not-cloned)
- Per-clone index.db and score_cache.db isolation (contextvar seam; propagated into the listing thread pool with per-task context copies)
- Refresh-on-entry (?refresh=1) with stale flag and a 30s bound on in-request git fetches; published-by/at metadata from git log (pipe-safe parsing)
- Publish allowlist fixes surfaced by parity: evaluation/<dim>.json frozen scores and project-level scan.json now published (spec amended)
- POST /api/shared/projects/<id>/pull materializes a local copy via a pure-code-motion extraction (import_zip_stream) of the hardened import machinery, streaming the zip (no double buffering)
- Shared listing never mutates the clone (onboarding backfill skipped for the shared root)
- Parity integration test: identical project renders byte-identically from local dir and shared clone (dashboard, scores, violations; dismissal-aware; coverage fields included)
- Route-map sweep test enforcing the read-only invariant under /api/shared/*

🤖 Generated with [Claude Code](https://claude.com/claude-code)