### PR TITLE
fix(ui): repositories online tab click dies on missing handleNavigateReplace

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -223,6 +223,62 @@ export function shouldShowProjectTabs({ selectedSource, hasCurrentProjectRuns, s
 }
 
 /**
+ * Build the `navigation` prop bundle ROUTE_RENDERERS consume. Every
+ * navigation key a route renderer reads MUST be forwarded here -- a route
+ * consuming a key the bundle lacks fails silently at click time (the
+ * handler throws mid-event and the UI just doesn't respond; that's how the
+ * repositories local/online tab flip broke when handleNavigateReplace was
+ * consumed but never forwarded). Exported so producer and consumer can be
+ * pinned together in tests without mounting the whole App.
+ */
+export function buildNavigationBundle({ state, navTab, navStackLength, isEvaluating, showToast, setWizardEntry }) {
+  return {
+    selectedProject: state.selectedProject, selectedSource: state.selectedSource, selectedRun: state.selectedRun, projects: state.projects,
+    projectsLoaded: state.projectsLoaded,
+    loadProjects: state.loadProjects,
+    handleNavigate: state.handleNavigate, handleNavigateReplace: state.handleNavigateReplace, handleRunSelect: state.handleRunSelect,
+    handleProjectChange: state.handleProjectChange, navTab, navStackLength,
+    handleDeleteProject: state.handleDeleteProject, handleExportProject: state.handleExportProject, handleRelocateProject: state.handleRelocateProject, handleImportProject: state.handleImportProject,
+    historySelectedRun: state.historySelectedRun, setHistorySelectedRun: state.setHistorySelectedRun,
+    currentOverviewRun: state.currentOverviewRun, handleRunPrev: state.handleRunPrev, handleRunNext: state.handleRunNext, handleRunLatest: state.handleRunLatest,
+    prefetchHandlers: state.prefetchHandlers,
+    onAddProject: () => {
+      if (isEvaluating) {
+        showToast('An evaluation is in progress. Cancel it before adding a project.');
+        return;
+      }
+      setWizardEntry({ startStep: 'repo-scan', isFirstProject: state.projects.length === 0 });
+    },
+    onImportProject: () => {
+      if (isEvaluating) {
+        showToast('An evaluation is in progress. Cancel it before importing a project.');
+        return;
+      }
+      state.handleImportProject();
+    },
+    onTakeTour: () => {
+      if (isEvaluating) {
+        showToast('An evaluation is in progress. Cancel it before starting the tour.');
+        return;
+      }
+      setWizardEntry({ startStep: 'welcome', isFirstProject: true });
+    },
+    onResumeSetup: (projectId) => {
+      if (isEvaluating) {
+        showToast('An evaluation is in progress. Cancel it before resuming setup.');
+        return;
+      }
+      setWizardEntry({
+        startStep: 'provider',
+        isFirstProject: false,
+        presetProjectId: projectId,
+      });
+    },
+    isEvaluating,
+  };
+}
+
+/**
  * After the shared repository is disconnected in Settings, a currently
  * 'shared' selection is left pointing at a project that no longer resolves
  * anywhere in the app (its source has no config left) -- the user would be
@@ -785,50 +841,10 @@ export default function App() {
       selectedDisplayName: state.selectedDisplayName,
       granularity: state.granularity, onGranularityChange: state.onGranularityChange,
     },
-    navigation: {
-      selectedProject: state.selectedProject, selectedSource: state.selectedSource, selectedRun: state.selectedRun, projects: state.projects,
-      projectsLoaded: state.projectsLoaded,
-      loadProjects: state.loadProjects,
-      handleNavigate: state.handleNavigate, handleRunSelect: state.handleRunSelect,
-      handleProjectChange: state.handleProjectChange, navTab, navStackLength: navStack.length,
-      handleDeleteProject: state.handleDeleteProject, handleExportProject: state.handleExportProject, handleRelocateProject: state.handleRelocateProject, handleImportProject: state.handleImportProject,
-      historySelectedRun: state.historySelectedRun, setHistorySelectedRun: state.setHistorySelectedRun,
-      currentOverviewRun: state.currentOverviewRun, handleRunPrev: state.handleRunPrev, handleRunNext: state.handleRunNext, handleRunLatest: state.handleRunLatest,
-      prefetchHandlers: state.prefetchHandlers,
-      onAddProject: () => {
-        if (isEvaluating) {
-          showToast('An evaluation is in progress. Cancel it before adding a project.');
-          return;
-        }
-        setWizardEntry({ startStep: 'repo-scan', isFirstProject: state.projects.length === 0 });
-      },
-      onImportProject: () => {
-        if (isEvaluating) {
-          showToast('An evaluation is in progress. Cancel it before importing a project.');
-          return;
-        }
-        state.handleImportProject();
-      },
-      onTakeTour: () => {
-        if (isEvaluating) {
-          showToast('An evaluation is in progress. Cancel it before starting the tour.');
-          return;
-        }
-        setWizardEntry({ startStep: 'welcome', isFirstProject: true });
-      },
-      onResumeSetup: (projectId) => {
-        if (isEvaluating) {
-          showToast('An evaluation is in progress. Cancel it before resuming setup.');
-          return;
-        }
-        setWizardEntry({
-          startStep: 'provider',
-          isFirstProject: false,
-          presetProjectId: projectId,
-        });
-      },
-      isEvaluating,
-    },
+    navigation: buildNavigationBundle({
+      state, navTab, navStackLength: navStack.length,
+      isEvaluating, showToast, setWizardEntry,
+    }),
     evaluation: state.evalLifecycle,
     serverHealth: { connected: state.serverConnected, setConnected: state.setServerConnected },
     settings: state.settings,

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom/vitest';
 import {
   buildEvalPrincipal, ROUTE_RENDERERS, isSharedSource, shouldBounceToEvaluate, shouldShowEvaluateButton,
   resolveSelectionAfterSharedDisconnect, shouldAutoOpenOnboardingWizard, shouldShowProjectTabs,
+  buildNavigationBundle,
 } from './App.jsx';
 import Sidebar from './components/Sidebar.jsx';
 
@@ -300,6 +301,51 @@ describe('Sidebar project-data tabs for a shared-only selection (component)', ()
     for (const tab of DATA_TABS) {
       expect(screen.queryByTitle(tab)).toBeNull();
     }
+  });
+});
+
+// PR #819 regression class: a route renderer started consuming a navigation
+// key (handleNavigateReplace) that the bundle App builds never forwarded --
+// the repositories local/online tab click threw "handleNavigateReplace is
+// not a function" and the tab never flipped. The bundle producer is exported
+// as buildNavigationBundle so producer and consumer can be pinned together
+// without mounting the whole App.
+describe('buildNavigationBundle', () => {
+  function stubState() {
+    return {
+      selectedProject: 'p1', selectedSource: 'local', selectedRun: 'latest',
+      projects: [{ id: 'p1', name: 'p1' }], projectsLoaded: true,
+      loadProjects: vi.fn(),
+      handleNavigate: vi.fn(), handleNavigateReplace: vi.fn(), handleRunSelect: vi.fn(),
+      handleProjectChange: vi.fn(),
+      handleDeleteProject: vi.fn(), handleExportProject: vi.fn(),
+      handleRelocateProject: vi.fn(), handleImportProject: vi.fn(),
+      historySelectedRun: 'latest', setHistorySelectedRun: vi.fn(),
+      currentOverviewRun: null, handleRunPrev: vi.fn(), handleRunNext: vi.fn(), handleRunLatest: vi.fn(),
+      prefetchHandlers: {},
+    };
+  }
+  const build = (state) => buildNavigationBundle({
+    state, navTab: vi.fn(), navStackLength: 1,
+    isEvaluating: false, showToast: vi.fn(), setWizardEntry: vi.fn(),
+  });
+
+  it('forwards handleNavigateReplace from state (repositories tab flips die without it)', () => {
+    const state = stubState();
+    const bundle = build(state);
+    bundle.handleNavigateReplace('projects', { sourceTab: 'online' });
+    expect(state.handleNavigateReplace).toHaveBeenCalledWith('projects', { sourceTab: 'online' });
+  });
+
+  it("projects route's onTabChange reaches state.handleNavigateReplace through the real bundle", () => {
+    // Producer x consumer: the element ROUTE_RENDERERS.projects builds must
+    // find every navigation key it consumes in the bundle App actually
+    // provides -- this is the seam the #819 regression slipped through.
+    const state = stubState();
+    const el = ROUTE_RENDERERS.projects({}, { navigation: build(state) });
+    el.props.actions.onTabChange('online');
+    expect(state.handleNavigateReplace).toHaveBeenCalledWith('projects', { sourceTab: 'online' });
+    expect(state.handleNavigate).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Problem

Since #819, pressing the **online** sub-tab on the repositories page does nothing. #819 rewired `onTabChange` to call `props.navigation.handleNavigateReplace`, but the `navigation` prop bundle App builds never forwarded that function from `useAppState` -- the click throws `props.navigation.handleNavigateReplace is not a function` mid-handler (verified live with a window error listener), so the tab never flips. #819's tests covered `useNavStack.navReplace` in isolation; nothing covered the bundle seam.

## Fix

- Forward `handleNavigateReplace` in the navigation bundle (the one-line root-cause fix).
- Extract the bundle into an exported `buildNavigationBundle` (mechanical move of the existing object literal, same pattern as `shouldBounceToEvaluate` etc.) so the producer and the route renderers that consume it can be pinned together without mounting the whole App.

## Tests

- `buildNavigationBundle` forwards `handleNavigateReplace` (written first, watched fail with the exact production symptom).
- Producer x consumer: `ROUTE_RENDERERS.projects`' `onTabChange('online')` driven through the REAL bundle reaches `state.handleNavigateReplace('projects', {sourceTab:'online'})` and never falls back to `handleNavigate` -- this is the seam #819 slipped through.
- Full suites green: `npx vitest run` 1138 passed / 162 files, `npm test` 289 passed.

## Verified in the browser

On the develop tip: reproduced the dead click (local tab stays underlined, TypeError captured). With this fix: online tab activates and lists the shared project, and two local/online flips leave `history.length` unchanged (4 -> 4), preserving #819's no-history-growth intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)