### PR TITLE
fix(clone): shallow-clone online repos with full-clone fallback

### DIFF
--- a/src/quodeq/_cli_resolution.py
+++ b/src/quodeq/_cli_resolution.py
@@ -26,6 +26,9 @@ import logging
 _logger = logging.getLogger(__name__)
 
 _WORKTREE_TIMEOUT_S = 30
+# Branch fetches go over the network; give them the clone budget, not the
+# local worktree one.
+_FETCH_TIMEOUT_S = int(os.environ.get("QUODEQ_GIT_CLONE_TIMEOUT_S", "300"))
 
 
 # ---------------------------------------------------------------------------
@@ -45,23 +48,48 @@ class ResolvedInputs:
 # Worktree management
 # ---------------------------------------------------------------------------
 
+def _fetch_branch(repo_dir: Path, branch: str) -> bool:
+    """Fetch *branch* from origin into a local branch of the same name.
+
+    Single-branch clones (online repos registered via run_git_clone) have no
+    refspec for other branches, so a plain ``fetch origin <branch>`` would
+    only update FETCH_HEAD; the explicit ``<branch>:<branch>`` refspec makes
+    it usable by ``worktree add``. Returns True when the fetch succeeded.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_dir), "fetch", "origin", f"{branch}:{branch}"],
+            capture_output=True, text=True, encoding="utf-8", timeout=_FETCH_TIMEOUT_S,
+        )
+        return result.returncode == 0
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+
 def _create_worktree(repo_dir: Path, branch: str) -> Path | None:
     """Create a temporary git worktree for the given branch.
 
-    Returns the worktree path, or None on failure.
+    Returns the worktree path, or None on failure. When the first attempt
+    fails, the branch is fetched from origin and the attempt repeated once:
+    single-branch clones (online repos) don't have other branches locally
+    until someone asks for them.
     """
     worktree_dir = Path(_tempfile.mkdtemp(prefix=f"quodeq-wt-{branch.replace('/', '-')}-"))
-    try:
-        subprocess.run(
-            ["git", "-C", str(repo_dir), "worktree", "add", str(worktree_dir), branch],
-            capture_output=True, text=True, encoding="utf-8", check=True, timeout=_WORKTREE_TIMEOUT_S,
-        )
-        return worktree_dir
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
-        print(f"Failed to create worktree for branch '{branch}': {exc}", file=sys.stderr)
-        _cleanup_worktree(repo_dir, worktree_dir)
-        shutil.rmtree(worktree_dir, ignore_errors=True)
-        return None
+    for retried in (False, True):
+        try:
+            subprocess.run(
+                ["git", "-C", str(repo_dir), "worktree", "add", str(worktree_dir), branch],
+                capture_output=True, text=True, encoding="utf-8", check=True, timeout=_WORKTREE_TIMEOUT_S,
+            )
+            return worktree_dir
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+            if not retried and _fetch_branch(repo_dir, branch):
+                continue
+            print(f"Failed to create worktree for branch '{branch}': {exc}", file=sys.stderr)
+            _cleanup_worktree(repo_dir, worktree_dir)
+            shutil.rmtree(worktree_dir, ignore_errors=True)
+            return None
+    return None
 
 
 def _cleanup_worktree(repo_dir: Path, worktree_dir: Path) -> None:

--- a/src/quodeq/services/_fs_clone.py
+++ b/src/quodeq/services/_fs_clone.py
@@ -3,11 +3,28 @@
 from __future__ import annotations
 
 import errno
+import logging
 import os
+import shutil
 import subprocess as _subprocess
 from pathlib import Path
 
+_logger = logging.getLogger(__name__)
+
 _GIT_CLONE_TIMEOUT_S = int(os.environ.get("QUODEQ_GIT_CLONE_TIMEOUT_S", "300"))
+
+# One month of slack over the default git churn lookback (git_lookback_months,
+# 3) so the boundary commit is never cut off. Raise QUODEQ_CLONE_SHALLOW_MONTHS
+# when a project configures a larger lookback; 0 forces full-history clones.
+_DEFAULT_SHALLOW_MONTHS = 4
+
+
+def _shallow_months() -> int:
+    raw = os.environ.get("QUODEQ_CLONE_SHALLOW_MONTHS", "")
+    try:
+        return int(raw) if raw else _DEFAULT_SHALLOW_MONTHS
+    except ValueError:
+        return _DEFAULT_SHALLOW_MONTHS
 
 
 class CloneError(RuntimeError):
@@ -15,13 +32,15 @@ class CloneError(RuntimeError):
     auth | network | repo_not_found | dest_exists | disk | unknown.
 
     Inherits from RuntimeError so existing ``except RuntimeError`` blocks
-    still catch it.
+    still catch it. ``retryable`` marks failures where a different clone
+    strategy could still succeed (used for the shallow → full fallback).
     """
 
-    def __init__(self, kind: str, message: str, stderr: str = "") -> None:
+    def __init__(self, kind: str, message: str, stderr: str = "", *, retryable: bool = False) -> None:
         super().__init__(message)
         self.kind = kind
         self.stderr = stderr
+        self.retryable = retryable
 
 
 _AUTH_MARKERS = (
@@ -56,12 +75,18 @@ def _classify_stderr(stderr: str) -> str:
     return "unknown"
 
 
-def run_git_clone(url: str, clone_dest: Path) -> None:
-    """Execute ``git clone`` for *url* into *clone_dest*. Raises CloneError on failure."""
+# Kinds where a shallow-specific rejection is indistinguishable from a real
+# failure (servers answer unsatisfiable --shallow-since requests with generic
+# hang-up/protocol errors), so a full clone may still succeed. Deterministic
+# kinds (auth, repo_not_found, dest_exists, disk) would fail identically.
+_RETRYABLE_KINDS = ("network", "unknown")
+
+
+def _clone_once(url: str, clone_dest: Path, extra_args: list[str]) -> None:
     env = {**os.environ, "GIT_LFS_SKIP_SMUDGE": "1", "LC_ALL": "C", "LANG": "C"}
     try:
         _subprocess.run(
-            ["git", "clone", "--progress", "--", url, str(clone_dest)],
+            ["git", "clone", "--progress", *extra_args, "--", url, str(clone_dest)],
             check=True,
             env=env,
             timeout=_GIT_CLONE_TIMEOUT_S,
@@ -74,11 +99,49 @@ def run_git_clone(url: str, clone_dest: Path) -> None:
         else:
             stderr = raw or ""
         kind = _classify_stderr(stderr)
-        raise CloneError(kind, f"git clone failed ({kind})", stderr) from exc
+        raise CloneError(
+            kind, f"git clone failed ({kind})", stderr, retryable=kind in _RETRYABLE_KINDS,
+        ) from exc
     except _subprocess.TimeoutExpired as exc:
+        # Not retryable: the attempt already spent the whole clone timeout,
+        # a full clone can only be slower.
         raise CloneError("network", "git clone timed out") from exc
     except FileNotFoundError as exc:
         raise CloneError("unknown", f"git binary not found: {exc}") from exc
     except OSError as exc:
         kind = "disk" if exc.errno == errno.ENOSPC else "unknown"
         raise CloneError(kind, f"git clone could not start: {exc}") from exc
+
+
+def run_git_clone(url: str, clone_dest: Path) -> None:
+    """Execute ``git clone`` for *url* into *clone_dest*. Raises CloneError on failure.
+
+    Clones shallow by default (``--single-branch``, ``--no-tags``,
+    ``--shallow-since``): the working copy is evaluated at HEAD and the only
+    history consumer is git churn scoring, whose lookback the default window
+    covers (see ``_DEFAULT_SHALLOW_MONTHS``). Branch evaluations against such
+    a clone rely on ``_cli_resolution._fetch_branch`` fetching the missing
+    branch on demand. Shallow requests the remote cannot satisfy (e.g. no
+    commits inside the window) fall back to one full clone. A shallow working
+    copy can be completed manually with ``git fetch --unshallow``.
+    """
+    months = _shallow_months()
+    if months <= 0:
+        _clone_once(url, clone_dest, [])
+        return
+    try:
+        _clone_once(
+            url,
+            clone_dest,
+            ["--single-branch", "--no-tags", f"--shallow-since={months} months ago"],
+        )
+    except CloneError as exc:
+        if not exc.retryable:
+            raise
+        _logger.info("shallow clone of %s failed (%s), retrying with full history", url, exc.kind)
+        # git usually removes the dest it created on failure, but not when
+        # killed or on checkout-phase errors; a leftover partial dir would
+        # turn the retry into a bogus dest_exists failure.
+        if clone_dest.exists():
+            shutil.rmtree(clone_dest, ignore_errors=True)
+        _clone_once(url, clone_dest, [])

--- a/tests/services/test_clone_shallow.py
+++ b/tests/services/test_clone_shallow.py
@@ -1,0 +1,114 @@
+"""Tests for shallow cloning in run_git_clone and its full-clone fallback.
+
+Online (URL) repos are cloned with a bounded history window: enough for the
+git churn scoring lookback (git_lookback_months, default 3), a fraction of
+the download of a full clone. Servers or repos that cannot satisfy a shallow
+request fall back to a full clone; deterministic failures (auth, not found)
+do not retry.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.services._fs_clone import CloneError, run_git_clone
+
+
+def _stderr(text: str) -> subprocess.CalledProcessError:
+    err = subprocess.CalledProcessError(returncode=128, cmd=["git", "clone"])
+    err.stderr = text.encode()
+    return err
+
+
+def _has_shallow_args(cmd: list[str]) -> bool:
+    return (
+        "--single-branch" in cmd
+        and "--no-tags" in cmd
+        and any(a.startswith("--shallow-since=") for a in cmd)
+    )
+
+
+def test_clone_is_shallow_by_default(tmp_path):
+    with patch("quodeq.services._fs_clone._subprocess.run") as run_mock:
+        run_mock.return_value = None
+        run_git_clone("https://x/y.git", tmp_path / "dest")
+    assert run_mock.call_count == 1
+    assert _has_shallow_args(run_mock.call_args[0][0])
+
+
+def test_shallow_failure_falls_back_to_full_clone(tmp_path):
+    """A shallow request the server/repo cannot satisfy retries as a full clone."""
+    with patch("quodeq.services._fs_clone._subprocess.run") as run_mock:
+        run_mock.side_effect = [_stderr("fatal: error processing shallow info: 4"), None]
+        run_git_clone("https://x/y.git", tmp_path / "dest")
+    assert run_mock.call_count == 2
+    assert not _has_shallow_args(run_mock.call_args_list[1][0][0])
+
+
+def test_fallback_removes_partial_clone_dir(tmp_path):
+    """A failed shallow attempt may leave a partial dest; the retry must not
+    trip over it with a dest_exists error."""
+    dest = tmp_path / "dest"
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if len(calls) == 1:
+            dest.mkdir()
+            raise _stderr("some unrelated git error")
+        assert not dest.exists(), "partial clone dir must be removed before the retry"
+
+    with patch("quodeq.services._fs_clone._subprocess.run", side_effect=fake_run):
+        run_git_clone("https://x/y.git", dest)
+    assert len(calls) == 2
+
+
+@pytest.mark.parametrize(
+    "stderr_text,expected_kind",
+    [
+        ("Permission denied (publickey).", "auth"),
+        ("Repository not found.", "repo_not_found"),
+        ("destination path 'foo' already exists and is not an empty directory.", "dest_exists"),
+        ("No space left on device", "disk"),
+    ],
+)
+def test_deterministic_failures_do_not_retry(stderr_text, expected_kind, tmp_path):
+    """Failures a full clone would hit identically raise once, without a retry."""
+    with patch("quodeq.services._fs_clone._subprocess.run") as run_mock:
+        run_mock.side_effect = _stderr(stderr_text)
+        with pytest.raises(CloneError) as exc:
+            run_git_clone("https://x/y.git", tmp_path / "dest")
+    assert exc.value.kind == expected_kind
+    assert run_mock.call_count == 1
+
+
+def test_timeout_does_not_retry(tmp_path):
+    """A shallow clone that already spent the whole timeout must not start a
+    second, slower full clone."""
+    timeout = subprocess.TimeoutExpired(cmd=["git", "clone"], timeout=300)
+    with patch("quodeq.services._fs_clone._subprocess.run", side_effect=timeout) as run_mock:
+        with pytest.raises(CloneError) as exc:
+            run_git_clone("https://x/y.git", tmp_path / "dest")
+    assert exc.value.kind == "network"
+    assert run_mock.call_count == 1
+
+
+def test_env_zero_disables_shallow(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_CLONE_SHALLOW_MONTHS", "0")
+    with patch("quodeq.services._fs_clone._subprocess.run") as run_mock:
+        run_mock.return_value = None
+        run_git_clone("https://x/y.git", tmp_path / "dest")
+    assert run_mock.call_count == 1
+    assert not _has_shallow_args(run_mock.call_args[0][0])
+
+
+def test_env_overrides_shallow_window(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_CLONE_SHALLOW_MONTHS", "12")
+    with patch("quodeq.services._fs_clone._subprocess.run") as run_mock:
+        run_mock.return_value = None
+        run_git_clone("https://x/y.git", tmp_path / "dest")
+    cmd = run_mock.call_args[0][0]
+    assert "--shallow-since=12 months ago" in cmd

--- a/tests/test_cli_branch_scope.py
+++ b/tests/test_cli_branch_scope.py
@@ -62,6 +62,28 @@ class TestCreateWorktree:
         wt = _create_worktree(repo, "nonexistent-branch")
         assert wt is None
 
+    def test_fetches_missing_branch_from_origin(self, tmp_path: Path) -> None:
+        """Online repos are registered via a single-branch shallow clone, so a
+        branch evaluation targets a branch the clone doesn't have yet; it must
+        be fetched from origin instead of failing."""
+        from quodeq.cli import _create_worktree
+        origin = tmp_path / "origin"
+        origin.mkdir()
+        _make_git_repo(origin, branches=["feature/other"])
+        clone = tmp_path / "clone"
+        subprocess.run(
+            ["git", "clone", "--single-branch", "--branch", "main", str(origin), str(clone)],
+            capture_output=True, check=True,
+        )
+
+        wt = _create_worktree(clone, "feature/other")
+        try:
+            assert wt is not None
+            assert (wt / "branch_file.txt").read_text() == "from feature/other"
+        finally:
+            if wt is not None:
+                subprocess.run(["git", "-C", str(clone), "worktree", "remove", str(wt), "--force"], capture_output=True)
+
 
 class TestCleanupWorktree:
     def test_removes_worktree(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

Adding an online repo clones the full history synchronously. Big repos take minutes and can hit the 300s clone timeout. For shaka-player that is 293 MB of `.git` for an evaluation that only reads HEAD plus 3 months of churn data.

## Change

`run_git_clone` now clones with `--single-branch --no-tags --shallow-since="4 months ago"`.

- The only history consumer is git churn scoring (`git_lookback_months`, default 3). The 4-month window covers it with slack. Churn scores on a shallow clone are identical to a full clone (verified on shaka-player, 122/122 files, `GIT_NO_LAZY_FETCH=1`).
- `QUODEQ_CLONE_SHALLOW_MONTHS` overrides the window. `0` restores full clones. Projects that raise `git_lookback_months` above 3 should raise it too.
- Shallow requests the server cannot satisfy (stale repos with no commits in the window, servers without `deepen-since`) fall back to one full clone. Deterministic failures (auth, not found, dest exists, disk) and timeouts do not retry. Partial clone dirs are removed before the retry.
- Branch evaluations keep working: single-branch clones lack other remote-tracking refs, so `_create_worktree` fetches the requested branch (`fetch origin <branch>:<branch>`) and retries once when `worktree add` fails. Success path is unchanged (one subprocess call).

## Numbers (same network, GitHub)

| repo | full clone | shallow clone |
|---|---|---|
| quodeq | 2.8s / 18 MB | 4.6s / 11 MB |
| shaka-player | 34.6s / 293 MB | 9.8-30.8s / 146 MB |

Shallow wall time varies with GitHub's server-side `deepen-since` walk. Bytes transferred halve, which is what dominates on slow connections. Small repos pay up to ~2s extra server think time.

Considered `--filter=blob:none` instead (smaller and faster): rejected because `git log --name-only` with default rename detection needs blob contents, so churn scoring either lazy-fetches over the network on every evaluation or silently truncates (measured 38 of 122 entries).

## Testing

- `tests/services/test_clone_shallow.py` (new): shallow args, fallback, no-retry cases, partial-dir cleanup, env overrides.
- `tests/test_cli_branch_scope.py`: branch fetch from a single-branch clone against a real local git origin.
- Full deterministic suite: 4735 passed. E2E against GitHub: shallow register (3.3s), stale-repo fallback (octocat/Hello-World), on-demand branch fetch, churn parity.