### PR TITLE
fix(ui): show sidebar data tabs for shared projects without a local mirror

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -206,6 +206,23 @@ export function shouldShowEvaluateButton(projectsCount, selectedSource) {
 }
 
 /**
+ * Whether the sidebar's project-data tabs (overview/violations/map/history)
+ * should render. The local signal is the run count from the LOCAL project
+ * list -- which is null/zero for a shared selection with no local mirror, so
+ * gating on it alone hides the tabs for shared projects whose pages all work
+ * (and a colliding local twin's zero runs would hide them just the same).
+ * For 'shared', gate on the resolved sharedProjectInfo instead: the shared
+ * info payload carries no runsCount at all, and a project only appears in
+ * the shared repo once published with runs, so its info resolving is the
+ * "has data to show" signal. Exported (like shouldBounceToEvaluate) so the
+ * source-gating contract is testable without mounting the whole App.
+ */
+export function shouldShowProjectTabs({ selectedSource, hasCurrentProjectRuns, sharedProjectInfo }) {
+  if (selectedSource === 'shared') return !!sharedProjectInfo;
+  return hasCurrentProjectRuns;
+}
+
+/**
  * After the shared repository is disconnected in Settings, a currently
  * 'shared' selection is left pointing at a project that no longer resolves
  * anywhere in the app (its source has no config left) -- the user would be
@@ -851,7 +868,11 @@ export default function App() {
               activeTab={activeTab}
               onNavTab={navTab}
               hasEvaluations={state.projects.length > 0}
-              showProjectTabs={hasCurrentProjectRuns}
+              showProjectTabs={shouldShowProjectTabs({
+                selectedSource: state.selectedSource,
+                hasCurrentProjectRuns,
+                sharedProjectInfo: state.sharedProjectInfo,
+              })}
               selectedSource={state.selectedSource}
               projectInfo={{
                 displayName: resolvedDisplayName,

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
 import {
   buildEvalPrincipal, ROUTE_RENDERERS, isSharedSource, shouldBounceToEvaluate, shouldShowEvaluateButton,
-  resolveSelectionAfterSharedDisconnect, shouldAutoOpenOnboardingWizard,
+  resolveSelectionAfterSharedDisconnect, shouldAutoOpenOnboardingWizard, shouldShowProjectTabs,
 } from './App.jsx';
+import Sidebar from './components/Sidebar.jsx';
 
 // Pins the contract that App.jsx's ``buildEvalPrincipal`` threads the
 // dimension's run id into ``evalPrincipal.runId``. Without it, the dismiss
@@ -226,6 +229,77 @@ describe('shouldAutoOpenOnboardingWizard', () => {
 
   it('does not open while an evaluation is running', () => {
     expect(shouldAutoOpenOnboardingWizard({ ...base, isEvaluating: true })).toBe(false);
+  });
+});
+
+// Sidebar tab gating must be source-aware. hasCurrentProjectRuns is derived
+// from the LOCAL project list, so a shared selection with no local mirror
+// resolves to null info / zero runs and the four project-data tabs vanish
+// even though every one of those pages works for shared projects. The shared
+// signal is the resolved sharedProjectInfo (already fetched at App level by
+// useDashboard): the shared info payload carries no runsCount at all, and a
+// project only appears in the shared repo once published with runs, so
+// presence of its info is the correct "has data to show" signal.
+describe('shouldShowProjectTabs', () => {
+  it('shows tabs for a local project with runs', () => {
+    expect(shouldShowProjectTabs({
+      selectedSource: 'local', hasCurrentProjectRuns: true, sharedProjectInfo: null,
+    })).toBe(true);
+  });
+
+  it('hides tabs for a local project with zero runs', () => {
+    expect(shouldShowProjectTabs({
+      selectedSource: 'local', hasCurrentProjectRuns: false, sharedProjectInfo: null,
+    })).toBe(false);
+  });
+
+  it('shows tabs for a shared selection once its shared info has resolved, ignoring the local run count', () => {
+    expect(shouldShowProjectTabs({
+      selectedSource: 'shared',
+      hasCurrentProjectRuns: false, // no local mirror -> the local signal reads empty
+      sharedProjectInfo: { id: 'team-proj', name: 'team-proj' },
+    })).toBe(true);
+  });
+
+  it('hides tabs for a shared selection while its shared info has not resolved', () => {
+    expect(shouldShowProjectTabs({
+      selectedSource: 'shared', hasCurrentProjectRuns: false, sharedProjectInfo: null,
+    })).toBe(false);
+  });
+
+  it('ignores a colliding local twin\'s shared info for a local selection', () => {
+    // A shared project's id can collide with a local one by design. When the
+    // LOCAL twin is selected, the gate must read the local run count, not the
+    // leftover shared info object.
+    expect(shouldShowProjectTabs({
+      selectedSource: 'local', hasCurrentProjectRuns: false, sharedProjectInfo: { id: 'team-proj' },
+    })).toBe(false);
+  });
+});
+
+describe('Sidebar project-data tabs for a shared-only selection (component)', () => {
+  const DATA_TABS = ['overview', 'violations', 'map', 'history'];
+
+  it('renders all four data tabs when the shared project info has resolved', () => {
+    const show = shouldShowProjectTabs({
+      selectedSource: 'shared',
+      hasCurrentProjectRuns: false, // shared-only: no local mirror
+      sharedProjectInfo: { id: 'team-proj', name: 'team-proj' },
+    });
+    render(<Sidebar activeTab="overview" onNavTab={vi.fn()} selectedSource="shared" showProjectTabs={show} />);
+    for (const tab of DATA_TABS) {
+      expect(screen.getByTitle(tab)).toBeInTheDocument();
+    }
+  });
+
+  it('hides the data tabs while the shared info is still loading', () => {
+    const show = shouldShowProjectTabs({
+      selectedSource: 'shared', hasCurrentProjectRuns: false, sharedProjectInfo: null,
+    });
+    render(<Sidebar activeTab="overview" onNavTab={vi.fn()} selectedSource="shared" showProjectTabs={show} />);
+    for (const tab of DATA_TABS) {
+      expect(screen.queryByTitle(tab)).toBeNull();
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

App.jsx gates the sidebar's project-data tabs (overview / violations / map / history) on `hasCurrentProjectRuns`, which is derived from the LOCAL project list only. Selecting a shared project with no local mirror resolves `selectedProjectInfo` to null, so all four tabs vanish from the sidebar even though every one of those pages works for shared projects (read-only mirrors, #815/#816).

## Fix

New exported `shouldShowProjectTabs({ selectedSource, hasCurrentProjectRuns, sharedProjectInfo })` helper (same pattern as `shouldBounceToEvaluate` / `shouldShowEvaluateButton`):

- `'shared'`: gate on the resolved `sharedProjectInfo`, which useDashboard already fetches at App level for every shared selection. The shared `/info` payload carries no `runsCount` at all, and a project only appears in the shared repo once published with runs, so its info resolving is the correct "has data to show" signal. This also sidesteps the colliding-local-twin case (a local twin with zero runs would hide a shared selection's tabs just the same).
- `'local'`: unchanged, still the local run count.

## Tests

- Unit suite for `shouldShowProjectTabs` (5 cases incl. the colliding-twin one), written first and watched fail.
- Component test rendering `Sidebar` for a shared-only selection: all four data tabs render once shared info resolves, stay hidden while it is loading.
- Full suites green: `npx vitest run` 1133 passed / 162 files, `npm test` 289 passed.

## Verified end to end

Fake shared repo (bare origin + `publish_project` + `sync_shared_index`, isolated `QUODEQ_DIR`/`QUODEQ_CACHE_ROOT`/`QUODEQ_EVALUATIONS_DIR`), API on a scratch port, Vite dev against it. Selecting the shared-only project now renders all four tabs; violations/history navigate and show the shared data with counts; the evaluate item stays hidden for shared.

## Out of scope (flagged separately)

With ZERO local projects, DashboardPage/MapPage/HistoryPage still early-return "No projects yet" for a shared selection (content-side gate on the local list, before any source check). Same bug class, separate surface; spawned as its own task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)