### PR TITLE
polish(shared): minors batch from the #814 review

### DIFF
--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -118,13 +118,20 @@ def register_shared_routes(app: Flask) -> None:
     def shared_status() -> Response:
         settings = read_settings()
         synced = last_synced_at(settings.url) if settings.url else None
+        # The wire shape is camelCase throughout; the publish status dict is
+        # a service-internal snake_case structure, so rename at the boundary.
+        publish = get_publish_status()
+        publish["finishedAt"] = publish.pop("finished_at", None)
         return jsonify(
             {
                 "configured": settings.url is not None,
                 "url": settings.url,
                 "lastSynced": synced,
                 "syncing": False,
-                "publish": get_publish_status(),
+                # Reserved for sync-level failures; always present so the UI
+                # can bind to it without existence checks.
+                "error": None,
+                "publish": publish,
             }
         )
 
@@ -174,11 +181,16 @@ def register_shared_routes(app: Flask) -> None:
         settings = read_settings()
         if not settings.url:
             return jsonify({"error": "no shared repository configured"}), 400
-        started = start_publish(
+        outcome = start_publish(
             project, settings.url, evaluations_root=Path(reports_dir())
         )
-        if not started:
+        if outcome == "already_running":
             return jsonify({"error": "a publish is already running"}), 409
+        if outcome != "started":
+            return (
+                jsonify({"error": "could not start the publish job, see server logs"}),
+                500,
+            )
         return jsonify({"started": True}), 202
 
     # -- pull a shared project into local evaluations -----------------------

--- a/src/quodeq/services/shared_publish.py
+++ b/src/quodeq/services/shared_publish.py
@@ -25,6 +25,7 @@ from quodeq.services.shared_repo import (
 )
 from quodeq.shared.dimensions_state import FILENAME as DIMENSIONS_FILENAME
 from quodeq.shared.run_status import STATUS_FILENAME, UnsupportedSchemaError, read_status
+from quodeq.shared.validation import validate_path_segment
 
 logger = logging.getLogger(__name__)
 
@@ -144,6 +145,12 @@ def _app_version() -> str:
 def publish_project(
     project_id: str, url: str, *, evaluations_root: Path, env: dict | None = None
 ) -> int:
+    # The route validates too, but this is the last stop before project_id
+    # becomes a filesystem path and a git pathspec, so guard it here as well.
+    try:
+        validate_path_segment(project_id)
+    except ValueError as exc:
+        raise PublishError(str(exc)) from exc
     project_dir = evaluations_root / project_id
     if not project_dir.is_dir():
         raise PublishError(f"project {project_id} not found in local evaluations")
@@ -280,10 +287,17 @@ def _run_publish(project_id: str, url: str, evaluations_root: Path) -> None:
             _STATUS.update(state="error", error=str(exc), finished_at=time.time())
 
 
-def start_publish(project_id: str, url: str, *, evaluations_root: Path) -> bool:
+def start_publish(project_id: str, url: str, *, evaluations_root: Path) -> str:
+    """Kick off a background publish.
+
+    Returns "started", "already_running" (another publish holds the slot),
+    or "failed" (the worker thread could not be started; the status dict
+    carries the error). Callers must not collapse the last two: one is a
+    409-style conflict, the other a server-side failure.
+    """
     with _STATUS_LOCK:
         if _STATUS["state"] == "running":
-            return False
+            return "already_running"
         _STATUS.update(
             state="running", project=project_id, runs=None, error=None, finished_at=None
         )
@@ -296,5 +310,5 @@ def start_publish(project_id: str, url: str, *, evaluations_root: Path) -> bool:
         with _STATUS_LOCK:
             _STATUS.update(state="error", error=str(exc), finished_at=time.time())
         logger.exception("failed to start publish thread")
-        return False
-    return True
+        return "failed"
+    return "started"

--- a/src/quodeq/services/shared_repo.py
+++ b/src/quodeq/services/shared_repo.py
@@ -33,6 +33,12 @@ def _git_env() -> dict[str, str]:
     GIT_LFS_SKIP_SMUDGE avoids pulling LFS blobs we don't need. GIT_TERMINAL_PROMPT=0
     stops git from blocking on an interactive credential or passphrase prompt, since
     these subprocess calls have stdin closed (see run_git) and nobody is there to answer.
+
+    Known limitation: GIT_TERMINAL_PROMPT only covers prompts issued by git
+    itself. ssh reads from /dev/tty directly, so a first-contact host-key
+    confirmation or a key passphrase without a loaded agent still blocks, and
+    the call only dies at the run_git timeout. ssh remotes need the host in
+    known_hosts and the key in an agent (or use an https remote instead).
     """
     return {**os.environ, "GIT_LFS_SKIP_SMUDGE": "1", "GIT_TERMINAL_PROMPT": "0"}
 

--- a/src/quodeq/services/shared_settings.py
+++ b/src/quodeq/services/shared_settings.py
@@ -40,7 +40,12 @@ def read_settings(env: dict | None = None) -> SharedSettings:
     if not isinstance(data, dict):
         return SharedSettings()
     known = {f for f in SharedSettings().__dict__}
-    return SharedSettings(**{k: v for k, v in data.items() if k in known})
+    settings = SharedSettings(**{k: v for k, v in data.items() if k in known})
+    # A hand-edited file can hold any JSON type; url is either a usable
+    # string or nothing, callers never see other types (or "").
+    if not isinstance(settings.url, str) or not settings.url:
+        settings.url = None
+    return settings
 
 
 def write_settings(settings: SharedSettings, env: dict | None = None) -> None:
@@ -52,4 +57,7 @@ def write_settings(settings: SharedSettings, env: dict | None = None) -> None:
         tmp.write_text(json.dumps(asdict(settings)), encoding="utf-8")
         os.replace(tmp, path)
     except OSError:
-        pass  # fail-silent: a notice is never worth crashing over
+        # Fail-soft: not worth a 500 on the config routes. A lost write is
+        # not silent, status reads come from this file, so the UI shows
+        # whatever was actually persisted.
+        pass

--- a/src/quodeq/ui/src/api/shared.js
+++ b/src/quodeq/ui/src/api/shared.js
@@ -35,7 +35,7 @@ function epochSecondsToMs(seconds) {
  * Get the shared repository connection status.
  * @returns {Promise<{configured: boolean, url: string|null, lastSynced: number|null, publish: Object}>}
  *   lastSynced is epoch-milliseconds (converted from the backend's epoch
- *   seconds; see epochSecondsToMs). `publish.finished_at`, if present, is
+ *   seconds; see epochSecondsToMs). `publish.finishedAt`, if present, is
  *   passed through unconverted (raw epoch seconds) -- no UI consumer currently
  *   formats it as a date.
  */

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.test.jsx
@@ -329,7 +329,7 @@ describe('ProjectsPage — local tab, publish action', () => {
       getSharedStatus: vi.fn(async () => ({
         configured: true,
         url: 'https://github.com/team/results.git',
-        publish: { state: 'idle', project: null, runs: null, error: null, finished_at: null },
+        publish: { state: 'idle', project: null, runs: null, error: null, finishedAt: null },
       })),
       sharedListProjects: vi.fn(async () => ({ projects: [], lastSynced: null, stale: false })),
       publishProject: vi.fn(async () => ({ started: true })),
@@ -397,7 +397,7 @@ describe('ProjectsPage — local tab, publish action', () => {
     try {
       const getSharedStatus = vi.fn()
         .mockResolvedValueOnce({
-          configured: true, publish: { state: 'idle', project: null, runs: null, error: null, finished_at: null },
+          configured: true, publish: { state: 'idle', project: null, runs: null, error: null, finishedAt: null },
         })
         .mockResolvedValueOnce({ configured: true, publish: { state: 'done', project: 'p1', runs: 2 } });
       const sharedListProjects = vi.fn()

--- a/src/quodeq/ui/src/features/dashboard/hooks/usePublish.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/usePublish.test.jsx
@@ -10,7 +10,7 @@ function makeFakeApi(overrides = {}) {
     getSharedStatus: vi.fn(async () => ({
       configured: true,
       url: 'https://github.com/team/results.git',
-      publish: { state: 'idle', project: null, runs: null, error: null, finished_at: null },
+      publish: { state: 'idle', project: null, runs: null, error: null, finishedAt: null },
     })),
     sharedListProjects: vi.fn(async () => ({ projects: [], lastSynced: null, stale: false })),
     publishProject: vi.fn(async () => ({ started: true })),

--- a/tests/api/test_routes_shared.py
+++ b/tests/api/test_routes_shared.py
@@ -62,6 +62,25 @@ def test_shared_status_configured(client, tmp_path):
     assert body["url"] == "git@github.com:t/r.git"
 
 
+def test_shared_status_survives_non_string_url_in_settings_file(client, tmp_path):
+    """A hand-edited shared.json with a non-string url must not 500 the status route."""
+    (tmp_path / "shared.json").write_text(json.dumps({"url": 123}))
+    resp = client.get("/api/shared/status")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["configured"] is False
+    assert body["url"] is None
+
+
+def test_shared_status_shape_is_camel_case_with_top_level_error(client):
+    """The phase-2/3 UI binds to this shape: camelCase keys, error always present."""
+    body = client.get("/api/shared/status").get_json()
+    assert body["error"] is None
+    publish = body["publish"]
+    assert "finishedAt" in publish
+    assert "finished_at" not in publish
+
+
 # --- PUT /api/shared/config ---------------------------------------------------
 
 def test_put_config_rejects_invalid_url(client, monkeypatch, tmp_path):
@@ -168,14 +187,26 @@ def test_publish_without_config_400(client, monkeypatch, tmp_path):
 
 def test_publish_conflict_returns_409(client, tmp_path, monkeypatch):
     (tmp_path / "shared.json").write_text(json.dumps({"url": "git@github.com:t/r.git"}))
-    monkeypatch.setattr("quodeq.api.routes_shared.start_publish", lambda *a, **kw: False)
+    monkeypatch.setattr(
+        "quodeq.api.routes_shared.start_publish", lambda *a, **kw: "already_running"
+    )
     resp = client.post("/api/projects/some-proj/publish", headers=_ORIGIN)
     assert resp.status_code == 409
+    assert "already running" in resp.get_json()["error"]
+
+
+def test_publish_thread_start_failure_returns_500_not_409(client, tmp_path, monkeypatch):
+    """A thread-start failure is a server error, not "a publish is already running"."""
+    (tmp_path / "shared.json").write_text(json.dumps({"url": "git@github.com:t/r.git"}))
+    monkeypatch.setattr("quodeq.api.routes_shared.start_publish", lambda *a, **kw: "failed")
+    resp = client.post("/api/projects/some-proj/publish", headers=_ORIGIN)
+    assert resp.status_code == 500
+    assert "already running" not in resp.get_json()["error"]
 
 
 def test_publish_started_returns_202(client, tmp_path, monkeypatch):
     (tmp_path / "shared.json").write_text(json.dumps({"url": "git@github.com:t/r.git"}))
-    monkeypatch.setattr("quodeq.api.routes_shared.start_publish", lambda *a, **kw: True)
+    monkeypatch.setattr("quodeq.api.routes_shared.start_publish", lambda *a, **kw: "started")
     resp = client.post("/api/projects/some-proj/publish", headers=_ORIGIN)
     assert resp.status_code == 202
     assert resp.get_json()["started"] is True
@@ -189,7 +220,7 @@ def test_publish_rejects_path_traversal_project_segment(client, tmp_path, monkey
     called = {"n": 0}
     monkeypatch.setattr(
         "quodeq.api.routes_shared.start_publish",
-        lambda *a, **kw: called.__setitem__("n", called["n"] + 1) or True,
+        lambda *a, **kw: called.__setitem__("n", called["n"] + 1) or "started",
     )
 
     resp = client.post("/api/projects/%2e%2e/publish", headers=_ORIGIN)

--- a/tests/services/test_shared_publish_git.py
+++ b/tests/services/test_shared_publish_git.py
@@ -40,6 +40,20 @@ def _git_identity(monkeypatch, tmp_path):
     monkeypatch.setenv("GIT_COMMITTER_EMAIL", "t@t")
 
 
+def test_publish_project_rejects_traversal_project_id(tmp_path, monkeypatch):
+    """The service boundary validates project_id itself, not just the route."""
+    (tmp_path / "evil").mkdir()  # make evaluations/../evil a real directory
+    evals = tmp_path / "evaluations"
+    evals.mkdir()
+    monkeypatch.setattr(
+        shared_publish,
+        "ensure_shared_clone",
+        lambda *a, **kw: pytest.fail("must not reach git with an invalid project id"),
+    )
+    with pytest.raises(PublishError, match="Invalid path segment"):
+        publish_project("../evil", "file:///unused", evaluations_root=evals)
+
+
 def test_publish_bootstraps_and_pushes(tmp_path):
     url = _bare_origin(tmp_path)
     root = _local_project(tmp_path)

--- a/tests/services/test_shared_publish_job.py
+++ b/tests/services/test_shared_publish_job.py
@@ -37,7 +37,7 @@ def _run_inline(monkeypatch):
 def test_publish_job_success(tmp_path, monkeypatch):
     _run_inline(monkeypatch)
     with patch.object(shared_publish, "publish_project", return_value=3) as pub:
-        assert start_publish("p1", "u", evaluations_root=tmp_path) is True
+        assert start_publish("p1", "u", evaluations_root=tmp_path) == "started"
     status = get_publish_status()
     assert status["state"] == "done"
     assert status["runs"] == 3
@@ -56,7 +56,7 @@ def test_publish_job_error_captured(tmp_path, monkeypatch):
 def test_publish_rejected_while_running(tmp_path):
     with shared_publish._STATUS_LOCK:
         shared_publish._STATUS.update({"state": "running", "project": "p0"})
-    assert start_publish("p1", "u", evaluations_root=tmp_path) is False
+    assert start_publish("p1", "u", evaluations_root=tmp_path) == "already_running"
 
 
 def test_publish_thread_start_failure(tmp_path, monkeypatch):
@@ -73,7 +73,7 @@ def test_publish_thread_start_failure(tmp_path, monkeypatch):
 
     result = start_publish("p1", "u", evaluations_root=tmp_path)
 
-    assert result is False
+    assert result == "failed"
     status = get_publish_status()
     assert status["state"] == "error"
     assert "thread creation failed" in status["error"]

--- a/tests/services/test_shared_settings.py
+++ b/tests/services/test_shared_settings.py
@@ -1,4 +1,6 @@
 """Tests for the shared-repo settings store."""
+import json
+
 from quodeq.services.shared_settings import (
     SharedSettings,
     read_settings,
@@ -23,4 +25,16 @@ def test_write_then_read_round_trip(tmp_path):
 def test_read_settings_corrupt_file_returns_empty(tmp_path):
     env = {"QUODEQ_DIR": str(tmp_path)}
     (tmp_path / "shared.json").write_text("{not json", encoding="utf-8")
+    assert read_settings(env=env).url is None
+
+
+def test_read_settings_non_string_url_coerced_to_none(tmp_path):
+    env = {"QUODEQ_DIR": str(tmp_path)}
+    (tmp_path / "shared.json").write_text(json.dumps({"url": 123}), encoding="utf-8")
+    assert read_settings(env=env).url is None
+
+
+def test_read_settings_empty_url_coerced_to_none(tmp_path):
+    env = {"QUODEQ_DIR": str(tmp_path)}
+    (tmp_path / "shared.json").write_text(json.dumps({"url": ""}), encoding="utf-8")
     assert read_settings(env=env).url is None


### PR DESCRIPTION
## Summary

Follow-up to #814: the five non-blocking Minors flagged in review, each with tests.

- **Settings hardening**: `read_settings` coerces a non-string or empty `url` to `None`. A hand-edited `shared.json` with `{"url": 123}` used to 500 `GET /api/shared/status`; it now reads as unconfigured. The fail-silent write comment (copied from `update/state.py`) is reworded for user-initiated config.
- **Service-boundary guard**: `publish_project` now runs `validate_path_segment(project_id)` itself before the id becomes a filesystem path and a git pathspec, instead of relying only on the route.
- **Status shape aligned**: `GET /api/shared/status` no longer mixes `lastSynced` with `publish.finished_at`. The wire shape is camelCase throughout (`publish.finishedAt`) and a reserved top-level `error` key is always present. The phase-2/3 UI landed before this rename, but no runtime code reads `finished_at` (verified); the JSDoc in `ui/src/api/shared.js` and the UI test fixtures are updated to match.
- **Thread-start failure is not a conflict**: `start_publish` returns `"started" | "already_running" | "failed"`; the route maps a thread-start failure to 500 instead of the misleading 409 "a publish is already running".
- **Known limitation documented**: `GIT_TERMINAL_PROMPT=0` only covers git's own prompts. ssh reads `/dev/tty` directly (host-key confirmation, passphrase without an agent), so those still block until the `run_git` timeout; noted in the `_git_env` docstring.

## Testing

- 10 new/updated tests across `test_shared_settings.py`, `test_shared_publish_git.py`, `test_shared_publish_job.py`, `test_routes_shared.py` (TDD, red then green)
- Full backend suite: 4721 passed. UI: 83 tests across the 4 shared-status suites pass
- Verified end-to-end against the running API server: corrupt `{"url": 123}` config returns 200 on status and 400 on publish; a real publish to a local bare origin lands the commit and reports `finishedAt` camelCase over the wire

🤖 Generated with [Claude Code](https://claude.com/claude-code)