### PR TITLE
fix(projects): clear perpetual 'Resume setup' badge once a project evaluates

### DIFF
--- a/src/quodeq/services/_fs_project_helpers.py
+++ b/src/quodeq/services/_fs_project_helpers.py
@@ -19,13 +19,20 @@ from quodeq.services.ports import RunInfo
 from quodeq.shared.utils import _env_int
 
 
-def _backfill_onboarding_field(project_dir: Path) -> dict | None:
-    """Add ``onboardingCompletedAt`` to ``repository_info.json`` if missing.
+def _backfill_onboarding_field(
+    project_dir: Path, *, heal_completed_at: str | None = None,
+) -> dict | None:
+    """Normalize ``onboardingCompletedAt`` in ``repository_info.json``.
 
     Returns the (possibly modified) data dict, or ``None`` if the file is
     missing or unreadable. Persists the change back to disk when a backfill
     happens. Treats absence of the field as already-onboarded — backfills to
     the project's existing ``createdAt`` timestamp, falling back to "now".
+
+    *heal_completed_at*: when set and the field is present but null, stamp it
+    with this value. Callers pass a timestamp only for projects that have
+    evaluation runs — running an evaluation IS completing setup, so a null
+    left behind by a pre-stamp wizard must not show 'Resume setup' forever.
     """
     info_path = project_dir / "repository_info.json"
     if not info_path.exists():
@@ -35,6 +42,12 @@ def _backfill_onboarding_field(project_dir: Path) -> dict | None:
     except (json.JSONDecodeError, OSError):
         return None
     if "onboardingCompletedAt" in data:
+        if data["onboardingCompletedAt"] is None and heal_completed_at:
+            data["onboardingCompletedAt"] = heal_completed_at
+            try:
+                info_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+            except OSError:
+                pass
         return data
     data["onboardingCompletedAt"] = data.get("createdAt") or datetime.now(timezone.utc).isoformat()
     try:
@@ -57,8 +70,12 @@ def _build_project_entry(
     # ``onboardingCompletedAt`` field so the wizard never auto-opens for
     # already-onboarded projects. Returns the (possibly updated) info dict
     # so we can pass the field through to the entry without re-reading.
+    # Projects with runs also heal a null field to the first run's date:
+    # an evaluation happened, so setup is complete (records that predate the
+    # start_evaluation stamp would otherwise show 'Resume setup' forever).
     project_dir = reports_root / entry_name
-    backfilled = _backfill_onboarding_field(project_dir) if backfill else None
+    heal_at = (runs[-1].date_iso or datetime.now(timezone.utc).isoformat()) if runs else None
+    backfilled = _backfill_onboarding_field(project_dir, heal_completed_at=heal_at) if backfill else None
     info = backfilled if backfilled is not None else _read_repo_info(reports_root, entry_name)
     meta = _extract_project_metadata(info, entry_name)
     latest_grade, latest_score, files_count = _read_accumulated_summary(

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -7,6 +7,7 @@ import logging
 import os
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Protocol
 
@@ -216,6 +217,28 @@ def _ensure_onboarding_field(project_dir: Path) -> None:
     info_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
+def _mark_onboarding_complete(project_dir: Path) -> None:
+    """Stamp `onboardingCompletedAt` in repository_info.json if not already set.
+
+    An existing timestamp is left untouched so re-evaluations don't move the
+    original completion time.
+    """
+    info_path = project_dir / "repository_info.json"
+    if not info_path.exists():
+        return
+    try:
+        data = json.loads(info_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return
+    if data.get("onboardingCompletedAt"):
+        return
+    data["onboardingCompletedAt"] = datetime.now(timezone.utc).isoformat()
+    try:
+        info_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    except OSError:
+        pass
+
+
 class FsEvaluationMixin:
     """Evaluation lifecycle collaborator: start, status, cancel, score.
 
@@ -296,7 +319,12 @@ class FsEvaluationMixin:
             )
 
         cmd = _build_evaluate_cmd(repo, options, reports_dir)
-        _register_project(repo, options.discipline, reports_dir, scope_path=options.scope_path)
+        project_uuid = _register_project(repo, options.discipline, reports_dir, scope_path=options.scope_path)
+        # Launching an evaluation is the terminal step of project setup, so
+        # the 'Resume setup' badge must clear here. Without this stamp the
+        # null written at registration persists forever (the lazy backfill
+        # only fills in a *missing* field, never a null one).
+        _mark_onboarding_complete(Path(reports_dir) / project_uuid)
         # Keep JobManager aware of the current reports root so _tee_run_log
         # can resolve run.log paths for dashboard-spawned evaluations.
         # Guard with hasattr so custom/stub job managers remain compatible.

--- a/tests/api/test_post_projects.py
+++ b/tests/api/test_post_projects.py
@@ -158,3 +158,72 @@ def test_get_projects_backfills_onboarding_field_for_legacy_projects(app_client,
     )
     assert target is not None, f"legacy project not in response: {projects}"
     assert target.get("onboardingCompletedAt") == "2025-12-01T00:00:00Z"
+
+
+def _write_project_record(reports_root: Path, project_id: str, *, onboarding=None) -> Path:
+    """Create a minimal registered project (repository_info.json) on disk."""
+    project_dir = reports_root / project_id
+    project_dir.mkdir(parents=True)
+    info = project_dir / "repository_info.json"
+    info.write_text(json.dumps({
+        "name": project_id,
+        "repository": f"/some/path/{project_id}",
+        "createdAt": "2025-12-01T00:00:00Z",
+        "location": "local",
+        "onboardingCompletedAt": onboarding,
+    }))
+    return info
+
+
+def _write_minimal_run(project_dir: Path, run_name: str = "2025-12-02_00-00-00") -> None:
+    run_dir = project_dir / run_name
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "evidence" / "manifest.json").write_text(json.dumps({"language_stats": {}}))
+
+
+def test_get_projects_heals_null_onboarding_field_when_runs_exist(app_client):
+    """A wizard-created project whose setup was never explicitly finished but
+    that has evaluation runs must stop showing 'Resume setup': the list read
+    heals the null field to a timestamp (evaluating IS completing setup)."""
+    c, home, _ = app_client
+    reports_root = home / "evaluations"
+    info = _write_project_record(reports_root, "stuck-uuid-1234", onboarding=None)
+    _write_minimal_run(reports_root / "stuck-uuid-1234")
+
+    with _patch_home(home):
+        resp = c.get("/api/projects", headers=_ORIGIN)
+    assert resp.status_code == 200
+
+    healed = json.loads(info.read_text())["onboardingCompletedAt"]
+    assert isinstance(healed, str) and healed
+
+    body = resp.get_json()
+    projects = body["projects"] if isinstance(body, dict) else body
+    target = next((p for p in projects if p.get("id") == "stuck-uuid-1234"), None)
+    assert target is not None, f"project not in response: {projects}"
+    assert target.get("onboardingCompletedAt") == healed
+
+
+def test_get_projects_keeps_null_onboarding_field_without_runs(app_client):
+    """A registered project with no runs is genuinely mid-setup: the null
+    field must survive the list read so 'Resume setup' keeps showing.
+
+    Note: zero-run projects may or may not surface in the listing itself
+    (that gate is a separate concern, see PR #823); what this test pins is
+    that the read never stamps a run-less record, on disk or in the payload.
+    """
+    c, home, _ = app_client
+    reports_root = home / "evaluations"
+    info = _write_project_record(reports_root, "midsetup-uuid-1234", onboarding=None)
+
+    with _patch_home(home):
+        resp = c.get("/api/projects", headers=_ORIGIN)
+    assert resp.status_code == 200
+
+    assert json.loads(info.read_text())["onboardingCompletedAt"] is None
+
+    body = resp.get_json()
+    projects = body["projects"] if isinstance(body, dict) else body
+    target = next((p for p in projects if p.get("id") == "midsetup-uuid-1234"), None)
+    if target is not None:
+        assert target.get("onboardingCompletedAt") is None

--- a/tests/services/test_evaluation_mixin_register.py
+++ b/tests/services/test_evaluation_mixin_register.py
@@ -196,3 +196,63 @@ def test_start_evaluation_rejects_url_input(tmp_path):
             str(tmp_path),
             EvaluationOptions(),
         )
+
+
+class _FakeDispatcher:
+    """Records dispatch calls without spawning a subprocess."""
+
+    def __init__(self):
+        self.calls = []
+
+    def dispatch(self, cmd, *, cwd=None, env=None, ai_provider=None, ai_model=None):
+        self.calls.append(cmd)
+        return {"id": "fake-job"}
+
+
+def _make_mixin():
+    from quodeq.services.evaluation_mixin import FsEvaluationMixin
+
+    mixin = FsEvaluationMixin()
+    mixin._jobs = object()  # no set_reports_root attr -> guard skips it
+    mixin._dispatcher = _FakeDispatcher()
+    return mixin
+
+
+def test_start_evaluation_stamps_onboarding_completed(tmp_path):
+    """Starting an evaluation completes onboarding: the null field written at
+    registration time must become a timestamp, otherwise the Projects page
+    shows 'Resume setup' forever for wizard-created projects."""
+    from quodeq.services.base import EvaluationOptions
+
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    (repo / "main.py").write_text("print('hi')\n")
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    uuid = _register_project(str(repo), None, str(reports))
+    assert _read_info(reports, uuid)["onboardingCompletedAt"] is None
+
+    _make_mixin().start_evaluation(str(repo), str(reports), EvaluationOptions())
+
+    stamped = _read_info(reports, uuid)["onboardingCompletedAt"]
+    assert isinstance(stamped, str) and stamped
+
+
+def test_start_evaluation_preserves_existing_onboarding_stamp(tmp_path):
+    """A later evaluation must not move an already-set completion timestamp."""
+    from quodeq.services.base import EvaluationOptions
+
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    (repo / "main.py").write_text("print('hi')\n")
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    uuid = _register_project(str(repo), None, str(reports))
+    info_path = reports / uuid / "repository_info.json"
+    data = json.loads(info_path.read_text())
+    data["onboardingCompletedAt"] = "2025-12-01T00:00:00Z"
+    info_path.write_text(json.dumps(data))
+
+    _make_mixin().start_evaluation(str(repo), str(reports), EvaluationOptions())
+
+    assert _read_info(reports, uuid)["onboardingCompletedAt"] == "2025-12-01T00:00:00Z"

--- a/tests/services/test_fs_project_helpers_onboarding.py
+++ b/tests/services/test_fs_project_helpers_onboarding.py
@@ -1,0 +1,96 @@
+"""Tests for the onboardingCompletedAt heal in _build_project_entry.
+
+A wizard-created project gets ``onboardingCompletedAt: null`` at registration
+time. Setup completion is stamped when an evaluation starts (see
+evaluation_mixin), but records created before that stamp existed are stuck at
+null forever despite having runs. The list read heals those: null + runs =>
+timestamp. Run-less records stay null (they are genuinely mid-setup), and the
+shared-repo route (backfill=False) never writes.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.services._fs_project_helpers import _build_project_entry
+from quodeq.services.ports import RunInfo
+
+
+def _make_project(tmp_path: Path, name: str = "proj-1", *, onboarding=None) -> Path:
+    project_dir = tmp_path / name
+    project_dir.mkdir()
+    (project_dir / "repository_info.json").write_text(json.dumps({
+        "name": name,
+        "location": "local",
+        "path": str(tmp_path / "src" / name),
+        "onboardingCompletedAt": onboarding,
+    }))
+    return project_dir
+
+
+def _run(run_id: str, date_iso: str | None) -> RunInfo:
+    return RunInfo(run_id=run_id, date_iso=date_iso, date_label=run_id)
+
+
+def _read_field(project_dir: Path):
+    return json.loads((project_dir / "repository_info.json").read_text())["onboardingCompletedAt"]
+
+
+def test_entry_heals_null_onboarding_to_first_run_date(tmp_path):
+    project_dir = _make_project(tmp_path, onboarding=None)
+    # list_runs order: newest first, so the last element is the first run.
+    runs = [
+        _run("2026-01-05_00-00-00", "2026-01-05T00:00:00"),
+        _run("2025-12-02_00-00-00", "2025-12-02T00:00:00"),
+    ]
+
+    entry = _build_project_entry(tmp_path, "proj-1", runs)
+
+    assert entry.onboarding_completed_at == "2025-12-02T00:00:00"
+    assert _read_field(project_dir) == "2025-12-02T00:00:00"
+
+
+def test_entry_heals_null_onboarding_without_run_date(tmp_path):
+    """A run with no parseable date still proves an evaluation happened."""
+    project_dir = _make_project(tmp_path, onboarding=None)
+
+    entry = _build_project_entry(tmp_path, "proj-1", [_run("some-run", None)])
+
+    assert isinstance(entry.onboarding_completed_at, str) and entry.onboarding_completed_at
+    assert _read_field(project_dir) == entry.onboarding_completed_at
+
+
+def test_entry_keeps_null_onboarding_without_runs(tmp_path):
+    project_dir = _make_project(tmp_path, onboarding=None)
+
+    entry = _build_project_entry(tmp_path, "proj-1", [])
+
+    assert entry.onboarding_completed_at is None
+    assert _read_field(project_dir) is None
+
+
+def test_entry_preserves_existing_onboarding_stamp(tmp_path):
+    project_dir = _make_project(tmp_path, onboarding="2025-11-01T00:00:00Z")
+
+    entry = _build_project_entry(
+        tmp_path, "proj-1", [_run("2025-12-02_00-00-00", "2025-12-02T00:00:00")],
+    )
+
+    assert entry.onboarding_completed_at == "2025-11-01T00:00:00Z"
+    assert _read_field(project_dir) == "2025-11-01T00:00:00Z"
+
+
+def test_entry_backfill_false_never_writes(tmp_path):
+    """The shared-repo route lists clones read-only: no heal, no dirty worktree."""
+    project_dir = _make_project(tmp_path, onboarding=None)
+    info_path = project_dir / "repository_info.json"
+    before = info_path.read_text()
+
+    entry = _build_project_entry(
+        tmp_path, "proj-1",
+        [_run("2025-12-02_00-00-00", "2025-12-02T00:00:00")],
+        backfill=False,
+    )
+
+    assert entry.onboarding_completed_at is None
+    assert info_path.read_text() == before

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -19,8 +19,8 @@ src/quodeq/services/_external_jobs.py:22:analysis
 src/quodeq/services/_violations_jsonl.py:11:analysis
 src/quodeq/services/_violations_stream.py:10:analysis
 src/quodeq/services/_violations_stream.py:11:analysis
-src/quodeq/services/evaluation_mixin.py:19:analysis
-src/quodeq/services/evaluation_mixin.py:454:analysis
+src/quodeq/services/evaluation_mixin.py:20:analysis
+src/quodeq/services/evaluation_mixin.py:482:analysis
 src/quodeq/services/jobs.py:20:analysis
 src/quodeq/services/scan_progress.py:23:analysis
 src/quodeq/services/tooling_mixin.py:17:analysis


### PR DESCRIPTION
## Problem

The "Resume setup" badge on project cards (`ProjectsPage.jsx`, condition `onboardingCompletedAt === null`) persisted forever for wizard-created projects, even after they completed evaluations. `_register_project` writes `onboardingCompletedAt: null`, and nothing ever stamped it: the legacy backfill only fills in a *missing* field, never a null one. Real example: growstuff with 13 runs still showed "Resume setup".

## Semantics decision

**Starting an evaluation completes setup.** The wizard's terminal step is launching an evaluation, so the stamp lives on the backend eval-start path and also covers first evaluations started from the Evaluate tab. A saved mid-wizard exit intentionally keeps the badge, since that is exactly the state "Resume setup" exists to resume. No new endpoint, no frontend change.

## Changes

- `start_evaluation` stamps `onboardingCompletedAt` (now UTC) after `_register_project`; an existing stamp is never moved by later evaluations.
- The project-list read heals a null field for projects that already have runs (records that predate the stamp, like growstuff), using the first run's date with a now fallback. Run-less records keep null so the badge still shows for genuinely mid-setup projects. The shared-repo route (`backfill=False`) stays read-only.
- `tools/import_baseline.txt`: line-number shifts only, for the two grandfathered `evaluation_mixin` imports (both gate tests confirmed the same-file+target signature).

## Interaction with #823

On this base, zero-run projects are hidden from the list, so the badge is unreachable until #823 (instant add) lands. The changes compose: #823 surfaces zero-run wizard projects, which keep null here, so the badge shows and resume works; once they evaluate, the stamp clears it.

## Testing

- TDD: each behavior test was watched failing first (including the no-runs and read-only guards, verified against a deliberately ungated intermediate implementation).
- New tests: stamp on eval start, stamp preservation, list-read heal (API + services level), no heal without runs, shared route never writes.
- Full suite: 4730 passed, 1 skipped (`-m "not integration"`).
- E2E: served a fixture project (1 run, null field) through the real dashboard; the card renders without the badge and the record on disk is stamped.