### PR TITLE
fix: show newly added projects in the projects tab immediately

### DIFF
--- a/src/quodeq/api/routes_project_list.py
+++ b/src/quodeq/api/routes_project_list.py
@@ -338,6 +338,11 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
             )
             return jsonify(body), status
 
+        # The 5s ProjectsCache would otherwise hide the new project from an
+        # immediately-following GET /api/projects (the wizard refetches the
+        # list as soon as it closes).
+        provider.invalidate_projects_cache()
+
         # scan.json is now always present after _register_project succeeds.
         scan_path = Path(reports_root) / project_uuid / "scan.json"
         try:

--- a/src/quodeq/services/_fs_projects.py
+++ b/src/quodeq/services/_fs_projects.py
@@ -114,10 +114,18 @@ def build_project_list(reports_root: Path, *, backfill: bool = True) -> list[Pro
             _backfill_onboarding_field(reports_root / name)
 
     parent_ids, subproject_ids = _build_parent_child_sets(reports_root, dir_names)
+    # A registered project (repository_info.json present) is listed even with
+    # zero runs — the onboarding wizard creates projects before any evaluation
+    # exists and the UI shows an empty state for them. Only dirs with neither
+    # runs nor a project record (stray non-project dirs) are dropped.
+    registered_ids = {
+        name for name in dir_names
+        if (reports_root / name / "repository_info.json").exists()
+    }
 
     def _build_one(name: str) -> ProjectEntry | None:
         runs = list_runs(reports_root, name)
-        if not runs and name not in parent_ids and name not in subproject_ids:
+        if not runs and name not in registered_ids and name not in parent_ids and name not in subproject_ids:
             return None
         return _build_project_entry(reports_root, name, runs, backfill=backfill)
 

--- a/src/quodeq/services/base.py
+++ b/src/quodeq/services/base.py
@@ -53,6 +53,14 @@ class ProjectActions(Protocol):
         """Remove a project and all its report data. Return True on success."""
         ...
 
+    def invalidate_projects_cache(self) -> None:
+        """Drop any cached project list so the next listing re-reads from disk.
+
+        Default is a no-op; providers that cache ``list_projects`` results
+        (see ``ProjectsCache``) override this so registration is visible in
+        an immediately-following listing.
+        """
+
 
 class ReportActions(Protocol):
     """Methods for reading evaluation reports and dashboards."""

--- a/src/quodeq/services/filesystem.py
+++ b/src/quodeq/services/filesystem.py
@@ -159,6 +159,9 @@ class FilesystemActionProvider(ActionProvider):
     def list_projects(self, reports_dir: str) -> dict[str, Any]:
         return self._projects.list(reports_dir)
 
+    def invalidate_projects_cache(self) -> None:
+        self._projects.invalidate()
+
     def update_project_path(self, reports_dir: str, project: str, new_path: str) -> bool:
         return _fs_projects.update_project_path(reports_dir, project, new_path)
 

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -279,6 +279,42 @@ export function buildNavigationBundle({ state, navTab, navStackLength, isEvaluat
 }
 
 /**
+ * Exit handlers for the onboarding wizard. The wizard registers the project
+ * on its Repo & Scan step (POST /api/projects), well before either exit
+ * fires — so both exits that leave a registered project behind (a saved
+ * close and a launch) must reload the projects list, or the new project
+ * stays invisible in the Projects tab until an evaluation finishes (the
+ * only other path that calls loadProjects). Exported so the reload contract
+ * is testable without mounting the whole App.
+ */
+export function buildWizardHandlers({ state, setWizardEntry, navTab }) {
+  return {
+    onClose: ({ saved, projectId }) => {
+      setWizardEntry(null);
+      if (saved && projectId) {
+        state.loadProjects?.();
+        state.refreshDashboard?.();
+      }
+    },
+    onLaunch: ({ projectId, repo, scopePath, branch, provider, standardIds, totalTimeLimitS }) => {
+      setWizardEntry(null);
+      state.loadProjects?.();
+      const payload = {
+        repo: repo || projectId,
+        dimensions: standardIds,
+      };
+      if (scopePath) payload.scopePath = scopePath;
+      if (branch) payload.branch = branch;
+      if (provider?.id) payload.aiCmd = provider.id;
+      if (provider?.model) payload.aiModel = provider.model;
+      if (totalTimeLimitS) payload.timeLimit = totalTimeLimitS;
+      state.evalLifecycle.handleStartEvaluation(payload);
+      navTab('evaluate');
+    },
+  };
+}
+
+/**
  * After the shared repository is disconnected in Settings, a currently
  * 'shared' selection is left pointing at a project that no longer resolves
  * anywhere in the app (its source has no config left) -- the user would be
@@ -951,26 +987,7 @@ export default function App() {
               {wizardEntry && (
                 <OnboardingWizard
                   entry={wizardEntry}
-                  onClose={({ saved, projectId }) => {
-                    setWizardEntry(null);
-                    if (saved && projectId) {
-                      state.refreshDashboard?.();
-                    }
-                  }}
-                  onLaunch={({ projectId, repo, scopePath, branch, provider, standardIds, totalTimeLimitS }) => {
-                    setWizardEntry(null);
-                    const payload = {
-                      repo: repo || projectId,
-                      dimensions: standardIds,
-                    };
-                    if (scopePath) payload.scopePath = scopePath;
-                    if (branch) payload.branch = branch;
-                    if (provider?.id) payload.aiCmd = provider.id;
-                    if (provider?.model) payload.aiModel = provider.model;
-                    if (totalTimeLimitS) payload.timeLimit = totalTimeLimitS;
-                    state.evalLifecycle.handleStartEvaluation(payload);
-                    navTab('evaluate');
-                  }}
+                  {...buildWizardHandlers({ state, setWizardEntry, navTab })}
                 />
               )}
             </Suspense>

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom/vitest';
 import {
   buildEvalPrincipal, ROUTE_RENDERERS, isSharedSource, shouldBounceToEvaluate, shouldShowEvaluateButton,
   resolveSelectionAfterSharedDisconnect, shouldAutoOpenOnboardingWizard, shouldShowProjectTabs,
-  buildNavigationBundle, shouldWallEmptyProjects,
+  buildNavigationBundle, shouldWallEmptyProjects, buildWizardHandlers,
 } from './App.jsx';
 import Sidebar from './components/Sidebar.jsx';
 
@@ -372,6 +372,63 @@ describe('shouldWallEmptyProjects', () => {
 
   it('does not wall once local projects exist', () => {
     expect(shouldWallEmptyProjects({ page: 'file', projects: [{ id: 'p1' }], selectedSource: 'local' })).toBe(false);
+  });
+});
+
+// The wizard registers a project on its Repo & Scan step, but the projects
+// list in React state is only reloaded at boot and when an evaluation
+// finishes. Both wizard exits that leave a registered project behind (saved
+// close and launch) must reload the list so the new project appears in the
+// Projects tab immediately, before any run exists.
+describe('buildWizardHandlers', () => {
+  function stubState() {
+    return {
+      loadProjects: vi.fn(),
+      refreshDashboard: vi.fn(),
+      evalLifecycle: { handleStartEvaluation: vi.fn() },
+    };
+  }
+
+  it('onClose after a saved exit reloads the projects list', () => {
+    const state = stubState();
+    const setWizardEntry = vi.fn();
+    const { onClose } = buildWizardHandlers({ state, setWizardEntry, navTab: vi.fn() });
+    onClose({ saved: true, projectId: 'proj-1' });
+    expect(setWizardEntry).toHaveBeenCalledWith(null);
+    expect(state.loadProjects).toHaveBeenCalled();
+    expect(state.refreshDashboard).toHaveBeenCalled();
+  });
+
+  it('onClose without a saved project does not reload anything', () => {
+    const state = stubState();
+    const setWizardEntry = vi.fn();
+    const { onClose } = buildWizardHandlers({ state, setWizardEntry, navTab: vi.fn() });
+    onClose({ saved: false });
+    expect(setWizardEntry).toHaveBeenCalledWith(null);
+    expect(state.loadProjects).not.toHaveBeenCalled();
+    expect(state.refreshDashboard).not.toHaveBeenCalled();
+  });
+
+  it('onLaunch reloads the projects list, starts the evaluation, and navigates', () => {
+    const state = stubState();
+    const navTab = vi.fn();
+    const { onLaunch } = buildWizardHandlers({ state, setWizardEntry: vi.fn(), navTab });
+    onLaunch({
+      projectId: 'proj-1', repo: '/x/repo', scopePath: null, branch: null,
+      provider: { id: 'claude', model: 'sonnet' }, standardIds: ['security'], totalTimeLimitS: 60,
+    });
+    expect(state.loadProjects).toHaveBeenCalled();
+    expect(state.evalLifecycle.handleStartEvaluation).toHaveBeenCalledWith(expect.objectContaining({
+      repo: '/x/repo', dimensions: ['security'], aiCmd: 'claude', aiModel: 'sonnet', timeLimit: 60,
+    }));
+    expect(navTab).toHaveBeenCalledWith('evaluate');
+  });
+
+  it('onLaunch falls back to the projectId when no repo path is present', () => {
+    const state = stubState();
+    const { onLaunch } = buildWizardHandlers({ state, setWizardEntry: vi.fn(), navTab: vi.fn() });
+    onLaunch({ projectId: 'proj-1', repo: null, provider: {}, standardIds: [] });
+    expect(state.evalLifecycle.handleStartEvaluation).toHaveBeenCalledWith(expect.objectContaining({ repo: 'proj-1' }));
   });
 });
 

--- a/tests/api/test_post_projects.py
+++ b/tests/api/test_post_projects.py
@@ -102,6 +102,27 @@ def test_post_projects_duplicate_returns_409(app_client, tmp_path):
     assert body.get("existingProjectId") == first_id
 
 
+def test_post_projects_appears_in_projects_list_immediately(app_client):
+    """A freshly registered project must show in GET /api/projects right away.
+
+    The list is fetched once before the POST so the 5-second ProjectsCache is
+    warm — registration must invalidate it, and the zero-run project must not
+    be filtered out of build_project_list.
+    """
+    c, home, _ = app_client
+    repo = _make_local_repo(home, "instant-repo")
+    with _patch_home(home):
+        warm = c.get("/api/projects")
+        assert warm.status_code == 200
+        resp = c.post("/api/projects", json={"repo": str(repo)}, headers=_ORIGIN)
+        assert resp.status_code == 200, resp.get_json()
+        project_id = resp.get_json()["projectId"]
+        listed = c.get("/api/projects").get_json()["projects"]
+    entry = next((p for p in listed if p["id"] == project_id), None)
+    assert entry is not None, "registered project missing from /api/projects"
+    assert entry["runsCount"] == 0
+
+
 def test_post_projects_writes_onboarding_field_null(app_client):
     c, home, _ = app_client
     repo = _make_local_repo(home, "field-repo")

--- a/tests/services/test_fs_projects.py
+++ b/tests/services/test_fs_projects.py
@@ -11,6 +11,7 @@ import pytest
 from quodeq.services._fs_projects import (
     find_children,
     _build_parent_child_sets,
+    build_project_list,
     update_project_path,
     delete_project,
     get_project_info,
@@ -89,6 +90,36 @@ class TestBuildParentChildSets:
         parents, subs = _build_parent_child_sets(tmp_path, ["bad"])
         assert parents == set()
         assert subs == set()
+
+
+# ---------------------------------------------------------------------------
+# build_project_list
+# ---------------------------------------------------------------------------
+
+
+class TestBuildProjectList:
+    def test_includes_registered_project_with_no_runs(self, tmp_path: Path):
+        # A project registered by the onboarding wizard (POST /api/projects)
+        # has repository_info.json but no runs yet — it must still appear in
+        # the projects list so the UI can show its empty state immediately.
+        proj = tmp_path / "fresh-uuid"
+        proj.mkdir()
+        (proj / "repository_info.json").write_text(json.dumps({
+            "name": "fresh",
+            "path": str(tmp_path),
+            "location": "local",
+            "onboardingCompletedAt": None,
+        }))
+        entries = build_project_list(tmp_path)
+        entry = next((e for e in entries if e.id == "fresh-uuid"), None)
+        assert entry is not None
+        assert entry.runs_count == 0
+        assert entry.latest_run_id is None
+        assert entry.onboarding_completed_at is None
+
+    def test_excludes_dir_without_repo_info_or_runs(self, tmp_path: Path):
+        (tmp_path / "junk-dir").mkdir()
+        assert build_project_list(tmp_path) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Adding a project through the onboarding wizard registered it on disk, but it never appeared in the projects tab until its first evaluation finished. The tab has empty states for exactly this case, so a registered project should show up right away with "0 runs".

(Real-world confirmation: the local evaluations dir had three registered zero-run project dirs that were invisible in the UI.)

## Root cause (three layers)

1. **`build_project_list` dropped zero-run projects** (`_fs_projects.py`). The filter predates scan-only registration: back then a project dir only existed once an evaluation created runs, so no-runs meant garbage. The wizard's POST `/api/projects` flow broke that assumption.
2. **`ProjectsCache` (5s TTL) was never invalidated on create**, so the GET that immediately follows registration could serve the pre-create payload.
3. **The React projects list was only reloaded at boot and when an evaluation finished** — neither wizard exit (saved close, launch) refreshed it.

## Fix

- `_build_one` now keeps dirs that have a `repository_info.json` (registered projects) even with zero runs; stray dirs with neither runs nor a project record stay hidden.
- New `invalidate_projects_cache()` provider seam (no-op default on the protocol, real implementation on `FilesystemActionProvider`), called after a successful create.
- Wizard `onClose`/`onLaunch` handlers extracted into an exported `buildWizardHandlers` seam that calls `loadProjects()` on both exits that leave a registered project behind.

## Tests

- `TestBuildProjectList`: zero-run registered project included with `runs_count == 0`; junk dir still excluded.
- `test_post_projects_appears_in_projects_list_immediately`: warms the cache, POSTs, and asserts the very next GET lists the project — pins both the filter and the invalidation.
- `buildWizardHandlers` suite: reload on saved close and on launch, no reload on unsaved close, launch payload/navigation unchanged.
- Full suites green: 1562 backend (api+services), 1142 UI.

Verified end-to-end in the browser against an isolated evaluations dir: wizard → scan → close lands on the projects tab with the "e2e-repo · 0 runs" card visible immediately, and clicking it selects the project and bounces to Evaluate as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)