### PR TITLE
feat(precedent): semantic matching of dismissed findings

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,13 +10,13 @@
 | `services/` | Business logic: dashboard, accumulated views, dismissals, standards CRUD | core/, data/ (via `services/ports.py`) |
 | `assistant/` | Embedded LLM assistant: sessions, tool registry, provider turn adapters, guard | core/, data/, services/, llm_bridge/ |
 | `api/` | HTTP layer: Flask routes, security, rate limiting | core/, services/, update/, assistant/ |
-| `analysis/` | Evaluation pipeline: AI orchestration, subagents, prompts, MCP | core/, engine/, data/, services/ |
+| `analysis/` | Evaluation pipeline: AI orchestration, subagents, prompts, MCP | core/, engine/, data/, services/, context/ |
 | `dashboard/` | Server/process management: build UI, start API, health checks | services/, api/, update/ |
 | `llm_bridge/` | LLM provider bridge: Ollama, OpenRouter, CLI-tool providers | (not yet covered by import checker) |
 | `terminal/` | Embedded-terminal PTY backends (Unix pty / Windows ConPTY) + manager | core/ |
 | `update/` | Update-notification subsystem (notify-only; never self-replaces the binary) | None |
 | `ci/` | CI integration: report posting, evidence reading, SARIF export | (not yet covered by import checker) |
-| `context/` | Context enrichment: path-role classification, project shape, precedent fingerprinting | (not yet covered by import checker) |
+| `context/` | Context enrichment: path-role classification, project shape, precedent fingerprinting | core/, data/, llm_bridge/ |
 | `ui/` | React + Vite dashboard frontend (npm project, served by the Flask API) | n/a (JavaScript) |
 | `shared/` | Cross-cutting utilities: config, logging, env helpers | None (stdlib only) |
 | `config/` | Configuration: paths, discipline detection, standards fetching | shared/ |
@@ -30,15 +30,16 @@ data/          -> core/
 services/      -> core/, data/ (by convention via services/ports.py)
 assistant/     -> core/, data/, services/, llm_bridge/
 api/           -> core/, services/, update/, assistant/, terminal/
-analysis/      -> core/, engine/, data/, services/
+analysis/      -> core/, engine/, data/, services/, context/
 dashboard/     -> services/, api/, update/
 terminal/      -> core/
 update/        -> (nothing)
+context/       -> core/, data/, llm_bridge/
 ```
 
 Every checked layer may additionally import stdlib plus the cross-cutting
 `shared/` and `config/` packages. Layers not listed (`llm_bridge/`, `ci/`,
-`context/`, `ui/`) are not yet covered by the checker.
+`ui/`) are not yet covered by the checker.
 
 These rules are enforced in CI by `tools/check_imports.py` via `tests/tools/test_import_layers.py`.
 Pre-existing violations are grandfathered in `tools/import_baseline.txt` (a burn-down list: fix

--- a/benchmarks/precedent_golden.py
+++ b/benchmarks/precedent_golden.py
@@ -1,0 +1,97 @@
+"""Golden-set threshold calibration for semantic precedent matching (Phase B).
+
+Dataset: benchmarks/data/precedent_golden.jsonl, one record per line:
+  {"id": "d1", "kind": "dismissal",  "req": "...", "snippet": "..."}
+  {"id": "p1", "kind": "paraphrase", "of": "d1", "req": "...", "snippet": "..."}
+  {"id": "n1", "kind": "negative",   "req": "...", "snippet": "..."}
+Paraphrases should match their dismissal; negatives should match nothing.
+Include scope-level negatives (same file, different requirement).
+
+Usage (needs a running Ollama with the embedding model pulled):
+  uv run python benchmarks/precedent_golden.py
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+_DEFAULT_DATA = Path(__file__).parent / "data" / "precedent_golden.jsonl"
+_DEFAULT_THRESHOLDS = [round(0.70 + i * 0.01, 2) for i in range(26)]  # 0.70..0.95
+
+
+def _unit(vec: list[float]) -> list[float]:
+    norm = math.sqrt(sum(x * x for x in vec))
+    return [x / norm for x in vec] if norm else vec
+
+
+def _cos(a: list[float], b: list[float]) -> float:
+    return sum(x * y for x, y in zip(a, b))
+
+
+def sweep(
+    records: list[dict[str, Any]],
+    embed_record: Callable[[dict[str, Any]], list[float]],
+    thresholds: list[float] = _DEFAULT_THRESHOLDS,
+) -> list[dict[str, Any]]:
+    """For each threshold: TP = paraphrase matches its dismissal's corpus,
+    FP = negative matches any dismissal, FN = paraphrase fails to match."""
+    dismissals = [r for r in records if r["kind"] == "dismissal"]
+    candidates = [r for r in records if r["kind"] != "dismissal"]
+    corpus = {d["id"]: _unit(embed_record(d)) for d in dismissals}
+
+    scored: list[tuple[dict[str, Any], float]] = []
+    for rec in candidates:
+        vec = _unit(embed_record(rec))
+        best = max((_cos(vec, v) for v in corpus.values()), default=-1.0)
+        scored.append((rec, best))
+
+    rows = []
+    for thr in thresholds:
+        tp = sum(1 for rec, s in scored if rec["kind"] == "paraphrase" and s >= thr)
+        fn = sum(1 for rec, s in scored if rec["kind"] == "paraphrase" and s < thr)
+        fp = sum(1 for rec, s in scored if rec["kind"] == "negative" and s >= thr)
+        precision = tp / (tp + fp) if tp + fp else 1.0
+        recall = tp / (tp + fn) if tp + fn else 0.0
+        rows.append({"threshold": thr, "tp": tp, "fp": fp, "fn": fn,
+                     "precision": round(precision, 3), "recall": round(recall, 3)})
+    return rows
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data", type=Path, default=_DEFAULT_DATA)
+    args = parser.parse_args(argv)
+    if not args.data.is_file():
+        print(f"No golden set at {args.data} — build it in Phase B (see docstring).")
+        return 1
+
+    from quodeq.context.precedent import precedent_text
+    from quodeq.llm_bridge._embeddings import BATCH_TIMEOUT, embed_texts
+    from quodeq.shared._env import get_embedding_base_url, get_embedding_model
+
+    records = [
+        json.loads(line)
+        for line in args.data.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    model = get_embedding_model()
+    base = get_embedding_base_url()
+    texts = [precedent_text(r["req"], r["snippet"]) or "" for r in records]
+    vectors = embed_texts(texts, model=model, base_url=base, timeout=BATCH_TIMEOUT)
+    by_id = {r["id"]: v for r, v in zip(records, vectors)}
+
+    rows = sweep(records, lambda rec: by_id[rec["id"]])
+    print(f"model={model} records={len(records)}")
+    print(f"{'thr':>5} {'tp':>4} {'fp':>4} {'fn':>4} {'precision':>10} {'recall':>7}")
+    for row in rows:
+        print(f"{row['threshold']:>5} {row['tp']:>4} {row['fp']:>4} "
+              f"{row['fn']:>4} {row['precision']:>10} {row['recall']:>7}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/precedent_golden.py
+++ b/benchmarks/precedent_golden.py
@@ -9,6 +9,10 @@ Include scope-level negatives (same file, different requirement).
 
 Usage (needs a running Ollama with the embedding model pulled):
   uv run python benchmarks/precedent_golden.py
+
+Standalone script, deliberately NOT part of the quodeq_bench package: that
+package is the accuracy-benchmark harness, while this is a one-off Phase B
+calibration CLI for the precedent similarity threshold.
 """
 from __future__ import annotations
 

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -33,7 +33,7 @@ from quodeq.analysis.mcp.router import CompiledContext, FindingsRouter
 
 if TYPE_CHECKING:
     from quodeq.analysis._types import RunConfig
-from quodeq.context.precedent import load_precedent_fingerprints
+from quodeq.context.precedent import load_precedent_corpus, load_precedent_fingerprints
 from quodeq.context.project_shape import detect_shape
 from quodeq.core.standards.refs import load_compiled_requirements
 from quodeq.core.standards.refs import load_compiled_refs
@@ -378,6 +378,7 @@ def _build_router_context(
     dimension: str | None,
     work_dir: Path | None,
     project_dir: Path | None,
+    run_dir: Path | None,
 ) -> CompiledContext | None:
     """Build the CompiledContext that FindingsRouter needs for enrichment.
 
@@ -391,6 +392,10 @@ def _build_router_context(
         compiled_reqs = load_compiled_requirements(compiled_dir, dimension) or {}
         project_shape = detect_shape(work_dir) if work_dir is not None else None
         precedents = load_precedent_fingerprints(project_dir) if project_dir else set()
+        corpus = (
+            load_precedent_corpus(project_dir, run_dir)
+            if project_dir and run_dir else None
+        )
         return CompiledContext(
             compiled_refs=compiled_refs,
             compiled_reqs=compiled_reqs,
@@ -398,6 +403,7 @@ def _build_router_context(
             work_dir=work_dir,
             project_shape=project_shape,
             precedent_fingerprints=precedents,
+            precedent_corpus=corpus,
         )
     except Exception as exc:
         _log.warning("Could not build enrichment context: %s -- writing raw", exc)
@@ -476,10 +482,13 @@ def run_api_analysis(
     _infer_end_line(findings)
 
     # jsonl_file is `<project_dir>/<run_id>/evidence/<dim>_evidence.jsonl`,
-    # so the project directory is its great-grandparent. Used by the
-    # context-enricher pipeline to load prior dismissals as precedents.
+    # so the project directory is its great-grandparent and the run
+    # directory its grandparent. Used by the context-enricher pipeline to
+    # load prior dismissals as precedents (fingerprints and, when the
+    # semantic-precedents flag is on, the embedded corpus).
     project_dir = jsonl_file.parent.parent.parent if jsonl_file else None
-    ctx = _build_router_context(compiled_dir, dimension, work_dir, project_dir)
+    run_dir = jsonl_file.parent.parent if jsonl_file else None
+    ctx = _build_router_context(compiled_dir, dimension, work_dir, project_dir, run_dir)
 
     _log.debug(
         "API runner: %d findings, lossy=%s, marking %d file(s) as %s",

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -384,6 +384,9 @@ def _build_router_context(
 
     Returns ``None`` when *compiled_dir* is unset, signalling that the
     caller should write findings without enrichment (legacy behaviour).
+
+    *run_dir* locates the run directory holding the semantic precedent
+    corpus's circuit-breaker marker (see ``load_precedent_corpus``).
     """
     if not compiled_dir:
         return None

--- a/src/quodeq/analysis/mcp/enricher.py
+++ b/src/quodeq/analysis/mcp/enricher.py
@@ -15,7 +15,11 @@ from quodeq.analysis.mcp.enrichment import enrich_code
 from quodeq.analysis.mcp.provenance_gate import apply_provenance_gate
 from quodeq.analysis.mcp.ref_scoring import select_best_refs
 from quodeq.context.path_role import NON_PROD_ROLES, path_role
-from quodeq.context.precedent import fingerprint as _precedent_fingerprint
+from quodeq.context.precedent import (
+    PrecedentCorpus,
+    fingerprint as _precedent_fingerprint,
+    precedent_text as _precedent_text,
+)
 from quodeq.context.project_shape import Deployment, ProjectShape
 
 _logger = logging.getLogger(__name__)
@@ -58,6 +62,7 @@ class CompiledContext:
     work_dir: Path | None = None
     project_shape: ProjectShape | None = None
     precedent_fingerprints: set[str] = field(default_factory=set)
+    precedent_corpus: PrecedentCorpus | None = None
 
 
 def _apply_path_role_downweight(finding: dict[str, object]) -> None:
@@ -108,21 +113,54 @@ def _apply_shape_downweight(
         finding["confidence"] = _SHAPE_DOWNWEIGHT
 
 
+def _semantic_eligible(finding: dict[str, object]) -> bool:
+    """Scope-level and empty-snippet findings are excluded from the semantic
+    tier: their enriched snippet is the first ~40 lines of the file regardless
+    of the issue (enrichment.py), so any two scope-level findings on the same
+    file embed near-identical texts and would cross-match across requirements.
+    The exact tier still covers them."""
+    line = finding.get("line")
+    if not isinstance(line, int) or line <= 0:
+        return False
+    if finding.get("scope"):
+        return False
+    snippet = finding.get("snippet")
+    return isinstance(snippet, str) and bool(snippet.strip())
+
+
 def _apply_precedent_downweight(
-    finding: dict[str, object], fingerprints: set[str] | None,
+    finding: dict[str, object],
+    fingerprints: set[str] | None,
+    corpus: PrecedentCorpus | None = None,
 ) -> None:
-    """Drop confidence to ~25 when this finding's fingerprint matches a prior dismissal."""
-    if not fingerprints:
-        return
+    """Drop confidence to ~25 when this finding matches a prior dismissal.
+
+    Tier 1: exact fingerprint (unchanged, SARIF-compatible). Tier 2: semantic
+    similarity via the corpus, only on exact miss and only for eligible
+    findings. Same effect, same guard for both tiers.
+    """
     if finding.get("t") != "violation":
         return
     req = finding.get("req")
     snippet = finding.get("snippet")
-    fp = _precedent_fingerprint(
-        req if isinstance(req, str) else None,
-        snippet if isinstance(snippet, str) else None,
-    )
-    if fp is None or fp not in fingerprints:
+    req_s = req if isinstance(req, str) else None
+    snippet_s = snippet if isinstance(snippet, str) else None
+
+    fp = _precedent_fingerprint(req_s, snippet_s)
+    matched = fp is not None and fingerprints is not None and fp in fingerprints
+
+    if not matched and corpus is not None and _semantic_eligible(finding):
+        text = _precedent_text(req_s, snippet_s)
+        if text is not None:
+            score = corpus.match(text)
+            if score is not None and score >= corpus.threshold:
+                matched = True
+                _logger.debug(
+                    "Semantic precedent match (%.3f) for %s:%s",
+                    score, finding.get("file"), finding.get("line"),
+                )
+
+    if not matched:
         return
     existing = finding.get("confidence")
     if existing is None or existing == 100:
@@ -153,6 +191,7 @@ class FindingEnricher:
         self._work_dir = context.work_dir
         self._project_shape = context.project_shape
         self._precedent_fingerprints = context.precedent_fingerprints
+        self._precedent_corpus = context.precedent_corpus
         self._read_file: Callable[[Path], str] = file_reader or _default_read_file
 
     def dedup_key(self, args: dict) -> tuple:
@@ -202,7 +241,9 @@ class FindingEnricher:
         enrich_code(finding, self._work_dir, self._read_file)
         _apply_path_role_downweight(finding)
         _apply_shape_downweight(finding, self._project_shape)
-        _apply_precedent_downweight(finding, self._precedent_fingerprints)
+        _apply_precedent_downweight(
+            finding, self._precedent_fingerprints, self._precedent_corpus,
+        )
         apply_provenance_gate(finding)  # deterministic critical-severity gate (#639)
 
         return finding

--- a/src/quodeq/analysis/mcp/findings_server.py
+++ b/src/quodeq/analysis/mcp/findings_server.py
@@ -17,7 +17,7 @@ from quodeq.analysis.subagents.file_queue import FileQueue
 from quodeq.analysis.mcp.args import ServerArgs, parse_args
 from quodeq.analysis.mcp.dispatch import read_message, dispatch as _dispatch
 from quodeq.core.standards.refs import load_compiled_refs as _load_compiled_refs
-from quodeq.context.precedent import load_precedent_fingerprints
+from quodeq.context.precedent import load_precedent_corpus, load_precedent_fingerprints
 from quodeq.context.project_shape import detect_shape
 from quodeq.core.standards.refs import load_compiled_requirements as _load_compiled_requirements
 from quodeq.core.standards.overrides import load_project_overrides
@@ -112,6 +112,7 @@ def _build_router(
     run_dir = Path(findings_path).parent.parent
     project_dir = run_dir.parent
     ctx.precedent_fingerprints = load_precedent_fingerprints(project_dir)
+    ctx.precedent_corpus = load_precedent_corpus(project_dir, run_dir)
     from quodeq.core.events.writer import EventLogWriter  # noqa: PLC0415
     event_log = EventLogWriter(run_dir / "events.jsonl")
 

--- a/src/quodeq/context/__init__.py
+++ b/src/quodeq/context/__init__.py
@@ -15,12 +15,19 @@ from quodeq.context.online_cache import (
     wipe_cache,
 )
 from quodeq.context.path_role import NON_PROD_ROLES, Role, path_role
-from quodeq.context.precedent import fingerprint, load_precedent_fingerprints
+from quodeq.context.precedent import (
+    PrecedentCorpus,
+    fingerprint,
+    load_precedent_corpus,
+    load_precedent_fingerprints,
+    precedent_text,
+)
 from quodeq.context.project_shape import Deployment, ProjectShape, detect_shape
 
 __all__ = [
     "Deployment",
     "NON_PROD_ROLES",
+    "PrecedentCorpus",
     "ProjectShape",
     "Role",
     "cache_disabled",
@@ -30,8 +37,10 @@ __all__ = [
     "ensure_clone",
     "fingerprint",
     "is_inside_cache",
+    "load_precedent_corpus",
     "load_precedent_fingerprints",
     "path_role",
+    "precedent_text",
     "repo_path_for_url",
     "wipe_cache",
 ]

--- a/src/quodeq/context/precedent.py
+++ b/src/quodeq/context/precedent.py
@@ -11,15 +11,20 @@ trailing punctuation are normalized so cosmetic edits to surrounding
 code don't break the match. Code identifiers are *not* normalized:
 renaming a variable produces legitimately different code.
 
-The global cross-project precedent corpus (sentence-transformer
-embeddings) is a follow-up; this module ships exact-match only.
+A semantic tier now exists behind the ``QUODEQ_SEMANTIC_PRECEDENTS`` flag
+(off by default): :class:`PrecedentCorpus` embeds dismissed findings and
+scores near-miss matches by cosine similarity, on top of the exact-match
+fingerprint above.
 """
 from __future__ import annotations
 
 import hashlib
 import logging
+import math
 import re
+import time
 from pathlib import Path
+from typing import Callable
 
 _logger = logging.getLogger(__name__)
 
@@ -86,3 +91,250 @@ def load_precedent_fingerprints(project_dir: Path) -> set[str]:
             )
             continue
     return out
+
+
+MARKER_NAME = ".semantic_precedents_off"
+_EMBED_BUDGET_S = 20.0
+_BACKFILL_BUDGET_S = 60.0
+_BACKFILL_CHUNK = 32
+
+EmbedFn = Callable[..., list[list[float]]]
+AvailabilityFn = Callable[[str, str], bool]
+
+
+def precedent_text(req: str | None, snippet: str | None) -> str | None:
+    """Canonical text embedded for a finding -- used on BOTH store and match
+    sides so the comparison is symmetric. None when both parts are blank.
+
+    Note: ``.rstrip()`` on top of ``_normalize_snippet`` mops up the trailing
+    space that punctuation-stripping can leave behind (e.g. "x = 1 ;" ->
+    "x = 1 "); it's applied here rather than in ``_normalize_snippet``
+    itself so ``fingerprint()``'s hash stays byte-for-byte unchanged.
+    """
+    norm = _normalize_snippet(snippet).rstrip()
+    req_part = (req or "").strip()
+    if not req_part and not norm:
+        return None
+    return f"{req_part}\n\n{norm}"
+
+
+def _unit(vec: list[float]) -> list[float] | None:
+    norm = math.sqrt(math.sumprod(vec, vec))
+    if norm == 0.0:
+        return None
+    return [x / norm for x in vec]
+
+
+class PrecedentCorpus:
+    """In-memory dismissed-finding vectors plus the embed capability.
+
+    Owns embedding so the analysis enricher never imports llm_bridge (layer
+    rules). match() is contractually total: it returns a score or None and
+    NEVER raises -- an escaping exception would drop the finding in MCP mode
+    (findings_server dispatch catches-and-drops) or crash the API batch.
+    """
+
+    def __init__(
+        self,
+        *,
+        vectors: list[list[float]],
+        embed: Callable[[list[str]], list[list[float]]],
+        threshold: float,
+        marker_path: Path,
+    ) -> None:
+        self._vectors = [u for v in vectors if (u := _unit(v)) is not None]
+        self._embed = embed
+        self.threshold = threshold
+        self._marker_path = marker_path
+        self._disabled = False
+        self._elapsed = 0.0
+
+    def _trip(self, why: str) -> None:
+        self._disabled = True
+        _logger.warning("Semantic precedent matching disabled for this run: %s", why)
+        try:
+            self._marker_path.touch()
+        except OSError:
+            pass
+
+    def match(self, text: str) -> float | None:
+        """Best cosine similarity of *text* against the corpus, or None."""
+        if self._disabled or not self._vectors:
+            return None
+        try:
+            start = time.monotonic()
+            query = self._embed([text])[0]
+            self._elapsed += time.monotonic() - start
+            q = _unit(query)
+            if q is None:
+                return None
+            best = max(math.sumprod(q, v) for v in self._vectors)
+            if self._elapsed > _EMBED_BUDGET_S:
+                self._trip("cumulative embedding time budget exceeded")
+            return best
+        except Exception as exc:  # noqa: BLE001 -- contractually total
+            self._trip(f"embedding failed: {exc}")
+            return None
+
+
+def _collect_dismissed_texts(project_dir: Path) -> dict[str, str]:
+    """Map fingerprint -> canonical text for every dismissed finding."""
+    out: dict[str, str] = {}
+    if not project_dir or not project_dir.is_dir():
+        return out
+    for run_dir in project_dir.iterdir():
+        if not run_dir.is_dir() or not (run_dir / "evaluation.db").is_file():
+            continue
+        try:
+            from quodeq.data.sqlite.connection import open_evaluation_db  # noqa: PLC0415
+            with open_evaluation_db(run_dir) as conn:
+                for req, snippet in conn.execute(
+                    "SELECT requirement, snippet FROM findings WHERE verdict = 'dismissed'"
+                ):
+                    fp = fingerprint(req, snippet)
+                    text = precedent_text(req, snippet)
+                    if fp is not None and text is not None:
+                        out[fp] = text
+        except Exception as exc:
+            _logger.warning("Could not read dismissed texts from %s: %s", run_dir, exc)
+            continue
+    return out
+
+
+def _resolve_embedding(model: str, base_url: str) -> tuple[EmbedFn, AvailabilityFn, object]:
+    """Build the production embed/availability callables from llm_bridge.
+
+    Split out from load_precedent_corpus because assigning a nested
+    ``def embed_fn(...)`` over a parameter already annotated
+    ``EmbedFn | None`` is a redefinition mypy strict rejects; giving the
+    closure its own function with a fresh return-typed binding avoids that.
+    Returns ``(embed_fn, availability_fn, batch_timeout)`` -- the timeout is
+    the production BATCH_TIMEOUT, used only when the loader explicitly
+    overrides the query-time default for backfill chunks.
+    """
+    from quodeq.llm_bridge._embeddings import (  # noqa: PLC0415
+        BATCH_TIMEOUT,
+        QUERY_TIMEOUT,
+        embed_texts,
+        embedding_model_available,
+    )
+
+    def _embed(texts: list[str], **kw: object) -> list[list[float]]:
+        timeout = kw.get("timeout", QUERY_TIMEOUT)
+        return embed_texts(texts, model=model, base_url=base_url, timeout=timeout)  # type: ignore[arg-type]
+
+    return _embed, embedding_model_available, BATCH_TIMEOUT
+
+
+def load_precedent_corpus(
+    project_dir: Path,
+    run_dir: Path,
+    *,
+    embed_fn: EmbedFn | None = None,
+    availability_fn: AvailabilityFn | None = None,
+) -> "PrecedentCorpus | None":
+    """Build the semantic corpus, or None. NEVER raises (never breaks a scan).
+
+    *embed_fn* / *availability_fn* are test seams; production resolves them
+    from llm_bridge. The run-dir marker file is the cross-process circuit
+    breaker: one process's failure disables the tier for sibling agents,
+    respawns, and per-call API context rebuilds.
+    """
+    from quodeq.shared._env import (  # noqa: PLC0415 -- cross-cutting layer
+        get_embedding_base_url,
+        get_embedding_model,
+        get_precedent_similarity_threshold,
+        semantic_precedents_enabled,
+    )
+
+    if not semantic_precedents_enabled():
+        _logger.debug("Semantic precedents: flag off")
+        return None
+    marker = run_dir / MARKER_NAME
+    try:
+        if marker.exists():
+            _logger.debug("Semantic precedents: circuit marker present")
+            return None
+
+        model = get_embedding_model()
+        base_url = get_embedding_base_url()
+        batch_timeout: object = None
+        if embed_fn is None or availability_fn is None:
+            prod_embed_fn, prod_availability_fn, prod_batch_timeout = _resolve_embedding(
+                model, base_url
+            )
+            if embed_fn is None:
+                embed_fn = prod_embed_fn
+                batch_timeout = prod_batch_timeout
+            if availability_fn is None:
+                availability_fn = prod_availability_fn
+
+        if not availability_fn(model, base_url):
+            _logger.info(
+                "Semantic precedent matching off: model %r not found at %s. "
+                "Pull it with: ollama pull %s", model, base_url, model,
+            )
+            return None
+
+        texts = _collect_dismissed_texts(project_dir)
+        if not texts:
+            _logger.debug("Semantic precedents: no dismissed findings")
+            return None
+
+        from quodeq.data.sqlite.precedent_vectors import (  # noqa: PLC0415
+            insert_vectors,
+            load_vectors,
+            open_vector_store,
+            release_backfill_claim,
+            stored_fingerprints,
+            try_claim_backfill,
+        )
+
+        start = time.monotonic()
+        embedded_new = 0
+        with open_vector_store(project_dir, model) as conn:
+            if conn is None:
+                return None
+            if try_claim_backfill(conn):
+                try:
+                    deadline = time.monotonic() + _BACKFILL_BUDGET_S
+                    while time.monotonic() < deadline:
+                        missing = [fp for fp in texts if fp not in stored_fingerprints(conn)]
+                        if not missing:
+                            break
+                        chunk = missing[:_BACKFILL_CHUNK]
+                        try:
+                            vecs = embed_fn(
+                                [texts[fp] for fp in chunk], timeout=batch_timeout,
+                            )
+                        except Exception as exc:  # noqa: BLE001 -- partial corpus is fine
+                            _logger.warning("Precedent backfill stopped: %s", exc)
+                            break
+                        if not insert_vectors(conn, model, list(zip(chunk, vecs))):
+                            break
+                        embedded_new += len(chunk)
+                finally:
+                    release_backfill_claim(conn)
+            pairs = load_vectors(conn)
+
+        vectors = [vec for fp, vec in pairs if fp in texts]
+        if not vectors:
+            _logger.debug("Semantic precedents: nothing embedded yet")
+            return None
+
+        corpus = PrecedentCorpus(
+            vectors=vectors,
+            embed=lambda ts: embed_fn(ts),
+            threshold=get_precedent_similarity_threshold(),
+            marker_path=marker,
+        )
+        _logger.info(
+            "Semantic precedent corpus: %d vector(s), %d newly embedded, "
+            "model=%s, %dms",
+            len(vectors), embedded_new, model,
+            int((time.monotonic() - start) * 1000),
+        )
+        return corpus
+    except Exception as exc:  # noqa: BLE001 -- never break a scan
+        _logger.warning("Semantic precedent corpus unavailable: %s", exc)
+        return None

--- a/src/quodeq/context/precedent.py
+++ b/src/quodeq/context/precedent.py
@@ -177,8 +177,24 @@ class PrecedentCorpus:
             return None
 
 
+_SEMANTIC_ELIGIBLE_SQL = (
+    "SELECT requirement, snippet FROM findings WHERE verdict = 'dismissed' "
+    "AND (scope IS NULL OR scope = '') "
+    "AND line > 0 "
+    "AND snippet IS NOT NULL AND TRIM(snippet) <> ''"
+)
+
+
 def _collect_dismissed_texts(project_dir: Path) -> dict[str, str]:
-    """Map fingerprint -> canonical text for every dismissed finding."""
+    """Map fingerprint -> canonical text for every dismissed finding.
+
+    Mirrors ``_semantic_eligible`` in ``analysis/mcp/enricher.py`` on the
+    match side: scope-level and empty-snippet/line<=0 dismissals are
+    excluded here too. Without this, a single empty-snippet dismissal
+    (``fingerprint`` text like ``"REQ\\n\\n"``) would cosine-match every
+    future finding filed under that requirement, and corpus/match-side
+    eligibility would be asymmetric.
+    """
     out: dict[str, str] = {}
     if not project_dir or not project_dir.is_dir():
         return out
@@ -188,9 +204,7 @@ def _collect_dismissed_texts(project_dir: Path) -> dict[str, str]:
         try:
             from quodeq.data.sqlite.connection import open_evaluation_db  # noqa: PLC0415
             with open_evaluation_db(run_dir) as conn:
-                for req, snippet in conn.execute(
-                    "SELECT requirement, snippet FROM findings WHERE verdict = 'dismissed'"
-                ):
+                for req, snippet in conn.execute(_SEMANTIC_ELIGIBLE_SQL):
                     fp = fingerprint(req, snippet)
                     text = precedent_text(req, snippet)
                     if fp is not None and text is not None:

--- a/src/quodeq/context/precedent.py
+++ b/src/quodeq/context/precedent.py
@@ -299,7 +299,8 @@ def load_precedent_corpus(
                 try:
                     deadline = time.monotonic() + _BACKFILL_BUDGET_S
                     while time.monotonic() < deadline:
-                        missing = [fp for fp in texts if fp not in stored_fingerprints(conn)]
+                        stored = stored_fingerprints(conn)
+                        missing = [fp for fp in texts if fp not in stored]
                         if not missing:
                             break
                         chunk = missing[:_BACKFILL_CHUNK]

--- a/src/quodeq/data/sqlite/precedent_vectors.py
+++ b/src/quodeq/data/sqlite/precedent_vectors.py
@@ -93,30 +93,47 @@ def open_vector_store(
     """Yield a model-validated connection, or None when the store is unusable.
 
     None means "degrade to no semantic tier this load" — never an exception.
+
+    The setup/probe work (``_init`` / ``_ensure_model``) is fully resolved
+    to a connection (or None) BEFORE the single ``yield`` below runs, and
+    that ``yield`` is not itself wrapped in an ``except sqlite3.DatabaseError``.
+    Previously it was: if the caller's with-body raised a DatabaseError,
+    contextlib.throw() re-raised it into the generator at the yield, which
+    landed back in that same except clause and tried to ``yield None`` a
+    second time -- generators can only yield once per throw(), so Python
+    raised ``RuntimeError("generator didn't stop after throw()")`` instead
+    of letting the caller's original exception propagate, and the
+    connection was never closed. Structuring it this way lets an exception
+    raised in the caller's body propagate untouched, with cleanup still
+    guaranteed by ``finally``.
     """
     path = project_dir / DB_NAME
     conn: sqlite3.Connection | None = None
     try:
-        try:
-            conn = _init(path, busy_timeout_ms)
-        except sqlite3.DatabaseError as exc:
-            if not _is_corruption(exc):
-                _logger.warning("Precedent vector store busy/unreadable: %s", exc)
-                yield None
-                return
+        conn = _init(path, busy_timeout_ms)
+    except sqlite3.DatabaseError as exc:
+        if not _is_corruption(exc):
+            _logger.warning("Precedent vector store busy/unreadable: %s", exc)
+        else:
             _logger.warning("Precedent vector store corrupt; rebuilding: %s", exc)
             try:
                 path.unlink(missing_ok=True)
-            except PermissionError:
-                # Windows: another process holds the file open. Degrade.
-                yield None
-                return
-            conn = _init(path, busy_timeout_ms)
-        _ensure_model(conn, model)
+                conn = _init(path, busy_timeout_ms)
+            except (PermissionError, sqlite3.DatabaseError):
+                # Windows: another process holds the file open, or the
+                # rebuild itself failed. Degrade.
+                conn = None
+
+    if conn is not None:
+        try:
+            _ensure_model(conn, model)
+        except sqlite3.DatabaseError as exc:
+            _logger.warning("Precedent vector store error: %s", exc)
+            conn.close()
+            conn = None
+
+    try:
         yield conn
-    except sqlite3.DatabaseError as exc:
-        _logger.warning("Precedent vector store error: %s", exc)
-        yield None
     finally:
         if conn is not None:
             conn.close()

--- a/src/quodeq/data/sqlite/precedent_vectors.py
+++ b/src/quodeq/data/sqlite/precedent_vectors.py
@@ -1,0 +1,208 @@
+"""Per-project vector store for dismissed-finding embeddings.
+
+Derived, rebuildable state (like index.db / score_cache.db) living at
+``<evaluations_dir>/<project>/precedent_vectors.db`` next to actions.jsonl.
+Deliberately NOT inside evaluation.db: no shared migration chain, no
+SCHEMA_VERSION coupling, and only precedent code ever opens it.
+
+Concurrency: up to N agent processes open this DB at scan start. Rules:
+- busy_timeout is set FIRST (before any other pragma) so contention waits
+  instead of erroring (score_cache sets WAL first — do not copy that).
+- Lock contention degrades (yields None); ONLY genuine corruption rebuilds.
+- All vector writes are INSERT OR IGNORE and re-verify the model stamp
+  inside the same transaction, so mixed-model vectors are never served.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import struct
+import time
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
+
+_logger = logging.getLogger(__name__)
+
+DB_NAME = "precedent_vectors.db"
+_BUSY_TIMEOUT_MS = 5000
+_CLAIM_STALE_S = 120.0
+_CORRUPTION_MARKERS = ("file is not a database", "database disk image is malformed")
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+CREATE TABLE IF NOT EXISTS vectors (
+  fingerprint TEXT PRIMARY KEY,
+  vector BLOB NOT NULL,
+  created_at TEXT NOT NULL
+);
+"""
+
+
+def _is_corruption(exc: sqlite3.DatabaseError) -> bool:
+    msg = str(exc).lower()
+    if any(marker in msg for marker in _CORRUPTION_MARKERS):
+        return True
+    # OperationalError covers locks/timeouts/IO-busy: never treat as corrupt.
+    return not isinstance(exc, sqlite3.OperationalError)
+
+
+def _init(path: Path, busy_timeout_ms: int) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(f"PRAGMA busy_timeout = {busy_timeout_ms}")
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.executescript(_SCHEMA)
+        conn.commit()
+        # Verify write access to detect lock contention early (e.g., in WAL mode).
+        conn.execute("BEGIN")
+        conn.execute("INSERT OR IGNORE INTO meta VALUES ('__placeholder__', '__1')")
+        conn.rollback()
+    except sqlite3.DatabaseError:
+        # Close before re-raising so a rebuild can unlink with no open handle
+        # (Windows raises PermissionError otherwise).
+        conn.close()
+        raise
+    return conn
+
+
+def _ensure_model(conn: sqlite3.Connection, model: str) -> None:
+    row = conn.execute(
+        "SELECT value FROM meta WHERE key = 'embedding_model'"
+    ).fetchone()
+    if row is None:
+        conn.execute(
+            "INSERT OR IGNORE INTO meta VALUES ('embedding_model', ?)", (model,)
+        )
+        conn.commit()
+    elif row[0] != model:
+        _logger.info(
+            "Embedding model changed (%s -> %s): wiping precedent vectors", row[0], model
+        )
+        conn.execute("DELETE FROM vectors")
+        conn.execute("DELETE FROM meta")
+        conn.execute("INSERT INTO meta VALUES ('embedding_model', ?)", (model,))
+        conn.commit()
+
+
+@contextmanager
+def open_vector_store(
+    project_dir: Path, model: str, *, busy_timeout_ms: int = _BUSY_TIMEOUT_MS,
+) -> Iterator[sqlite3.Connection | None]:
+    """Yield a model-validated connection, or None when the store is unusable.
+
+    None means "degrade to no semantic tier this load" — never an exception.
+    """
+    path = project_dir / DB_NAME
+    conn: sqlite3.Connection | None = None
+    try:
+        try:
+            conn = _init(path, busy_timeout_ms)
+        except sqlite3.DatabaseError as exc:
+            if not _is_corruption(exc):
+                _logger.warning("Precedent vector store busy/unreadable: %s", exc)
+                yield None
+                return
+            _logger.warning("Precedent vector store corrupt; rebuilding: %s", exc)
+            try:
+                path.unlink(missing_ok=True)
+            except PermissionError:
+                # Windows: another process holds the file open. Degrade.
+                yield None
+                return
+            conn = _init(path, busy_timeout_ms)
+        _ensure_model(conn, model)
+        yield conn
+    except sqlite3.DatabaseError as exc:
+        _logger.warning("Precedent vector store error: %s", exc)
+        yield None
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+def _pack(vec: list[float]) -> bytes:
+    return struct.pack(f"{len(vec)}f", *vec)
+
+
+def _unpack(blob: bytes) -> list[float]:
+    return list(struct.unpack(f"{len(blob) // 4}f", blob))
+
+
+def stored_fingerprints(conn: sqlite3.Connection) -> set[str]:
+    return {row[0] for row in conn.execute("SELECT fingerprint FROM vectors")}
+
+
+def insert_vectors(
+    conn: sqlite3.Connection, model: str, items: list[tuple[str, list[float]]],
+) -> bool:
+    """INSERT OR IGNORE *items*; abort (False) if the model stamp changed."""
+    if not items:
+        return True
+    dims = len(items[0][1])
+    now = datetime.now(timezone.utc).isoformat()
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            "SELECT value FROM meta WHERE key = 'embedding_model'"
+        ).fetchone()
+        if row is None or row[0] != model:
+            conn.rollback()
+            return False
+        conn.execute("INSERT OR IGNORE INTO meta VALUES ('dims', ?)", (str(dims),))
+        conn.executemany(
+            "INSERT OR IGNORE INTO vectors VALUES (?, ?, ?)",
+            [(fp, _pack(vec), now) for fp, vec in items],
+        )
+        conn.commit()
+        return True
+    except sqlite3.DatabaseError as exc:
+        _logger.warning("Precedent vector insert failed: %s", exc)
+        try:
+            conn.rollback()
+        except sqlite3.DatabaseError:
+            pass
+        return False
+
+
+def load_vectors(conn: sqlite3.Connection) -> list[tuple[str, list[float]]]:
+    """Load all vectors whose byte length matches the stamped dims."""
+    row = conn.execute("SELECT value FROM meta WHERE key = 'dims'").fetchone()
+    if row is None:
+        return []
+    expected = int(row[0]) * 4
+    out: list[tuple[str, list[float]]] = []
+    for fp, blob in conn.execute("SELECT fingerprint, vector FROM vectors"):
+        if len(blob) == expected:
+            out.append((fp, _unpack(blob)))
+    return out
+
+
+def try_claim_backfill(conn: sqlite3.Connection) -> bool:
+    """Advisory single-writer claim for the backfill; stale claims are stolen."""
+    now = time.time()
+    try:
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO meta VALUES ('backfill_claim', ?)", (str(now),)
+        )
+        if cur.rowcount == 1:
+            conn.commit()
+            return True
+        cur = conn.execute(
+            "UPDATE meta SET value = ? WHERE key = 'backfill_claim' "
+            "AND CAST(value AS REAL) < ?",
+            (str(now), now - _CLAIM_STALE_S),
+        )
+        conn.commit()
+        return cur.rowcount == 1
+    except sqlite3.DatabaseError:
+        return False
+
+
+def release_backfill_claim(conn: sqlite3.Connection) -> None:
+    try:
+        conn.execute("DELETE FROM meta WHERE key = 'backfill_claim'")
+        conn.commit()
+    except sqlite3.DatabaseError:
+        pass

--- a/src/quodeq/llm_bridge/__init__.py
+++ b/src/quodeq/llm_bridge/__init__.py
@@ -26,6 +26,11 @@ from quodeq.llm_bridge._omlx import (
     run_concurrency_test as run_omlx_concurrency_test,
 )
 from quodeq.llm_bridge._cloud import check_cloud_connection
+from quodeq.llm_bridge._embeddings import (
+    embed_texts,
+    embedding_model_available,
+    reset_embedding_availability_cache,
+)
 from quodeq.llm_bridge._models import get_known_models
 
 __all__ = [
@@ -44,5 +49,8 @@ __all__ = [
     "list_omlx_models",
     "run_omlx_concurrency_test",
     "check_cloud_connection",
+    "embed_texts",
+    "embedding_model_available",
+    "reset_embedding_availability_cache",
     "get_known_models",
 ]

--- a/src/quodeq/llm_bridge/_embeddings.py
+++ b/src/quodeq/llm_bridge/_embeddings.py
@@ -1,0 +1,114 @@
+"""Embeddings client for OpenAI-compatible local providers (Ollama et al.).
+
+Deliberately separate from the chat clients (analysis/_api_runner.py,
+assistant/adapters/_api.py): embeddings use short timeouts — never the 500s
+chat read budget — and their model/base URL are configured independently of
+the chat provider (CLI providers have no HTTP endpoint; llama.cpp serves one
+model per process). All failures raise; callers own graceful degradation.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Callable, Dict, List, Sequence, Tuple
+
+import httpx
+
+try:
+    import openai
+except ImportError:
+    openai = None  # type: ignore[assignment]
+
+_log = logging.getLogger(__name__)
+
+BATCH_TIMEOUT = httpx.Timeout(connect=10.0, read=60.0, write=30.0, pool=10.0)
+QUERY_TIMEOUT = httpx.Timeout(connect=10.0, read=10.0, write=30.0, pool=10.0)
+
+ClientFactory = Callable[[], Any]
+
+
+def _v1_base(base_url: str) -> str:
+    base = base_url.rstrip("/")
+    return base if base.endswith("/v1") else base + "/v1"
+
+
+def embed_texts(
+    texts: Sequence[str],
+    *,
+    model: str,
+    base_url: str,
+    api_key: str | None = None,
+    timeout: httpx.Timeout | None = None,
+    client_factory: ClientFactory | None = None,
+) -> list[list[float]]:
+    """Embed *texts* in one request, preserving input order.
+
+    Raises on any failure (missing SDK, HTTP error, count mismatch); callers
+    degrade gracefully. *client_factory* is the test seam — tests inject a
+    scripted client instead of patching module internals.
+    """
+    if not texts:
+        return []
+    if client_factory is None:
+        if openai is None:
+            raise RuntimeError("openai package not installed")
+
+        def client_factory() -> Any:
+            return openai.OpenAI(
+                base_url=_v1_base(base_url),
+                api_key=api_key or "ollama",
+                timeout=timeout or BATCH_TIMEOUT,
+                max_retries=0,
+            )
+
+    with client_factory() as client:
+        resp = client.embeddings.create(model=model, input=list(texts))
+    items = sorted(resp.data, key=lambda item: item.index)
+    if len(items) != len(texts):
+        raise RuntimeError(
+            f"embedding count mismatch: sent {len(texts)}, got {len(items)}"
+        )
+    return [list(item.embedding) for item in items]
+
+
+_availability_cache: Dict[Tuple[str, str], bool] = {}
+_availability_lock = threading.Lock()
+
+
+def embedding_model_available(
+    model: str,
+    base_url: str,
+    *,
+    lister: Callable[[str], List[Dict[str, Any]]] | None = None,
+) -> bool:
+    """True when *model* is served at *base_url*. Cached per process.
+
+    Ollama bases are probed via /api/tags (list_ollama_models); non-Ollama
+    OpenAI-compatible bases return True permissively — they fail gracefully
+    at call time. The cache keeps the per-call API path cheap.
+    """
+    key = (model, base_url)
+    with _availability_lock:
+        cached = _availability_cache.get(key)
+    if cached is not None:
+        return cached
+    if lister is None:
+        if "11434" in base_url or "ollama" in base_url.lower():
+            from quodeq.llm_bridge._ollama import list_ollama_models  # noqa: PLC0415
+            lister = list_ollama_models
+        else:
+            with _availability_lock:
+                _availability_cache[key] = True
+            return True
+    names = {m.get("name", "") for m in lister(base_url)}
+    tagged = model if ":" in model else f"{model}:latest"
+    result = model in names or tagged in names
+    with _availability_lock:
+        _availability_cache[key] = result
+    return result
+
+
+def reset_embedding_availability_cache() -> None:
+    """Test hook: clear the per-process availability cache."""
+    with _availability_lock:
+        _availability_cache.clear()

--- a/src/quodeq/llm_bridge/_embeddings.py
+++ b/src/quodeq/llm_bridge/_embeddings.py
@@ -8,9 +8,8 @@ model per process). All failures raise; callers own graceful degradation.
 """
 from __future__ import annotations
 
-import logging
 import threading
-from typing import Any, Callable, Dict, List, Sequence, Tuple
+from typing import Any, Callable, Sequence
 
 import httpx
 
@@ -18,8 +17,6 @@ try:
     import openai
 except ImportError:
     openai = None  # type: ignore[assignment]
-
-_log = logging.getLogger(__name__)
 
 BATCH_TIMEOUT = httpx.Timeout(connect=10.0, read=60.0, write=30.0, pool=10.0)
 QUERY_TIMEOUT = httpx.Timeout(connect=10.0, read=10.0, write=30.0, pool=10.0)
@@ -30,6 +27,20 @@ ClientFactory = Callable[[], Any]
 def _v1_base(base_url: str) -> str:
     base = base_url.rstrip("/")
     return base if base.endswith("/v1") else base + "/v1"
+
+
+def _client_kwargs(
+    base_url: str,
+    api_key: str | None,
+    timeout: httpx.Timeout | None,
+) -> dict[str, Any]:
+    """Build kwargs for openai.OpenAI instantiation (testable without patching)."""
+    return {
+        "base_url": _v1_base(base_url),
+        "api_key": api_key or "ollama",
+        "timeout": timeout or BATCH_TIMEOUT,
+        "max_retries": 0,
+    }
 
 
 def embed_texts(
@@ -54,12 +65,7 @@ def embed_texts(
             raise RuntimeError("openai package not installed")
 
         def client_factory() -> Any:
-            return openai.OpenAI(
-                base_url=_v1_base(base_url),
-                api_key=api_key or "ollama",
-                timeout=timeout or BATCH_TIMEOUT,
-                max_retries=0,
-            )
+            return openai.OpenAI(**_client_kwargs(base_url, api_key, timeout))
 
     with client_factory() as client:
         resp = client.embeddings.create(model=model, input=list(texts))
@@ -71,7 +77,7 @@ def embed_texts(
     return [list(item.embedding) for item in items]
 
 
-_availability_cache: Dict[Tuple[str, str], bool] = {}
+_availability_cache: dict[tuple[str, str], bool] = {}
 _availability_lock = threading.Lock()
 
 
@@ -79,7 +85,7 @@ def embedding_model_available(
     model: str,
     base_url: str,
     *,
-    lister: Callable[[str], List[Dict[str, Any]]] | None = None,
+    lister: Callable[[str], list[dict[str, Any]]] | None = None,
 ) -> bool:
     """True when *model* is served at *base_url*. Cached per process.
 
@@ -93,6 +99,7 @@ def embedding_model_available(
     if cached is not None:
         return cached
     if lister is None:
+        # Narrower than _providers._LOCAL_API_MARKERS on purpose: this gates "/api/tags exists", not "is local" — localhost llama.cpp/omlx must NOT match.
         if "11434" in base_url or "ollama" in base_url.lower():
             from quodeq.llm_bridge._ollama import list_ollama_models  # noqa: PLC0415
             lister = list_ollama_models

--- a/src/quodeq/llm_bridge/_embeddings.py
+++ b/src/quodeq/llm_bridge/_embeddings.py
@@ -99,7 +99,9 @@ def embedding_model_available(
     if cached is not None:
         return cached
     if lister is None:
-        # Narrower than _providers._LOCAL_API_MARKERS on purpose: this gates "/api/tags exists", not "is local" — localhost llama.cpp/omlx must NOT match.
+        # Narrower than _providers._LOCAL_API_MARKERS on purpose: this gates
+        # "/api/tags exists", not "is local" — localhost llama.cpp/omlx must
+        # NOT match.
         if "11434" in base_url or "ollama" in base_url.lower():
             from quodeq.llm_bridge._ollama import list_ollama_models  # noqa: PLC0415
             lister = list_ollama_models

--- a/src/quodeq/shared/_env.py
+++ b/src/quodeq/shared/_env.py
@@ -179,3 +179,55 @@ def sqlite_disabled() -> bool:
     """
     raw = os.environ.get("QUODEQ_DISABLE_SQLITE", "")
     return raw.strip().lower() in _SQLITE_DISABLE_TRUTHY
+
+
+_DEFAULT_EMBEDDING_MODEL = "nomic-embed-text"
+_DEFAULT_EMBEDDING_BASE_URL = "http://localhost:11434"
+_DEFAULT_PRECEDENT_SIMILARITY = 0.85
+
+
+def get_embedding_model(env: dict[str, str] | None = None) -> str:
+    """Embedding model for semantic precedent matching (QUODEQ_EMBEDDING_MODEL).
+
+    Independent of the chat provider: CLI providers have no HTTP endpoint and
+    llama.cpp serves one model per process, so embeddings get their own model.
+    """
+    return (env if env is not None else os.environ).get(
+        "QUODEQ_EMBEDDING_MODEL", _DEFAULT_EMBEDDING_MODEL
+    )
+
+
+def get_embedding_base_url(env: dict[str, str] | None = None) -> str:
+    """Base URL of the embeddings server.
+
+    Resolution: QUODEQ_EMBEDDING_BASE_URL, then OLLAMA_BASE_URL, then localhost.
+    """
+    environ = env if env is not None else os.environ
+    return (
+        environ.get("QUODEQ_EMBEDDING_BASE_URL")
+        or environ.get("OLLAMA_BASE_URL")
+        or _DEFAULT_EMBEDDING_BASE_URL
+    )
+
+
+def semantic_precedents_enabled(env: dict[str, str] | None = None) -> bool:
+    """True when QUODEQ_SEMANTIC_PRECEDENTS is truthy. Default OFF in v1."""
+    environ = env if env is not None else os.environ
+    raw = environ.get("QUODEQ_SEMANTIC_PRECEDENTS", "")
+    return raw.strip().lower() in _SQLITE_DISABLE_TRUTHY
+
+
+def get_precedent_similarity_threshold(env: dict[str, str] | None = None) -> float:
+    """Cosine threshold for a semantic precedent match (QUODEQ_PRECEDENT_SIMILARITY).
+
+    Default 0.85 is a placeholder until Phase B golden-set calibration.
+    Out-of-range or unparsable values fall back to the default.
+    """
+    raw = (env if env is not None else os.environ).get("QUODEQ_PRECEDENT_SIMILARITY", "")
+    try:
+        val = float(raw)
+    except ValueError:
+        return _DEFAULT_PRECEDENT_SIMILARITY
+    if not 0.0 < val <= 1.0:
+        return _DEFAULT_PRECEDENT_SIMILARITY
+    return val

--- a/tests/analysis/mcp/test_finding_enricher.py
+++ b/tests/analysis/mcp/test_finding_enricher.py
@@ -179,6 +179,76 @@ def test_precedent_respects_llm_emitted_confidence() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Semantic precedent tier
+# ---------------------------------------------------------------------------
+
+class _FakeCorpus:
+    def __init__(self, score: float | None, threshold: float = 0.85) -> None:
+        self._score = score
+        self.threshold = threshold
+        self.calls: list[str] = []
+
+    def match(self, text: str) -> float | None:
+        self.calls.append(text)
+        return self._score
+
+
+def _violation_args(**over):
+    args = {
+        "t": "violation", "req": "S-CON-1", "file": "auth.py", "line": 42,
+        "reason": "hardcoded secret", "snippet": "password = 'secret'",
+    }
+    args.update(over)
+    return args
+
+
+def test_semantic_match_downweights_on_exact_miss() -> None:
+    ctx = CompiledContext(precedent_fingerprints=set())
+    ctx.precedent_corpus = _FakeCorpus(score=0.91)
+    enricher = FindingEnricher(ctx, file_reader=lambda p: "")
+    finding = enricher.enrich(_violation_args())
+    assert finding["confidence"] == 25
+
+
+def test_semantic_below_threshold_keeps_confidence() -> None:
+    ctx = CompiledContext(precedent_fingerprints=set())
+    ctx.precedent_corpus = _FakeCorpus(score=0.5)
+    enricher = FindingEnricher(ctx, file_reader=lambda p: "")
+    finding = enricher.enrich(_violation_args())
+    assert "confidence" not in finding or finding["confidence"] == 100
+
+
+def test_semantic_skipped_when_exact_matches() -> None:
+    fp = make_fingerprint("S-CON-1", "password = 'secret'")
+    corpus = _FakeCorpus(score=0.99)
+    ctx = CompiledContext(precedent_fingerprints={fp})
+    ctx.precedent_corpus = corpus
+    enricher = FindingEnricher(ctx, file_reader=lambda p: "")
+    finding = enricher.enrich(_violation_args())
+    assert finding["confidence"] == 25
+    assert corpus.calls == []  # exact tier won; no embed call spent
+
+
+def test_semantic_skips_scope_level_findings() -> None:
+    corpus = _FakeCorpus(score=0.99)
+    ctx = CompiledContext(precedent_fingerprints=set())
+    ctx.precedent_corpus = corpus
+    enricher = FindingEnricher(ctx, file_reader=lambda p: "")
+    enricher.enrich(_violation_args(line=0))
+    enricher.enrich(_violation_args(scope="file"))
+    enricher.enrich(_violation_args(snippet=""))
+    assert corpus.calls == []
+
+
+def test_semantic_none_score_keeps_confidence() -> None:
+    ctx = CompiledContext(precedent_fingerprints=set())
+    ctx.precedent_corpus = _FakeCorpus(score=None)
+    enricher = FindingEnricher(ctx, file_reader=lambda p: "")
+    finding = enricher.enrich(_violation_args())
+    assert "confidence" not in finding or finding["confidence"] == 100
+
+
+# ---------------------------------------------------------------------------
 # dedup_key
 # ---------------------------------------------------------------------------
 

--- a/tests/analysis/mcp/test_finding_enricher.py
+++ b/tests/analysis/mcp/test_finding_enricher.py
@@ -248,6 +248,26 @@ def test_semantic_none_score_keeps_confidence() -> None:
     assert "confidence" not in finding or finding["confidence"] == 100
 
 
+def test_semantic_score_equal_to_threshold_matches() -> None:
+    """The comparison is `score >= threshold`; an exact tie must still match."""
+    ctx = CompiledContext(precedent_fingerprints=set())
+    ctx.precedent_corpus = _FakeCorpus(score=0.85, threshold=0.85)
+    enricher = FindingEnricher(ctx, file_reader=lambda p: "")
+    finding = enricher.enrich(_violation_args())
+    assert finding["confidence"] == 25
+
+
+def test_semantic_respects_llm_emitted_confidence() -> None:
+    """Mirrors test_precedent_respects_llm_emitted_confidence for the exact
+    tier: the downweight guard only fires on None/100, so a pre-set
+    confidence survives a high-scoring semantic match too."""
+    ctx = CompiledContext(precedent_fingerprints=set())
+    ctx.precedent_corpus = _FakeCorpus(score=0.99)
+    enricher = FindingEnricher(ctx, file_reader=lambda p: "")
+    finding = enricher.enrich(_violation_args(confidence=50))
+    assert finding["confidence"] == 50
+
+
 # ---------------------------------------------------------------------------
 # dedup_key
 # ---------------------------------------------------------------------------

--- a/tests/analysis/mcp/test_findings_server.py
+++ b/tests/analysis/mcp/test_findings_server.py
@@ -56,6 +56,65 @@ def test_build_router_loads_precedent_fingerprints_from_project_dir(tmp_path: Pa
     assert fingerprint("S-CON-1", "password = 'secret'") in router._enricher._precedent_fingerprints
 
 
+def test_build_router_sets_corpus_none_when_flag_off(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("QUODEQ_SEMANTIC_PRECEDENTS", raising=False)
+
+    findings_path = tmp_path / "run-1" / "evidence" / "security_evidence.jsonl"
+    findings_path.parent.mkdir(parents=True)
+    ctx = CompiledContext()
+
+    _build_router(io.StringIO(), findings_path, ctx, ServerArgs())
+
+    assert ctx.precedent_corpus is None
+
+
+def test_build_router_degrades_when_flag_on_but_no_embedder(tmp_path: Path, monkeypatch):
+    from quodeq.llm_bridge._embeddings import reset_embedding_availability_cache
+
+    reset_embedding_availability_cache()
+    monkeypatch.setenv("QUODEQ_SEMANTIC_PRECEDENTS", "1")
+    monkeypatch.setenv("QUODEQ_EMBEDDING_BASE_URL", "http://127.0.0.1:1")  # nothing listens
+
+    findings_path = tmp_path / "run-1" / "evidence" / "security_evidence.jsonl"
+    findings_path.parent.mkdir(parents=True)
+    ctx = CompiledContext()
+
+    _build_router(io.StringIO(), findings_path, ctx, ServerArgs())
+
+    assert ctx.precedent_corpus is None
+
+
+def test_build_router_wires_load_precedent_corpus_with_project_and_run_dir(
+    tmp_path: Path, monkeypatch,
+):
+    """Proves `_build_router` actually calls load_precedent_corpus with the
+    resolved (project_dir, run_dir) and stores its return value -- the
+    None-when-flag-off tests above pass trivially against the field default,
+    so this closes that gap."""
+    import quodeq.analysis.mcp.findings_server as findings_server_module
+
+    sentinel = object()
+    calls = []
+
+    def fake_load_precedent_corpus(project_dir, run_dir):
+        calls.append((project_dir, run_dir))
+        return sentinel
+
+    monkeypatch.setattr(
+        findings_server_module, "load_precedent_corpus", fake_load_precedent_corpus,
+    )
+
+    project_dir = tmp_path / "project"
+    findings_path = project_dir / "run-1" / "evidence" / "security_evidence.jsonl"
+    findings_path.parent.mkdir(parents=True)
+    ctx = CompiledContext()
+
+    _build_router(io.StringIO(), findings_path, ctx, ServerArgs())
+
+    assert calls == [(project_dir, project_dir / "run-1")]
+    assert ctx.precedent_corpus is sentinel
+
+
 def test_build_router_emits_findings_to_jsonl_and_event_log(tmp_path: Path):
     findings_path = tmp_path / "run-1" / "evidence" / "timeliness_evidence.jsonl"
     findings_path.parent.mkdir(parents=True)

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -12,6 +12,7 @@ pytest.importorskip("openai", reason="requires the openai SDK")
 
 from quodeq.analysis._api_runner import (
     run_api_analysis, ApiRunnerConfig,
+    _build_router_context,
     _call_api, _parse_findings, _Finding, _FindingType, _Severity, _LOCAL_TIMEOUT,
 )
 
@@ -466,3 +467,55 @@ class TestApiRunnerConfig:
         )
         assert cfg.temperature == 0.0
         assert cfg.max_tokens == 4096
+
+
+class TestBuildRouterContextCorpus:
+    """`_build_router_context` wires precedent_corpus (env-gated, never raises)."""
+
+    def test_corpus_none_when_flag_off(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("QUODEQ_SEMANTIC_PRECEDENTS", raising=False)
+
+        ctx = _build_router_context(
+            tmp_path, "security", None, tmp_path, tmp_path / "run-1",
+        )
+
+        assert ctx is not None
+        assert ctx.precedent_corpus is None
+
+    def test_corpus_degrades_when_flag_on_but_no_embedder(self, tmp_path, monkeypatch):
+        from quodeq.llm_bridge._embeddings import reset_embedding_availability_cache
+
+        reset_embedding_availability_cache()
+        monkeypatch.setenv("QUODEQ_SEMANTIC_PRECEDENTS", "1")
+        monkeypatch.setenv("QUODEQ_EMBEDDING_BASE_URL", "http://127.0.0.1:1")  # nothing listens
+
+        ctx = _build_router_context(
+            tmp_path, "security", None, tmp_path, tmp_path / "run-1",
+        )
+
+        assert ctx is not None
+        assert ctx.precedent_corpus is None
+
+    def test_wires_load_precedent_corpus_with_project_and_run_dir(self, tmp_path, monkeypatch):
+        """Proves `_build_router_context` actually calls load_precedent_corpus
+        with (project_dir, run_dir) and stores its return value -- the
+        None-when-flag-off test above passes trivially against the
+        CompiledContext field default, so this closes that gap."""
+        import quodeq.analysis._api_runner as api_runner_module
+
+        sentinel = object()
+        calls = []
+
+        def fake_load_precedent_corpus(project_dir, run_dir):
+            calls.append((project_dir, run_dir))
+            return sentinel
+
+        monkeypatch.setattr(
+            api_runner_module, "load_precedent_corpus", fake_load_precedent_corpus,
+        )
+
+        run_dir = tmp_path / "run-1"
+        ctx = _build_router_context(tmp_path, "security", None, tmp_path, run_dir)
+
+        assert calls == [(tmp_path, run_dir)]
+        assert ctx.precedent_corpus is sentinel

--- a/tests/analysis/test_api_runner_coverage.py
+++ b/tests/analysis/test_api_runner_coverage.py
@@ -326,14 +326,14 @@ class TestBuildRouterContext:
         """Without a compiled standards dir there is no enrichment context to
         build. Callers fall back to a default-context router (still emits
         markers and writes findings, just no req-ref enrichment)."""
-        assert _build_router_context(None, None, None, None) is None
+        assert _build_router_context(None, None, None, None, None) is None
 
     def test_returns_none_on_load_failure(self):
         """A broken compiled dir must not propagate -- the API runner needs
         to keep writing findings + markers even when enrichment fails."""
         with patch("quodeq.analysis._api_runner.load_compiled_refs",
                    side_effect=OSError("boom")):
-            ctx = _build_router_context(Path("/nonexistent"), "security", None, None)
+            ctx = _build_router_context(Path("/nonexistent"), "security", None, None, None)
         assert ctx is None
 
 

--- a/tests/analysis/test_precedent_golden.py
+++ b/tests/analysis/test_precedent_golden.py
@@ -1,4 +1,6 @@
 """Threshold-sweep logic for the golden-set calibration script."""
+# Flat import: precedent_golden.py is a standalone script on the benchmarks/
+# pythonpath entry, intentionally outside the quodeq_bench harness package.
 from precedent_golden import sweep
 
 

--- a/tests/analysis/test_precedent_golden.py
+++ b/tests/analysis/test_precedent_golden.py
@@ -1,0 +1,22 @@
+"""Threshold-sweep logic for the golden-set calibration script."""
+from precedent_golden import sweep
+
+
+def test_sweep_counts_tp_fp_fn() -> None:
+    # d1 dismissed; p1 paraphrases d1; n1 unrelated.
+    records = [
+        {"id": "d1", "kind": "dismissal", "req": "R1", "snippet": "a"},
+        {"id": "p1", "kind": "paraphrase", "of": "d1", "req": "R1", "snippet": "a'"},
+        {"id": "n1", "kind": "negative", "req": "R9", "snippet": "z"},
+    ]
+    # Hand-crafted vectors: p1 close to d1 (cos ~0.98), n1 orthogonal.
+    vectors = {
+        "d1": [1.0, 0.0],
+        "p1": [0.98, 0.2],
+        "n1": [0.0, 1.0],
+    }
+    rows = sweep(records, lambda rec: vectors[rec["id"]], thresholds=[0.5, 0.99])
+    by_thr = {row["threshold"]: row for row in rows}
+    assert by_thr[0.5] == {"threshold": 0.5, "tp": 1, "fp": 0, "fn": 0,
+                           "precision": 1.0, "recall": 1.0}
+    assert by_thr[0.99]["tp"] == 0 and by_thr[0.99]["fn"] == 1

--- a/tests/context/conftest.py
+++ b/tests/context/conftest.py
@@ -1,0 +1,29 @@
+"""Shared helpers for context-layer tests."""
+from pathlib import Path
+
+from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.writer import EventLogWriter
+from quodeq.data.projection.projector import Projector
+from quodeq.services.dismissed import dismiss_finding
+
+
+def seed_dismissed(
+    project_dir: Path,
+    run_id: str,
+    *,
+    req: str,
+    snippet: str,
+    file: str,
+    line: int,
+) -> Path:
+    """Seed a violation into a run, dismiss it, then project into SQL."""
+    run_dir = project_dir / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    log = run_dir / "events.jsonl"
+    EventLogWriter(log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file=file, line=line, reason="r", req=req, snippet=snippet,
+    )))
+    dismiss_finding(project_dir, {"req": req, "file": file, "line": line})
+    Projector().ensure_projected(log, run_dir, project_dir=project_dir)
+    return run_dir

--- a/tests/context/conftest.py
+++ b/tests/context/conftest.py
@@ -15,14 +15,21 @@ def seed_dismissed(
     snippet: str,
     file: str,
     line: int,
+    scope: str | None = None,
 ) -> Path:
-    """Seed a violation into a run, dismiss it, then project into SQL."""
+    """Seed a violation into a run, dismiss it, then project into SQL.
+
+    *scope* lets a test seed a scope-level finding (excluded from the
+    semantic-precedent tier -- see ``_semantic_eligible`` /
+    ``_collect_dismissed_texts``); defaults to None for a normal,
+    line-level finding.
+    """
     run_dir = project_dir / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
     log = run_dir / "events.jsonl"
     EventLogWriter(log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(
         practice_id="P1", verdict="violation", dimension="Security",
-        file=file, line=line, reason="r", req=req, snippet=snippet,
+        file=file, line=line, reason="r", req=req, snippet=snippet, scope=scope,
     )))
     dismiss_finding(project_dir, {"req": req, "file": file, "line": line})
     Projector().ensure_projected(log, run_dir, project_dir=project_dir)

--- a/tests/context/test_precedent.py
+++ b/tests/context/test_precedent.py
@@ -1,43 +1,7 @@
-import json
 from pathlib import Path
 
-import pytest
-
 from quodeq.context.precedent import fingerprint, load_precedent_fingerprints
-from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
-from quodeq.core.events.writer import EventLogWriter
-from quodeq.data.projection.projector import Projector
-from quodeq.services.dismissed import dismiss_finding
-
-
-# ---------------------------------------------------------------------------
-# Helper
-# ---------------------------------------------------------------------------
-
-
-def _seed_dismissed(
-    project_dir: Path,
-    run_id: str,
-    *,
-    req: str,
-    snippet: str,
-    file: str,
-    line: int,
-) -> Path:
-    """Seed a violation into a run, dismiss it, then project into SQL."""
-    run_dir = project_dir / run_id
-    run_dir.mkdir(parents=True, exist_ok=True)
-    log = run_dir / "events.jsonl"
-    EventLogWriter(log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(
-        practice_id="P1", verdict="violation", dimension="Security",
-        file=file, line=line, reason="r", req=req, snippet=snippet,
-    )))
-    # Dismiss via the new service (writes to actions.jsonl).
-    dismiss_finding(project_dir, {"req": req, "file": file, "line": line})
-    # Project both events.jsonl and actions.jsonl into evaluation.db.
-    Projector().ensure_projected(log, run_dir, project_dir=project_dir)
-    return run_dir
-
+from tests.context.conftest import seed_dismissed
 
 # ---------------------------------------------------------------------------
 # New SQL-based test (was the failing regression)
@@ -48,7 +12,7 @@ def test_load_reads_dismissed_from_sql(tmp_path: Path) -> None:
     """load_precedent_fingerprints must read from SQL, not dismissed.json."""
     project_dir = tmp_path / "project"
     project_dir.mkdir()
-    _seed_dismissed(
+    seed_dismissed(
         project_dir, "r1",
         req="S-CON-1", snippet="password = 'secret'",
         file="auth.py", line=42,
@@ -64,8 +28,8 @@ def test_load_reads_dismissed_from_sql(tmp_path: Path) -> None:
 def test_load_aggregates_across_multiple_runs(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
     project_dir.mkdir()
-    _seed_dismissed(project_dir, "r1", req="R1", snippet="x = 1", file="a.py", line=1)
-    _seed_dismissed(project_dir, "r2", req="R2", snippet="y = 2", file="b.py", line=2)
+    seed_dismissed(project_dir, "r1", req="R1", snippet="x = 1", file="a.py", line=1)
+    seed_dismissed(project_dir, "r2", req="R2", snippet="y = 2", file="b.py", line=2)
 
     out = load_precedent_fingerprints(project_dir)
 
@@ -141,9 +105,9 @@ def test_load_returns_fingerprints_from_sql(tmp_path: Path):
     """Dismissed findings stored in SQL are returned as fingerprints."""
     project_dir = tmp_path / "proj"
     project_dir.mkdir()
-    _seed_dismissed(project_dir, "r1", req="S-CON-1", snippet="password = 'secret'",
+    seed_dismissed(project_dir, "r1", req="S-CON-1", snippet="password = 'secret'",
                     file="x.py", line=1)
-    _seed_dismissed(project_dir, "r2", req="M-MOD-2", snippet="def foo(): pass",
+    seed_dismissed(project_dir, "r2", req="M-MOD-2", snippet="def foo(): pass",
                     file="y.py", line=5)
 
     out = load_precedent_fingerprints(project_dir)
@@ -158,7 +122,7 @@ def test_load_skips_run_dirs_without_db(tmp_path: Path):
     project_dir = tmp_path / "proj"
     (project_dir / "r_no_db").mkdir(parents=True)
     # Only a real dismissed run seeds the expected fingerprint.
-    _seed_dismissed(project_dir, "r_real", req="X", snippet="s", file="f.py", line=1)
+    seed_dismissed(project_dir, "r_real", req="X", snippet="s", file="f.py", line=1)
 
     out = load_precedent_fingerprints(project_dir)
 
@@ -170,7 +134,7 @@ def test_load_skips_findings_with_blank_req_and_snippet(tmp_path: Path):
     project_dir = tmp_path / "proj"
     project_dir.mkdir()
     # Seed a real finding to ensure the DB exists with *some* rows.
-    _seed_dismissed(project_dir, "r1", req="REAL", snippet="code()", file="a.py", line=1)
+    seed_dismissed(project_dir, "r1", req="REAL", snippet="code()", file="a.py", line=1)
 
     out = load_precedent_fingerprints(project_dir)
 

--- a/tests/context/test_precedent_corpus.py
+++ b/tests/context/test_precedent_corpus.py
@@ -117,7 +117,7 @@ def test_loader_model_unavailable_returns_none(tmp_path: Path, monkeypatch) -> N
     ) is None
 
 
-def test_loader_embed_failure_degrades_to_partial(tmp_path: Path, monkeypatch) -> None:
+def test_loader_embed_failure_with_nothing_stored_degrades_to_none(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("QUODEQ_SEMANTIC_PRECEDENTS", "1")
     project_dir = tmp_path / "project"
     project_dir.mkdir()
@@ -134,3 +134,47 @@ def test_loader_embed_failure_degrades_to_partial(tmp_path: Path, monkeypatch) -
         project_dir, run_dir,
         embed_fn=broken_embed, availability_fn=lambda m, b: True,
     ) is None
+
+
+def test_loader_embed_failure_partial_corpus(tmp_path: Path, monkeypatch) -> None:
+    """Seed two findings, embed first chunk successfully, fail on second chunk.
+
+    Verifies the loader returns a partial corpus with at least the first
+    dismissed finding's vector, instead of abandoning the whole tier.
+    """
+    monkeypatch.setenv("QUODEQ_SEMANTIC_PRECEDENTS", "1")
+    monkeypatch.setattr("quodeq.context.precedent._BACKFILL_CHUNK", 1)
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    run_dir = seed_dismissed(
+        project_dir, "r1",
+        req="S-CON-1", snippet="password = 'secret'", file="auth.py", line=42,
+    )
+    seed_dismissed(
+        project_dir, run_dir,
+        req="S-CON-2", snippet="api_key = None", file="db.py", line=7,
+    )
+
+    call_count = [0]
+
+    def stateful_embed(texts, **kwargs):
+        """Succeeds on first call, raises on subsequent calls."""
+        call_count[0] += 1
+        if call_count[0] > 1:
+            raise RuntimeError("server 500")
+        # Return vectors for the requested texts.
+        return [[1.0, 0.0] for _ in texts]
+
+    corpus = load_precedent_corpus(
+        project_dir, run_dir,
+        embed_fn=stateful_embed, availability_fn=lambda m, b: True,
+    )
+
+    # Corpus is not None: partial is better than nothing.
+    assert corpus is not None
+    # Patch the corpus's embed to succeed for matching (backfill failed partway).
+    corpus._embed = lambda texts: [[1.0, 0.0] for _ in texts]
+    # We can match against the first finding (which was embedded before failure).
+    score = corpus.match(precedent_text("S-CON-1", "password = 'secret'"))
+    assert score is not None and score == pytest.approx(1.0)

--- a/tests/context/test_precedent_corpus.py
+++ b/tests/context/test_precedent_corpus.py
@@ -106,6 +106,49 @@ def test_loader_end_to_end_with_fake_embedder(tmp_path: Path, monkeypatch) -> No
     assert calls == []  # backfill had nothing to do
 
 
+def test_loader_excludes_scope_level_and_empty_snippet_dismissals(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Corpus-side eligibility must mirror match-side ``_semantic_eligible``.
+
+    A scope-level (or empty-snippet/line<=0) dismissal must never enter the
+    semantic corpus: its enriched snippet is a whole-file excerpt, so it
+    would cosine-match near everything filed under the same requirement.
+    The exact-fingerprint tier still covers it (see test_precedent.py); only
+    the embedding-backed tier excludes it.
+    """
+    monkeypatch.setenv("QUODEQ_SEMANTIC_PRECEDENTS", "1")
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    run_dir = seed_dismissed(
+        project_dir, "r1",
+        req="S-CON-1", snippet="password = 'secret'", file="auth.py", line=42,
+    )
+    # Scope-level / empty-snippet dismissal under the SAME requirement: if
+    # not excluded corpus-side, its near-blank text would cosine-match
+    # almost anything else filed under "S-CON-1".
+    seed_dismissed(
+        project_dir, "r2",
+        req="S-CON-1", snippet="", file="auth.py", line=0, scope="file",
+    )
+
+    calls: list[int] = []
+
+    def counting_embed(texts, **kwargs):
+        calls.append(len(texts))
+        return [[1.0, 0.0] for _ in texts]
+
+    corpus = load_precedent_corpus(
+        project_dir, run_dir,
+        embed_fn=counting_embed, availability_fn=lambda m, b: True,
+    )
+
+    assert corpus is not None
+    # Exactly one text was ever handed to the embedder: the scope-level /
+    # empty-snippet dismissal never made it into the backfill batch.
+    assert calls == [1]
+
+
 def test_loader_model_unavailable_returns_none(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("QUODEQ_SEMANTIC_PRECEDENTS", "1")
     project_dir = tmp_path / "p"
@@ -139,7 +182,7 @@ def test_loader_embed_failure_with_nothing_stored_degrades_to_none(tmp_path: Pat
 def test_loader_embed_failure_partial_corpus(tmp_path: Path, monkeypatch) -> None:
     """Seed two findings, embed first chunk successfully, fail on second chunk.
 
-    Verifies the loader returns a partial corpus with at least the first
+    Verifies the loader returns a partial corpus with exactly the first
     dismissed finding's vector, instead of abandoning the whole tier.
     """
     monkeypatch.setenv("QUODEQ_SEMANTIC_PRECEDENTS", "1")
@@ -152,14 +195,14 @@ def test_loader_embed_failure_partial_corpus(tmp_path: Path, monkeypatch) -> Non
         req="S-CON-1", snippet="password = 'secret'", file="auth.py", line=42,
     )
     seed_dismissed(
-        project_dir, run_dir,
+        project_dir, "r2",
         req="S-CON-2", snippet="api_key = None", file="db.py", line=7,
     )
 
     call_count = [0]
 
     def stateful_embed(texts, **kwargs):
-        """Succeeds on first call, raises on subsequent calls."""
+        """Succeeds on the first backfill chunk, raises on the second."""
         call_count[0] += 1
         if call_count[0] > 1:
             raise RuntimeError("server 500")
@@ -173,8 +216,25 @@ def test_loader_embed_failure_partial_corpus(tmp_path: Path, monkeypatch) -> Non
 
     # Corpus is not None: partial is better than nothing.
     assert corpus is not None
-    # Patch the corpus's embed to succeed for matching (backfill failed partway).
-    corpus._embed = lambda texts: [[1.0, 0.0] for _ in texts]
-    # We can match against the first finding (which was embedded before failure).
-    score = corpus.match(precedent_text("S-CON-1", "password = 'secret'"))
-    assert score is not None and score == pytest.approx(1.0)
+    # Exactly two backfill attempts: chunk 1 (size 1) succeeded, chunk 2
+    # failed and stopped the loop -- proves the loop didn't retry forever
+    # nor skip straight past the failure.
+    assert call_count[0] == 2
+
+    # Prove exactly one vector was stored (not zero, not both): a second
+    # load with a fully-working embedder should only need to backfill the
+    # one still-missing finding. (No public size accessor exists on
+    # PrecedentCorpus, and reaching into the private `_vectors`/`_embed`
+    # attributes is exactly what this test used to do and was told not to.)
+    second_calls: list[int] = []
+
+    def counting_embed(texts, **kwargs):
+        second_calls.append(len(texts))
+        return [[1.0, 0.0] for _ in texts]
+
+    corpus2 = load_precedent_corpus(
+        project_dir, run_dir,
+        embed_fn=counting_embed, availability_fn=lambda m, b: True,
+    )
+    assert corpus2 is not None
+    assert second_calls == [1]

--- a/tests/context/test_precedent_corpus.py
+++ b/tests/context/test_precedent_corpus.py
@@ -1,0 +1,136 @@
+"""PrecedentCorpus: matching, budgets, circuit breaker, loader degrade paths."""
+import math
+from pathlib import Path
+
+import pytest
+
+from quodeq.context.precedent import (
+    MARKER_NAME,
+    PrecedentCorpus,
+    load_precedent_corpus,
+    precedent_text,
+)
+from tests.context.conftest import seed_dismissed
+
+
+def _unit(vec: list[float]) -> list[float]:
+    n = math.sqrt(sum(x * x for x in vec))
+    return [x / n for x in vec]
+
+
+def _corpus(tmp_path: Path, vectors, embed, threshold=0.85) -> PrecedentCorpus:
+    return PrecedentCorpus(
+        vectors=vectors, embed=embed, threshold=threshold,
+        marker_path=tmp_path / MARKER_NAME,
+    )
+
+
+def test_precedent_text_symmetric_normalization() -> None:
+    assert precedent_text("R-1", "x  =  1 ;") == "R-1\n\nx = 1"
+    assert precedent_text(None, None) is None
+
+
+def test_match_returns_best_cosine(tmp_path: Path) -> None:
+    corpus = _corpus(
+        tmp_path,
+        vectors=[_unit([1.0, 0.0]), _unit([0.0, 1.0])],
+        embed=lambda texts: [[0.9, 0.1]],
+    )
+    score = corpus.match("anything")
+    assert score is not None and score == pytest.approx(0.9939, abs=1e-3)
+
+
+def test_match_error_trips_breaker_and_writes_marker(tmp_path: Path) -> None:
+    def boom(texts):
+        raise RuntimeError("embedder down")
+    corpus = _corpus(tmp_path, vectors=[_unit([1.0, 0.0])], embed=boom)
+    assert corpus.match("t") is None
+    assert (tmp_path / MARKER_NAME).exists()
+    # Subsequent calls short-circuit without calling the embedder.
+    assert corpus.match("t") is None
+
+
+def test_match_dims_mismatch_is_caught(tmp_path: Path) -> None:
+    corpus = _corpus(
+        tmp_path,
+        vectors=[_unit([1.0, 0.0])],
+        embed=lambda texts: [[1.0, 0.0, 0.0]],  # 3 dims vs stored 2
+    )
+    assert corpus.match("t") is None
+    assert (tmp_path / MARKER_NAME).exists()
+
+
+def test_loader_flag_off_returns_none(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("QUODEQ_SEMANTIC_PRECEDENTS", raising=False)
+    assert load_precedent_corpus(tmp_path, tmp_path) is None
+
+
+def test_loader_marker_short_circuits(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("QUODEQ_SEMANTIC_PRECEDENTS", "1")
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / MARKER_NAME).touch()
+    assert load_precedent_corpus(tmp_path, run_dir) is None
+
+
+def test_loader_end_to_end_with_fake_embedder(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("QUODEQ_SEMANTIC_PRECEDENTS", "1")
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    run_dir = seed_dismissed(
+        project_dir, "r1",
+        req="S-CON-1", snippet="password = 'secret'", file="auth.py", line=42,
+    )
+
+    def fake_embed(texts, **kwargs):
+        return [[1.0, 0.0] for _ in texts]
+
+    corpus = load_precedent_corpus(
+        project_dir, run_dir,
+        embed_fn=fake_embed, availability_fn=lambda m, b: True,
+    )
+    assert corpus is not None
+    assert corpus.match(precedent_text("S-CON-1", "password = 'secret'")) == pytest.approx(1.0)
+    # Second load reads vectors from the store without re-embedding.
+    calls: list[int] = []
+
+    def counting_embed(texts, **kwargs):
+        calls.append(len(texts))
+        return [[1.0, 0.0] for _ in texts]
+
+    corpus2 = load_precedent_corpus(
+        project_dir, run_dir,
+        embed_fn=counting_embed, availability_fn=lambda m, b: True,
+    )
+    assert corpus2 is not None
+    assert calls == []  # backfill had nothing to do
+
+
+def test_loader_model_unavailable_returns_none(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("QUODEQ_SEMANTIC_PRECEDENTS", "1")
+    project_dir = tmp_path / "p"
+    project_dir.mkdir()
+    run_dir = project_dir / "r"
+    run_dir.mkdir()
+    assert load_precedent_corpus(
+        project_dir, run_dir, availability_fn=lambda m, b: False,
+    ) is None
+
+
+def test_loader_embed_failure_degrades_to_partial(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("QUODEQ_SEMANTIC_PRECEDENTS", "1")
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    run_dir = seed_dismissed(
+        project_dir, "r1",
+        req="S-CON-1", snippet="password = 'secret'", file="auth.py", line=42,
+    )
+
+    def broken_embed(texts, **kwargs):
+        raise RuntimeError("server 500")
+
+    # Backfill fails -> nothing stored yet -> corpus is None, but NO exception.
+    assert load_precedent_corpus(
+        project_dir, run_dir,
+        embed_fn=broken_embed, availability_fn=lambda m, b: True,
+    ) is None

--- a/tests/data/sqlite/test_precedent_vectors.py
+++ b/tests/data/sqlite/test_precedent_vectors.py
@@ -2,6 +2,8 @@
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 from quodeq.data.sqlite.precedent_vectors import (
     DB_NAME,
     insert_vectors,
@@ -83,3 +85,28 @@ def test_lock_contention_yields_none_and_keeps_file(tmp_path: Path) -> None:
         blocker.close()
     with open_vector_store(tmp_path, "m1") as conn:
         assert stored_fingerprints(conn) == {"fp1"}  # data survived
+
+
+def test_caller_body_database_error_propagates_not_runtime_error(tmp_path: Path) -> None:
+    """A DatabaseError raised INSIDE the with-body must propagate as-is.
+
+    Regression test: open_vector_store used to wrap the whole body
+    (including the `yield conn` itself) in `except sqlite3.DatabaseError:
+    yield None`. contextlib.throw()-ing the caller's exception back into
+    the generator at that yield landed in the same except clause and tried
+    to yield a second time, which Python turns into
+    `RuntimeError("generator didn't stop after throw()")` -- masking the
+    real error and leaking the connection (never reached the `finally`
+    close). The fix keeps `yield` outside any except catching
+    DatabaseError, so the caller's exception propagates untouched.
+    """
+    with pytest.raises(sqlite3.DatabaseError):
+        with open_vector_store(tmp_path, "m1") as conn:
+            assert conn is not None
+            raise sqlite3.DatabaseError("simulated caller-body failure")
+
+    # The connection from the failed `with` was closed (not leaked), and a
+    # fresh open still works normally afterward.
+    with open_vector_store(tmp_path, "m1") as conn:
+        assert conn is not None
+        assert stored_fingerprints(conn) == set()

--- a/tests/data/sqlite/test_precedent_vectors.py
+++ b/tests/data/sqlite/test_precedent_vectors.py
@@ -1,0 +1,85 @@
+"""Vector store: roundtrip, model wipe, dims filter, claims, corruption."""
+import sqlite3
+from pathlib import Path
+
+from quodeq.data.sqlite.precedent_vectors import (
+    DB_NAME,
+    insert_vectors,
+    load_vectors,
+    open_vector_store,
+    release_backfill_claim,
+    stored_fingerprints,
+    try_claim_backfill,
+)
+
+
+def test_roundtrip(tmp_path: Path) -> None:
+    with open_vector_store(tmp_path, "m1") as conn:
+        assert conn is not None
+        assert insert_vectors(conn, "m1", [("fp1", [1.0, 2.0]), ("fp2", [3.0, 4.0])])
+        assert stored_fingerprints(conn) == {"fp1", "fp2"}
+        assert dict(load_vectors(conn)) == {"fp1": [1.0, 2.0], "fp2": [3.0, 4.0]}
+
+
+def test_insert_or_ignore_is_idempotent(tmp_path: Path) -> None:
+    with open_vector_store(tmp_path, "m1") as conn:
+        assert insert_vectors(conn, "m1", [("fp1", [1.0, 0.0])])
+        assert insert_vectors(conn, "m1", [("fp1", [9.0, 9.0])])  # ignored, no error
+        assert dict(load_vectors(conn))["fp1"] == [1.0, 0.0]
+
+
+def test_model_change_wipes(tmp_path: Path) -> None:
+    with open_vector_store(tmp_path, "m1") as conn:
+        insert_vectors(conn, "m1", [("fp1", [1.0, 0.0])])
+    with open_vector_store(tmp_path, "m2") as conn:
+        assert conn is not None
+        assert stored_fingerprints(conn) == set()
+
+
+def test_insert_aborts_if_model_changed_underneath(tmp_path: Path) -> None:
+    with open_vector_store(tmp_path, "m1") as conn:
+        assert insert_vectors(conn, "other-model", [("fp1", [1.0, 0.0])]) is False
+        assert stored_fingerprints(conn) == set()
+
+
+def test_load_discards_dims_mismatch(tmp_path: Path) -> None:
+    with open_vector_store(tmp_path, "m1") as conn:
+        insert_vectors(conn, "m1", [("fp1", [1.0, 2.0])])  # stamps dims=2
+        # Force a bad row past the API to simulate a mixed-space write.
+        conn.execute(
+            "INSERT INTO vectors VALUES ('bad', ?, 'now')", (b"\x00" * 12,)
+        )  # 3 floats
+        conn.commit()
+        assert dict(load_vectors(conn)) == {"fp1": [1.0, 2.0]}
+
+
+def test_backfill_claim_single_winner(tmp_path: Path) -> None:
+    with open_vector_store(tmp_path, "m1") as conn:
+        assert try_claim_backfill(conn) is True
+        assert try_claim_backfill(conn) is False  # already claimed, not stale
+        release_backfill_claim(conn)
+        assert try_claim_backfill(conn) is True
+
+
+def test_corruption_rebuilds(tmp_path: Path) -> None:
+    db = tmp_path / DB_NAME
+    db.write_bytes(b"this is not a sqlite database at all, padding padding")
+    with open_vector_store(tmp_path, "m1") as conn:
+        assert conn is not None  # rebuilt from scratch
+        assert stored_fingerprints(conn) == set()
+
+
+def test_lock_contention_yields_none_and_keeps_file(tmp_path: Path) -> None:
+    with open_vector_store(tmp_path, "m1") as conn:
+        insert_vectors(conn, "m1", [("fp1", [1.0, 0.0])])
+    blocker = sqlite3.connect(tmp_path / DB_NAME)
+    blocker.execute("PRAGMA busy_timeout = 0")
+    blocker.execute("BEGIN EXCLUSIVE")
+    try:
+        with open_vector_store(tmp_path, "m1", busy_timeout_ms=50) as conn:
+            assert conn is None  # degraded, NOT rebuilt
+    finally:
+        blocker.rollback()
+        blocker.close()
+    with open_vector_store(tmp_path, "m1") as conn:
+        assert stored_fingerprints(conn) == {"fp1"}  # data survived

--- a/tests/llm_bridge/test_embeddings.py
+++ b/tests/llm_bridge/test_embeddings.py
@@ -1,0 +1,93 @@
+"""Embeddings client: order preservation, seams, availability cache."""
+from types import SimpleNamespace
+
+import pytest
+
+from quodeq.llm_bridge._embeddings import (
+    BATCH_TIMEOUT,
+    QUERY_TIMEOUT,
+    embed_texts,
+    embedding_model_available,
+    reset_embedding_availability_cache,
+)
+
+
+class _FakeClient:
+    """Scripted OpenAI-style embeddings client (context-manager protocol)."""
+
+    def __init__(self, vectors_by_index: list[list[float]]) -> None:
+        self._vectors = vectors_by_index
+        self.requests: list[dict] = []
+        self.embeddings = SimpleNamespace(create=self._create)
+
+    def _create(self, *, model: str, input: list[str]):  # noqa: A002 - SDK arg name
+        self.requests.append({"model": model, "input": input})
+        # Return items deliberately out of order to prove sorting by index.
+        # Only return embeddings for vectors we have available (allows testing count mismatches).
+        data = [
+            SimpleNamespace(index=i, embedding=self._vectors[i])
+            for i in reversed(range(min(len(input), len(self._vectors))))
+        ]
+        return SimpleNamespace(data=data)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache():
+    reset_embedding_availability_cache()
+    yield
+    reset_embedding_availability_cache()
+
+
+def test_embed_texts_preserves_order() -> None:
+    fake = _FakeClient([[1.0, 0.0], [0.0, 1.0]])
+    out = embed_texts(
+        ["a", "b"], model="m", base_url="http://x", client_factory=lambda: fake,
+    )
+    assert out == [[1.0, 0.0], [0.0, 1.0]]
+    assert fake.requests == [{"model": "m", "input": ["a", "b"]}]
+
+
+def test_embed_texts_empty_input_short_circuits() -> None:
+    def boom():
+        raise AssertionError("factory must not be called for empty input")
+    assert embed_texts([], model="m", base_url="http://x", client_factory=boom) == []
+
+
+def test_embed_texts_count_mismatch_raises() -> None:
+    fake = _FakeClient([[1.0]])
+    with pytest.raises(RuntimeError, match="mismatch"):
+        embed_texts(["a", "b"], model="m", base_url="http://x", client_factory=lambda: fake)
+
+
+def test_availability_uses_lister_and_caches() -> None:
+    calls: list[str] = []
+
+    def lister(base_url: str) -> list[dict]:
+        calls.append(base_url)
+        return [{"name": "nomic-embed-text:latest"}]
+
+    assert embedding_model_available("nomic-embed-text", "http://localhost:11434", lister=lister)
+    assert embedding_model_available("nomic-embed-text", "http://localhost:11434", lister=lister)
+    assert calls == ["http://localhost:11434"]  # second call served from cache
+
+
+def test_availability_missing_model() -> None:
+    def lister(base_url: str) -> list[dict]:
+        return [{"name": "gemma4:26b"}]
+
+    assert not embedding_model_available("nomic-embed-text", "http://localhost:11434", lister=lister)
+
+
+def test_availability_permissive_for_non_ollama_base() -> None:
+    assert embedding_model_available("anything", "http://lan-box:8080")
+
+
+def test_timeout_profiles_are_short() -> None:
+    assert BATCH_TIMEOUT.read == 60.0
+    assert QUERY_TIMEOUT.read == 10.0

--- a/tests/llm_bridge/test_embeddings.py
+++ b/tests/llm_bridge/test_embeddings.py
@@ -6,6 +6,8 @@ import pytest
 from quodeq.llm_bridge._embeddings import (
     BATCH_TIMEOUT,
     QUERY_TIMEOUT,
+    _client_kwargs,
+    _v1_base,
     embed_texts,
     embedding_model_available,
     reset_embedding_availability_cache,
@@ -91,3 +93,20 @@ def test_availability_permissive_for_non_ollama_base() -> None:
 def test_timeout_profiles_are_short() -> None:
     assert BATCH_TIMEOUT.read == 60.0
     assert QUERY_TIMEOUT.read == 10.0
+
+
+def test_v1_base_normalization() -> None:
+    assert _v1_base("http://localhost:11434") == "http://localhost:11434/v1"
+    assert _v1_base("http://localhost:11434/") == "http://localhost:11434/v1"
+    assert _v1_base("http://box:8080/v1") == "http://box:8080/v1"
+
+
+def test_default_client_kwargs() -> None:
+    kwargs = _client_kwargs("http://localhost:11434", None, None)
+    assert kwargs == {
+        "base_url": "http://localhost:11434/v1",
+        "api_key": "ollama",
+        "timeout": BATCH_TIMEOUT,
+        "max_retries": 0,
+    }
+    assert _client_kwargs("http://x", "key", None)["api_key"] == "key"

--- a/tests/shared/test_env_embeddings.py
+++ b/tests/shared/test_env_embeddings.py
@@ -1,0 +1,48 @@
+"""Env accessors for the semantic-precedent embedding configuration."""
+from quodeq.shared._env import (
+    get_embedding_base_url,
+    get_embedding_model,
+    get_precedent_similarity_threshold,
+    semantic_precedents_enabled,
+)
+
+
+def test_embedding_model_default() -> None:
+    assert get_embedding_model(env={}) == "nomic-embed-text"
+
+
+def test_embedding_model_override() -> None:
+    assert get_embedding_model(env={"QUODEQ_EMBEDDING_MODEL": "mxbai-embed-large"}) == "mxbai-embed-large"
+
+
+def test_base_url_default() -> None:
+    assert get_embedding_base_url(env={}) == "http://localhost:11434"
+
+
+def test_base_url_falls_back_to_ollama_base() -> None:
+    assert get_embedding_base_url(env={"OLLAMA_BASE_URL": "http://box:11434"}) == "http://box:11434"
+
+
+def test_base_url_explicit_override_wins() -> None:
+    env = {"OLLAMA_BASE_URL": "http://box:11434", "QUODEQ_EMBEDDING_BASE_URL": "http://other:8080"}
+    assert get_embedding_base_url(env=env) == "http://other:8080"
+
+
+def test_flag_default_off() -> None:
+    assert semantic_precedents_enabled(env={}) is False
+
+
+def test_flag_truthy_values() -> None:
+    for raw in ("1", "true", "YES", " on "):
+        assert semantic_precedents_enabled(env={"QUODEQ_SEMANTIC_PRECEDENTS": raw}) is True
+    assert semantic_precedents_enabled(env={"QUODEQ_SEMANTIC_PRECEDENTS": "0"}) is False
+
+
+def test_threshold_default() -> None:
+    assert get_precedent_similarity_threshold(env={}) == 0.85
+
+
+def test_threshold_override_and_garbage() -> None:
+    assert get_precedent_similarity_threshold(env={"QUODEQ_PRECEDENT_SIMILARITY": "0.9"}) == 0.9
+    assert get_precedent_similarity_threshold(env={"QUODEQ_PRECEDENT_SIMILARITY": "nope"}) == 0.85
+    assert get_precedent_similarity_threshold(env={"QUODEQ_PRECEDENT_SIMILARITY": "7"}) == 0.85

--- a/tests/shared/test_env_embeddings.py
+++ b/tests/shared/test_env_embeddings.py
@@ -46,3 +46,6 @@ def test_threshold_override_and_garbage() -> None:
     assert get_precedent_similarity_threshold(env={"QUODEQ_PRECEDENT_SIMILARITY": "0.9"}) == 0.9
     assert get_precedent_similarity_threshold(env={"QUODEQ_PRECEDENT_SIMILARITY": "nope"}) == 0.85
     assert get_precedent_similarity_threshold(env={"QUODEQ_PRECEDENT_SIMILARITY": "7"}) == 0.85
+    # Boundary: 0.0 is excluded by the `0.0 < val` check, not just non-positive garbage.
+    assert get_precedent_similarity_threshold(env={"QUODEQ_PRECEDENT_SIMILARITY": "0"}) == 0.85
+    assert get_precedent_similarity_threshold(env={"QUODEQ_PRECEDENT_SIMILARITY": "-0.5"}) == 0.85

--- a/tools/check_imports.py
+++ b/tools/check_imports.py
@@ -20,10 +20,13 @@ LAYER_RULES = {
     # Empty rule + the implicit self/cross-cutting allowances keep it a leaf.
     "update": set(),
     "api": {"core", "services", "update", "assistant", "terminal"},
-    "analysis": {"core", "engine", "data", "services"},
+    "analysis": {"core", "engine", "data", "services", "context"},
     "dashboard": {"services", "api", "update"},
     "assistant": {"core", "data", "services", "llm_bridge"},
     "terminal": {"core"},
+    # context/ compiles cross-run knowledge (precedents, project shape) for the
+    # analysis pipeline; llm_bridge access is for the embeddings client only.
+    "context": {"core", "data", "llm_bridge"},
 }
 CROSS_CUTTING = {"shared", "config"}
 IMPORT_RE = re.compile(

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -1,15 +1,6 @@
 # Grandfathered layer-import violations. Do NOT add entries without
 # justification -- the goal is to burn this list down, not grow it.
 # Regenerate intentionally: python tools/check_imports.py --update-baseline
-src/quodeq/analysis/_api_runner.py:36:context
-src/quodeq/analysis/_api_runner.py:37:context
-src/quodeq/analysis/api_prompt_assembly.py:14:context
-src/quodeq/analysis/api_prompt_assembly.py:15:context
-src/quodeq/analysis/mcp/enricher.py:17:context
-src/quodeq/analysis/mcp/enricher.py:18:context
-src/quodeq/analysis/mcp/enricher.py:19:context
-src/quodeq/analysis/mcp/findings_server.py:20:context
-src/quodeq/analysis/mcp/findings_server.py:21:context
 src/quodeq/analysis/subprocess.py:262:llm_bridge
 src/quodeq/api/_evaluation_routes.py:21:analysis
 src/quodeq/api/import_project.py:30:data


### PR DESCRIPTION
## What

Dismissed findings come back at full confidence when the model rewords them, because precedent matching is an exact sha256 of (requirement, normalized snippet). This adds a semantic tier next to the exact one: dismissed findings are embedded (local Ollama, nomic-embed-text by default) and a new finding scoring >= 0.85 cosine against a dismissal gets the same confidence downweight to 25.

Off by default. Enable with `QUODEQ_SEMANTIC_PRECEDENTS=1`. With the flag off the only change to existing behavior is nothing: the exact tier is untouched and `fingerprint()` is byte-for-byte the same, so SARIF partialFingerprints are unaffected.

## How

- `llm_bridge/_embeddings.py`: embeddings client on the OpenAI-compatible `/v1/embeddings` endpoint. Own short timeouts (60s batch, 10s per query), never the 500s chat budget. Injectable seams for tests.
- `data/sqlite/precedent_vectors.py`: per-project vector store next to `actions.jsonl`. Derived and rebuildable. INSERT OR IGNORE writes, advisory backfill claim so only one of the N agent processes embeds, lock contention degrades instead of rebuilding, model change wipes and restamps, dims-mismatched blobs are discarded at load.
- `context/precedent.py`: `PrecedentCorpus` owns the embed callable, so the analysis layer never imports llm_bridge. `match()` never raises. Circuit breaker: on any error or 20s cumulative embed time it disables in process and writes a marker file in the run dir that sibling processes honor. Backfill is chunked (32), budgeted (60s), and serves a partial corpus on failure.
- `analysis/mcp/enricher.py`: exact tier first, semantic only on miss, same constant and guard. Scope-level, line 0, and empty-snippet findings are excluded on both store and match sides (their snippet is the file head and would cross-match across requirements).
- Wired at both router build sites (`findings_server._build_router`, `_api_runner._build_router_context`).
- `tools/check_imports.py`: context/ brought under the checker, analysis to context legalized, baseline shrinks by 9 entries. ARCHITECTURE.md synced.
- `benchmarks/precedent_golden.py`: threshold sweep script for Phase B calibration (golden dataset comes in Phase B).

Config: `QUODEQ_EMBEDDING_MODEL` (default nomic-embed-text), `QUODEQ_EMBEDDING_BASE_URL` (default OLLAMA_BASE_URL or localhost:11434), `QUODEQ_PRECEDENT_SIMILARITY` (default 0.85, placeholder until calibration).

## Testing

- Full suite: 4654 passed, coverage 86.09%. mypy strict clean on the new modules. Import checker green.
- Every degrade path is unit tested with a deterministic fake embedder, no Ollama needed in CI. Concurrency cases covered: racing backfills, lock contention vs corruption, model-change wipe.
- End-to-end smoke against a real Ollama: a reworded dismissed finding drops to confidence 25, an unrelated finding stays untouched.

## Follow-ups before flipping the default on

Tracked in docs/RAG.md, the two that matter most:

- findings_server builds the corpus before answering MCP initialize; a first-ever backfill on a big project can exceed CLI startup timeouts.
- Validate `QUODEQ_EMBEDDING_BASE_URL` with `validate_url_safe` like the other provider clients.

Design spec and plan: docs/superpowers/specs and docs/superpowers/plans, 2026-07-17-semantic-precedent-matching (local docs).