### PR TITLE
fix: shared/online repo consistency (audit A1-A4, B2-B3, C1-C6)

### DIFF
--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import shutil
 import zipfile
 from http import HTTPStatus
 from pathlib import Path
@@ -34,6 +35,7 @@ from quodeq.services.shared_repo import (
     published_meta,
     read_state,
     refresh_shared_clone,
+    shared_cache_dir,
     shared_evaluations_root,
     shared_index_db_path,
     shared_score_cache_path,
@@ -171,6 +173,14 @@ def register_shared_routes(app: Flask) -> None:
             validate_remote_url(url)
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
+        # Audit finding A4: reconnecting to a URL whose cache dir is already
+        # on disk (a prior connect, possibly stale) must not silently keep
+        # serving whatever was last fetched -- ensure_shared_clone below
+        # early-returns an existing clone without fetching, so the freshness
+        # check has to happen here, before it. refresh_shared_clone acquires
+        # clone_lock itself (RLock, so nesting would be safe too, but there
+        # is nothing else in this route that needs the lock held around it).
+        pre_existing = read_state(url) != "missing"
         repo = ensure_shared_clone(url)
         if repo is None:
             return (
@@ -179,6 +189,8 @@ def register_shared_routes(app: Flask) -> None:
                 ),
                 502,
             )
+        if pre_existing:
+            ok, _ = refresh_shared_clone(url)  # best effort; failure just leaves the pre-existing clone as-is, reason already logged internally
         # Format validation only makes sense once the clone actually exists,
         # so it runs AFTER ensure_shared_clone, not before -- a foreign or
         # too-new repo must never reach write_settings (that would connect
@@ -203,7 +215,18 @@ def register_shared_routes(app: Flask) -> None:
 
     @app.delete("/api/shared/config")
     def shared_config_delete() -> Response:
+        # Audit finding A4: disconnecting must not leave the clone's cache
+        # dir (repo + index.db + score_cache.db, all under shared_cache_dir)
+        # behind on disk forever. Read the url BEFORE clearing settings (it's
+        # gone from settings after write_settings), then remove it AFTER --
+        # so a crash between the two leaves the (still-usable) clone in
+        # place rather than an orphaned dir with no settings pointing at it.
+        # ignore_errors=True: a half-removed or permission-denied cache dir
+        # must not turn a disconnect into a 500.
+        settings = read_settings()
         write_settings(SharedSettings(url=None))
+        if settings.url is not None:
+            shutil.rmtree(shared_cache_dir(settings.url), ignore_errors=True)
         return jsonify({"configured": False})
 
     @app.post("/api/shared/refresh")
@@ -211,9 +234,16 @@ def register_shared_routes(app: Flask) -> None:
         settings = read_settings()
         if not settings.url:
             return jsonify({"error": "no shared repository configured"}), 400
-        if not refresh_shared_clone(settings.url):
+        ok, reason = refresh_shared_clone(settings.url)
+        if not ok:
             return (
-                jsonify({"stale": True, "lastSynced": last_synced_at(settings.url)}),
+                jsonify(
+                    {
+                        "stale": True,
+                        "lastSynced": last_synced_at(settings.url),
+                        "error": reason,
+                    }
+                ),
                 502,
             )
         return jsonify({"stale": False, "lastSynced": last_synced_at(settings.url)})
@@ -329,7 +359,8 @@ def register_shared_routes(app: Flask) -> None:
             # clone contents, just flag it. The index is only re-synced
             # after a successful refresh; there is nothing new to index
             # when the fetch itself failed.
-            if refresh_shared_clone(url):
+            ok, _ = refresh_shared_clone(url)
+            if ok:
                 sync_shared_index(url)
                 stale = False
             else:

--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -30,6 +30,7 @@ from quodeq.services.scoring import get_project_scores, get_scores_slim
 from quodeq.services.shared_publish import get_publish_status, start_publish
 from quodeq.services.shared_repo import (
     check_repo_format,
+    clone_lock,
     ensure_shared_clone,
     last_synced_at,
     published_meta,
@@ -223,10 +224,17 @@ def register_shared_routes(app: Flask) -> None:
         # place rather than an orphaned dir with no settings pointing at it.
         # ignore_errors=True: a half-removed or permission-denied cache dir
         # must not turn a disconnect into a 500.
+        #
+        # Review finding: rmtree must run under clone_lock(url), same as
+        # every other clone mutator (ensure_shared_clone, refresh_shared_clone,
+        # publish_project) -- otherwise a concurrent publish/refresh holding
+        # the lock can have its clone directory removed mid-operation,
+        # potentially leaving a partially-deleted .git that doesn't self-heal.
         settings = read_settings()
         write_settings(SharedSettings(url=None))
         if settings.url is not None:
-            shutil.rmtree(shared_cache_dir(settings.url), ignore_errors=True)
+            with clone_lock(settings.url):
+                shutil.rmtree(shared_cache_dir(settings.url), ignore_errors=True)
         return jsonify({"configured": False})
 
     @app.post("/api/shared/refresh")

--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -28,6 +28,7 @@ from quodeq.services.score_cache import score_cache_path_override
 from quodeq.services.scoring import get_project_scores, get_scores_slim
 from quodeq.services.shared_publish import get_publish_status, start_publish
 from quodeq.services.shared_repo import (
+    check_repo_format,
     ensure_shared_clone,
     last_synced_at,
     published_meta,
@@ -59,13 +60,18 @@ _MAX_DISMISSED_LIMIT = 5000
 def _with_shared_root(fn):
     """Resolve the configured clone; inject eval_root; scope the score cache.
 
-    Every decorated route becomes: 409 when unconfigured, 409 when the clone's
-    format is newer than this build understands, 503 when the clone hasn't
-    been fetched yet (or is otherwise unreadable), else the wrapped view runs
-    with ``eval_root`` (the shared clone's evaluations directory) and ``url``
-    (the configured remote) injected as keyword arguments, with the score
-    cache transparently scoped to this clone's own cache DB (Task 9) so its
-    rows never mix with the local clone's cache.
+    Every decorated route becomes: 409 when unconfigured, 409 when the
+    clone's format is foreign or newer than this build understands, 503 when
+    the clone hasn't been fetched yet at all, else the wrapped view runs with
+    ``eval_root`` (the shared clone's evaluations directory) and ``url`` (the
+    configured remote) injected as keyword arguments, with the score cache
+    transparently scoped to this clone's own cache DB (Task 9) so its rows
+    never mix with the local clone's cache.
+
+    "ok" and "empty" (cloned, never published into) both proceed: an empty
+    clone is a legitimate first-connect state, not an error, and every
+    wrapped list-shaped route already tolerates a missing evaluations dir by
+    returning an empty result (see build_project_list) rather than raising.
     """
 
     @functools.wraps(fn)
@@ -79,8 +85,23 @@ def _with_shared_root(fn):
                 jsonify({"error": "this shared repository requires a newer version of quodeq"}),
                 409,
             )
-        if state != "ok":
-            return jsonify({"error": "shared repository has not been cloned yet"}), 503
+        if state == "foreign":
+            return (
+                jsonify(
+                    {
+                        "error": "the configured repository does not look like a quodeq results repository",
+                        "code": "FOREIGN_REPO",
+                    }
+                ),
+                409,
+            )
+        if state == "missing":
+            return (
+                jsonify(
+                    {"error": "the shared repository has not been cloned yet — reconnect it in Settings"}
+                ),
+                503,
+            )
         root = shared_evaluations_root(settings.url)
         with score_cache_path_override(shared_score_cache_path(settings.url)):
             return fn(*args, eval_root=root, url=settings.url, **kwargs)
@@ -132,6 +153,11 @@ def register_shared_routes(app: Flask) -> None:
                 # can bind to it without existence checks.
                 "error": None,
                 "publish": publish,
+                # ok | empty | foreign | unsupported_version | missing | None
+                # (unconfigured) -- lets the UI distinguish "healthy but
+                # never published into" from the failure states instead of
+                # inferring clone health from configured+lastSynced alone.
+                "repoState": read_state(settings.url) if settings.url else None,
             }
         )
 
@@ -145,12 +171,32 @@ def register_shared_routes(app: Flask) -> None:
             validate_remote_url(url)
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
-        if ensure_shared_clone(url) is None:
+        repo = ensure_shared_clone(url)
+        if repo is None:
             return (
                 jsonify(
                     {"error": f"could not clone the repository, check that git can access {url}"}
                 ),
                 502,
+            )
+        # Format validation only makes sense once the clone actually exists,
+        # so it runs AFTER ensure_shared_clone, not before -- a foreign or
+        # too-new repo must never reach write_settings (that would connect
+        # the UI to a repo every subsequent /api/shared/* route then 409s
+        # on). "empty" (never published into) is a legitimate first-connect
+        # state and is accepted here same as "ok".
+        fmt = check_repo_format(repo)
+        if fmt == "foreign":
+            return (
+                jsonify(
+                    {"error": "the repository exists but does not look like a quodeq results repository"}
+                ),
+                400,
+            )
+        if fmt == "unsupported_version":
+            return (
+                jsonify({"error": "this shared repository requires a newer version of quodeq"}),
+                400,
             )
         write_settings(SharedSettings(url=url))
         return jsonify({"configured": True, "url": url})

--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import functools
 import logging
-import shutil
 import zipfile
 from http import HTTPStatus
 from pathlib import Path
@@ -36,6 +35,7 @@ from quodeq.services.shared_repo import (
     published_meta,
     read_state,
     refresh_shared_clone,
+    remove_clone_dir,
     shared_cache_dir,
     shared_evaluations_root,
     shared_index_db_path,
@@ -222,8 +222,10 @@ def register_shared_routes(app: Flask) -> None:
         # gone from settings after write_settings), then remove it AFTER --
         # so a crash between the two leaves the (still-usable) clone in
         # place rather than an orphaned dir with no settings pointing at it.
-        # ignore_errors=True: a half-removed or permission-denied cache dir
-        # must not turn a disconnect into a 500.
+        # remove_clone_dir handles git's read-only object files (plain
+        # rmtree leaves them behind on Windows, corrupting a later
+        # reconnect's adopted clone) and never raises: a half-removed or
+        # permission-denied cache dir must not turn a disconnect into a 500.
         #
         # Review finding: rmtree must run under clone_lock(url), same as
         # every other clone mutator (ensure_shared_clone, refresh_shared_clone,
@@ -234,7 +236,7 @@ def register_shared_routes(app: Flask) -> None:
         write_settings(SharedSettings(url=None))
         if settings.url is not None:
             with clone_lock(settings.url):
-                shutil.rmtree(shared_cache_dir(settings.url), ignore_errors=True)
+                remove_clone_dir(shared_cache_dir(settings.url))
         return jsonify({"configured": False})
 
     @app.post("/api/shared/refresh")

--- a/src/quodeq/core/types/project.py
+++ b/src/quodeq/core/types/project.py
@@ -29,6 +29,7 @@ class ProjectEntry:
     scope_path: str | None = None
     runs_count: int = 0
     latest_run_id: str | None = None
+    latest_done_run_id: str | None = None
     latest_date: str | None = None
     path_exists: bool | None = None
     files_count: int | None = None

--- a/src/quodeq/services/_fs_project_helpers.py
+++ b/src/quodeq/services/_fs_project_helpers.py
@@ -81,6 +81,14 @@ def _build_project_entry(
     latest_grade, latest_score, files_count = _read_accumulated_summary(
         reports_root, entry_name, runs,
     )
+    # runs is sorted newest-first (list_runs); status is already read there
+    # (cancelled/failed/in_progress detection), so no extra per-run read is
+    # needed here. "Done" == the "complete" bucket list_runs assigns to
+    # anything that isn't a live/cancelled/failed run -- this is what the
+    # update-vs-in-sync comparison needs: the newest run a republish would
+    # actually move forward, skipping a newer run that failed or was
+    # cancelled after the last successful one.
+    latest_done_run_id = next((run.run_id for run in runs if run.status == "complete"), None)
     return ProjectEntry(
         id=entry_name,
         name=meta["name"],
@@ -92,6 +100,7 @@ def _build_project_entry(
         scope_path=meta.get("scopePath"),
         runs_count=len(runs),
         latest_run_id=runs[0].run_id if runs else None,
+        latest_done_run_id=latest_done_run_id,
         latest_date=runs[0].date_iso if runs else None,
         path_exists=_check_path_exists(meta["path"], meta["location"]),
         files_count=files_count,

--- a/src/quodeq/services/shared_publish.py
+++ b/src/quodeq/services/shared_publish.py
@@ -23,6 +23,7 @@ from quodeq.services.shared_repo import (
     PUBLISHED_META_FILENAME,
     bootstrap_repo_layout,
     check_repo_format,
+    clone_lock,
     ensure_shared_clone,
     refresh_shared_clone,
     run_git,
@@ -190,67 +191,77 @@ def publish_project(
     if not project_dir.is_dir():
         raise PublishError(f"project {project_id} not found in local evaluations")
 
-    repo = ensure_shared_clone(url, env)
-    if repo is None:
-        raise PublishError(
-            f"could not reach the shared repository, check that git can access {url}"
-        )
-    refresh_shared_clone(url, env)  # best effort, publish is still guarded by push
+    # Everything from here through the final push/rebase runs under one
+    # process-wide clone lock (audit finding C2): a background refresh
+    # racing this stage/commit/push on the same clone directory can tear a
+    # commit or contend on .git/index.lock. clone_lock is an RLock, so the
+    # ensure_shared_clone / refresh_shared_clone calls below (each of which
+    # acquires it again internally) reenter on this same thread instead of
+    # deadlocking.
+    with clone_lock(url, env):
+        repo = ensure_shared_clone(url, env)
+        if repo is None:
+            raise PublishError(
+                f"could not reach the shared repository, check that git can access {url}"
+            )
+        refresh_shared_clone(url, env)  # best effort, publish is still guarded by push
 
-    fmt = check_repo_format(repo)
-    if fmt == "unsupported_version":
-        raise PublishError("this shared repository requires a newer version of quodeq")
-    if fmt == "foreign":
-        raise PublishError(
-            "the configured repository does not look like a quodeq results repository, "
-            "refusing to publish into it"
-        )
-    try:
-        if fmt == "empty":
-            bootstrap_repo_layout(repo)
+        fmt = check_repo_format(repo)
+        if fmt == "unsupported_version":
+            raise PublishError("this shared repository requires a newer version of quodeq")
+        if fmt == "foreign":
+            raise PublishError(
+                "the configured repository does not look like a quodeq results repository, "
+                "refusing to publish into it"
+            )
+        try:
+            if fmt == "empty":
+                bootstrap_repo_layout(repo)
 
-        count = stage_project(project_dir, repo / "evaluations" / project_id)
-    except (OSError, ValueError) as exc:
-        raise PublishError(f"failed to stage project files, {exc}") from exc
+            count = stage_project(project_dir, repo / "evaluations" / project_id)
+        except (OSError, ValueError) as exc:
+            raise PublishError(f"failed to stage project files, {exc}") from exc
 
-    add_paths = [MARKER_FILENAME, ".gitignore", f"evaluations/{project_id}"]
-    if (repo / "evaluations" / ".gitkeep").exists():
-        add_paths.append("evaluations/.gitkeep")
-    ok, out = run_git(["add", "--", *add_paths], cwd=repo)
-    if not ok:
-        raise PublishError(f"git add failed, {out.strip()[:300]}")
-
-    # A clean `diff --cached` only means nothing NEW was staged this call; it
-    # does not mean the remote already has our commits. A prior publish can
-    # have committed locally and then failed to push (transient network
-    # error), leaving a local commit the remote never received. Retrying
-    # with unchanged project files hits this exact "nothing staged" state,
-    # so we must still fall through to the push below rather than returning
-    # early. A push with nothing new to send exits 0 ("Everything
-    # up-to-date"), so this stays a no-op for the true idempotent case.
-    nothing_staged, _ = run_git(["diff", "--cached", "--quiet"], cwd=repo)
-    if not nothing_staged:
-        message = f"Publish {project_id} ({count} runs) via quodeq {_app_version()}"
-        ok, out = run_git(["commit", "-m", message], cwd=repo)
+        add_paths = [MARKER_FILENAME, ".gitignore", f"evaluations/{project_id}"]
+        if (repo / "evaluations" / ".gitkeep").exists():
+            add_paths.append("evaluations/.gitkeep")
+        ok, out = run_git(["add", "--", *add_paths], cwd=repo)
         if not ok:
-            raise PublishError(f"git commit failed, {out.strip()[:300]}")
+            raise PublishError(f"git add failed, {out.strip()[:300]}")
 
-    ok, out = _push(repo)
-    if not ok:
-        ok_rebase, out_rebase = run_git(["pull", "--rebase", "origin", "HEAD"], cwd=repo)
-        if ok_rebase:
-            ok, out = _push(repo)
-        else:
-            # A real conflict wedges the persistent clone with a lingering
-            # .git/rebase-merge directory, breaking every future publish.
-            # The clone is reused across calls, so always leave it clean.
-            run_git(["rebase", "--abort"], cwd=repo)
-            out = out_rebase
-    if not ok:
-        raise PublishError(
-            f"push to the shared repository failed, try again. {out.strip()[:300]}"
-        )
-    return count
+        # A clean `diff --cached` only means nothing NEW was staged this
+        # call; it does not mean the remote already has our commits. A
+        # prior publish can have committed locally and then failed to push
+        # (transient network error), leaving a local commit the remote never
+        # received. Retrying with unchanged project files hits this exact
+        # "nothing staged" state, so we must still fall through to the push
+        # below rather than returning early. A push with nothing new to
+        # send exits 0 ("Everything up-to-date"), so this stays a no-op for
+        # the true idempotent case.
+        nothing_staged, _ = run_git(["diff", "--cached", "--quiet"], cwd=repo)
+        if not nothing_staged:
+            message = f"Publish {project_id} ({count} runs) via quodeq {_app_version()}"
+            ok, out = run_git(["commit", "-m", message], cwd=repo)
+            if not ok:
+                raise PublishError(f"git commit failed, {out.strip()[:300]}")
+
+        ok, out = _push(repo)
+        if not ok:
+            ok_rebase, out_rebase = run_git(["pull", "--rebase", "origin", "HEAD"], cwd=repo)
+            if ok_rebase:
+                ok, out = _push(repo)
+            else:
+                # A real conflict wedges the persistent clone with a
+                # lingering .git/rebase-merge directory, breaking every
+                # future publish. The clone is reused across calls, so
+                # always leave it clean.
+                run_git(["rebase", "--abort"], cwd=repo)
+                out = out_rebase
+        if not ok:
+            raise PublishError(
+                f"push to the shared repository failed, try again. {out.strip()[:300]}"
+            )
+        return count
 
 
 def _push(repo: Path) -> tuple[bool, str]:

--- a/src/quodeq/services/shared_publish.py
+++ b/src/quodeq/services/shared_publish.py
@@ -204,7 +204,7 @@ def publish_project(
             raise PublishError(
                 f"could not reach the shared repository, check that git can access {url}"
             )
-        refresh_shared_clone(url, env)  # best effort, publish is still guarded by push
+        ok, _ = refresh_shared_clone(url, env)  # best effort, publish is still guarded by push
 
         fmt = check_repo_format(repo)
         if fmt == "unsupported_version":

--- a/src/quodeq/services/shared_publish.py
+++ b/src/quodeq/services/shared_publish.py
@@ -1,6 +1,8 @@
 """Staging logic for publishing a project into the shared results repo.
 
-Pure file operations, no git. Invariants (spec):
+Mostly pure file operations; the one exception is a `git config user.name`
+read (stage_project writes published.json, see audit finding C1). Invariants
+(spec):
 - only completed runs (state == "done") are published
 - explicit allowlist of source-of-truth files, never derived artifacts
 - actions.jsonl is union-merged with the remote copy, never overwritten
@@ -9,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shutil
 import threading
 import time
@@ -17,6 +20,7 @@ from pathlib import Path
 from quodeq.data.actions_log import ACTIONS_LOG_FILENAME
 from quodeq.services.shared_repo import (
     MARKER_FILENAME,
+    PUBLISHED_META_FILENAME,
     bootstrap_repo_layout,
     check_repo_format,
     ensure_shared_clone,
@@ -108,6 +112,20 @@ def merge_actions_log(ours: Path, theirs: Path, dest: Path) -> None:
 _SCAN_FILENAME = "scan.json"
 
 
+def _publish_attribution(clone_root: Path) -> str:
+    """Who is publishing, per `git config user.name` in the shared clone.
+
+    Reads git config rather than GIT_AUTHOR_NAME/GIT_COMMITTER_NAME: those
+    env vars only affect a new commit's recorded author/committer identity,
+    not `git config` lookups. Falls back to "unknown" (never raises) so a
+    missing git identity never blocks a publish -- audit finding C1 is about
+    truthful attribution when it IS known, not about requiring one.
+    """
+    ok, out = run_git(["config", "user.name"], cwd=clone_root)
+    author = out.strip() if ok else ""
+    return author or "unknown"
+
+
 def stage_project(project_dir: Path, dest_project_dir: Path) -> int:
     dest_project_dir.mkdir(parents=True, exist_ok=True)
     info = project_dir / "repository_info.json"
@@ -129,6 +147,23 @@ def stage_project(project_dir: Path, dest_project_dir: Path) -> int:
     runs = list_completed_runs(project_dir)
     for run_dir in runs:
         copy_run(run_dir, dest_project_dir / run_dir.name)
+
+    # Record who published and when at publish time (audit finding C1),
+    # rather than relying solely on git-log against the shared clone, which
+    # published_meta() still falls back to for dirs published before this
+    # file existed. dest_project_dir is <clone>/evaluations/<project_id>, so
+    # its grandparent is the clone root -- the same root publish_project's
+    # own `repo` variable points at.
+    clone_root = dest_project_dir.parent.parent
+    meta = {
+        "publishedBy": _publish_attribution(clone_root),
+        "publishedAt": int(time.time()),
+    }
+    meta_path = dest_project_dir / PUBLISHED_META_FILENAME
+    tmp = meta_path.with_suffix(meta_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(meta), encoding="utf-8")
+    os.replace(tmp, meta_path)
+
     return len(runs)
 
 
@@ -221,8 +256,8 @@ def publish_project(
 def _push(repo: Path) -> tuple[bool, str]:
     """Push HEAD to the remote's default branch.
 
-    A fresh --depth 1 clone of a brand-new empty bare repo has no commits
-    and no origin/HEAD symref yet, so plain ``push origin HEAD`` has nothing
+    A fresh clone of a brand-new empty bare repo has no commits and no
+    origin/HEAD symref yet, so plain ``push origin HEAD`` has nothing
     to compare against. Detect that case and push with an explicit refspec
     instead, deriving the target branch name from the remote's symref (or
     falling back to the local clone's current branch name).

--- a/src/quodeq/services/shared_publish.py
+++ b/src/quodeq/services/shared_publish.py
@@ -229,6 +229,25 @@ def publish_project(
         if not ok:
             raise PublishError(f"git add failed, {out.strip()[:300]}")
 
+        # stage_project unconditionally rewrites published.json with a fresh
+        # publishedAt/publishedBy (needed so those fields DO advance when
+        # content really changes). That means an otherwise-unchanged
+        # republish still stages a one-line diff on that file alone once the
+        # wall clock ticks to a new second. Detect that "staged set is only
+        # published.json" case and revert it to HEAD before the nothing-staged
+        # check below, so attribution only updates when real project content
+        # changed. A project's first-ever publish can never hit this
+        # incorrectly: published.json isn't in HEAD yet, so the staged set
+        # always includes the new runs/info files alongside it too. If it
+        # somehow doesn't, the checkout below simply fails against a
+        # nonexistent HEAD path; that failure is ignored and the normal
+        # commit path proceeds as if nothing special happened.
+        published_rel = f"evaluations/{project_id}/{PUBLISHED_META_FILENAME}"
+        ok_names, names_out = run_git(["diff", "--cached", "--name-only"], cwd=repo)
+        staged_names = [line.strip() for line in names_out.splitlines() if line.strip()]
+        if ok_names and staged_names == [published_rel]:
+            run_git(["checkout", "HEAD", "--", published_rel], cwd=repo)
+
         # A clean `diff --cached` only means nothing NEW was staged this
         # call; it does not mean the remote already has our commits. A
         # prior publish can have committed locally and then failed to push

--- a/src/quodeq/services/shared_repo.py
+++ b/src/quodeq/services/shared_repo.py
@@ -202,15 +202,13 @@ def sync_shared_index(url: str, env: dict | None = None) -> None:
 
 
 def read_state(url: str, env: dict | None = None) -> str:
+    """State of the local shared clone: ok | empty | foreign |
+    unsupported_version | missing. "empty" (cloned, never published into)
+    is servable -- routes return an empty listing for it."""
     repo = shared_repo_path(url, env)
     if not (repo / ".git").exists():
         return "missing"
-    fmt = check_repo_format(repo)
-    if fmt == "unsupported_version":
-        return "unsupported_version"
-    if fmt == "ok" or shared_evaluations_root(url, env).is_dir():
-        return "ok"
-    return "missing"
+    return check_repo_format(repo)
 
 
 def published_meta(url: str, env: dict | None = None) -> dict[str, dict]:

--- a/src/quodeq/services/shared_repo.py
+++ b/src/quodeq/services/shared_repo.py
@@ -1,8 +1,11 @@
 """Shared results repository: clone, refresh, and path management.
 
 The shared repo is a git remote holding an evaluations/ tree in the same
-layout as the local evaluations dir. We keep a shallow clone under
-~/.quodeq/cache/shared/<url-hash>/repo (QUODEQ_CACHE_ROOT overrides the base).
+layout as the local evaluations dir. We keep a full clone (no --depth,
+results repos are small; a shallow clone made git-log-based attribution
+misattribute every project to whoever pushed last -- audit finding C1)
+under ~/.quodeq/cache/shared/<url-hash>/repo (QUODEQ_CACHE_ROOT overrides
+the base).
 """
 from __future__ import annotations
 
@@ -88,7 +91,7 @@ def ensure_shared_clone(url: str, env: dict | None = None) -> Path | None:
     if (repo / ".git").exists():
         return repo
     repo.parent.mkdir(parents=True, exist_ok=True)
-    ok, out = run_git(["clone", "--depth", "1", "--", url, str(repo)])
+    ok, out = run_git(["clone", "--", url, str(repo)])
     if not ok:
         logger.warning("shared clone failed for %s: %s", url, out.strip()[:500])
         shutil.rmtree(repo, ignore_errors=True)
@@ -114,7 +117,7 @@ def refresh_shared_clone(url: str, env: dict | None = None, *, timeout: int = _D
     repo = shared_repo_path(url, env)
     if not (repo / ".git").exists():
         return ensure_shared_clone(url, env) is not None
-    ok, _ = run_git(["fetch", "--depth", "1", "origin", "HEAD"], cwd=repo, timeout=timeout)
+    ok, _ = run_git(["fetch", "origin", "HEAD"], cwd=repo, timeout=timeout)
     if not ok:
         return False
     ok, _ = run_git(["reset", "--hard", "FETCH_HEAD"], cwd=repo, timeout=timeout)
@@ -135,6 +138,7 @@ def last_synced_at(url: str, env: dict | None = None) -> float | None:
 MARKER_FILENAME = "quodeq.json"
 FORMAT_NAME = "quodeq-shared-evaluations"
 FORMAT_VERSION = 1
+PUBLISHED_META_FILENAME = "published.json"
 
 _GITIGNORE_CONTENT = "**/evaluation.db\n*.log\n"
 
@@ -211,7 +215,38 @@ def read_state(url: str, env: dict | None = None) -> str:
     return check_repo_format(repo)
 
 
+def _read_published_json(entry: Path) -> dict | None:
+    """Read <entry>/published.json, validating both keys.
+
+    Returns None on any failure (missing file, bad JSON, wrong shape) so the
+    caller can fall back to the git-log-derived legacy path -- never raises.
+    """
+    try:
+        data = json.loads((entry / PUBLISHED_META_FILENAME).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    by = data.get("publishedBy")
+    at = data.get("publishedAt")
+    if not isinstance(by, str) or not by:
+        return None
+    if not isinstance(at, int) or isinstance(at, bool):
+        return None
+    return {"publishedBy": by, "publishedAt": at}
+
+
 def published_meta(url: str, env: dict | None = None) -> dict[str, dict]:
+    """Attribution per published project: who published it, and when.
+
+    Prefers the published.json written by stage_project at publish time
+    (see shared_publish.py). Falls back to the legacy git-log-derived
+    lookup for project dirs published before that file existed. The
+    fallback is only correct because the clone is full history (no
+    --depth) -- a shallow clone made `git log -1 -- path` return the tip
+    commit for every path, misattributing every project except the most
+    recently pushed one (audit finding C1).
+    """
     repo = shared_repo_path(url, env)
     root = shared_evaluations_root(url, env)
     result: dict[str, dict] = {}
@@ -219,6 +254,10 @@ def published_meta(url: str, env: dict | None = None) -> dict[str, dict]:
         return result
     for entry in sorted(root.iterdir()):
         if not entry.is_dir():
+            continue
+        meta = _read_published_json(entry)
+        if meta is not None:
+            result[entry.name] = meta
             continue
         ok, out = run_git(
             ["log", "-1", "--format=%an|%ct", "--", f"evaluations/{entry.name}"],

--- a/src/quodeq/services/shared_repo.py
+++ b/src/quodeq/services/shared_repo.py
@@ -6,6 +6,17 @@ results repos are small; a shallow clone made git-log-based attribution
 misattribute every project to whoever pushed last -- audit finding C1)
 under ~/.quodeq/cache/shared/<url-hash>/repo (QUODEQ_CACHE_ROOT overrides
 the base).
+
+Git-mutation serialization (audit finding C2): background refreshes and an
+in-flight publish share one clone directory, so an unserialized fetch +
+hard-reset racing a stage/commit/push can tear a commit or contend on
+.git/index.lock. `clone_lock()` gives every mutator (refresh_shared_clone,
+ensure_shared_clone, publish_project) one process-wide lock per clone path.
+Readers (published_meta, sync_shared_index, the read-only /api/shared/*
+route mirrors) are deliberately NOT serialized against this lock -- full
+reader serialization is deferred. Torn reads are bounded instead by Task 2's
+atomic meta writes (published.json via tmp+rename): a reader can see a
+project that is one publish stale, never a half-written published.json.
 """
 from __future__ import annotations
 
@@ -15,6 +26,7 @@ import logging
 import os
 import shutil
 import subprocess
+import threading
 from pathlib import Path
 
 # Re-exported so the api layer can validate a shared-repo URL without
@@ -86,17 +98,38 @@ def shared_evaluations_root(url: str, env: dict | None = None) -> Path:
     return shared_repo_path(url, env) / "evaluations"
 
 
+_CLONE_LOCKS: dict[str, threading.RLock] = {}
+_CLONE_LOCKS_GUARD = threading.Lock()
+
+
+def clone_lock(url: str, env: dict | None = None) -> threading.RLock:
+    """Process-wide reentrant lock serializing git mutations on one clone.
+
+    Keyed by the clone's resolved path (shared_repo_path), so any two
+    callers that resolve to the same cache directory share one lock
+    regardless of how they spelled the url. RLock, not Lock: publish_project
+    holds this lock across its own internal refresh_shared_clone call, and
+    refresh_shared_clone / ensure_shared_clone each acquire it again inside
+    their own bodies -- a plain Lock would deadlock a thread against itself.
+    See the module docstring for what this does and does not serialize.
+    """
+    key = str(shared_repo_path(url, env))
+    with _CLONE_LOCKS_GUARD:
+        return _CLONE_LOCKS.setdefault(key, threading.RLock())
+
+
 def ensure_shared_clone(url: str, env: dict | None = None) -> Path | None:
-    repo = shared_repo_path(url, env)
-    if (repo / ".git").exists():
+    with clone_lock(url, env):
+        repo = shared_repo_path(url, env)
+        if (repo / ".git").exists():
+            return repo
+        repo.parent.mkdir(parents=True, exist_ok=True)
+        ok, out = run_git(["clone", "--", url, str(repo)])
+        if not ok:
+            logger.warning("shared clone failed for %s: %s", url, out.strip()[:500])
+            shutil.rmtree(repo, ignore_errors=True)
+            return None
         return repo
-    repo.parent.mkdir(parents=True, exist_ok=True)
-    ok, out = run_git(["clone", "--", url, str(repo)])
-    if not ok:
-        logger.warning("shared clone failed for %s: %s", url, out.strip()[:500])
-        shutil.rmtree(repo, ignore_errors=True)
-        return None
-    return repo
 
 
 _DEFAULT_REFRESH_TIMEOUT_S = 30
@@ -122,17 +155,23 @@ def refresh_shared_clone(url: str, env: dict | None = None, *, timeout: int = _D
     `.git/shallow` is present, try `git fetch --unshallow origin` first; a
     failure there (network hiccup, odd remote) is not fatal -- fall through
     to the plain fetch below, and a later refresh call retries the unshallow.
+
+    Runs entirely under clone_lock (audit finding C2): without it, this
+    fetch + hard-reset can interleave with an in-flight publish_project's
+    stage/commit/push on the same clone directory, tearing a commit or
+    contending on .git/index.lock.
     """
-    repo = shared_repo_path(url, env)
-    if not (repo / ".git").exists():
-        return ensure_shared_clone(url, env) is not None
-    if (repo / ".git" / "shallow").exists():
-        run_git(["fetch", "--unshallow", "origin"], cwd=repo, timeout=timeout)
-    ok, _ = run_git(["fetch", "origin", "HEAD"], cwd=repo, timeout=timeout)
-    if not ok:
-        return False
-    ok, _ = run_git(["reset", "--hard", "FETCH_HEAD"], cwd=repo, timeout=timeout)
-    return ok
+    with clone_lock(url, env):
+        repo = shared_repo_path(url, env)
+        if not (repo / ".git").exists():
+            return ensure_shared_clone(url, env) is not None
+        if (repo / ".git" / "shallow").exists():
+            run_git(["fetch", "--unshallow", "origin"], cwd=repo, timeout=timeout)
+        ok, _ = run_git(["fetch", "origin", "HEAD"], cwd=repo, timeout=timeout)
+        if not ok:
+            return False
+        ok, _ = run_git(["reset", "--hard", "FETCH_HEAD"], cwd=repo, timeout=timeout)
+        return ok
 
 
 def last_synced_at(url: str, env: dict | None = None) -> float | None:

--- a/src/quodeq/services/shared_repo.py
+++ b/src/quodeq/services/shared_repo.py
@@ -25,6 +25,7 @@ import json
 import logging
 import os
 import shutil
+import stat
 import subprocess
 import threading
 from pathlib import Path
@@ -40,6 +41,29 @@ logger = logging.getLogger(__name__)
 
 _CACHE_ENV = "QUODEQ_CACHE_ROOT"
 _DEFAULT_GIT_TIMEOUT_S = 300
+
+
+def _clear_readonly_and_retry(func, path, exc):  # noqa: ARG001
+    """rmtree onexc callback for git trees. Git marks object files read-only,
+    and on Windows deleting a read-only file raises PermissionError (POSIX
+    deletion only checks the parent dir). Clear the bit and retry once; if
+    that also fails, log instead of raising so cleanup stays best-effort."""
+    try:
+        os.chmod(path, stat.S_IWRITE)
+        func(path)
+    except OSError as retry_exc:
+        logger.warning("failed to remove %s: %s", path, retry_exc)
+
+
+def remove_clone_dir(path: Path | str) -> None:
+    """Best-effort recursive delete that tolerates git's read-only files.
+
+    Missing paths are a no-op. Never raises: a half-removed or
+    permission-denied dir must not turn cleanup into a 500.
+    """
+    if not os.path.lexists(path):
+        return
+    shutil.rmtree(path, onexc=_clear_readonly_and_retry)
 
 
 def _git_env() -> dict[str, str]:
@@ -127,7 +151,7 @@ def ensure_shared_clone(url: str, env: dict | None = None) -> Path | None:
         ok, out = run_git(["clone", "--", url, str(repo)])
         if not ok:
             logger.warning("shared clone failed for %s: %s", url, out.strip()[:500])
-            shutil.rmtree(repo, ignore_errors=True)
+            remove_clone_dir(repo)
             return None
         return repo
 

--- a/src/quodeq/services/shared_repo.py
+++ b/src/quodeq/services/shared_repo.py
@@ -113,10 +113,21 @@ def refresh_shared_clone(url: str, env: dict | None = None, *, timeout: int = _D
     into a stale=true response in ~*timeout* seconds instead. Does not
     affect ensure_shared_clone's own (still 300s) clone timeout -- an
     initial clone can legitimately take much longer than a refresh.
+
+    Unshallowing only applies to NEW clones: ensure_shared_clone stopped
+    passing --depth 1 in a prior fix, but a shared-clone cache directory
+    created back when it still did stays shallow forever otherwise --
+    ensure_shared_clone early-returns because `.git` already exists, and a
+    plain `fetch origin HEAD` does not unshallow a repo on its own. If
+    `.git/shallow` is present, try `git fetch --unshallow origin` first; a
+    failure there (network hiccup, odd remote) is not fatal -- fall through
+    to the plain fetch below, and a later refresh call retries the unshallow.
     """
     repo = shared_repo_path(url, env)
     if not (repo / ".git").exists():
         return ensure_shared_clone(url, env) is not None
+    if (repo / ".git" / "shallow").exists():
+        run_git(["fetch", "--unshallow", "origin"], cwd=repo, timeout=timeout)
     ok, _ = run_git(["fetch", "origin", "HEAD"], cwd=repo, timeout=timeout)
     if not ok:
         return False

--- a/src/quodeq/services/shared_repo.py
+++ b/src/quodeq/services/shared_repo.py
@@ -135,8 +135,20 @@ def ensure_shared_clone(url: str, env: dict | None = None) -> Path | None:
 _DEFAULT_REFRESH_TIMEOUT_S = 30
 
 
-def refresh_shared_clone(url: str, env: dict | None = None, *, timeout: int = _DEFAULT_REFRESH_TIMEOUT_S) -> bool:
+def refresh_shared_clone(
+    url: str, env: dict | None = None, *, timeout: int = _DEFAULT_REFRESH_TIMEOUT_S
+) -> tuple[bool, str]:
     """Fetch + hard-reset the clone to the remote's HEAD.
+
+    Returns ``(ok, reason)``: *reason* is ``""`` on success, else the
+    failing git command's stderr/stdout tail (<=200 chars) -- callers (the
+    refresh route, the ?refresh=1 listing branch) surface this so a failed
+    refresh reads as "could not resolve host" or "authentication failed"
+    instead of a bare "Request failed: 502" that can't distinguish DNS vs
+    auth vs a deleted origin (audit finding B3). Every failure is ALSO
+    logged via logger.warning, so a background/best-effort caller that
+    discards *reason* (e.g. publish_project's internal refresh) still gets
+    a diagnosable server-side trail.
 
     Called in-request (GET /api/shared/projects?refresh=1, POST
     /api/shared/refresh), so it must not inherit run_git's 300s default --
@@ -164,14 +176,24 @@ def refresh_shared_clone(url: str, env: dict | None = None, *, timeout: int = _D
     with clone_lock(url, env):
         repo = shared_repo_path(url, env)
         if not (repo / ".git").exists():
-            return ensure_shared_clone(url, env) is not None
+            if ensure_shared_clone(url, env) is not None:
+                return True, ""
+            reason = f"could not clone the repository, check that git can access {url}"
+            logger.warning("refresh_shared_clone: %s", reason)
+            return False, reason
         if (repo / ".git" / "shallow").exists():
             run_git(["fetch", "--unshallow", "origin"], cwd=repo, timeout=timeout)
-        ok, _ = run_git(["fetch", "origin", "HEAD"], cwd=repo, timeout=timeout)
+        ok, out = run_git(["fetch", "origin", "HEAD"], cwd=repo, timeout=timeout)
         if not ok:
-            return False
-        ok, _ = run_git(["reset", "--hard", "FETCH_HEAD"], cwd=repo, timeout=timeout)
-        return ok
+            reason = out.strip()[:200]
+            logger.warning("refresh_shared_clone: fetch failed for %s: %s", url, reason)
+            return False, reason
+        ok, out = run_git(["reset", "--hard", "FETCH_HEAD"], cwd=repo, timeout=timeout)
+        if not ok:
+            reason = out.strip()[:200]
+            logger.warning("refresh_shared_clone: reset failed for %s: %s", url, reason)
+            return False, reason
+        return True, ""
 
 
 def last_synced_at(url: str, env: dict | None = None) -> float | None:

--- a/src/quodeq/ui/src/api/queryKeys.js
+++ b/src/quodeq/ui/src/api/queryKeys.js
@@ -63,4 +63,5 @@ export const settingsKeys = {
 export const sharedKeys = {
   all: () => ["shared"],
   status: () => ["shared", "status"],
+  list: () => ["shared", "list"],
 };

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
@@ -500,7 +500,7 @@ function FilterPill({ label, value, options, valueLabels = {}, onChange }) {
   );
 }
 
-function ProjectsToolbar({ filters = {}, onFiltersChange, configured, lastSynced, stale, refreshing, onRefresh }) {
+function ProjectsToolbar({ filters = {}, onFiltersChange, configured, lastSynced, stale, error, refreshing, onRefresh }) {
   const { query = '', location = 'all', sort = 'activity' } = filters;
   const set = (patch) => onFiltersChange?.({ query, location, sort, ...patch });
   return (
@@ -528,25 +528,31 @@ function ProjectsToolbar({ filters = {}, onFiltersChange, configured, lastSynced
         valueLabels={{ activity: 'recent activity' }}
         onChange={(s) => set({ sort: s })}
       />
-      <SyncedIndicator configured={configured} lastSynced={lastSynced} stale={stale} refreshing={refreshing} onRefresh={onRefresh} />
+      <SyncedIndicator configured={configured} lastSynced={lastSynced} stale={stale} error={error} refreshing={refreshing} onRefresh={onRefresh} />
     </div>
   );
 }
 
-// "syncing…" while a background refresh is in flight, else "synced <relative
-// time>" (+ " · stale" when the last refresh failed), or "not synced yet"
-// before the first list has ever landed -- the merged list's only
-// sync-status surface now that the old online sub-tab (and its "refresh
-// failed, showing results synced..." banner) is gone. Renders nothing at
-// all (refresh button included) when no shared repo is configured -- there
-// is nothing to sync.
-function SyncedIndicator({ configured, lastSynced, stale, refreshing, onRefresh }) {
+// "syncing…" while a background refresh is in flight, else "sync failed ·
+// retry" when the shared hook reports an error (an initial status/list load
+// that never landed -- audit A2; onRefresh doubles as the retry affordance
+// since useSharedProjects' refresh() re-checks both status and list), else
+// "synced <relative time>" (+ " · stale" when the last refresh failed but a
+// prior successful listing is still on screen), or "not synced yet" before
+// the first list has EVER landed and there is no error either -- the merged
+// list's only sync-status surface now that the old online sub-tab (and its
+// "refresh failed, showing results synced..." banner) is gone. Renders
+// nothing at all (refresh button included) when no shared repo is
+// configured -- there is nothing to sync.
+function SyncedIndicator({ configured, lastSynced, stale, error, refreshing, onRefresh }) {
   if (!configured) return null;
   const label = refreshing
     ? 'syncing…'
-    : lastSynced == null
-      ? 'not synced yet'
-      : `synced ${relativeTime(lastSynced)}${stale ? ' · stale' : ''}`;
+    : error
+      ? 'sync failed · retry'
+      : lastSynced == null
+        ? 'not synced yet'
+        : `synced ${relativeTime(lastSynced)}${stale ? ' · stale' : ''}`;
   return (
     <span className="projects-toolbar-sync">
       <span className="projects-toolbar-sync-label">{label}</span>
@@ -803,6 +809,7 @@ export default function ProjectsPage({ projects = [], selectedProject, isEvaluat
             configured={shared.configured}
             lastSynced={shared.lastSynced}
             stale={shared.stale}
+            error={shared.error}
             refreshing={shared.refreshing}
             onRefresh={shared.refresh}
           />

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
@@ -597,27 +597,14 @@ export default function ProjectsPage({ projects = [], selectedProject, isEvaluat
     publish,
   } = usePublish({ enabled: projects.length > 0 });
 
-  // Important-2 (review): usePublish's own re-fetch on job completion only
-  // updates ITS `publishedAtByProject` map -- useSharedProjects' list (which
-  // useMergedProjects reads to derive each entry's chips/action) is never
-  // re-fetched by a publish completing, so a card would keep showing a live
-  // 'publish'/'update' button with stale chips after the job finishes.
-  // Refresh the shared list exactly once per completion; the ref (not
-  // state) means re-renders while publishState stays 'done' don't re-fire
-  // it.
-  const prevPublishStateRef = useRef(publishState);
-  useEffect(() => {
-    if (publishState === 'done' && prevPublishStateRef.current !== 'done') {
-      shared.refresh();
-    }
-    prevPublishStateRef.current = publishState;
-  }, [publishState, shared.refresh]);
-
   // Local project objects never carry publishedAt on their own (it lives
   // only on the shared list's git-log-derived metadata) -- merge it in by
-  // id/name so ProjectCard can read `project.publishedAt` uniformly, and so
-  // a publish that just completed is reflected immediately even though
-  // useSharedProjects' own list isn't re-fetched by it.
+  // id/name so ProjectCard can read `project.publishedAt` uniformly. Belt
+  // and suspenders with `entry.shared?.publishedAt` below (the merged
+  // entry already carries it too, since usePublish and useSharedProjects
+  // share the same sharedKeys.list() cache entry -- see Task 5) but this
+  // keeps LocalPublishedMeta's prop stable even for callers that only ever
+  // look at `project.publishedAt` directly.
   const projectsWithPublished = useMemo(() => {
     if (!sharedConfigured || Object.keys(publishedAtByProject).length === 0) return projects;
     return projects.map((p) => {
@@ -714,7 +701,12 @@ export default function ProjectsPage({ projects = [], selectedProject, isEvaluat
     publishingProject,
     publishError,
     publishErrorProject,
-    onPublish: publish,
+    // Passes the local project object alongside its id -- usePublish's own
+    // done-branch optimistic cache patch (audit C3/C4) needs
+    // originUrl/latestRunId/latestDoneRunId to attribute the completed
+    // publish to the right merged entry, and CardFooter's onClick only ever
+    // hands back the bare id/name string.
+    onPublish: (id) => publish(id, localEntryById.get(id)?.local),
   };
 
   // Pull-to-local (shared-only cards): mirrors the delete-confirm idiom for

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.test.jsx
@@ -520,12 +520,21 @@ describe('ProjectsPage — publish action (local cards)', () => {
     }
   });
 
-  // Important 2 (final whole-branch review): useSharedProjects' own list is
-  // never re-fetched by usePublish completing on its own (usePublish's
-  // fetchSharedList is a separate call feeding a separate map) -- without
-  // ProjectsPage explicitly refreshing it, a card would keep showing a live
-  // 'publish'/'update' button and stale chips after the job finishes.
-  it('post-publish: a completed job triggers exactly one shared.refresh() call that re-fetches the list', async () => {
+  // Audit C4 regression lock (final whole-branch review + Task 6): the old
+  // fix routed post-publish completion through ProjectsPage's own effect
+  // calling shared.refresh() -- a full remote git fetch that can take up to
+  // 30s -- so the PUBLISHED badge/no-button state lagged behind the
+  // "published <relative time>" meta line (which updated off usePublish's
+  // own cheap refetch) by however long that fetch took. usePublish now owns
+  // completion end to end: it optimistically upserts the published id into
+  // the shared list cache the instant the job reports 'done' (see
+  // usePublish.js's applyOptimisticPublish), synchronously before its own
+  // authoritative re-list call even starts. Since useSharedProjects reads
+  // that SAME cache entry (sharedKeys.list(), unified in Task 5), the badge
+  // and the button both flip in that same render -- proven here by holding
+  // the authoritative re-list open and asserting the card has already
+  // flipped before it resolves.
+  it('post-publish: the card flips to PUBLISHED with no publish button immediately, before the authoritative refresh resolves (C4 regression lock)', async () => {
     vi.useFakeTimers();
     try {
       let publishDone = false;
@@ -535,28 +544,23 @@ describe('ProjectsPage — publish action (local cards)', () => {
           ? { state: 'done', project: 'p1', runs: 2 }
           : { state: 'idle', project: null, runs: null, error: null, finishedAt: null },
       }));
-      const sharedListProjects = vi.fn(async () => ({ projects: [], lastSynced: null, stale: false }));
-      const refreshShared = vi.fn(async () => ({ stale: false, lastSynced: '2026-07-19T00:00:00Z' }));
-      const fakeApi = configuredLocalApi({ getSharedStatus, sharedListProjects, refreshShared });
+      let resolveList;
+      const sharedListProjects = vi.fn(() => {
+        if (!publishDone) return Promise.resolve({ projects: [], lastSynced: null, stale: false });
+        // Held pending once the job is done -- the card must already show
+        // PUBLISHED/no-button from the optimistic patch alone, before this
+        // authoritative call ever resolves.
+        return new Promise((resolve) => { resolveList = resolve; });
+      });
+      const fakeApi = configuredLocalApi({ getSharedStatus, sharedListProjects });
       renderWithApi(<ProjectsPage projects={localProjects} actions={{}} />, fakeApi);
 
-      await act(async () => { await vi.advanceTimersByTimeAsync(0); });
-      expect(screen.getAllByRole('button', { name: 'publish' })).toHaveLength(2);
-
-      // Isolate the post-publish refresh from useSharedProjects' own
-      // mount-time background revalidate, which also calls these mocks.
-      // react-query's notifyManager schedules cache-update notifications
-      // via a real setTimeout(fn, 0) (see @tanstack/query-core's
-      // timeoutManager), which fake timers intercept -- and the mount
-      // revalidate is a multi-hop cascade (status settles -> list enables
-      // -> list settles -> refresh() -> re-invalidate), each hop its own
-      // scheduled timer. runOnlyPendingTimersAsync drains the whole
-      // cascade (including timers newly scheduled by ones it just ran),
-      // where a fixed number of advanceTimersByTimeAsync(0) calls isn't
-      // guaranteed to reach the end of the chain.
+      // Drain the mount-time cascade (status -> list -> background
+      // revalidate) before touching the publish flow -- see the sibling
+      // test above for why runOnlyPendingTimersAsync is needed here instead
+      // of a fixed number of advanceTimersByTimeAsync(0) calls.
       await act(async () => { await vi.runOnlyPendingTimersAsync(); });
-      refreshShared.mockClear();
-      sharedListProjects.mockClear();
+      expect(screen.getAllByRole('button', { name: 'publish' })).toHaveLength(2);
 
       fireEvent.click(screen.getAllByRole('button', { name: 'publish' })[0]);
       await act(async () => { await vi.advanceTimersByTimeAsync(0); });
@@ -564,15 +568,26 @@ describe('ProjectsPage — publish action (local cards)', () => {
 
       publishDone = true;
       await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
-      await act(async () => { await vi.advanceTimersByTimeAsync(0); });
 
-      expect(refreshShared).toHaveBeenCalledTimes(1);
-      expect(sharedListProjects).toHaveBeenCalled();
+      // The authoritative refresh is still pending (captured but not yet
+      // resolved) -- the card must already reflect completion regardless.
+      expect(resolveList).toBeDefined();
+      expect(screen.getByText('PUBLISHED')).toBeInTheDocument();
+      // p1's own publish button is gone; p2 (never published) still has one.
+      expect(screen.getAllByRole('button', { name: 'publish' })).toHaveLength(1);
 
-      // A further tick with publishState still 'done' (no new completion)
-      // must not re-fire the refresh -- re-renders alone don't re-trigger it.
-      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
-      expect(refreshShared).toHaveBeenCalledTimes(1);
+      // Resolving the refresh with authoritative data must not regress the
+      // card -- it only overwrites the optimistic entry.
+      await act(async () => {
+        resolveList({
+          projects: [{ id: 'p1', name: 'demo-one', publishedAt: '2026-07-19T00:00:00Z' }],
+          lastSynced: '2026-07-19T00:00:00Z',
+          stale: false,
+        });
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(screen.getByText('PUBLISHED')).toBeInTheDocument();
+      expect(screen.getAllByRole('button', { name: 'publish' })).toHaveLength(1);
     } finally {
       vi.useRealTimers();
     }

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.test.jsx
@@ -545,6 +545,16 @@ describe('ProjectsPage — publish action (local cards)', () => {
 
       // Isolate the post-publish refresh from useSharedProjects' own
       // mount-time background revalidate, which also calls these mocks.
+      // react-query's notifyManager schedules cache-update notifications
+      // via a real setTimeout(fn, 0) (see @tanstack/query-core's
+      // timeoutManager), which fake timers intercept -- and the mount
+      // revalidate is a multi-hop cascade (status settles -> list enables
+      // -> list settles -> refresh() -> re-invalidate), each hop its own
+      // scheduled timer. runOnlyPendingTimersAsync drains the whole
+      // cascade (including timers newly scheduled by ones it just ran),
+      // where a fixed number of advanceTimersByTimeAsync(0) calls isn't
+      // guaranteed to reach the end of the chain.
+      await act(async () => { await vi.runOnlyPendingTimersAsync(); });
       refreshShared.mockClear();
       sharedListProjects.mockClear();
 
@@ -618,7 +628,7 @@ describe('ProjectsPage — group-aware filtering and the empty-filter trap', () 
     // present -- before the fix, the child's entry (and its action) was
     // built from the post-filter list and vanished the moment the query
     // excluded the child's own name.
-    expect(screen.getAllByRole('button', { name: 'publish' })).toHaveLength(2);
+    await waitFor(() => expect(screen.getAllByRole('button', { name: 'publish' })).toHaveLength(2));
   });
 
   it('filtering everything out keeps the toolbar mounted and shows a no-match line, not the empty-CTA', async () => {
@@ -695,6 +705,31 @@ describe('ProjectsPage — SyncedIndicator: "not synced yet" and unconfigured hi
 
     await waitFor(() => expect(screen.getByText('not synced yet')).toBeInTheDocument());
     expect(screen.queryByText(/just now/)).not.toBeInTheDocument();
+  });
+
+  // Audit A2: a list that never loads used to render "not synced yet" with
+  // no error and no working recovery control. It now renders a distinct
+  // error state, and the same button that used to just say "refresh" is
+  // the retry affordance -- clicking it calls the refresh endpoint (which
+  // useSharedProjects' refresh() also uses to re-check status, see that
+  // hook's own tests).
+  it('shows "sync failed · retry" (no em-dash) when the shared list fails to load, and the button retries via refreshShared()', async () => {
+    const refreshShared = vi.fn(async () => ({ stale: false, lastSynced: '2026-07-19T00:00:00Z' }));
+    const fakeApi = makeFakeApi({
+      getSharedStatus: vi.fn(async () => ({ configured: true, url: 'https://github.com/team/results.git' })),
+      sharedListProjects: vi.fn(async () => { throw new Error('list failed'); }),
+      refreshShared,
+    });
+    const user = userEvent.setup();
+    renderWithApi(<ProjectsPage projects={[{ id: 'a', name: 'app' }]} actions={{}} />, fakeApi);
+
+    await waitFor(() => expect(screen.getByText('sync failed · retry')).toBeInTheDocument());
+    expect(screen.getByText('sync failed · retry').textContent).not.toMatch(/—/);
+    expect(screen.queryByText('not synced yet')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'refresh' }));
+
+    await waitFor(() => expect(refreshShared).toHaveBeenCalled());
   });
 
   it('hides the sync indicator and its refresh button entirely when no shared repo is configured', async () => {

--- a/src/quodeq/ui/src/features/dashboard/hooks/usePublish.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/usePublish.js
@@ -1,5 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useApi } from '../../../api/ApiContext.jsx';
+import { sharedKeys } from '../../../api/queryKeys.js';
 
 const POLL_INTERVAL_MS = 2000;
 
@@ -20,24 +22,59 @@ function buildPublishedAtMap(list) {
  * carries: whether a shared repo is configured at all (to decide whether the
  * publish button shows), and each project's publishedAt, which only exists
  * on the SHARED project list (git log of the clone -- see
- * services/shared_repo.py's published_meta()). This hook fetches both with
- * `refresh: false` -- it must never force an actual git fetch of the remote
- * just because a local card is rendering; that stays exclusively
- * useSharedProjects' background-refresh job (see that hook's own doc
- * comment). `enabled` lets the caller skip this fetch entirely when there
- * is nothing to decorate (e.g. there are no local projects yet).
+ * services/shared_repo.py's published_meta()). `configured` and
+ * `publishedAtByProject` derive from the SAME two react-query queries
+ * useSharedProjects itself reads -- `sharedKeys.status()` and
+ * `sharedKeys.list()` -- so mounting both hooks together never issues
+ * duplicate requests: react-query dedupes any active observers sharing a
+ * key (audit C6). Both queries fetch with `refresh: false` -- this hook
+ * must never force an actual git fetch of the remote just because a local
+ * card is rendering; that stays exclusively useSharedProjects' background-
+ * refresh job (see that hook's own doc comment). `enabled` lets the caller
+ * skip these queries entirely when there is nothing to decorate (e.g. there
+ * are no local projects yet) -- though if some OTHER mounted consumer
+ * (typically useSharedProjects itself) already has the same query active,
+ * the shared cache entry is fetched regardless; `enabled` here only governs
+ * whether THIS hook's own observer, in isolation, would trigger it.
  *
  * The publish trigger and its job-progress polling live here rather than in
  * a component per the Task 20 design: a single publish job is global to the
  * whole app (one project publishing at a time, enforced server-side), so
  * "is anything publishing right now" has to be state shared by every local
- * card's button, not something any one card owns.
+ * card's button, not something any one card owns. Polling during a RUNNING
+ * publish calls `getSharedStatus()` directly every 2s -- deliberately
+ * bypassing the query cache -- because it's polling job status, not list
+ * data; routing it through `sharedKeys.status()` would churn that cache
+ * (and every other consumer re-rendering off it) every 2s for no reason.
+ * Once the job finishes, the shared LIST query IS the right thing to
+ * refresh (so publishedAtByProject picks up the new publishedAt) -- that
+ * goes through `queryClient.fetchQuery`, which (unlike `enabled`) ignores
+ * this hook's own gating and always performs the fetch, updating the same
+ * cache entry every other consumer reads.
  */
 export function usePublish({ enabled = true } = {}) {
   const { getSharedStatus, sharedListProjects, publishProject } = useApi();
+  const queryClient = useQueryClient();
 
-  const [configured, setConfigured] = useState(false);
-  const [publishedAtByProject, setPublishedAtByProject] = useState({});
+  const statusQuery = useQuery({
+    queryKey: sharedKeys.status(),
+    queryFn: getSharedStatus,
+    enabled,
+  });
+
+  const configured = !!statusQuery.data?.configured;
+
+  const listQuery = useQuery({
+    queryKey: sharedKeys.list(),
+    queryFn: () => sharedListProjects({ refresh: false }),
+    enabled: enabled && configured,
+  });
+
+  const publishedAtByProject = useMemo(
+    () => buildPublishedAtMap(listQuery.data?.projects),
+    [listQuery.data],
+  );
+
   // idle | running | done | error -- mirrors the backend's global publish job.
   const [publishState, setPublishState] = useState('idle');
   const [publishingProject, setPublishingProject] = useState(null);
@@ -45,13 +82,13 @@ export function usePublish({ enabled = true } = {}) {
   const [publishErrorProject, setPublishErrorProject] = useState(null);
 
   // In-flight guard for the publish trigger -- same synchronous-ref idiom as
-  // useSharedProjects' connectingRef/refreshingRef/pullingRef. A ref (not
-  // state) because it must be readable synchronously on the very next call,
-  // before any state update triggered by this call has committed/re-rendered.
-  // It only guards the POST round-trip itself (a rapid double-click/Enter
-  // race), not the whole background job -- once the POST resolves, a click
-  // on a DIFFERENT card's button is expected to reach the backend and get a
-  // real 409, which is how that card's own inline error gets populated.
+  // useSharedProjects' connectingRef/pullingRef. A ref (not state) because
+  // it must be readable synchronously on the very next call, before any
+  // state update triggered by this call has committed/re-rendered. It only
+  // guards the POST round-trip itself (a rapid double-click/Enter race),
+  // not the whole background job -- once the POST resolves, a click on a
+  // DIFFERENT card's button is expected to reach the backend and get a real
+  // 409, which is how that card's own inline error gets populated.
   const publishingRef = useRef(false);
   const pollTimerRef = useRef(null);
   const mountedRef = useRef(true);
@@ -72,17 +109,20 @@ export function usePublish({ enabled = true } = {}) {
     }
   }, []);
 
-  const fetchSharedList = useCallback(async () => {
-    try {
-      const envelope = await sharedListProjects({ refresh: false });
-      if (!mountedRef.current) return;
-      setPublishedAtByProject(buildPublishedAtMap(envelope?.projects));
-    } catch {
-      // Best effort -- a failed refresh just leaves the "published <time
-      // ago>" meta stale on cards; it is not primary content worth an
-      // error banner over.
-    }
-  }, [sharedListProjects]);
+  const refreshListAfterCompletion = useCallback(() => {
+    // Imperative and cache-key-targeted rather than a plain refetch of
+    // THIS hook's own (possibly disabled) listQuery -- fetchQuery ignores
+    // `enabled` entirely, so the meta line updates even when this hook was
+    // mounted with `enabled: false` (e.g. no local projects at the moment
+    // the job that just finished was started for a project elsewhere).
+    return queryClient
+      .fetchQuery({ queryKey: sharedKeys.list(), queryFn: () => sharedListProjects({ refresh: false }) })
+      .catch(() => {
+        // Best effort -- a failed refresh just leaves the "published <time
+        // ago>" meta stale on cards; it is not primary content worth an
+        // error banner over.
+      });
+  }, [queryClient, sharedListProjects]);
 
   const checkStatus = useCallback(async () => {
     let data;
@@ -111,60 +151,10 @@ export function usePublish({ enabled = true } = {}) {
       setPublishState('done');
       setPublishError(null);
       setPublishErrorProject(null);
-      await fetchSharedList();
+      await refreshListAfterCompletion();
     }
     setPublishingProjectBoth(null);
-  }, [getSharedStatus, stopPolling, fetchSharedList, setPublishingProjectBoth]);
-
-  const loadStatus = useCallback(async () => {
-    try {
-      const data = await getSharedStatus();
-      if (!mountedRef.current) return;
-      setConfigured(!!data?.configured);
-      if (data?.configured) {
-        await fetchSharedList();
-      }
-      const publish = data?.publish || {};
-      if (publish.state === 'running') {
-        // A job was already in flight before this mount (e.g. the user
-        // navigated away mid-publish and back) -- pick polling back up
-        // rather than showing every button as idle while it's really not.
-        setPublishState('running');
-        setPublishingProjectBoth(publish.project ?? null);
-        stopPolling();
-        pollTimerRef.current = setInterval(checkStatus, POLL_INTERVAL_MS);
-      } else if (publishingProjectRef.current) {
-        // The hook was disabled and re-enabled (tab toggle) while a job was
-        // running. The fetched status is no longer running, meaning the job
-        // completed while away -- reconcile local state to match the server.
-        if (publish.state === 'error') {
-          setPublishState('error');
-          setPublishError(publish.error || 'publish failed');
-          setPublishErrorProject(publish.project ?? publishingProjectRef.current);
-        } else {
-          // 'done' or an unexpected 'idle' -- refresh the shared list once
-          setPublishState('done');
-          await fetchSharedList();
-        }
-        setPublishingProjectBoth(null);
-      }
-    } catch {
-      // Best effort -- this is a supporting meta fetch (button visibility +
-      // published-at decoration), not primary page content.
-    }
-  }, [getSharedStatus, fetchSharedList, checkStatus, stopPolling, setPublishingProjectBoth]);
-
-  useEffect(() => {
-    mountedRef.current = true;
-    if (enabled) loadStatus();
-    return () => {
-      mountedRef.current = false;
-      stopPolling();
-    };
-    // Runs once per mount (or when `enabled` flips true) -- see the hook's
-    // own doc comment above for why this always fetches with refresh:false.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled]);
+  }, [getSharedStatus, stopPolling, refreshListAfterCompletion, setPublishingProjectBoth]);
 
   const publish = useCallback(async (projectId) => {
     if (publishingRef.current) return; // already in flight -- ignore the repeat click
@@ -189,6 +179,60 @@ export function usePublish({ enabled = true } = {}) {
       publishingRef.current = false;
     }
   }, [publishProject, checkStatus, stopPolling, setPublishingProjectBoth]);
+
+  // Mount/unmount lifecycle -- guards the async checkStatus/refreshList
+  // continuations above against setting state after unmount, and always
+  // clears any live interval on the way out.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      stopPolling();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount/unmount only
+  }, []);
+
+  // Polling must stop whenever `enabled` toggles (either direction), same
+  // as the old effect's cleanup used to -- a tab switch away must not keep
+  // ticking in the background for a hook the caller has disabled.
+  useEffect(() => {
+    return () => { stopPolling(); };
+  }, [enabled, stopPolling]);
+
+  // Reconcile local publish state whenever a fresh status lands (mount,
+  // re-enable after being disabled while a job was running, or any OTHER
+  // consumer's invalidation of sharedKeys.status() -- e.g. useSharedProjects'
+  // own refresh()). Mirrors the old loadStatus()'s two branches exactly:
+  // the server saying "running" is adopted unconditionally (a job started
+  // elsewhere -- a CLI publish, or before this mount -- surfaces here too);
+  // otherwise, if THIS hook was locally tracking a running job that the
+  // fresh status no longer reports as running, the job finished while this
+  // hook wasn't polling (disabled, or a fresh mount after external
+  // completion) and local state is reconciled to match the server.
+  useEffect(() => {
+    const publish = statusQuery.data?.publish;
+    if (!publish) return;
+    if (publish.state === 'running') {
+      setPublishState('running');
+      setPublishingProjectBoth(publish.project ?? null);
+      stopPolling();
+      pollTimerRef.current = setInterval(checkStatus, POLL_INTERVAL_MS);
+    } else if (publishingProjectRef.current) {
+      stopPolling();
+      if (publish.state === 'error') {
+        setPublishState('error');
+        setPublishError(publish.error || 'publish failed');
+        setPublishErrorProject(publish.project ?? publishingProjectRef.current);
+      } else {
+        setPublishState('done');
+        setPublishError(null);
+        setPublishErrorProject(null);
+        refreshListAfterCompletion();
+      }
+      setPublishingProjectBoth(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-run on a genuinely new status payload
+  }, [statusQuery.data]);
 
   return {
     configured,

--- a/src/quodeq/ui/src/features/dashboard/hooks/usePublish.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/usePublish.js
@@ -14,6 +14,37 @@ function buildPublishedAtMap(list) {
   return map;
 }
 
+// Upserts the just-published project into the shared list cache's `projects`
+// array, merging over any existing entry with the same id (audit C3/C4).
+// `local` is the LOCAL project object the publish() call was made with (see
+// publishingLocalRef below) -- its originUrl/latestRunId/latestDoneRunId are
+// copied over so the merge in projectsMerge.js immediately recognizes this as
+// the SAME project (chips flip to PUBLISHED, no stale publish/update button)
+// without waiting for the authoritative refresh to learn those fields from
+// the backend. Falls back to whatever the existing entry already had for any
+// field `local` doesn't know, so a merge never regresses already-good data.
+function upsertPublishedProject(projects, id, local) {
+  const idx = projects.findIndex((p) => (p.id || p.name) === id);
+  const existing = idx === -1 ? null : projects[idx];
+  const merged = {
+    ...existing,
+    id,
+    name: local?.name ?? existing?.name ?? id,
+    publishedAt: Date.now(),
+    publishedBy: null, // backend's published.json is authoritative; the UI
+    // shows "published <relative time>" regardless (see PublishedMeta/
+    // LocalPublishedMeta -- both render gracefully with no publishedBy).
+    source: 'shared',
+    latestRunId: local?.latestRunId ?? existing?.latestRunId ?? null,
+    latestDoneRunId: local?.latestDoneRunId ?? existing?.latestDoneRunId ?? null,
+    originUrl: local?.originUrl ?? existing?.originUrl ?? null,
+  };
+  if (idx === -1) return [...projects, merged];
+  const next = [...projects];
+  next[idx] = merged;
+  return next;
+}
+
 /**
  * usePublish -- publish action + job progress for local cards on the merged
  * Projects page (one list, no tabs -- see ProjectsPage.jsx).
@@ -96,6 +127,11 @@ export function usePublish({ enabled = true } = {}) {
   // (memoized once, reused across ticks) always reads the latest value
   // instead of whatever was captured in its closure at creation time.
   const publishingProjectRef = useRef(null);
+  // The local project object passed to the most recent publish() call (see
+  // that callback below) -- carries the identity fields (name, originUrl,
+  // latestRunId, latestDoneRunId) the optimistic cache patch needs but the
+  // backend's status/publish payload doesn't echo back.
+  const publishingLocalRef = useRef(null);
 
   const setPublishingProjectBoth = useCallback((id) => {
     publishingProjectRef.current = id;
@@ -108,6 +144,24 @@ export function usePublish({ enabled = true } = {}) {
       pollTimerRef.current = null;
     }
   }, []);
+
+  // Synchronous, BEFORE any network round trip: patches the shared list
+  // cache with the just-published id the instant the job reports 'done', so
+  // every consumer of sharedKeys.list() (useMergedProjects' chips/action via
+  // useSharedProjects, and this hook's own publishedAtByProject) flips in the
+  // SAME render (audit C3/C4) instead of waiting up to 30s for the
+  // authoritative refresh below to land. Only uses `publishingLocalRef` when
+  // it actually corresponds to `id` -- a fresh mount that reconciles a job
+  // started elsewhere never had a local project object handed to it, and a
+  // stale ref must never get attributed to the wrong id.
+  const applyOptimisticPublish = useCallback((id) => {
+    const local = publishingLocalRef.current;
+    const matchedLocal = local && (local.id ?? local.name) === id ? local : null;
+    queryClient.setQueryData(sharedKeys.list(), (old) => ({
+      ...old,
+      projects: upsertPublishedProject(old?.projects ?? [], id, matchedLocal),
+    }));
+  }, [queryClient]);
 
   const refreshListAfterCompletion = useCallback(() => {
     // Imperative and cache-key-targeted rather than a plain refetch of
@@ -159,12 +213,15 @@ export function usePublish({ enabled = true } = {}) {
       setPublishState('done');
       setPublishError(null);
       setPublishErrorProject(null);
+      // Flip the card BEFORE the network round trip below, then let the
+      // authoritative refresh overwrite this optimistic entry once it lands.
+      if (finishedProject) applyOptimisticPublish(finishedProject);
       await refreshListAfterCompletion();
     }
     setPublishingProjectBoth(null);
-  }, [getSharedStatus, stopPolling, refreshListAfterCompletion, setPublishingProjectBoth]);
+  }, [getSharedStatus, stopPolling, applyOptimisticPublish, refreshListAfterCompletion, setPublishingProjectBoth]);
 
-  const publish = useCallback(async (projectId) => {
+  const publish = useCallback(async (projectId, localProject) => {
     if (publishingRef.current) return; // already in flight -- ignore the repeat click
     publishingRef.current = true;
     setPublishError(null);
@@ -178,6 +235,11 @@ export function usePublish({ enabled = true } = {}) {
       // result), never optimistically before the POST resolves.
       setPublishState('running');
       setPublishingProjectBoth(projectId);
+      // Stashed for the done-branch's optimistic cache patch (see
+      // applyOptimisticPublish) -- the caller's local project object is the
+      // only place originUrl/latestRunId/latestDoneRunId are known from,
+      // since the backend's publish/status payloads never echo them back.
+      publishingLocalRef.current = localProject ?? null;
       stopPolling();
       pollTimerRef.current = setInterval(checkStatus, POLL_INTERVAL_MS);
     } catch (err) {
@@ -235,6 +297,8 @@ export function usePublish({ enabled = true } = {}) {
         setPublishState('done');
         setPublishError(null);
         setPublishErrorProject(null);
+        const doneProject = publish.project ?? publishingProjectRef.current;
+        if (doneProject) applyOptimisticPublish(doneProject);
         refreshListAfterCompletion();
       }
       setPublishingProjectBoth(null);

--- a/src/quodeq/ui/src/features/dashboard/hooks/usePublish.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/usePublish.js
@@ -116,7 +116,15 @@ export function usePublish({ enabled = true } = {}) {
     // mounted with `enabled: false` (e.g. no local projects at the moment
     // the job that just finished was started for a project elsewhere).
     return queryClient
-      .fetchQuery({ queryKey: sharedKeys.list(), queryFn: () => sharedListProjects({ refresh: false }) })
+      .fetchQuery({
+        queryKey: sharedKeys.list(),
+        queryFn: () => sharedListProjects({ refresh: false }),
+        // Force the fetch: the production QueryClient's default staleTime is
+        // 30s (see api/queryClient.js), so without this a still-fresh cache
+        // entry would let fetchQuery resolve without ever hitting the
+        // network -- silently contradicting the comment above this function.
+        staleTime: 0,
+      })
       .catch(() => {
         // Best effort -- a failed refresh just leaves the "published <time
         // ago>" meta stale on cards; it is not primary content worth an

--- a/src/quodeq/ui/src/features/dashboard/hooks/usePublish.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/usePublish.test.jsx
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { usePublish } from './usePublish.js';
 import { useSharedProjects } from './useSharedProjects.js';
 import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
 import { ApiProvider } from '../../../api/ApiContext.jsx';
+import { sharedKeys } from '../../../api/queryKeys.js';
 
 function makeFakeApi(overrides = {}) {
   return {
@@ -143,6 +145,74 @@ describe('usePublish', () => {
         await vi.advanceTimersByTimeAsync(4000);
       });
       expect(getSharedStatus).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Minor finding (final whole-branch review): refreshListAfterCompletion's
+  // fetchQuery inherited the production QueryClient's staleTime: 30s (see
+  // api/queryClient.js), so it could resolve straight from a still-fresh
+  // cache entry instead of actually fetching -- silently contradicting its
+  // own doc comment ("always performs the fetch"). withQueryClient() (used by
+  // every other test in this file) sets staleTime: 0 for the whole test
+  // client, which would mask the bug -- a 0-staleTime entry is already
+  // "stale" regardless of the fix, so fetchQuery would refetch either way.
+  // This test builds its own client with production's real staleTime: 30_000
+  // so the assertion actually exercises the bug.
+  it('refetches the shared list after a completed publish even when the cached entry is still within staleTime', async () => {
+    vi.useFakeTimers();
+    try {
+      const getSharedStatus = vi.fn(async () => ({
+        configured: true,
+        publish: { state: 'done', project: 'p1', runs: 2 },
+      }));
+      const sharedListProjects = vi.fn(async () => ({
+        projects: [{ id: 'p1', name: 'demo', publishedAt: '2026-07-18T00:00:00Z' }],
+        lastSynced: '2026-07-18T00:00:00Z',
+        stale: false,
+      }));
+      const fakeApi = makeFakeApi({ getSharedStatus, sharedListProjects });
+
+      const client = new QueryClient({
+        defaultOptions: { queries: { staleTime: 30_000, gcTime: 5 * 60_000, retry: false } },
+      });
+      // Seed the list cache with a fresh entry (just written, well inside the
+      // 30s staleTime window) -- absent the fix, fetchQuery would resolve
+      // straight from this without ever calling sharedListProjects again.
+      client.setQueryData(sharedKeys.list(), {
+        projects: [{ id: 'p1', name: 'demo', publishedAt: '2026-07-17T00:00:00Z' }],
+        lastSynced: '2026-07-17T00:00:00Z',
+        stale: false,
+      });
+
+      const { result } = renderHook(() => usePublish({ enabled: false }), {
+        wrapper: ({ children }) => (
+          <QueryClientProvider client={client}>
+            <ApiProvider value={fakeApi}>{children}</ApiProvider>
+          </QueryClientProvider>
+        ),
+      });
+
+      await act(async () => {
+        await result.current.publish('p1');
+      });
+      expect(result.current.publishState).toBe('running');
+      expect(sharedListProjects).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+
+      // advanceTimersByTimeAsync flushes the microtask chain triggered by the
+      // tick (checkStatus -> refreshListAfterCompletion -> fetchQuery), so
+      // the outcome is already settled here -- no waitFor needed (and
+      // waitFor's own timer-driven polling would hang under fake timers).
+      expect(result.current.publishState).toBe('done');
+      // The completion refresh must hit the network for fresh data, not
+      // resolve silently from the still-fresh cache entry seeded above.
+      expect(sharedListProjects).toHaveBeenCalledWith({ refresh: false });
+      expect(result.current.publishedAtByProject.p1).toBe('2026-07-18T00:00:00Z');
     } finally {
       vi.useRealTimers();
     }

--- a/src/quodeq/ui/src/features/dashboard/hooks/usePublish.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/usePublish.test.jsx
@@ -218,6 +218,91 @@ describe('usePublish', () => {
     }
   });
 
+  // Audit C3/C4: the "published <relative time>" meta, the PUBLISHED badge,
+  // and the publish/update button used to update at different speeds --
+  // the meta from usePublish's own cheap refetch, the badge/button only once
+  // the (possibly-coalesced, possibly-slow) authoritative refresh landed.
+  // The fix optimistically upserts the published id into the shared list
+  // cache the instant the job reports 'done', synchronously before the
+  // authoritative refresh's network round trip even starts -- so every
+  // consumer of sharedKeys.list() flips in the same render. This test holds
+  // the authoritative refresh open to prove the cache is patched BEFORE it
+  // resolves, then resolves it to prove the optimistic entry gets
+  // overwritten by real server data rather than left stale.
+  it('optimistically patches the list cache with the published id before the authoritative refresh resolves, then the refresh overwrites it', async () => {
+    vi.useFakeTimers();
+    try {
+      const getSharedStatus = vi.fn(async () => ({
+        configured: true,
+        publish: { state: 'done', project: 'p1', runs: 1 },
+      }));
+      let resolveList;
+      const sharedListProjects = vi.fn(() => new Promise((resolve) => { resolveList = resolve; }));
+      const fakeApi = makeFakeApi({ getSharedStatus, sharedListProjects });
+
+      const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const { result } = renderHook(() => usePublish({ enabled: false }), {
+        wrapper: ({ children }) => (
+          <QueryClientProvider client={client}>
+            <ApiProvider value={fakeApi}>{children}</ApiProvider>
+          </QueryClientProvider>
+        ),
+      });
+
+      const local = {
+        id: 'p1',
+        name: 'demo',
+        latestRunId: 'run-9',
+        latestDoneRunId: 'run-9',
+        originUrl: 'https://github.com/org/demo',
+      };
+      await act(async () => {
+        await result.current.publish('p1', local);
+      });
+      expect(result.current.publishState).toBe('running');
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+
+      // The poll saw 'done' and the optimistic patch landed synchronously --
+      // the authoritative refresh (sharedListProjects) is still pending
+      // (resolveList captured but not yet called).
+      expect(resolveList).toBeDefined();
+      const midFlight = client.getQueryData(sharedKeys.list());
+      const optimisticEntry = midFlight.projects.find((p) => p.id === 'p1');
+      expect(optimisticEntry).toMatchObject({
+        id: 'p1',
+        name: 'demo',
+        publishedBy: null,
+        source: 'shared',
+        latestRunId: 'run-9',
+        latestDoneRunId: 'run-9',
+        originUrl: 'https://github.com/org/demo',
+      });
+      expect(optimisticEntry.publishedAt).toEqual(expect.any(Number));
+      expect(result.current.publishState).toBe('done');
+
+      // Now let the authoritative refresh resolve with real server data --
+      // it must overwrite the optimistic entry, not merely coexist with it.
+      resolveList({
+        projects: [{ id: 'p1', name: 'demo', publishedAt: '2026-07-19T00:00:00Z', publishedBy: 'alice' }],
+        lastSynced: '2026-07-19T00:00:00Z',
+        stale: false,
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      const settled = client.getQueryData(sharedKeys.list());
+      const finalEntry = settled.projects.find((p) => p.id === 'p1');
+      expect(finalEntry.publishedBy).toBe('alice');
+      expect(finalEntry.publishedAt).toBe('2026-07-19T00:00:00Z');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('a 409 from the POST itself surfaces the message inline without crashing', async () => {
     const err = new Error('a publish is already running');
     const fakeApi = makeFakeApi({ publishProject: vi.fn(async () => { throw err; }) });

--- a/src/quodeq/ui/src/features/dashboard/hooks/usePublish.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/usePublish.test.jsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import React from 'react';
 import { usePublish } from './usePublish.js';
+import { useSharedProjects } from './useSharedProjects.js';
 import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
 import { ApiProvider } from '../../../api/ApiContext.jsx';
 
@@ -210,12 +211,10 @@ describe('usePublish', () => {
       wrapper: ({ children }) => wrap(fakeApi, children),
     });
 
-    await act(async () => {});
-
+    await waitFor(() => expect(result.current.configured).toBe(true));
+    await waitFor(() => expect(fakeApi.sharedListProjects).toHaveBeenCalledWith({ refresh: false }));
     expect(fakeApi.getSharedStatus).toHaveBeenCalledTimes(1);
-    expect(fakeApi.sharedListProjects).toHaveBeenCalledWith({ refresh: false });
-    expect(result.current.configured).toBe(true);
-    expect(result.current.publishedAtByProject.p1).toBe('2026-07-10T00:00:00Z');
+    await waitFor(() => expect(result.current.publishedAtByProject.p1).toBe('2026-07-10T00:00:00Z'));
   });
 
   it('does not call sharedListProjects on mount when unconfigured', async () => {
@@ -252,9 +251,8 @@ describe('usePublish', () => {
       }
     );
 
-    // Mount enabled: loadStatus sees the running job and tracks it.
-    await act(async () => {});
-    expect(result.current.publishState).toBe('running');
+    // Mount enabled: the fresh status shows the running job; it's adopted.
+    await waitFor(() => expect(result.current.publishState).toBe('running'));
     expect(result.current.publishingProject).toBe('p1');
 
     // User switches to the online tab: hook disabled, polling stops,
@@ -270,20 +268,21 @@ describe('usePublish', () => {
       configured: true,
       publish: { state: 'done', project: 'p1' },
     }));
+    await waitFor(() => expect(sharedListProjects.mock.calls.length).toBeGreaterThan(0));
     const listCallsBefore = sharedListProjects.mock.calls.length;
 
-    // User returns to the local tab: hook re-enabled, loadStatus refetches.
+    // User returns to the local tab: hook re-enabled, status refetches.
     await act(async () => {
       rerender({ enabled: true });
     });
 
     // The wedge: without reconciliation, state stays 'running' forever.
-    expect(result.current.publishState).not.toBe('running');
-    expect(result.current.publishState).toBe('done');
+    await waitFor(() => expect(result.current.publishState).toBe('done'));
     expect(result.current.publishingProject).toBeNull();
     // The done transition triggered the shared-list re-fetch (on top of the
-    // configured-path fetch loadStatus always does): exactly 2 new calls.
-    expect(sharedListProjects.mock.calls.length).toBe(listCallsBefore + 2);
+    // configured-path fetch re-enabling the list query always does): exactly
+    // 2 new calls.
+    await waitFor(() => expect(sharedListProjects.mock.calls.length).toBe(listCallsBefore + 2));
     expect(sharedListProjects).toHaveBeenCalledWith({ refresh: false });
   });
 
@@ -301,8 +300,7 @@ describe('usePublish', () => {
       }
     );
 
-    await act(async () => {});
-    expect(result.current.publishState).toBe('running');
+    await waitFor(() => expect(result.current.publishState).toBe('running'));
     expect(result.current.publishingProject).toBe('p1');
 
     await act(async () => {
@@ -319,7 +317,7 @@ describe('usePublish', () => {
       rerender({ enabled: true });
     });
 
-    expect(result.current.publishState).toBe('error');
+    await waitFor(() => expect(result.current.publishState).toBe('error'));
     expect(result.current.publishingProject).toBeNull();
     expect(result.current.publishError).toBe('permission denied');
     expect(result.current.publishErrorProject).toBe('p1');
@@ -398,5 +396,36 @@ describe('usePublish', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  // Audit C6: useSharedProjects and usePublish used to each fetch status
+  // and list independently -- two of every request per Projects mount.
+  // Both hooks now read `sharedKeys.status()`/`sharedKeys.list()`, so
+  // react-query dedupes: mounting them together issues exactly one status
+  // fetch and one list fetch, not one pair per hook.
+  it('mounting alongside useSharedProjects issues exactly one status fetch and one list fetch (react-query dedup)', async () => {
+    // Held open so the background revalidate useSharedProjects fires after
+    // its own first successful list never completes during this test --
+    // otherwise its own re-list would add a second, legitimate list fetch
+    // and muddy the "exactly one" assertion this test is making.
+    const refreshShared = vi.fn(() => new Promise(() => {}));
+    const fakeApi = makeFakeApi({ refreshShared });
+
+    function BothHooks() {
+      useSharedProjects();
+      return usePublish({ enabled: true });
+    }
+
+    renderHook(() => BothHooks(), {
+      wrapper: ({ children }) => wrap(fakeApi, children),
+    });
+
+    await waitFor(() => expect(fakeApi.getSharedStatus).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(fakeApi.sharedListProjects).toHaveBeenCalledTimes(1));
+    // Give a would-be duplicate fetch (the bug this locks in against) a
+    // chance to show up before asserting the counts hold steady.
+    await act(async () => {});
+    expect(fakeApi.getSharedStatus).toHaveBeenCalledTimes(1);
+    expect(fakeApi.sharedListProjects).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/quodeq/ui/src/features/dashboard/hooks/useSharedProjects.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useSharedProjects.js
@@ -192,7 +192,13 @@ export function useSharedProjects() {
   }, [pullSharedProject, queryClient]);
 
   const url = statusQuery.data?.url ?? null;
-  const projects = listQuery.data?.projects || [];
+  // Gated on `configured`, not just read off listQuery.data: the list query
+  // is disabled (not removed) when unconfigured, so a lingering cache entry
+  // from before a disconnect (or from a DIFFERENT shared repo before a
+  // reconnect) would otherwise keep rendering shared cards -- with live pull
+  // buttons -- on a page that has nothing connected (ghost shared cards
+  // after disconnect, final whole-branch review).
+  const projects = configured ? (listQuery.data?.projects || []) : [];
   const lastSynced = listQuery.data?.lastSynced ?? statusQuery.data?.lastSynced ?? null;
   const stale = staleOverride || !!listQuery.data?.stale;
 

--- a/src/quodeq/ui/src/features/dashboard/hooks/useSharedProjects.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useSharedProjects.js
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useApi } from '../../../api/ApiContext.jsx';
+import { sharedKeys } from '../../../api/queryKeys.js';
 
 /**
  * useSharedProjects — shared-repo status + project list for the merged
@@ -7,38 +9,77 @@ import { useApi } from '../../../api/ApiContext.jsx';
  * shared-only cards, the toolbar's SyncedIndicator, and -- via
  * useMergedProjects -- every local card's chips/action. Wraps the Task 15
  * shared-repo API client (getSharedStatus, sharedListProjects,
- * connectShared, refreshShared, pullSharedProject) behind a small local
- * state machine.
+ * connectShared, refreshShared, pullSharedProject) behind two react-query
+ * queries (`sharedKeys.status()`, `sharedKeys.list()`) plus a small
+ * coalescing refresh.
  *
- * Cached-first mount: the very first project-list fetch always passes
- * `refresh: false` so the UI renders instantly from whatever the server
+ * This is the single source of shared status/list data in the app now:
+ * usePublish and Settings' SharedRepoSection read (and, on their own
+ * mutations, invalidate) these SAME cache entries, so a connect, disconnect,
+ * publish, or refresh anywhere in the app is reflected everywhere else
+ * through one cache instead of three independently-fetched copies that used
+ * to drift apart (audit C6).
+ *
+ * Cached-first mount: the list query's `queryFn` always passes
+ * `refresh: false`, so the UI renders instantly from whatever the server
  * already has cached, never blocking on a synchronous git fetch. Once that
- * cached render lands, a background `refresh()` kicks off automatically
- * (only when a shared repo is configured) to revalidate against the remote,
- * via `refreshShared()`. Every other re-list (after connect, after a publish
- * job completes, or the explicit toolbar refresh button) also passes
- * `refresh: false`; `refreshShared()` is what triggers the real remote
- * fetch.
+ * cached render lands (the list query's first success), a background
+ * `refresh()` kicks off automatically -- exactly once -- to revalidate
+ * against the remote, via `refreshShared()`. Every other re-list (after
+ * connect, after a publish job completes, or the explicit toolbar refresh
+ * button) also passes `refresh: false`; `refreshShared()` is what triggers
+ * the real remote fetch.
  *
- * Error handling has two tiers: a failed *initial* load (status or the
- * first list) surfaces `error` since there's nothing to show yet. A failed
- * *refresh* of an already-loaded page does NOT blank the view -- it flags
- * `stale` so the toolbar's SyncedIndicator can show "synced <time> ago ·
- * stale" over the still-valid last-known listing.
+ * Error handling has two tiers: a failed *initial* load (status, or the
+ * first list once configured -- i.e. before either has ever produced data)
+ * surfaces `error` since there's nothing to show yet. A failed *refresh* of
+ * an already-loaded page does NOT blank the view -- it flags `stale` so the
+ * toolbar's SyncedIndicator can show "synced <time> ago · stale" over the
+ * still-valid last-known listing.
+ *
+ * `lastSynced` seeds from the STATUS payload -- the server reports it on
+ * every /status response -- so a list-only failure still shows when the
+ * repo last synced instead of "not synced yet" (audit B2); once the list
+ * has its own envelope, that value overrides it.
+ *
+ * `refresh()` coalesces rather than drops: a call that arrives while one is
+ * already running doesn't start a second POST immediately -- it marks the
+ * run as pending and is satisfied by exactly one more round once the
+ * current one settles, no matter how many calls stack up in the meantime
+ * (audit C3 groundwork; the old in-flight guard used to just silently
+ * ignore the repeat call, which is how a post-publish refresh could get
+ * dropped on the floor). Both the POST and the follow-up re-list run again
+ * invalidating `sharedKeys.all()` -- not just the list -- so `refresh()`
+ * doubles as the retry affordance behind the toolbar's "sync failed ·
+ * retry" state even when the ORIGINAL failure was the status fetch itself
+ * (audit A2): a stuck `configured=false` with no data would otherwise never
+ * get another chance, since a disabled list query never fetches on its own.
  */
 export function useSharedProjects() {
   const { getSharedStatus, sharedListProjects, connectShared, refreshShared, pullSharedProject } = useApi();
+  const queryClient = useQueryClient();
 
-  const [configured, setConfigured] = useState(false);
-  const [url, setUrl] = useState(null);
-  const [projects, setProjects] = useState([]);
-  const [lastSynced, setLastSynced] = useState(null);
-  const [stale, setStale] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const statusQuery = useQuery({
+    queryKey: sharedKeys.status(),
+    queryFn: getSharedStatus,
+  });
+
+  const configured = !!statusQuery.data?.configured;
+
+  const listQuery = useQuery({
+    queryKey: sharedKeys.list(),
+    queryFn: () => sharedListProjects({ refresh: false }),
+    enabled: configured,
+  });
+
   const [connecting, setConnecting] = useState(false);
   const [connectError, setConnectError] = useState(null);
   const [refreshing, setRefreshing] = useState(false);
+  // Overridden to true by a failed refresh() round (either the POST or the
+  // re-list that follows it); reset on the next round's outcome. Combined
+  // with the list envelope's own `stale` flag below -- either can make the
+  // toolbar show "· stale".
+  const [staleOverride, setStaleOverride] = useState(false);
 
   // In-flight guards: aria-disabled on the triggering button does not stop
   // a click in this codebase's convention (buttons stay clickable so their
@@ -49,67 +90,74 @@ export function useSharedProjects() {
   // the very next call, before any state update triggered by this call has
   // committed/re-rendered.
   const connectingRef = useRef(false);
-  const refreshingRef = useRef(false);
   const pullingRef = useRef(false);
 
-  const fetchList = useCallback(async (refresh) => {
-    const envelope = await sharedListProjects({ refresh });
-    setProjects(envelope?.projects || []);
-    setLastSynced(envelope?.lastSynced ?? null);
-    setStale(!!envelope?.stale);
-    return envelope;
-  }, [sharedListProjects]);
+  // --- refresh(): coalescing wrapper around one POST + re-list round -----
+  // runningRef marks a round actually in flight; pendingRef marks that
+  // at least one more caller arrived while it was running and must be
+  // satisfied by an EXTRA round once the current one settles; waitersRef
+  // holds those callers' resolvers so their returned promise only settles
+  // once the round they asked for has actually run.
+  const runningRef = useRef(false);
+  const pendingRef = useRef(false);
+  const waitersRef = useRef([]);
 
-  const loadStatus = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await getSharedStatus();
-      setConfigured(!!data?.configured);
-      setUrl(data?.url ?? null);
-      if (data?.configured) {
-        await fetchList(false);
-        return true;
-      }
-      return false;
-    } catch (err) {
-      setError(err?.message || 'failed to load shared repository status');
-      return false;
-    } finally {
-      setLoading(false);
-    }
-  }, [getSharedStatus, fetchList]);
-
-  const refresh = useCallback(async () => {
-    if (refreshingRef.current) return; // already refreshing -- ignore the repeat click
-    refreshingRef.current = true;
-    setRefreshing(true);
+  const refreshCore = useCallback(async () => {
     try {
       await refreshShared();
-      await fetchList(false);
     } catch {
       // Keep whatever projects/lastSynced are already on screen; just flag
       // it stale. The exact API error message isn't shown here -- the
       // stale banner copy is fixed regardless of cause.
-      setStale(true);
-    } finally {
-      refreshingRef.current = false;
-      setRefreshing(false);
+      setStaleOverride(true);
+      return;
     }
-  }, [refreshShared, fetchList]);
+    try {
+      await queryClient.invalidateQueries({ queryKey: sharedKeys.all() });
+      const listState = queryClient.getQueryState(sharedKeys.list());
+      setStaleOverride(listState?.status === 'error');
+    } catch {
+      setStaleOverride(true);
+    }
+  }, [refreshShared, queryClient]);
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      const configuredNow = await loadStatus();
-      // Background revalidate: the cached list is already on screen; a failed
-      // refresh just flags stale (see refresh()).
-      if (configuredNow && !cancelled) refresh();
+  const refresh = useCallback(() => {
+    if (runningRef.current) {
+      pendingRef.current = true;
+      return new Promise((resolve) => { waitersRef.current.push(resolve); });
+    }
+    runningRef.current = true;
+    setRefreshing(true);
+    return (async () => {
+      try {
+        await refreshCore();
+        // Coalesce: run exactly one more round for every batch of callers
+        // that arrived while the previous round was in flight, instead of
+        // one round per call.
+        while (pendingRef.current) {
+          pendingRef.current = false;
+          const waiters = waitersRef.current;
+          waitersRef.current = [];
+          await refreshCore();
+          waiters.forEach((resolve) => resolve());
+        }
+      } finally {
+        runningRef.current = false;
+        setRefreshing(false);
+      }
     })();
-    return () => { cancelled = true; };
-    // Runs once per mount.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [refreshCore]);
+
+  // Background revalidate: fires once, the first time the cached list
+  // lands successfully (never when unconfigured, since the list query
+  // never runs in that case).
+  const bgTriggeredRef = useRef(false);
+  useEffect(() => {
+    if (listQuery.isSuccess && !bgTriggeredRef.current) {
+      bgTriggeredRef.current = true;
+      refresh();
+    }
+  }, [listQuery.isSuccess, refresh]);
 
   const connect = useCallback(async (nextUrl) => {
     if (connectingRef.current) return; // already connecting -- ignore the repeat click/Enter
@@ -118,24 +166,53 @@ export function useSharedProjects() {
     setConnectError(null);
     try {
       await connectShared(nextUrl);
-      await loadStatus();
+      // Invalidate everything "shared"-prefixed, not just status: a
+      // reconnect to a DIFFERENT url while already configured=true would
+      // otherwise never re-fetch the list (its `enabled` flag never
+      // toggles, since configured was already true before and after).
+      await queryClient.invalidateQueries({ queryKey: sharedKeys.all() });
     } catch (err) {
       setConnectError(err?.message || 'failed to connect');
     } finally {
       connectingRef.current = false;
       setConnecting(false);
     }
-  }, [connectShared, loadStatus]);
+  }, [connectShared, queryClient]);
 
   const pull = useCallback(async (projectId, action) => {
     if (pullingRef.current) return; // a pull is already in flight -- ignore the repeat click
     pullingRef.current = true;
     try {
-      return await pullSharedProject(projectId, action);
+      const result = await pullSharedProject(projectId, action);
+      queryClient.invalidateQueries({ queryKey: sharedKeys.list() });
+      return result;
     } finally {
       pullingRef.current = false;
     }
-  }, [pullSharedProject]);
+  }, [pullSharedProject, queryClient]);
+
+  const url = statusQuery.data?.url ?? null;
+  const projects = listQuery.data?.projects || [];
+  const lastSynced = listQuery.data?.lastSynced ?? statusQuery.data?.lastSynced ?? null;
+  const stale = staleOverride || !!listQuery.data?.stale;
+
+  // loading: true until BOTH the status query and (when configured) the
+  // list query have settled at least once. isLoading (not isPending) is
+  // "no data yet AND actively fetching" -- a disabled query is never
+  // isLoading, so an unconfigured repo's never-run list query doesn't hold
+  // this true forever.
+  const loading = statusQuery.isLoading || (configured && listQuery.isLoading);
+
+  // error: only for an INITIAL load failure (no data has ever landed for
+  // that query) -- a background refresh failure after data already exists
+  // is `stale`, not `error`, so it never blanks an already-working view.
+  const statusFailedInitial = statusQuery.isError && statusQuery.data === undefined;
+  const listFailedInitial = configured && listQuery.isError && listQuery.data === undefined;
+  const error = statusFailedInitial
+    ? (statusQuery.error?.message || 'failed to load shared repository status')
+    : listFailedInitial
+      ? (listQuery.error?.message || 'failed to load shared repository status')
+      : null;
 
   return {
     configured, url, projects, lastSynced, stale,

--- a/src/quodeq/ui/src/features/dashboard/hooks/useSharedProjects.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useSharedProjects.test.jsx
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useSharedProjects } from './useSharedProjects.js';
 import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
 import { ApiProvider } from '../../../api/ApiContext.jsx';
+import { sharedKeys } from '../../../api/queryKeys.js';
 
 function makeFakeApi(overrides = {}) {
   return {
@@ -237,6 +239,38 @@ describe('useSharedProjects', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.lastSynced).toBe('2026-07-15T00:00:00Z');
     expect(result.current.error).toBe('list failed');
+  });
+
+  // Ghost shared cards after disconnect (final whole-branch review, Important
+  // finding): the list query is disabled once `configured` flips false, but a
+  // disabled query's cached data is not cleared by invalidation alone -- it
+  // just sits there. Before the fix, `projects` read straight off
+  // `listQuery.data` ungated, so a lingering cache entry (left over from
+  // before a disconnect, or from a DIFFERENT shared repo before a reconnect)
+  // kept rendering shared cards with live pull buttons even though
+  // `configured` is false. Gate on `configured` so a stale cache can never
+  // surface regardless of how/when it was populated.
+  it('never returns projects from a lingering list cache when unconfigured', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } } });
+    // Seed the cache as if a previous, now-stale mount had already listed a
+    // (possibly different) shared repo's projects.
+    client.setQueryData(sharedKeys.list(), {
+      projects: [{ id: 'ghost', name: 'stale-repo-entry' }],
+      lastSynced: '2026-07-16T00:00:00Z',
+      stale: false,
+    });
+    const fakeApi = makeFakeApi({ getSharedStatus: vi.fn(async () => ({ configured: false, url: null })) });
+    const { result } = renderHook(() => useSharedProjects(), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={client}>
+          <ApiProvider value={fakeApi}>{children}</ApiProvider>
+        </QueryClientProvider>
+      ),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.configured).toBe(false);
+    expect(result.current.projects).toEqual([]);
   });
 
   it('pull(id, action) delegates to pullSharedProject', async () => {

--- a/src/quodeq/ui/src/features/dashboard/hooks/useSharedProjects.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useSharedProjects.test.jsx
@@ -96,8 +96,11 @@ describe('useSharedProjects', () => {
     });
 
     expect(fakeApi.connectShared).toHaveBeenCalledWith('https://github.com/team/results.git');
-    expect(result.current.configured).toBe(true);
-    expect(result.current.projects).toHaveLength(1);
+    await waitFor(() => expect(result.current.configured).toBe(true));
+    // The list query only becomes enabled once `configured` flips true (a
+    // render after connect()'s own status invalidation resolves), so its
+    // own fetch settles slightly after connect()'s returned promise does.
+    await waitFor(() => expect(result.current.projects).toHaveLength(1));
   });
 
   it('connect(url) surfaces the API error message on failure without touching configured state', async () => {
@@ -185,6 +188,57 @@ describe('useSharedProjects', () => {
     expect(result.current.stale).toBe(true);
   });
 
+  // Audit A2: a one-shot mount fetch with no retry used to leave
+  // configured=false forever on any transient failure, with the ⟳ control
+  // hidden (no error was ever exposed). react-query's own queries expose
+  // the failure as `error`; refresh() -- the same function behind the
+  // toolbar's "sync failed · retry" button -- now genuinely re-checks
+  // status too, not just the list, so the retry control actually heals a
+  // status-level failure instead of being a no-op forever.
+  it('exposes a status-load failure as `error`, and a manual refresh() recovers it', async () => {
+    const getSharedStatus = vi.fn()
+      .mockRejectedValueOnce(new Error('network unreachable'))
+      .mockResolvedValue({ configured: true, url: 'https://github.com/team/results.git' });
+    const fakeApi = makeFakeApi({ getSharedStatus });
+    const { result } = renderHook(() => useSharedProjects(), {
+      wrapper: ({ children }) => wrap(fakeApi, children),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('network unreachable');
+    expect(result.current.configured).toBe(false);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    await waitFor(() => expect(result.current.error).toBeNull());
+    await waitFor(() => expect(result.current.configured).toBe(true));
+    await waitFor(() => expect(result.current.projects).toHaveLength(1));
+  });
+
+  // Audit B2: /status carries lastSynced on every response; a list that
+  // never lands (fails on its very first fetch) must not regress the
+  // toolbar to "not synced yet" when the server just reported a real sync
+  // time moments ago.
+  it('lastSynced comes from the status payload even when the list has never succeeded', async () => {
+    const fakeApi = makeFakeApi({
+      getSharedStatus: vi.fn(async () => ({
+        configured: true,
+        url: 'https://github.com/team/results.git',
+        lastSynced: '2026-07-15T00:00:00Z',
+      })),
+      sharedListProjects: vi.fn(async () => { throw new Error('list failed'); }),
+    });
+    const { result } = renderHook(() => useSharedProjects(), {
+      wrapper: ({ children }) => wrap(fakeApi, children),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.lastSynced).toBe('2026-07-15T00:00:00Z');
+    expect(result.current.error).toBe('list failed');
+  });
+
   it('pull(id, action) delegates to pullSharedProject', async () => {
     const fakeApi = makeFakeApi();
     const { result } = renderHook(() => useSharedProjects(), {
@@ -233,7 +287,14 @@ describe('useSharedProjects', () => {
     expect(fakeApi.connectShared).toHaveBeenCalledTimes(1);
   });
 
-  it('refresh() ignores a second call while the first refresh is still in flight', async () => {
+  // Coalescing, not dropping (audit C3 groundwork): a refresh() that arrives
+  // while one is already running must not be silently ignored -- it must be
+  // satisfied by exactly one MORE round once the in-flight one settles, so
+  // callers like the post-publish "refresh the chips" effect never get
+  // dropped on the floor just because a background revalidate happened to
+  // be running at that instant. Two overlapping calls -> two POSTs total,
+  // not one (dropped) and not three (one per call).
+  it('refresh() coalesces a call that arrives while one is in flight into exactly one more round', async () => {
     const d = deferred();
     const fakeApi = makeFakeApi();
     const { result } = renderHook(() => useSharedProjects(), {
@@ -245,7 +306,7 @@ describe('useSharedProjects', () => {
     // not the mount's in-flight refresh.
     await waitFor(() => expect(fakeApi.sharedListProjects).toHaveBeenCalledTimes(2));
     fakeApi.refreshShared.mockClear();
-    fakeApi.refreshShared.mockImplementation(() => d.promise);
+    fakeApi.refreshShared.mockImplementationOnce(() => d.promise);
 
     let p1;
     let p2;
@@ -262,7 +323,10 @@ describe('useSharedProjects', () => {
       await p2;
     });
 
-    expect(fakeApi.refreshShared).toHaveBeenCalledTimes(1);
+    // The second call, queued while the first was in flight, triggered
+    // exactly one more POST once the first settled -- not zero (dropped),
+    // not two-per-caller.
+    expect(fakeApi.refreshShared).toHaveBeenCalledTimes(2);
   });
 
   it('pull() ignores a second call while the first pull is still in flight', async () => {

--- a/src/quodeq/ui/src/features/dashboard/projectsMerge.js
+++ b/src/quodeq/ui/src/features/dashboard/projectsMerge.js
@@ -89,6 +89,13 @@ export function deriveAction(entry, { configured }) {
   const { local, shared } = entry;
   if (local && !shared) return configured ? 'publish' : null;
   if (!local && shared) return 'pull';
+  // Both sides present. Prefer run identity: it's exact and immune to the
+  // date-only-vs-epoch skew a same-day timestamp comparison can't resolve.
+  // Legacy shared entries omit latestRunId (a project with zero runs), so
+  // fall back to the old timestamp comparison whenever either id is absent.
+  if (local?.latestRunId && shared?.latestRunId) {
+    return local.latestRunId !== shared.latestRunId ? 'update' : null;
+  }
   const lastEval = toMs(local?.latestDate);
   const publishedAt = toMs(shared?.publishedAt);
   if (lastEval != null && (publishedAt == null || lastEval > publishedAt)) return 'update';

--- a/src/quodeq/ui/src/features/dashboard/projectsMerge.js
+++ b/src/quodeq/ui/src/features/dashboard/projectsMerge.js
@@ -89,13 +89,27 @@ export function deriveAction(entry, { configured }) {
   const { local, shared } = entry;
   if (local && !shared) return configured ? 'publish' : null;
   if (!local && shared) return 'pull';
-  // Both sides present. Prefer run identity: it's exact and immune to the
-  // date-only-vs-epoch skew a same-day timestamp comparison can't resolve.
-  // Legacy shared entries omit latestRunId (a project with zero runs), so
-  // fall back to the old timestamp comparison whenever either id is absent.
-  if (local?.latestRunId && shared?.latestRunId) {
-    return local.latestRunId !== shared.latestRunId ? 'update' : null;
+  // Both sides present. Prefer done-run identity: it's exact and immune to
+  // the date-only-vs-epoch skew a same-day timestamp comparison can't
+  // resolve. local.latestRunId is the newest run of ANY status, but publish
+  // only ever copies done runs into the shared repo -- comparing raw
+  // latestRunId would show a permanent false 'update' once a later local run
+  // fails or is cancelled, since it could never again equal shared's id.
+  // latestDoneRunId is the newest run that actually finished, so use that
+  // instead (falling back to latestRunId on the shared side: every shared
+  // entry's runs are done runs already, by construction of publish).
+  const localId = local?.latestDoneRunId ?? null;
+  const sharedId = shared?.latestDoneRunId ?? shared?.latestRunId ?? null;
+  if (localId != null && sharedId != null) {
+    return localId !== sharedId ? 'update' : null;
   }
+  if (localId == null && sharedId != null) {
+    // No done local run to publish -- nothing new to offer, already in sync.
+    return null;
+  }
+  // Absent latestRunId means no manifest-bearing run was ever produced for
+  // that side (list_runs only counts runs with an evidence manifest), not
+  // strictly "zero runs" -- a run can exist on disk and still not count.
   const lastEval = toMs(local?.latestDate);
   const publishedAt = toMs(shared?.publishedAt);
   if (lastEval != null && (publishedAt == null || lastEval > publishedAt)) return 'update';

--- a/src/quodeq/ui/src/features/dashboard/projectsMerge.test.js
+++ b/src/quodeq/ui/src/features/dashboard/projectsMerge.test.js
@@ -106,24 +106,42 @@ describe('deriveAction', () => {
     );
     assert.equal(deriveAction(e, { configured: true }), null);
   });
-  it('both sides same latestRunId -> in sync even if local eval is "newer" by date', () => {
+  it('both sides same latestDoneRunId -> in sync even if local eval is "newer" by date', () => {
     const e = entry(
-      { id: 'a', latestDate: '2026-07-19T00:00:00Z', latestRunId: 'run-1' },
+      { id: 'a', latestDate: '2026-07-19T00:00:00Z', latestRunId: 'run-1', latestDoneRunId: 'run-1' },
       { id: 'a', publishedAt: 1, latestRunId: 'run-1' },
     );
     assert.equal(deriveAction(e, { configured: true }), null);
   });
-  it('differing latestRunId -> update, even same-day (the midnight-UTC bug)', () => {
+  it('differing latestDoneRunId -> update, even same-day (the midnight-UTC bug)', () => {
     // Local's date-only eval parses to midnight UTC; shared published later
     // the same day. Old timestamp comparison would say "not newer" -> null.
-    // Run identity must still win: different ids -> update.
+    // Done-run identity must still win: different ids -> update.
     const e = entry(
-      { id: 'a', latestDate: '2026-07-19', latestRunId: 'run-2' },
+      { id: 'a', latestDate: '2026-07-19', latestRunId: 'run-2', latestDoneRunId: 'run-2' },
       { id: 'a', publishedAt: Date.parse('2026-07-19T14:00:00Z'), latestRunId: 'run-1' },
     );
     assert.equal(deriveAction(e, { configured: true }), 'update');
   });
-  it('shared entry without latestRunId falls back to timestamp comparison', () => {
+  it('local latest run failed/cancelled after a done publish -> stays in sync', () => {
+    // Publish run A (done). Run B fails or is cancelled afterwards. Local's
+    // raw latestRunId moves to B, but latestDoneRunId still points at A --
+    // the comparison must use the done id, not the raw latest run, or this
+    // is a permanent false 'update' that republishing can never clear.
+    const e = entry(
+      { id: 'a', latestRunId: 'B', latestDoneRunId: 'A' },
+      { id: 'a', latestRunId: 'A' },
+    );
+    assert.equal(deriveAction(e, { configured: true }), null);
+  });
+  it('local has no done runs but shared has a published one -> nothing to publish, in sync', () => {
+    const e = entry(
+      { id: 'a', latestRunId: 'B', latestDoneRunId: null },
+      { id: 'a', latestRunId: 'A' },
+    );
+    assert.equal(deriveAction(e, { configured: true }), null);
+  });
+  it('shared entry without any run identity falls back to timestamp comparison', () => {
     const e = entry(
       { id: 'a', latestDate: '2026-07-19T00:00:00Z', latestRunId: 'run-1' },
       { id: 'a', publishedAt: 1 },

--- a/src/quodeq/ui/src/features/dashboard/projectsMerge.test.js
+++ b/src/quodeq/ui/src/features/dashboard/projectsMerge.test.js
@@ -106,4 +106,28 @@ describe('deriveAction', () => {
     );
     assert.equal(deriveAction(e, { configured: true }), null);
   });
+  it('both sides same latestRunId -> in sync even if local eval is "newer" by date', () => {
+    const e = entry(
+      { id: 'a', latestDate: '2026-07-19T00:00:00Z', latestRunId: 'run-1' },
+      { id: 'a', publishedAt: 1, latestRunId: 'run-1' },
+    );
+    assert.equal(deriveAction(e, { configured: true }), null);
+  });
+  it('differing latestRunId -> update, even same-day (the midnight-UTC bug)', () => {
+    // Local's date-only eval parses to midnight UTC; shared published later
+    // the same day. Old timestamp comparison would say "not newer" -> null.
+    // Run identity must still win: different ids -> update.
+    const e = entry(
+      { id: 'a', latestDate: '2026-07-19', latestRunId: 'run-2' },
+      { id: 'a', publishedAt: Date.parse('2026-07-19T14:00:00Z'), latestRunId: 'run-1' },
+    );
+    assert.equal(deriveAction(e, { configured: true }), 'update');
+  });
+  it('shared entry without latestRunId falls back to timestamp comparison', () => {
+    const e = entry(
+      { id: 'a', latestDate: '2026-07-19T00:00:00Z', latestRunId: 'run-1' },
+      { id: 'a', publishedAt: 1 },
+    );
+    assert.equal(deriveAction(e, { configured: true }), 'update');
+  });
 });

--- a/src/quodeq/ui/src/features/settings/components/SharedRepoSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/SharedRepoSection.jsx
@@ -87,6 +87,16 @@ export default function SharedRepoSection({ onDisconnected }) {
       }
     },
     onSuccess: () => {
+      // Remove the list's cached data BEFORE invalidating: sharedKeys.status()
+      // hasn't refetched/flipped `configured` to false anywhere yet at this
+      // point, so an already-mounted list observer elsewhere (ProjectsPage's
+      // useSharedProjects) is still enabled and would otherwise go on serving
+      // its now-stale cached projects until its own status update lands --
+      // removing first guarantees there is no shared-repo data left to render
+      // in that window, and no leftover entry from a since-disconnected repo
+      // to flash on a later reconnect to a different URL (ghost shared cards
+      // after disconnect, final whole-branch review).
+      queryClient.removeQueries({ queryKey: sharedKeys.list() });
       queryClient.invalidateQueries({ queryKey: sharedKeys.all() });
     },
   });

--- a/src/quodeq/ui/src/features/settings/components/SharedRepoSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/SharedRepoSection.jsx
@@ -1,4 +1,4 @@
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState, useRef, useEffect } from 'react';
 import SectionLabel from '../../../components/terminal/SectionLabel.jsx';
 import { useApi } from '../../../api/ApiContext.jsx';
@@ -6,6 +6,7 @@ import { sharedKeys } from '../../../api/queryKeys.js';
 
 export default function SharedRepoSection({ onDisconnected }) {
   const { getSharedStatus, connectShared, disconnectShared } = useApi();
+  const queryClient = useQueryClient();
 
   const [newUrl, setNewUrl] = useState('');
   const [confirming, setConfirming] = useState(false);
@@ -52,6 +53,14 @@ export default function SharedRepoSection({ onDisconnected }) {
         savingRef.current = false;
       }
     },
+    onSuccess: () => {
+      // Everything "shared"-prefixed, not just status: ProjectsPage's
+      // useSharedProjects and usePublish read the SAME cache entries (audit
+      // C6), so a connect made here must reach them too, not just this
+      // section's own settings-detail status query (refetchStatus below
+      // already covers that one specifically, for the inline UI).
+      queryClient.invalidateQueries({ queryKey: sharedKeys.all() });
+    },
   });
 
   const disconnectMutation = useMutation({
@@ -76,6 +85,9 @@ export default function SharedRepoSection({ onDisconnected }) {
       } finally {
         disconnectingRef.current = false;
       }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: sharedKeys.all() });
     },
   });
 

--- a/src/quodeq/ui/src/features/settings/components/SharedRepoSection.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/SharedRepoSection.test.jsx
@@ -285,6 +285,38 @@ describe('SharedRepoSection', () => {
     });
   });
 
+  // Ghost shared cards after disconnect (final whole-branch review, Important
+  // finding): invalidating sharedKeys.list() alone leaves its cached data in
+  // place once the list query is disabled (configured -> false), so the
+  // Projects page kept rendering the old shared cards. The disconnect
+  // mutation must actively clear that cache entry, not just mark it stale.
+  it('removes the shared list cache on a successful disconnect', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } } });
+    client.setQueryData(sharedKeys.list(), {
+      projects: [{ id: 'p1', name: 'demo' }],
+      lastSynced: '2026-07-16T00:00:00Z',
+      stale: false,
+    });
+    const fakeApi = makeFakeApi({
+      getSharedStatus: vi.fn(async () => ({ configured: true, url: 'https://github.com/team/results.git' })),
+      disconnectShared: vi.fn(async () => ({ configured: false })),
+    });
+    const user = userEvent.setup();
+    render(
+      <QueryClientProvider client={client}>
+        <ApiProvider value={fakeApi}><SharedRepoSection /></ApiProvider>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /disconnect/i })).toBeTruthy());
+    await user.click(screen.getByRole('button', { name: /disconnect/i }));
+    await waitFor(() => expect(screen.getByRole('button', { name: /yes/i })).toBeTruthy());
+    await user.click(screen.getByRole('button', { name: /yes/i }));
+
+    await waitFor(() => expect(fakeApi.disconnectShared).toHaveBeenCalled());
+    await waitFor(() => expect(client.getQueryData(sharedKeys.list())).toBeUndefined());
+  });
+
   it('does not call onDisconnected when disconnect is cancelled', async () => {
     const fakeApi = makeFakeApi({
       getSharedStatus: vi.fn(async () => ({ configured: true, url: 'https://github.com/team/results.git' })),

--- a/src/quodeq/ui/src/features/settings/components/SharedRepoSection.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/SharedRepoSection.test.jsx
@@ -2,8 +2,10 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
 import { ApiProvider } from '../../../api/ApiContext.jsx';
+import { sharedKeys } from '../../../api/queryKeys.js';
 import SharedRepoSection from './SharedRepoSection.jsx';
 
 function makeFakeApi(overrides = {}) {
@@ -229,6 +231,58 @@ describe('SharedRepoSection', () => {
     await user.click(screen.getByRole('button', { name: /yes/i }));
 
     await waitFor(() => expect(onDisconnected).toHaveBeenCalledTimes(1));
+  });
+
+  // Audit C6: this section's mutations must reach the SAME cache
+  // ProjectsPage's useSharedProjects/usePublish read, not just this
+  // section's own settings-detail status query -- otherwise a connect made
+  // here would leave the Projects page showing the stale pre-connect state
+  // until some unrelated action happened to invalidate it.
+  it('invalidates sharedKeys.all() on a successful connect', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } } });
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+    const fakeApi = makeFakeApi({
+      getSharedStatus: vi.fn(async () => ({ configured: false, url: null })),
+    });
+    const user = userEvent.setup();
+    render(
+      <QueryClientProvider client={client}>
+        <ApiProvider value={fakeApi}><SharedRepoSection /></ApiProvider>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => expect(screen.getByText(/repository url/i)).toBeTruthy());
+    const input = screen.getByRole('textbox', { name: /repository url/i });
+    await user.clear(input);
+    await user.type(input, 'https://github.com/team/results.git');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith(expect.objectContaining({ queryKey: sharedKeys.all() }));
+    });
+  });
+
+  it('invalidates sharedKeys.all() on a successful disconnect', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } } });
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+    const fakeApi = makeFakeApi({
+      getSharedStatus: vi.fn(async () => ({ configured: true, url: 'https://github.com/team/results.git' })),
+    });
+    const user = userEvent.setup();
+    render(
+      <QueryClientProvider client={client}>
+        <ApiProvider value={fakeApi}><SharedRepoSection /></ApiProvider>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /disconnect/i })).toBeTruthy());
+    await user.click(screen.getByRole('button', { name: /disconnect/i }));
+    await waitFor(() => expect(screen.getByRole('button', { name: /yes/i })).toBeTruthy());
+    await user.click(screen.getByRole('button', { name: /yes/i }));
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith(expect.objectContaining({ queryKey: sharedKeys.all() }));
+    });
   });
 
   it('does not call onDisconnected when disconnect is cancelled', async () => {

--- a/src/quodeq/ui/src/models/project.js
+++ b/src/quodeq/ui/src/models/project.js
@@ -13,6 +13,7 @@
  * @property {boolean|null} pathExists
  * @property {string|null}  latestDate
  * @property {string|null}  latestRunId
+ * @property {string|null}  latestDoneRunId - id of the newest run that finished (not cancelled/failed/in-progress), or null
  * @property {string|null}  latestGrade
  * @property {number|null}  latestScore
  * @property {number}       runsCount
@@ -43,6 +44,7 @@ export function createProject(raw) {
     pathExists:   raw.pathExists ?? null,
     latestDate:   raw.latestDate ?? null,
     latestRunId:  raw.latestRunId ?? null,
+    latestDoneRunId: raw.latestDoneRunId ?? null,
     latestGrade:  raw.latestGrade ?? null,
     latestScore:  raw.latestScore ?? null,
     runsCount:    raw.runsCount ?? 0,

--- a/tests/api/test_routes_shared.py
+++ b/tests/api/test_routes_shared.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import json
 import subprocess
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -14,6 +16,7 @@ from quodeq.api.app import create_app
 from quodeq.services import shared_publish
 from quodeq.services.shared_repo import (
     FORMAT_NAME,
+    clone_lock,
     ensure_shared_clone,
     shared_cache_dir,
     shared_repo_path,
@@ -326,6 +329,65 @@ def test_delete_config_when_unconfigured_does_not_crash(client, monkeypatch, tmp
     resp = client.delete("/api/shared/config", headers=_ORIGIN)
     assert resp.status_code == 200
     assert resp.get_json()["configured"] is False
+
+
+def test_delete_config_waits_for_clone_lock(client, monkeypatch, tmp_path):
+    """Review finding: DELETE rmtree'd the cache dir without holding
+    clone_lock(url), unlike every other clone mutator (ensure_shared_clone,
+    refresh_shared_clone, publish_project). A concurrent publish/refresh
+    holding the lock could have its clone directory yanked out from under
+    it mid-operation, potentially leaving a partially-deleted .git that
+    doesn't self-heal. DELETE must block on the lock before removing the
+    cache dir, same as everything else that touches the clone."""
+    monkeypatch.setenv("QUODEQ_DIR", str(tmp_path))
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    url = f"file://{origin}"
+    assert ensure_shared_clone(url) is not None
+    cache_dir = shared_cache_dir(url)
+    assert cache_dir.is_dir()
+
+    (tmp_path / "shared.json").write_text(json.dumps({"url": url}))
+
+    lock = clone_lock(url)
+    lock_acquired = threading.Event()
+    release_lock = threading.Event()
+
+    def _hold_lock():
+        with lock:
+            lock_acquired.set()
+            release_lock.wait(timeout=5)
+
+    holder = threading.Thread(target=_hold_lock, name="holder")
+    holder.start()
+    assert lock_acquired.wait(timeout=5), "lock holder thread never acquired the lock"
+
+    results: list = []
+    # A fresh, un-entered client (rather than the fixture's own `client`,
+    # which is held open via `with app.test_client() as c:` for the whole
+    # test) keeps this background thread's request/app-context push+pop
+    # self-contained instead of racing the fixture's context teardown.
+    bg_client = client.application.test_client()
+
+    def _do_delete():
+        results.append(bg_client.delete("/api/shared/config", headers=_ORIGIN))
+
+    delete_thread = threading.Thread(target=_do_delete, name="delete")
+    delete_thread.start()
+
+    # Give the DELETE thread a moment to reach (and block on) the lock.
+    time.sleep(0.2)
+    assert delete_thread.is_alive(), "DELETE returned without waiting for the clone lock"
+    assert cache_dir.exists(), "cache dir was removed while the clone lock was still held"
+
+    release_lock.set()
+    delete_thread.join(timeout=5)
+    holder.join(timeout=5)
+
+    assert not delete_thread.is_alive(), "DELETE deadlocked waiting for the clone lock"
+    assert not holder.is_alive()
+    assert not cache_dir.exists()
+    assert results[0].status_code == 200
 
 
 # --- POST /api/shared/refresh -------------------------------------------------

--- a/tests/api/test_routes_shared.py
+++ b/tests/api/test_routes_shared.py
@@ -12,7 +12,12 @@ import pytest
 
 from quodeq.api.app import create_app
 from quodeq.services import shared_publish
-from quodeq.services.shared_repo import FORMAT_NAME
+from quodeq.services.shared_repo import (
+    FORMAT_NAME,
+    ensure_shared_clone,
+    shared_cache_dir,
+    shared_repo_path,
+)
 
 _ORIGIN = {"Origin": "http://localhost"}
 
@@ -232,6 +237,60 @@ def test_put_config_happy_path(client, monkeypatch, tmp_path):
     assert status["url"] == "https://github.com/example/repo.git"
 
 
+def test_put_config_reconnect_refreshes_pre_existing_clone(client, monkeypatch, tmp_path):
+    """Audit A4: reconnecting to a URL whose clone already exists in the
+    cache must fetch fresh content before returning, not silently keep
+    serving whatever was last fetched. Regression: a project is published
+    directly to origin AFTER the first connect, then the same URL is
+    reconnected (second PUT) -- the listing must already show it, with no
+    separate POST /api/shared/refresh in between."""
+    monkeypatch.setenv("QUODEQ_DIR", str(tmp_path))
+    monkeypatch.setattr("quodeq.api.routes_shared.validate_remote_url", lambda url: None)
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    url = f"file://{origin}"
+    work = tmp_path / "origin-work"
+    subprocess.run(["git", "clone", str(origin), str(work)], check=True, capture_output=True)
+    (work / "quodeq.json").write_text(
+        json.dumps({"format": FORMAT_NAME, "version": 1}), encoding="utf-8"
+    )
+    for cmd in (
+        ["git", "add", "."],
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init"],
+        ["git", "push", "origin", "HEAD"],
+    ):
+        subprocess.run(cmd, cwd=work, check=True, capture_output=True)
+
+    # First connect clones the (currently project-less) repo.
+    resp = client.put("/api/shared/config", json={"url": url}, headers=_ORIGIN)
+    assert resp.status_code == 200
+    listing = client.get("/api/shared/projects").get_json()
+    assert listing["projects"] == []
+
+    # A new project is published directly to origin, bypassing this
+    # process's clone entirely (e.g. a teammate publishing from another
+    # machine).
+    project_dir = work / "evaluations" / "proj-new"
+    project_dir.mkdir(parents=True)
+    (project_dir / "repository_info.json").write_text('{"name":"proj-new"}', encoding="utf-8")
+    for cmd in (
+        ["git", "add", "."],
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "publish proj-new"],
+        ["git", "push", "origin", "HEAD"],
+    ):
+        subprocess.run(cmd, cwd=work, check=True, capture_output=True)
+
+    # Reconnect the SAME url -- the cache dir from the first PUT already
+    # exists on disk. Before this fix, ensure_shared_clone early-returns it
+    # unfetched, so proj-new would only appear after a manual refresh.
+    resp = client.put("/api/shared/config", json={"url": url}, headers=_ORIGIN)
+    assert resp.status_code == 200
+
+    listing = client.get("/api/shared/projects").get_json()
+    ids = [p.get("id") or p.get("name") for p in listing["projects"]]
+    assert "proj-new" in ids
+
+
 # --- DELETE /api/shared/config -----------------------------------------------
 
 def test_delete_config_clears(client, monkeypatch, tmp_path):
@@ -240,6 +299,33 @@ def test_delete_config_clears(client, monkeypatch, tmp_path):
     resp = client.delete("/api/shared/config", headers=_ORIGIN)
     assert resp.status_code == 200
     assert client.get("/api/shared/status").get_json()["configured"] is False
+
+
+def test_delete_config_removes_cache_dir(client, monkeypatch, tmp_path):
+    """Audit A4: disconnect must remove the clone's cache dir from disk, not
+    just clear settings -- otherwise a stale clone sits around forever."""
+    monkeypatch.setenv("QUODEQ_DIR", str(tmp_path))
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    url = f"file://{origin}"
+    assert ensure_shared_clone(url) is not None
+    cache_dir = shared_cache_dir(url)
+    assert cache_dir.is_dir()
+    assert shared_repo_path(url).is_dir()
+
+    (tmp_path / "shared.json").write_text(json.dumps({"url": url}))
+    resp = client.delete("/api/shared/config", headers=_ORIGIN)
+    assert resp.status_code == 200
+    assert not cache_dir.exists()
+
+
+def test_delete_config_when_unconfigured_does_not_crash(client, monkeypatch, tmp_path):
+    """Guard for url=None: disconnecting when nothing is configured must be
+    a no-op, not attempt shutil.rmtree on a None-derived path."""
+    monkeypatch.setenv("QUODEQ_DIR", str(tmp_path))
+    resp = client.delete("/api/shared/config", headers=_ORIGIN)
+    assert resp.status_code == 200
+    assert resp.get_json()["configured"] is False
 
 
 # --- POST /api/shared/refresh -------------------------------------------------
@@ -251,16 +337,36 @@ def test_refresh_without_config_400(client):
 
 def test_refresh_failure_returns_502(client, tmp_path, monkeypatch):
     (tmp_path / "shared.json").write_text(json.dumps({"url": "git@github.com:t/r.git"}))
-    monkeypatch.setattr("quodeq.api.routes_shared.refresh_shared_clone", lambda url: False)
+    monkeypatch.setattr(
+        "quodeq.api.routes_shared.refresh_shared_clone",
+        lambda url: (False, "Could not resolve host"),
+    )
     resp = client.post("/api/shared/refresh", headers=_ORIGIN)
     assert resp.status_code == 502
     body = resp.get_json()
     assert body["stale"] is True
 
 
+def test_refresh_failure_body_carries_error_reason(client, tmp_path, monkeypatch):
+    """Audit B3: the 502 body must carry the failure reason so the UI can
+    distinguish DNS vs auth vs a deleted origin, instead of only ever being
+    able to render "Request failed: 502"."""
+    (tmp_path / "shared.json").write_text(json.dumps({"url": "git@github.com:t/r.git"}))
+    monkeypatch.setattr(
+        "quodeq.api.routes_shared.refresh_shared_clone",
+        lambda url: (False, "Could not resolve host github.com"),
+    )
+    resp = client.post("/api/shared/refresh", headers=_ORIGIN)
+    assert resp.status_code == 502
+    body = resp.get_json()
+    assert body["error"] == "Could not resolve host github.com"
+
+
 def test_refresh_success_200(client, tmp_path, monkeypatch):
     (tmp_path / "shared.json").write_text(json.dumps({"url": "git@github.com:t/r.git"}))
-    monkeypatch.setattr("quodeq.api.routes_shared.refresh_shared_clone", lambda url: True)
+    monkeypatch.setattr(
+        "quodeq.api.routes_shared.refresh_shared_clone", lambda url: (True, "")
+    )
     resp = client.post("/api/shared/refresh", headers=_ORIGIN)
     assert resp.status_code == 200
     body = resp.get_json()

--- a/tests/api/test_routes_shared.py
+++ b/tests/api/test_routes_shared.py
@@ -5,11 +5,14 @@ under /api/shared/* or /api/projects/<project>/publish.
 from __future__ import annotations
 
 import json
+import subprocess
+from pathlib import Path
 
 import pytest
 
 from quodeq.api.app import create_app
 from quodeq.services import shared_publish
+from quodeq.services.shared_repo import FORMAT_NAME
 
 _ORIGIN = {"Origin": "http://localhost"}
 
@@ -50,6 +53,7 @@ def test_shared_status_unconfigured(client, monkeypatch, tmp_path):
     assert body["configured"] is False
     assert body["url"] is None
     assert body["lastSynced"] is None
+    assert body["repoState"] is None
     assert "publish" in body
 
 
@@ -60,6 +64,15 @@ def test_shared_status_configured(client, tmp_path):
     body = resp.get_json()
     assert body["configured"] is True
     assert body["url"] == "git@github.com:t/r.git"
+
+
+def test_shared_status_repo_state_reflects_read_state(client, tmp_path):
+    """Audit A1: /status must report the real clone state, not just whether
+    a URL is configured -- a configured-but-never-cloned URL is "missing"."""
+    (tmp_path / "shared.json").write_text(json.dumps({"url": "git@github.com:t/r.git"}))
+    resp = client.get("/api/shared/status")
+    assert resp.status_code == 200
+    assert resp.get_json()["repoState"] == "missing"
 
 
 def test_shared_status_survives_non_string_url_in_settings_file(client, tmp_path):
@@ -120,6 +133,83 @@ def test_put_config_clone_failure_returns_502(client, monkeypatch):
     )
     assert resp.status_code == 502
     assert "error" in resp.get_json()
+
+
+def _push_seed_file(origin: Path, name: str, content: str) -> None:
+    work = origin.parent / f"{origin.stem}-seed"
+    subprocess.run(["git", "clone", str(origin), str(work)], check=True, capture_output=True)
+    (work / name).write_text(content, encoding="utf-8")
+    for cmd in (
+        ["git", "add", "."],
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "seed"],
+        ["git", "push", "origin", "HEAD"],
+    ):
+        subprocess.run(cmd, cwd=work, check=True, capture_output=True)
+
+
+def test_put_config_rejects_foreign_repo_after_clone(client, monkeypatch, tmp_path):
+    """Audit A1: PUT must validate format AFTER a real clone succeeds --
+    a real, clonable git repo that isn't a quodeq results repo (no
+    quodeq.json marker) is rejected, and settings are never written for it.
+    """
+    monkeypatch.setenv("QUODEQ_DIR", str(tmp_path))
+    # validate_remote_url legitimately rejects file:// (SSRF guard scopes
+    # accepted schemes to https/ssh); bypass just that check so the local
+    # bare origin below can exercise the real clone + format-check path.
+    monkeypatch.setattr("quodeq.api.routes_shared.validate_remote_url", lambda url: None)
+    origin = tmp_path / "foreign-origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    _push_seed_file(origin, "README.md", "some other project")
+    url = f"file://{origin}"
+
+    resp = client.put("/api/shared/config", json={"url": url}, headers=_ORIGIN)
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == (
+        "the repository exists but does not look like a quodeq results repository"
+    )
+
+    status = client.get("/api/shared/status").get_json()
+    assert status["configured"] is False
+    assert status["url"] is None
+
+
+def test_put_config_rejects_unsupported_version_after_clone(client, monkeypatch, tmp_path):
+    """Audit A1: same AFTER-clone validation for a repo whose quodeq.json
+    marker declares a format version newer than this build understands."""
+    monkeypatch.setenv("QUODEQ_DIR", str(tmp_path))
+    monkeypatch.setattr("quodeq.api.routes_shared.validate_remote_url", lambda url: None)
+    origin = tmp_path / "future-origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    _push_seed_file(
+        origin, "quodeq.json", json.dumps({"format": FORMAT_NAME, "version": 99}),
+    )
+    url = f"file://{origin}"
+
+    resp = client.put("/api/shared/config", json={"url": url}, headers=_ORIGIN)
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "this shared repository requires a newer version of quodeq"
+
+    status = client.get("/api/shared/status").get_json()
+    assert status["configured"] is False
+    assert status["url"] is None
+
+
+def test_put_config_accepts_empty_repo(client, monkeypatch, tmp_path):
+    """Audit A1: a real clone of a bare origin with zero commits ("empty",
+    never published into) must be accepted, not rejected as foreign."""
+    monkeypatch.setenv("QUODEQ_DIR", str(tmp_path))
+    monkeypatch.setattr("quodeq.api.routes_shared.validate_remote_url", lambda url: None)
+    origin = tmp_path / "empty-origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    url = f"file://{origin}"
+
+    resp = client.put("/api/shared/config", json={"url": url}, headers=_ORIGIN)
+    assert resp.status_code == 200
+    assert resp.get_json()["configured"] is True
+
+    status = client.get("/api/shared/status").get_json()
+    assert status["configured"] is True
+    assert status["url"] == url
 
 
 def test_put_config_happy_path(client, monkeypatch, tmp_path):

--- a/tests/api/test_routes_shared_read.py
+++ b/tests/api/test_routes_shared_read.py
@@ -261,7 +261,7 @@ def test_shared_projects_refresh_success_reports_fresh_and_syncs_index(
     calls: list[str] = []
     monkeypatch.setattr(
         "quodeq.api.routes_shared.refresh_shared_clone",
-        lambda url: calls.append(f"refresh:{url}") or True,
+        lambda url: (calls.append(f"refresh:{url}") or True, ""),
     )
     monkeypatch.setattr(
         "quodeq.api.routes_shared.sync_shared_index",
@@ -279,7 +279,9 @@ def test_shared_projects_refresh_failure_reports_stale_and_skips_sync(
     """When refresh_shared_clone fails, the response gains "stale": True and
     sync_shared_index is never called (nothing new was fetched to index)."""
     sync_calls: list[str] = []
-    monkeypatch.setattr("quodeq.api.routes_shared.refresh_shared_clone", lambda url: False)
+    monkeypatch.setattr(
+        "quodeq.api.routes_shared.refresh_shared_clone", lambda url: (False, "network unreachable")
+    )
     monkeypatch.setattr(
         "quodeq.api.routes_shared.sync_shared_index",
         lambda url: sync_calls.append(url),

--- a/tests/api/test_routes_shared_read.py
+++ b/tests/api/test_routes_shared_read.py
@@ -28,6 +28,7 @@ from quodeq.services.shared_publish import publish_project
 from quodeq.services.shared_repo import (
     FORMAT_NAME,
     MARKER_FILENAME,
+    ensure_shared_clone,
     shared_evaluations_root,
     shared_repo_path,
     sync_shared_index,
@@ -121,6 +122,21 @@ def shared_clone_fixture(tmp_path, monkeypatch):
     return url
 
 
+@pytest.fixture()
+def empty_shared_clone_fixture(tmp_path):
+    """A cloned-but-never-published shared repo (audit A1's "empty" case).
+
+    The clone exists for real (a real `git clone` of a real local bare
+    origin) but nothing has ever been published into it, so read_state
+    reports "empty" rather than "missing". Mirrors shared_clone_fixture
+    minus the publish_project step.
+    """
+    url = _make_origin(tmp_path)
+    assert ensure_shared_clone(url) is not None
+    write_settings(SharedSettings(url=url))
+    return url
+
+
 # --- _with_shared_root decorator ---------------------------------------------
 
 def test_shared_routes_409_when_unconfigured(client, monkeypatch, tmp_path):
@@ -139,7 +155,9 @@ def test_shared_routes_503_when_clone_missing(client):
     write_settings(SharedSettings(url="file:///nonexistent/repo.git"))
     resp = client.get("/api/shared/projects")
     assert resp.status_code == 503
-    assert resp.get_json()["error"] == "shared repository has not been cloned yet"
+    assert resp.get_json()["error"] == (
+        "the shared repository has not been cloned yet — reconnect it in Settings"
+    )
 
 
 def test_shared_routes_409_when_unsupported_version(client):
@@ -154,6 +172,31 @@ def test_shared_routes_409_when_unsupported_version(client):
     resp = client.get("/api/shared/projects")
     assert resp.status_code == 409
     assert "newer version" in resp.get_json()["error"]
+
+
+def test_shared_routes_409_when_foreign(client):
+    """Audit A1: a foreign repo (real content, no quodeq.json marker) must
+    be rejected at read time with a distinct 409, not silently 503'd or
+    served as if it were a real quodeq clone."""
+    url = "file:///dummy/foreign.git"
+    repo = shared_repo_path(url)
+    repo.mkdir(parents=True)
+    (repo / ".git").mkdir()
+    (repo / "README.md").write_text("some other project", encoding="utf-8")
+    write_settings(SharedSettings(url=url))
+    resp = client.get("/api/shared/projects")
+    assert resp.status_code == 409
+    body = resp.get_json()
+    assert body["error"] == "the configured repository does not look like a quodeq results repository"
+    assert body["code"] == "FOREIGN_REPO"
+
+
+def test_empty_repo_lists_zero_projects_not_503(client, empty_shared_clone_fixture):
+    """Audit A1: first connect to an empty (never-published) repo must be
+    servable -- an empty projects list, not a false "not cloned yet" 503."""
+    resp = client.get("/api/shared/projects")
+    assert resp.status_code == 200
+    assert resp.get_json()["projects"] == []
 
 
 # --- read-only sweep ----------------------------------------------------------

--- a/tests/api/test_routes_shared_read.py
+++ b/tests/api/test_routes_shared_read.py
@@ -93,6 +93,16 @@ def shared_clone_fixture(tmp_path, monkeypatch):
     monkeypatch.setenv("GIT_COMMITTER_EMAIL", "t@t")
 
     url = _make_origin(tmp_path)
+    # published.json's publishedBy comes from `git config user.name` in the
+    # clone (GIT_AUTHOR_NAME/GIT_COMMITTER_NAME above only affect a commit's
+    # recorded identity, not `git config` lookups) -- pin it on the clone's
+    # LOCAL config so the "tester" assertion below is deterministic
+    # regardless of the machine running the test.
+    assert ensure_shared_clone(url) is not None
+    subprocess.run(
+        ["git", "config", "user.name", "tester"],
+        cwd=shared_repo_path(url), check=True, capture_output=True,
+    )
     local_root = tmp_path / "local-evaluations"
     project_dir = local_root / "proj-a"
     run_dir = project_dir / "run-1"

--- a/tests/services/test_fs_projects.py
+++ b/tests/services/test_fs_projects.py
@@ -290,3 +290,49 @@ def test_project_entry_carries_origin_url(tmp_path):
     entry = next(e for e in entries if e.id == "p1")
     assert entry.origin_url == "https://github.com/example/p1.git"
     assert to_camel_dict(entry)["originUrl"] == "https://github.com/example/p1.git"
+
+
+# ---------------------------------------------------------------------------
+# ProjectEntry.latest_done_run_id
+# ---------------------------------------------------------------------------
+
+
+def _make_run(proj: Path, run_id: str, *, state: str | None) -> None:
+    """Create a manifest-bearing run directory, optionally with a status.json state."""
+    run = proj / run_id
+    (run / "evidence").mkdir(parents=True)
+    (run / "evidence" / "manifest.json").write_text("{}")
+    if state is not None:
+        (run / "status.json").write_text(json.dumps({"schema_version": 2, "state": state}))
+
+
+def test_latest_done_run_id_is_newest_done_run_not_newest_run(tmp_path: Path):
+    # Publish run A (done). Run B is newer but cancelled. latestRunId must
+    # still reflect B (any status), but latestDoneRunId must fall back to A --
+    # otherwise the shared-vs-local comparison could never converge once a
+    # later run fails or is cancelled.
+    proj = tmp_path / "p1"
+    proj.mkdir()
+    (proj / "repository_info.json").write_text(json.dumps({"name": "p1"}))
+    _make_run(proj, "20260301", state="done")
+    _make_run(proj, "20260302", state="cancelled")
+
+    entries = build_project_list(tmp_path)
+    entry = next(e for e in entries if e.id == "p1")
+    assert entry.latest_run_id == "20260302"
+    assert entry.latest_done_run_id == "20260301"
+
+
+def test_latest_done_run_id_absent_when_no_done_runs(tmp_path: Path):
+    from quodeq.core.types import to_camel_dict
+
+    proj = tmp_path / "p2"
+    proj.mkdir()
+    (proj / "repository_info.json").write_text(json.dumps({"name": "p2"}))
+    _make_run(proj, "20260301", state="cancelled")
+
+    entries = build_project_list(tmp_path)
+    entry = next(e for e in entries if e.id == "p2")
+    assert entry.latest_run_id == "20260301"
+    assert entry.latest_done_run_id is None
+    assert "latestDoneRunId" not in to_camel_dict(entry)

--- a/tests/services/test_shared_publish.py
+++ b/tests/services/test_shared_publish.py
@@ -1,5 +1,7 @@
 """Tests for the publish staging logic (pure file operations)."""
 import json
+import subprocess
+import time
 from pathlib import Path
 
 from quodeq.services.shared_publish import (
@@ -132,6 +134,55 @@ def test_list_completed_runs_skips_unsupported_schema_version(tmp_path):
     runs = list_completed_runs(tmp_path)
     # Only the valid "done" run should be included; the unsupported one should be skipped
     assert [r.name for r in runs] == ["r-done"]
+
+
+def test_stage_project_writes_published_json(tmp_path):
+    """Task 2 (audit C1): stage_project records who published and when at
+    publish time, instead of relying solely on git log against the shared
+    clone (which used to be permanently shallow, misattributing every
+    project to whoever pushed last)."""
+    project = tmp_path / "local" / "proj-uuid"
+    project.mkdir(parents=True)
+    (project / "repository_info.json").write_text('{"name":"x"}')
+    _make_run(project, "r-done", "done")
+
+    clone = tmp_path / "clone"
+    clone.mkdir()
+    subprocess.run(["git", "init"], cwd=clone, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "alice"], cwd=clone, check=True, capture_output=True,
+    )
+
+    dest = clone / "evaluations" / "proj-uuid"
+    before = int(time.time())
+    stage_project(project, dest)
+    after = int(time.time())
+
+    meta = json.loads((dest / "published.json").read_text(encoding="utf-8"))
+    assert meta["publishedBy"] == "alice"
+    assert isinstance(meta["publishedAt"], int)
+    assert before <= meta["publishedAt"] <= after
+
+
+def test_stage_project_published_json_falls_back_to_unknown_without_git_identity(tmp_path, monkeypatch):
+    """When the clone has no git user.name configured at all (isolated from
+    whatever happens to be set on the machine running the tests), stage_project
+    must not crash and must record "unknown" rather than an empty string."""
+    isolated_global_config = tmp_path / "empty_gitconfig"
+    isolated_global_config.write_text("", encoding="utf-8")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(isolated_global_config))
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+    project = tmp_path / "local" / "proj-uuid"
+    project.mkdir(parents=True)
+    (project / "repository_info.json").write_text('{"name":"x"}')
+    _make_run(project, "r-done", "done")
+    dest = tmp_path / "clone" / "evaluations" / "proj-uuid"
+
+    stage_project(project, dest)
+
+    meta = json.loads((dest / "published.json").read_text(encoding="utf-8"))
+    assert meta["publishedBy"] == "unknown"
 
 
 def test_merge_actions_log_missing_timestamp_sorts_last(tmp_path):

--- a/tests/services/test_shared_publish_git.py
+++ b/tests/services/test_shared_publish_git.py
@@ -66,9 +66,18 @@ def test_publish_bootstraps_and_pushes(tmp_path):
     assert (verify / "evaluations" / "proj-uuid-1" / "run-1" / "status.json").exists()
 
 
-def test_publish_is_idempotent_no_empty_commit(tmp_path):
+def test_publish_is_idempotent_no_empty_commit(tmp_path, monkeypatch):
+    """Republishing unchanged project content must never commit, regardless
+    of wall-clock ticks between the two publishes. stage_project always
+    rewrites published.json with a fresh publishedAt, so without the fix
+    this only "passed" when both publishes happened to land in the same
+    wall-clock second -- forcing distinct timestamps here makes that flake
+    a deterministic failure.
+    """
     url = _bare_origin(tmp_path)
     root = _local_project(tmp_path)
+    times = iter([1_000_000.0, 1_000_050.0])
+    monkeypatch.setattr(shared_publish.time, "time", lambda: next(times))
     publish_project("proj-uuid-1", url, evaluations_root=root)
     publish_project("proj-uuid-1", url, evaluations_root=root)  # must not raise
     repo = shared_repo_path(url)
@@ -76,6 +85,38 @@ def test_publish_is_idempotent_no_empty_commit(tmp_path):
         ["git", "log", "--oneline"], cwd=repo, capture_output=True, text=True, check=True
     ).stdout.strip().splitlines()
     assert len(log) == 1  # second publish added no commit
+
+
+def test_publish_after_real_change_commits_and_advances_published_at(tmp_path, monkeypatch):
+    """Contrast case: when project content genuinely changes between two
+    publishes, a new commit IS created and published.json's publishedAt
+    advances -- the idempotency fix must not suppress real updates."""
+    url = _bare_origin(tmp_path)
+    root = _local_project(tmp_path)
+    times = iter([1_000_000.0, 1_000_100.0])
+    monkeypatch.setattr(shared_publish.time, "time", lambda: next(times))
+
+    publish_project("proj-uuid-1", url, evaluations_root=root)
+    repo = shared_repo_path(url)
+    meta_path = repo / "evaluations" / "proj-uuid-1" / "published.json"
+    first_meta = json.loads(meta_path.read_text(encoding="utf-8"))
+
+    # A genuinely new completed run appears locally before the second publish.
+    run2 = root / "proj-uuid-1" / "run-2"
+    (run2 / "evidence").mkdir(parents=True)
+    (run2 / "status.json").write_text(json.dumps({"state": "done", "schema_version": 2}))
+    (run2 / "dimensions.json").write_text("{}")
+    (run2 / "events.jsonl").write_text("{}\n")
+
+    publish_project("proj-uuid-1", url, evaluations_root=root)
+
+    log = subprocess.run(
+        ["git", "log", "--oneline"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip().splitlines()
+    assert len(log) == 2  # real content change produced a second commit
+
+    second_meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert second_meta["publishedAt"] > first_meta["publishedAt"]
 
 
 def test_publish_into_foreign_repo_refused(tmp_path):

--- a/tests/services/test_shared_repo.py
+++ b/tests/services/test_shared_repo.py
@@ -564,3 +564,53 @@ def test_published_meta_legacy_fallback_correct_per_path_author_with_full_histor
     meta = published_meta(url)
     assert meta["proj-a"]["publishedBy"] == "alice"
     assert meta["proj-b"]["publishedBy"] == "bob"
+
+
+def test_refresh_shared_clone_unshallows_legacy_cache(tmp_path, monkeypatch):
+    """Review finding on commit 09c3dd71: unshallowing only helps NEW clones
+    (ensure_shared_clone's `--depth 1` removal). A shared-clone cache
+    directory created while the old `--depth 1` code was live stays shallow
+    forever: ensure_shared_clone early-returns because `.git` already
+    exists, and a plain `fetch origin HEAD` does not unshallow on its own
+    (verified live). refresh_shared_clone must detect `.git/shallow` and run
+    `git fetch --unshallow origin` first, so a legacy shallow cache
+    self-heals on its next refresh instead of keeping the shallow-clone
+    misattribution (audit finding C1) forever.
+    """
+    builder_cache = tmp_path / "builder-cache"
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(builder_cache))
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    url = f"file://{origin}"
+    root = tmp_path / "evaluations"
+
+    # Two commits by different authors, same fixture shape as the C1
+    # regression above: a shallow (grafted-tip) clone attributes every path
+    # to bob (the later, tip commit) instead of proj-a's real author alice.
+    _make_minimal_project(root, "proj-a")
+    _publish_project_as(monkeypatch, url, root, "proj-a", "alice")
+    _make_minimal_project(root, "proj-b")
+    _publish_project_as(monkeypatch, url, root, "proj-b", "bob")
+
+    # Point QUODEQ_CACHE_ROOT at the real cache root this test targets, and
+    # manually build a shallow clone at the EXACT path shared_repo_path(url)
+    # expects -- simulating a cache dir created back when ensure_shared_clone
+    # still used `git clone --depth 1`.
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    repo = shared_repo_path(url)
+    repo.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "clone", "--depth", "1", url, str(repo)], check=True, capture_output=True,
+    )
+    assert (repo / ".git" / "shallow").exists()
+
+    assert refresh_shared_clone(url) is True
+    assert not (repo / ".git" / "shallow").exists()
+
+    # Force the legacy git-log fallback for proj-a, AFTER refresh (refresh's
+    # own reset --hard would otherwise restore published.json from history,
+    # masking the bug this test targets).
+    (shared_evaluations_root(url) / "proj-a" / "published.json").unlink()
+
+    meta = published_meta(url)
+    assert meta["proj-a"]["publishedBy"] == "alice"

--- a/tests/services/test_shared_repo.py
+++ b/tests/services/test_shared_repo.py
@@ -64,7 +64,9 @@ def test_ensure_clone_and_refresh(tmp_path, monkeypatch):
     assert (repo / "hello.txt").exists()
     # second call reuses without error
     assert ensure_shared_clone(url) == repo
-    assert refresh_shared_clone(url) is True
+    ok, reason = refresh_shared_clone(url)
+    assert ok is True
+    assert reason == ""
 
 
 def test_clone_and_refresh_are_not_shallow(tmp_path, monkeypatch):
@@ -78,7 +80,8 @@ def test_clone_and_refresh_are_not_shallow(tmp_path, monkeypatch):
     repo = ensure_shared_clone(url)
     assert repo is not None
     assert not (repo / ".git" / "shallow").exists()
-    assert refresh_shared_clone(url) is True
+    ok, _ = refresh_shared_clone(url)
+    assert ok is True
     assert not (repo / ".git" / "shallow").exists()
 
 
@@ -101,7 +104,8 @@ def test_refresh_shared_clone_passes_explicit_timeout_to_both_git_calls(tmp_path
 
     monkeypatch.setattr("quodeq.services.shared_repo.run_git", _spy)
 
-    assert refresh_shared_clone(url, timeout=7) is True
+    ok, _ = refresh_shared_clone(url, timeout=7)
+    assert ok is True
     assert seen_timeouts == [7, 7]
 
 
@@ -121,7 +125,8 @@ def test_refresh_shared_clone_default_timeout_is_bounded_not_300s(tmp_path, monk
 
     monkeypatch.setattr("quodeq.services.shared_repo.run_git", _spy)
 
-    assert refresh_shared_clone(url) is True
+    ok, _ = refresh_shared_clone(url)
+    assert ok is True
     assert seen_timeouts == [30, 30]
 
 
@@ -604,7 +609,8 @@ def test_refresh_shared_clone_unshallows_legacy_cache(tmp_path, monkeypatch):
     )
     assert (repo / ".git" / "shallow").exists()
 
-    assert refresh_shared_clone(url) is True
+    ok, _ = refresh_shared_clone(url)
+    assert ok is True
     assert not (repo / ".git" / "shallow").exists()
 
     # Force the legacy git-log fallback for proj-a, AFTER refresh (refresh's
@@ -614,3 +620,38 @@ def test_refresh_shared_clone_unshallows_legacy_cache(tmp_path, monkeypatch):
 
     meta = published_meta(url)
     assert meta["proj-a"]["publishedBy"] == "alice"
+
+
+def test_refresh_shared_clone_returns_reason_on_fetch_failure(tmp_path, monkeypatch, caplog):
+    """Audit finding B3: refresh_shared_clone must surface WHY a refresh
+    failed (the git stderr tail), not just False -- without it, the UI can
+    only render "Request failed: 502" for DNS failure vs auth failure vs a
+    deleted origin. The failure must also be logged via logger.warning so a
+    caller that discards the reason (e.g. publish_project's best-effort
+    refresh) still leaves a diagnosable server-side trail."""
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    url = _make_origin(tmp_path)
+    assert ensure_shared_clone(url) is not None
+
+    # The origin becomes unreachable, as if it had been deleted.
+    origin_path = Path(url.removeprefix("file://"))
+    origin_path.rename(tmp_path / "origin-gone.git")
+
+    with caplog.at_level("WARNING"):
+        ok, reason = refresh_shared_clone(url)
+
+    assert ok is False
+    assert reason  # non-empty
+    assert len(reason) <= 200
+    assert caplog.text  # logged via logger.warning, not silently swallowed
+
+
+def test_refresh_shared_clone_success_returns_empty_reason(tmp_path, monkeypatch):
+    """The reason string is "" on a successful refresh (no error to report)."""
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    url = _make_origin(tmp_path)
+    assert ensure_shared_clone(url) is not None
+
+    ok, reason = refresh_shared_clone(url)
+    assert ok is True
+    assert reason == ""

--- a/tests/services/test_shared_repo.py
+++ b/tests/services/test_shared_repo.py
@@ -322,8 +322,13 @@ def test_read_state_unsupported_version(tmp_path, monkeypatch):
     assert read_state(url) == "unsupported_version"
 
 
-def test_read_state_foreign_with_evaluations_dir_ok(tmp_path, monkeypatch):
-    """read_state returns 'ok' when evaluations/ dir exists even if format is foreign."""
+def test_read_state_foreign_with_evaluations_dir_still_foreign(tmp_path, monkeypatch):
+    """Audit A1: read_state must not treat "has an evaluations/ dir" as a
+    proxy for "ok" -- that let a real foreign repo (someone else's git repo
+    that happens to contain a directory named evaluations/) serve as if it
+    were a quodeq clone. A foreign repo is foreign regardless of its
+    contents; only the quodeq.json marker (checked by check_repo_format)
+    decides "ok"."""
     monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
     url = "file:///dummy/url"
     repo = shared_repo_path(url, {"QUODEQ_CACHE_ROOT": str(tmp_path / "cache")})
@@ -331,7 +336,51 @@ def test_read_state_foreign_with_evaluations_dir_ok(tmp_path, monkeypatch):
     (repo / ".git").mkdir()
     (repo / "README.md").write_text("Some other project")
     (repo / "evaluations").mkdir()
-    assert read_state(url) == "ok"
+    assert read_state(url) == "foreign"
+
+
+def test_read_state_distinguishes_empty_and_foreign(tmp_path, monkeypatch):
+    """Audit A1: read_state must surface all four check_repo_format outcomes
+    instead of collapsing "empty" and "foreign" down to "missing" -- real
+    clones of real local bare origins, not hand-built directories, so the
+    full ensure_shared_clone -> read_state path is exercised end to end."""
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+
+    # missing: no clone at all.
+    missing_url = "file:///nonexistent/repo-for-state-test.git"
+    assert read_state(missing_url) == "missing"
+
+    # empty: a real clone of a bare origin with zero commits.
+    empty_origin = tmp_path / "empty-origin.git"
+    subprocess.run(["git", "init", "--bare", str(empty_origin)], check=True, capture_output=True)
+    empty_url = f"file://{empty_origin}"
+    assert ensure_shared_clone(empty_url) is not None
+    assert read_state(empty_url) == "empty"
+
+    # foreign: a real clone of a bare origin holding a README but no marker.
+    foreign_origin = tmp_path / "foreign-origin.git"
+    subprocess.run(["git", "init", "--bare", str(foreign_origin)], check=True, capture_output=True)
+    foreign_seed = tmp_path / "foreign-seed"
+    subprocess.run(["git", "clone", str(foreign_origin), str(foreign_seed)], check=True, capture_output=True)
+    (foreign_seed / "README.md").write_text("some other project", encoding="utf-8")
+    for cmd in (
+        ["git", "add", "."],
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "seed"],
+        ["git", "push", "origin", "HEAD"],
+    ):
+        subprocess.run(cmd, cwd=foreign_seed, check=True, capture_output=True)
+    foreign_url = f"file://{foreign_origin}"
+    assert ensure_shared_clone(foreign_url) is not None
+    assert read_state(foreign_url) == "foreign"
+
+    # ok: marker present via bootstrap_repo_layout on a real clone.
+    ok_origin = tmp_path / "ok-origin.git"
+    subprocess.run(["git", "init", "--bare", str(ok_origin)], check=True, capture_output=True)
+    ok_url = f"file://{ok_origin}"
+    ok_repo = ensure_shared_clone(ok_url)
+    assert ok_repo is not None
+    bootstrap_repo_layout(ok_repo)
+    assert read_state(ok_url) == "ok"
 
 
 def test_published_meta_skips_uncommitted_project_dir(tmp_path, monkeypatch):

--- a/tests/services/test_shared_repo.py
+++ b/tests/services/test_shared_repo.py
@@ -1,6 +1,5 @@
 """Tests for shared repo clone management."""
 import json
-import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -15,6 +14,7 @@ from quodeq.services.shared_repo import (
     published_meta,
     read_state,
     refresh_shared_clone,
+    remove_clone_dir,
     run_git,
     shared_cache_dir,
     shared_evaluations_root,
@@ -557,7 +557,9 @@ def test_published_meta_legacy_fallback_correct_per_path_author_with_full_histor
     _publish_project_as(monkeypatch, url, root, "proj-b", "bob")
 
     # Force a fresh re-clone from origin, which now holds both commits.
-    shutil.rmtree(shared_repo_path(url))
+    # remove_clone_dir, not plain rmtree: git object files are read-only,
+    # which makes rmtree fail with PermissionError on Windows.
+    remove_clone_dir(shared_repo_path(url))
     assert ensure_shared_clone(url) is not None
 
     # Simulate a legacy dir published before published.json existed: drop
@@ -655,3 +657,51 @@ def test_refresh_shared_clone_success_returns_empty_reason(tmp_path, monkeypatch
     ok, reason = refresh_shared_clone(url)
     assert ok is True
     assert reason == ""
+
+
+# --- remove_clone_dir: Windows-safe deletion of git trees ---------------
+# Git marks object files read-only. POSIX deletion only checks the parent
+# dir, but on Windows rmtree raises PermissionError on them, so plain
+# rmtree fails (test suite) or silently leaves .git debris behind
+# (ignore_errors=True in disconnect, corrupting a later reconnect).
+
+
+def test_remove_clone_dir_deletes_tree_with_readonly_files(tmp_path):
+    """A tree holding read-only files (git objects) is fully removed."""
+    tree = tmp_path / "repo"
+    objects = tree / ".git" / "objects" / "09"
+    objects.mkdir(parents=True)
+    blob = objects / "abc123"
+    blob.write_bytes(b"x")
+    blob.chmod(0o444)
+
+    remove_clone_dir(tree)
+
+    assert not tree.exists()
+
+
+def test_remove_clone_dir_missing_path_is_noop(tmp_path):
+    remove_clone_dir(tmp_path / "never-created")
+
+
+def test_remove_clone_dir_never_raises_on_persistent_failure(tmp_path, caplog, monkeypatch):
+    """If chmod+retry also fails, the error is logged, not raised (a
+    permission-denied cache dir must not turn a disconnect into a 500)."""
+    import os as _os
+
+    tree = tmp_path / "repo"
+    tree.mkdir()
+    (tree / "f").write_bytes(b"x")
+
+    real_unlink = _os.unlink
+
+    def deny_unlink(path, *a, **kw):
+        if Path(path).name == "f":
+            raise PermissionError(5, "Access is denied", str(path))
+        return real_unlink(path, *a, **kw)
+
+    monkeypatch.setattr(_os, "unlink", deny_unlink)
+    with caplog.at_level("WARNING"):
+        remove_clone_dir(tree)  # must not raise
+
+    assert "failed to remove" in caplog.text

--- a/tests/services/test_shared_repo.py
+++ b/tests/services/test_shared_repo.py
@@ -1,5 +1,6 @@
 """Tests for shared repo clone management."""
 import json
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -16,6 +17,7 @@ from quodeq.services.shared_repo import (
     refresh_shared_clone,
     run_git,
     shared_cache_dir,
+    shared_evaluations_root,
     shared_index_db_path,
     shared_repo_path,
     sync_shared_index,
@@ -63,6 +65,21 @@ def test_ensure_clone_and_refresh(tmp_path, monkeypatch):
     # second call reuses without error
     assert ensure_shared_clone(url) == repo
     assert refresh_shared_clone(url) is True
+
+
+def test_clone_and_refresh_are_not_shallow(tmp_path, monkeypatch):
+    """Audit finding C1: a permanently-shallow (--depth 1) clone means
+    `git log -1 -- path` on the shallow root commit attributes EVERY path
+    to the tip commit, misattributing every project except the most
+    recently pushed one. Both the initial clone and the refresh fetch must
+    pull full history -- neither leaves a .git/shallow marker behind."""
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    url = _make_origin(tmp_path)
+    repo = ensure_shared_clone(url)
+    assert repo is not None
+    assert not (repo / ".git" / "shallow").exists()
+    assert refresh_shared_clone(url) is True
+    assert not (repo / ".git" / "shallow").exists()
 
 
 def test_refresh_shared_clone_passes_explicit_timeout_to_both_git_calls(tmp_path, monkeypatch):
@@ -263,6 +280,15 @@ def test_readable_and_index_sync_on_published_clone(tmp_path, monkeypatch):
     monkeypatch.setenv("GIT_AUTHOR_EMAIL", "a@a")
     monkeypatch.setenv("GIT_COMMITTER_NAME", "anna")
     monkeypatch.setenv("GIT_COMMITTER_EMAIL", "a@a")
+    # publishedBy (published.json) comes from `git config user.name` in the
+    # clone, not from GIT_AUTHOR_NAME/GIT_COMMITTER_NAME (those only affect a
+    # commit's recorded identity) -- pin it explicitly, on the clone's LOCAL
+    # config, so this assertion is deterministic regardless of the machine
+    # running the test.
+    assert ensure_shared_clone(url) is not None
+    subprocess.run(
+        ["git", "config", "user.name", "anna"], cwd=shared_repo_path(url), check=True, capture_output=True,
+    )
     publish_project("proj-a", url, evaluations_root=root)
 
     assert read_state(url) == "ok"
@@ -274,7 +300,14 @@ def test_readable_and_index_sync_on_published_clone(tmp_path, monkeypatch):
 
 
 def test_published_meta_author_name_with_pipe(tmp_path, monkeypatch):
-    """Test that author names containing pipes are correctly parsed."""
+    """Test that author names containing pipes are correctly parsed.
+
+    published_meta now prefers published.json, which round-trips a "|" in a
+    JSON string trivially -- so this test drops published.json after
+    publishing to force the legacy git-log fallback, which is what this
+    test actually targets: `rpartition("|")` in published_meta's git-log
+    branch must not misparse a `%an|%ct` line when %an itself contains "|".
+    """
     monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
     from quodeq.services.shared_publish import publish_project
     origin = tmp_path / "origin.git"
@@ -294,6 +327,9 @@ def test_published_meta_author_name_with_pipe(tmp_path, monkeypatch):
     monkeypatch.setenv("GIT_COMMITTER_NAME", "Jane | Marketing")
     monkeypatch.setenv("GIT_COMMITTER_EMAIL", "jane@example.com")
     publish_project("proj-pipe", url, evaluations_root=root)
+
+    # Force the legacy git-log fallback (see docstring).
+    (shared_evaluations_root(url) / "proj-pipe" / "published.json").unlink()
 
     meta = published_meta(url)
     assert "proj-pipe" in meta
@@ -414,3 +450,117 @@ def test_published_meta_skips_uncommitted_project_dir(tmp_path, monkeypatch):
     meta = published_meta(url)
     assert "proj-committed" in meta
     assert "proj-uncommitted" not in meta
+
+
+def _publish_project_as(
+    monkeypatch, url: str, root: Path, project_id: str, author: str
+) -> None:
+    """Publish project_id into the shared repo at url, attributed to author.
+
+    Pre-clones (if needed) and pins the clone's LOCAL git config user.name to
+    author before publishing, so published.json's publishedBy (sourced from
+    `git config user.name`, not GIT_AUTHOR_NAME/GIT_COMMITTER_NAME) is
+    deterministic. Also sets GIT_AUTHOR_NAME/EMAIL and GIT_COMMITTER_NAME/EMAIL
+    (via monkeypatch, so they don't leak into other tests) so the underlying
+    `git commit` succeeds without needing any git identity configured on the
+    machine running the tests.
+    """
+    from quodeq.services.shared_publish import publish_project
+
+    monkeypatch.setenv("GIT_AUTHOR_NAME", author)
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", f"{author}@example.com")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", author)
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", f"{author}@example.com")
+
+    assert ensure_shared_clone(url) is not None
+    subprocess.run(
+        ["git", "config", "user.name", author], cwd=shared_repo_path(url), check=True, capture_output=True,
+    )
+    publish_project(project_id, url, evaluations_root=root)
+
+
+def _make_minimal_project(root: Path, project_id: str) -> None:
+    project = root / project_id
+    run = project / "run-1"
+    (run / "evidence").mkdir(parents=True)
+    (project / "repository_info.json").write_text('{"name":"demo"}')
+    (run / "status.json").write_text(json.dumps({"state": "done", "schema_version": 2}))
+    (run / "dimensions.json").write_text("{}")
+    (run / "events.jsonl").write_text("{}\n")
+
+
+def test_published_meta_two_authors_each_keeps_own_attribution(tmp_path, monkeypatch):
+    """Regression for audit C1: publishing project B (by a different author,
+    later) must not change what published_meta reports for project A. Before
+    this fix, the clone was permanently shallow (--depth 1), so `git log -1
+    -- path` on project A's path returned the LATEST commit (project B's,
+    authored by bob) rather than project A's own commit -- misattributing
+    every project except the most recently published one. published.json,
+    written at publish time, makes each project's attribution independent of
+    any later commit anywhere else in the clone."""
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    url = f"file://{origin}"
+    root = tmp_path / "evaluations"
+
+    _make_minimal_project(root, "proj-a")
+    _publish_project_as(monkeypatch, url, root, "proj-a", "alice")
+
+    _make_minimal_project(root, "proj-b")
+    _publish_project_as(monkeypatch, url, root, "proj-b", "bob")
+
+    meta = published_meta(url)
+    assert meta["proj-a"]["publishedBy"] == "alice"
+    assert meta["proj-b"]["publishedBy"] == "bob"
+
+
+def test_published_meta_legacy_fallback_correct_per_path_author_with_full_history(tmp_path, monkeypatch):
+    """THE regression test for audit finding C1, verified experimentally:
+
+    `git clone --depth 1` of a remote already holding multiple commits keeps
+    only the tip commit, as a parentless ("grafted") commit. A parentless
+    commit is diffed against the empty tree, so `git log -- path` treats it
+    as having introduced EVERY path present in its snapshot -- including
+    paths that were really added by earlier, now-truncated commits. So on a
+    shallow clone, `git log -1 -- evaluations/proj-a` incorrectly returns
+    whoever authored the LATEST commit (bob, via proj-b), not proj-a's real
+    author (alice), for any legacy dir lacking published.json.
+
+    This reproduces that exact scenario: publish proj-a (alice) then proj-b
+    (bob) on one clone, force a FRESH re-clone (simulating a cache-recreate
+    or a different machine's first connect against the now-multi-commit
+    remote -- the only situation where clone shallow-ness actually matters,
+    since a single continuously-reused clone's own `git commit` calls always
+    keep a genuine full parent chain regardless of the original clone's
+    depth), then drop proj-a's published.json from the fresh clone's working
+    tree to simulate it predating the published.json feature. Before this
+    fix (ensure_shared_clone's `--depth 1`), the fresh clone is shallow and
+    proj-a incorrectly resolves to bob. With the fix (full clone), it
+    resolves to its true author, alice.
+    """
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    url = f"file://{origin}"
+    root = tmp_path / "evaluations"
+
+    _make_minimal_project(root, "proj-a")
+    _publish_project_as(monkeypatch, url, root, "proj-a", "alice")
+
+    _make_minimal_project(root, "proj-b")
+    _publish_project_as(monkeypatch, url, root, "proj-b", "bob")
+
+    # Force a fresh re-clone from origin, which now holds both commits.
+    shutil.rmtree(shared_repo_path(url))
+    assert ensure_shared_clone(url) is not None
+
+    # Simulate a legacy dir published before published.json existed: drop
+    # the file from proj-a's (freshly re-cloned) working tree.
+    # published_meta reads it straight off disk, not from git history, so no
+    # re-commit is needed to exercise the fallback; proj-b keeps its file.
+    (shared_evaluations_root(url) / "proj-a" / "published.json").unlink()
+
+    meta = published_meta(url)
+    assert meta["proj-a"]["publishedBy"] == "alice"
+    assert meta["proj-b"]["publishedBy"] == "bob"

--- a/tests/services/test_shared_repo_lock.py
+++ b/tests/services/test_shared_repo_lock.py
@@ -1,0 +1,162 @@
+"""Tests for clone_lock (audit finding C2): git mutations on one shared
+clone directory -- refresh vs refresh vs publish -- must be serialized
+behind one process-wide reentrant lock, not left to interleave.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from quodeq.services import shared_publish, shared_repo
+from quodeq.services.shared_publish import publish_project
+from quodeq.services.shared_repo import clone_lock, ensure_shared_clone, refresh_shared_clone
+
+
+def _bare_origin(tmp_path: Path, name: str = "origin.git") -> str:
+    origin = tmp_path / name
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    return f"file://{origin}"
+
+
+def _local_project(root: Path, project_id: str = "proj-1") -> None:
+    project = root / project_id
+    run = project / "run-1"
+    (run / "evidence").mkdir(parents=True)
+    (project / "repository_info.json").write_text('{"name":"demo"}')
+    (run / "status.json").write_text(json.dumps({"state": "done", "schema_version": 2}))
+    (run / "dimensions.json").write_text("{}")
+    (run / "events.jsonl").write_text("{}\n")
+
+
+@pytest.fixture(autouse=True)
+def _git_identity(monkeypatch, tmp_path):
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "tester")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "t@t")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "tester")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "t@t")
+
+
+def test_clone_lock_keyed_by_path_and_reentrant(tmp_path, monkeypatch):
+    """clone_lock returns the SAME RLock for the same resolved clone path,
+    a DIFFERENT one for a different clone, and allows the same thread to
+    acquire it more than once (RLock, not Lock)."""
+    lock_a1 = clone_lock("file:///a.git")
+    lock_a2 = clone_lock("file:///a.git")
+    lock_b = clone_lock("file:///b.git")
+
+    assert lock_a1 is lock_a2
+    assert lock_a1 is not lock_b
+
+    assert lock_a1.acquire(timeout=1)
+    try:
+        assert lock_a1.acquire(timeout=1)  # reentrant on the same thread
+        lock_a1.release()
+    finally:
+        lock_a1.release()
+
+
+def test_refresh_waits_for_publish(tmp_path, monkeypatch):
+    """A refresh entered while publish holds the clone lock must not
+    interleave: record git-op ordering with a monkeypatched run_git that
+    sleeps inside publish's staging window, fire refresh_shared_clone from
+    a thread, assert its first git op timestamp is after publish's last."""
+    url = _bare_origin(tmp_path)
+    root = tmp_path / "evaluations"
+    _local_project(root)
+    # Pre-clone so publish_project's own ensure_shared_clone call is a
+    # no-op filesystem check (no git call), keeping the recorded timeline
+    # focused on the commit/push vs refresh ordering this test targets.
+    assert ensure_shared_clone(url) is not None
+
+    events: list[tuple[str, float, str]] = []
+    events_lock = threading.Lock()
+    commit_reached = threading.Event()
+    real_run_git = shared_repo.run_git
+
+    def _recording_run_git(args, *, cwd=None, timeout=None):
+        op = args[0] if args else "?"
+        if op == "commit":
+            commit_reached.set()
+            time.sleep(0.3)  # widen publish's staging window
+        result = real_run_git(args, cwd=cwd, timeout=timeout)
+        with events_lock:
+            events.append((op, time.monotonic(), threading.current_thread().name))
+        return result
+
+    # publish_project and shared_repo's refresh/ensure helpers each hold
+    # their own imported reference to run_git, so both must be patched.
+    monkeypatch.setattr(shared_repo, "run_git", _recording_run_git)
+    monkeypatch.setattr(shared_publish, "run_git", _recording_run_git)
+
+    publish_errors: list[BaseException] = []
+
+    def _do_publish():
+        try:
+            publish_project("proj-1", url, evaluations_root=root)
+        except BaseException as exc:  # noqa: BLE001 - surfaced via assertion below
+            publish_errors.append(exc)
+
+    refresh_errors: list[BaseException] = []
+
+    def _fire_refresh():
+        try:
+            refresh_shared_clone(url)
+        except BaseException as exc:  # noqa: BLE001
+            refresh_errors.append(exc)
+
+    publish_thread = threading.Thread(target=_do_publish, name="publish")
+    refresh_thread = threading.Thread(target=_fire_refresh, name="refresh")
+
+    publish_thread.start()
+    assert commit_reached.wait(timeout=5), "publish never reached its commit step"
+    refresh_thread.start()
+
+    publish_thread.join(timeout=5)
+    refresh_thread.join(timeout=5)
+
+    assert not publish_thread.is_alive(), "publish_project deadlocked"
+    assert not refresh_thread.is_alive(), "refresh_shared_clone deadlocked"
+    assert not publish_errors, publish_errors
+    assert not refresh_errors, refresh_errors
+
+    publish_times = [t for _, t, name in events if name == "publish"]
+    refresh_times = [t for _, t, name in events if name == "refresh"]
+    assert publish_times, "publish recorded no git ops"
+    assert refresh_times, "refresh recorded no git ops"
+
+    # The refresh thread blocked on clone_lock until publish released it, so
+    # every git op refresh issued happened strictly after publish's last one.
+    assert min(refresh_times) > max(publish_times)
+
+
+def test_clone_lock_is_reentrant_for_publish_internal_refresh(tmp_path):
+    """publish_project's own refresh_shared_clone call under the held lock
+    completes (RLock), no deadlock (guard with a join timeout)."""
+    url = _bare_origin(tmp_path)
+    root = tmp_path / "evaluations"
+    _local_project(root)
+
+    results: list[tuple[str, object]] = []
+
+    def _do_publish():
+        try:
+            count = publish_project("proj-1", url, evaluations_root=root)
+            results.append(("ok", count))
+        except BaseException as exc:  # noqa: BLE001 - surfaced via assertion below
+            results.append(("error", exc))
+
+    thread = threading.Thread(target=_do_publish, name="publish")
+    thread.start()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive(), (
+        "publish_project deadlocked acquiring its own clone lock reentrantly "
+        "via ensure_shared_clone / refresh_shared_clone"
+    )
+    assert results and results[0] == ("ok", 1), results


### PR DESCRIPTION
Fixes the shared/online inconsistencies from the 2026-07-22 audit (findings A1-A4, B2-B3, C1-C6). Phase 3 polish is deferred.

Backend:
- Repo states are truthful end to end: empty repos are servable, foreign repos are rejected at connect with a real message, /status exposes repoState.
- Publish attribution is recorded at publish time in published.json (additive, format stays v1). The clone is unshallowed so the legacy git-log fallback is also correct.
- One reentrant lock per clone serializes refresh, publish and disconnect. Refresh failures carry a diagnosable reason. Reconnects fetch fresh content. Disconnect removes the cache dir.

Frontend:
- Shared status/list collapse onto one react-query source shared by ProjectsPage, usePublish and Settings, with invalidation on connect/disconnect/publish/refresh, retryable load errors and coalesced refreshes.
- Publish completion flips badges, action and meta atomically via an optimistic cache patch.
- The update action keys on done-run identity instead of date-only timestamps.

Verified: 4782 backend + 1481 UI tests green, plus a live E2E covering connect-empty, publish attribution, teammate-publish reconnect, broken-origin diagnostics and disconnect cleanup.

Known fast-follow: harden the post-publish list refetch against deduping onto an in-flight stale request (refetchQueries with cancelRefetch).
