### PR TITLE
fix(ui): shared selections no longer walled by local-list empty states

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -582,24 +582,36 @@ export const ROUTE_RENDERERS = {
   help: () => <HelpPage />,
 };
 
+// The app-level "no local projects" wall in MainContent. Route pages that
+// manage their own empty state (SELF_HANDLED_EMPTY) and the project-free
+// tabs (NO_PROJECT_TABS) are never walled; every other page is walled when
+// the LOCAL projects list is empty. A shared selection is never walled: its
+// data does not live in the local list, and the shared read paths carry
+// their own loading/empty states (teammate persona: zero local projects,
+// drilling from a shared Overview into file/finding/dimension detail).
+// Exported so the source-gating contract is unit-testable without mounting
+// MainContent's route renderers.
+export function shouldWallEmptyProjects({ page, projects, selectedSource }) {
+  if (isSharedSource(selectedSource)) return false;
+  if (NO_PROJECT_TABS.includes(page) || SELF_HANDLED_EMPTY.has(page)) return false;
+  return !projects || projects.length === 0;
+}
+
 /**
  * @param {{ activePage: { page: string }, props: Object }} params
  * @returns {JSX.Element|null}
  */
 function MainContent({ activePage, props }) {
   const { page, ...params } = activePage;
-  if (!NO_PROJECT_TABS.includes(page) && !SELF_HANDLED_EMPTY.has(page)) {
-    const projects = props.navigation?.projects;
-    if (!projects || projects.length === 0) {
-      if (!props.navigation?.projectsLoaded) return <LoadingScreen />;
-      return (
-        <EmptyStateWithTour
-          onAdd={() => props.navigation.onAddProject()}
-          onTour={() => props.navigation.onTakeTour()}
-          isEvaluating={props.navigation.isEvaluating}
-        />
-      );
-    }
+  if (shouldWallEmptyProjects({ page, projects: props.navigation?.projects, selectedSource: props.navigation?.selectedSource })) {
+    if (!props.navigation?.projectsLoaded) return <LoadingScreen />;
+    return (
+      <EmptyStateWithTour
+        onAdd={() => props.navigation.onAddProject()}
+        onTour={() => props.navigation.onTakeTour()}
+        isEvaluating={props.navigation.isEvaluating}
+      />
+    );
   }
   const renderer = ROUTE_RENDERERS[page];
   if (renderer) return renderer(params, props);

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom/vitest';
 import {
   buildEvalPrincipal, ROUTE_RENDERERS, isSharedSource, shouldBounceToEvaluate, shouldShowEvaluateButton,
   resolveSelectionAfterSharedDisconnect, shouldAutoOpenOnboardingWizard, shouldShowProjectTabs,
-  buildNavigationBundle,
+  buildNavigationBundle, shouldWallEmptyProjects,
 } from './App.jsx';
 import Sidebar from './components/Sidebar.jsx';
 
@@ -346,6 +346,32 @@ describe('buildNavigationBundle', () => {
     el.props.actions.onTabChange('online');
     expect(state.handleNavigateReplace).toHaveBeenCalledWith('projects', { sourceTab: 'online' });
     expect(state.handleNavigate).not.toHaveBeenCalled();
+  });
+});
+
+// Teammate persona, one click deeper than the data pages: with zero LOCAL
+// projects, drill-in pages (file/finding/dimension detail...) must not wall
+// a shared selection behind the add-a-project tour. Same gate class as the
+// DashboardPage/MapPage/HistoryPage/ViolationsPage empty-state fixes.
+describe('shouldWallEmptyProjects', () => {
+  it('never walls a shared selection, even with zero local projects', () => {
+    expect(shouldWallEmptyProjects({ page: 'file', projects: [], selectedSource: 'shared' })).toBe(false);
+  });
+
+  it('walls drill-in pages for a local source with zero projects (unchanged)', () => {
+    expect(shouldWallEmptyProjects({ page: 'file', projects: [], selectedSource: 'local' })).toBe(true);
+  });
+
+  it('never walls the self-handled data tabs', () => {
+    expect(shouldWallEmptyProjects({ page: 'overview', projects: [], selectedSource: 'local' })).toBe(false);
+  });
+
+  it('never walls the project-free tabs', () => {
+    expect(shouldWallEmptyProjects({ page: 'projects', projects: [], selectedSource: 'local' })).toBe(false);
+  });
+
+  it('does not wall once local projects exist', () => {
+    expect(shouldWallEmptyProjects({ page: 'file', projects: [{ id: 'p1' }], selectedSource: 'local' })).toBe(false);
   });
 });
 

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -176,7 +176,7 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
 
   const { projectsLoaded } = data;
   if (!projectsLoaded) return <LoadingScreen />;
-  if (projects.length === 0) {
+  if (projects.length === 0 && selectedSource !== 'shared') {
     return (
       <EmptyState
         title="No projects yet"

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -111,6 +111,51 @@ describe('DashboardPage no-completed-evaluation empty state', () => {
   });
 });
 
+// Teammate persona (shared-repo onboarding): a teammate with ZERO local
+// projects selects a shared project. The local-list empty-state gate must not
+// wall off the Overview when the selection is shared -- the shared data loads
+// fine and its own loading/empty states take over. Same gate class already
+// fixed on MapPage/HistoryPage/ViolationsPage.
+describe('DashboardPage, teammate persona: shared selection + zero local projects', () => {
+  const sharedNoLocalData = {
+    projectsLoaded: true,
+    projects: [],
+    selectedProject: 'shared-1',
+    selectedSource: 'shared',
+    sharedProjectInfo: { id: 'shared-1', name: 'shared-1', displayName: 'Shared Repo' },
+    dashboard: {
+      dimensions: [],
+      trend: [],
+      selectedRun: { runId: 'r1', dateLabel: '2026-05-01' },
+    },
+    accumulated: { dimensions: [] },
+    loading: false,
+    isFetching: false,
+    error: null,
+    availableRuns: [{ runId: 'r1', status: 'failed' }],
+  };
+
+  it('shared source with an empty LOCAL projects list renders the shared content path, not the Add-a-project wall', () => {
+    const { getByText, queryByText } = render(
+      <DashboardPage data={sharedNoLocalData} callbacks={{}} runMode={false} />,
+    );
+    expect(queryByText('No projects yet')).toBeNull();
+    expect(queryByText('Add a project')).toBeNull();
+    expect(getByText('no completed evaluation in this shared project yet')).toBeTruthy();
+  });
+
+  it('local source with an empty local projects list still shows the Add-a-project wall (unchanged)', () => {
+    const { getByText } = render(
+      <DashboardPage
+        data={{ ...sharedNoLocalData, selectedSource: 'local', selectedProject: '', sharedProjectInfo: null }}
+        callbacks={{}}
+        runMode={false}
+      />,
+    );
+    expect(getByText('No projects yet')).toBeTruthy();
+  });
+});
+
 // Finding 5 (final whole-branch review): projectInfo for a shared selection
 // must come from the shared-repo fetch (sharedProjectInfo, see useDashboard),
 // never the LOCAL projects list -- a shared selection's id can collide with


### PR DESCRIPTION
## Problem

Teammate-onboarding scenario for the shared-repo feature (#814-#816): a teammate with **zero local projects** connects the shared repo and selects a shared project. Every /api/shared/... request returns 200, but the UI walls them off at local-list empty-state gates that never check the source.

(Rebased on develop after #820, which fixed the third blocker in this flow: the dead repositories online tab.)

## Fixes

1. **Overview (DashboardPage)**: the `projects.length === 0` early return fired before any source check, showing "No projects yet" over a working shared Overview. Now skips the wall when `selectedSource === 'shared'`, matching the gates already fixed on MapPage/HistoryPage/ViolationsPage.

2. **App-level empty wall (MainContent)**: drill-in pages not in `SELF_HANDLED_EMPTY` (file/finding/dimension detail) still showed `EmptyStateWithTour` for a shared selection with zero local projects, one click below the shared Overview. Decision extracted into exported `shouldWallEmptyProjects` (following the `shouldShowProjectTabs` pattern), gated on `isSharedSource`.

## Tests

- TDD: each fix has tests that failed before the change (teammate-persona component tests mirroring MapPage.test.jsx; exported-helper unit tests).
- Full suites green after rebase: `npx vitest run` (1145) and `npm test` (289) from src/quodeq/ui.

## End-to-end verification

Reproduced the full teammate flow in a browser against a real published shared clone (bare origin + publish_project + sync_shared_index, isolated QUODEQ_DIR/QUODEQ_CACHE_ROOT/empty QUODEQ_EVALUATIONS_DIR): boot with zero local projects, repositories > online, select proj-a. Overview renders the shared dashboard (shared read-only chip, published-by, score/violations), dimension drill-in renders, all requests hit /api/shared/* with 200s, no console errors.