### PR TITLE
fix(services): remove ephemeral and partial clone dirs safely on Windows

### DIFF
--- a/src/quodeq/services/_ephemeral_cleanup.py
+++ b/src/quodeq/services/_ephemeral_cleanup.py
@@ -4,15 +4,11 @@ from __future__ import annotations
 
 import json
 import logging
-import shutil
 from pathlib import Path
 
+from quodeq.services.shared_repo import remove_clone_dir
+
 _logger = logging.getLogger(__name__)
-
-
-def _log_rmtree_error(func, path, exc):
-    """rmtree onexc callback that logs failures instead of swallowing them."""
-    _logger.warning("Failed to remove %s: %s", path, exc)
 
 
 def delete_ephemeral_clone(clones_root: Path, project_uuid: str) -> None:
@@ -30,9 +26,7 @@ def delete_ephemeral_clone(clones_root: Path, project_uuid: str) -> None:
         return
     if target == clones_root:
         return
-    if not target.exists():
-        return
-    shutil.rmtree(target, onexc=_log_rmtree_error)
+    remove_clone_dir(target)
 
 
 def maybe_cleanup_after_job(
@@ -78,4 +72,4 @@ def sweep_orphaned_clones(clones_root: Path, reports_root: Path) -> None:
         registered = set()
     for entry in clones_root.iterdir():
         if entry.is_dir() and entry.name not in registered:
-            shutil.rmtree(entry, onexc=_log_rmtree_error)
+            remove_clone_dir(entry)

--- a/src/quodeq/services/_fs_clone.py
+++ b/src/quodeq/services/_fs_clone.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import errno
 import logging
 import os
-import shutil
 import subprocess as _subprocess
 from pathlib import Path
+
+from quodeq.services.shared_repo import remove_clone_dir
 
 _logger = logging.getLogger(__name__)
 
@@ -142,6 +143,5 @@ def run_git_clone(url: str, clone_dest: Path) -> None:
         # git usually removes the dest it created on failure, but not when
         # killed or on checkout-phase errors; a leftover partial dir would
         # turn the retry into a bogus dest_exists failure.
-        if clone_dest.exists():
-            shutil.rmtree(clone_dest, ignore_errors=True)
+        remove_clone_dir(clone_dest)
         _clone_once(url, clone_dest, [])

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -1,0 +1,26 @@
+import os
+import stat
+
+import pytest
+
+
+@pytest.fixture
+def windows_unlink_semantics(monkeypatch):
+    """Make os.unlink refuse read-only files, like Windows (WinError 5).
+
+    POSIX deletion only checks the parent directory, so tests for git-tree
+    cleanup (git marks object files read-only) pass trivially on macOS/Linux
+    even when the code under test would fail on Windows. This fixture
+    reproduces the Windows failure mode so those tests are meaningful on
+    every platform. Deletion code must clear the read-only bit before
+    retrying the unlink (see quodeq.services.shared_repo.remove_clone_dir).
+    """
+    real_unlink = os.unlink
+
+    def unlink(path, *args, dir_fd=None, **kwargs):
+        mode = os.stat(path, dir_fd=dir_fd, follow_symlinks=False).st_mode
+        if not mode & stat.S_IWRITE:
+            raise PermissionError(5, "Access is denied", str(path))
+        return real_unlink(path, *args, dir_fd=dir_fd, **kwargs)
+
+    monkeypatch.setattr(os, "unlink", unlink)

--- a/tests/services/test_clone_shallow.py
+++ b/tests/services/test_clone_shallow.py
@@ -66,6 +66,32 @@ def test_fallback_removes_partial_clone_dir(tmp_path):
     assert len(calls) == 2
 
 
+def test_fallback_removes_partial_clone_with_readonly_objects(
+    tmp_path, windows_unlink_semantics
+):
+    """A partial dest holds read-only git object files, which Windows
+    refuses to unlink. rmtree(ignore_errors=True) silently left them
+    behind, turning the retry into a bogus dest_exists failure. Cleanup
+    must clear the read-only bit and retry (shared_repo.remove_clone_dir)."""
+    dest = tmp_path / "dest"
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if len(calls) == 1:
+            objects = dest / ".git" / "objects" / "09"
+            objects.mkdir(parents=True)
+            blob = objects / "deadbeef"
+            blob.write_bytes(b"x")
+            blob.chmod(0o444)
+            raise _stderr("some unrelated git error")
+        assert not dest.exists(), "partial clone dir must be removed before the retry"
+
+    with patch("quodeq.services._fs_clone._subprocess.run", side_effect=fake_run):
+        run_git_clone("https://x/y.git", dest)
+    assert len(calls) == 2
+
+
 @pytest.mark.parametrize(
     "stderr_text,expected_kind",
     [

--- a/tests/services/test_ephemeral_cleanup.py
+++ b/tests/services/test_ephemeral_cleanup.py
@@ -55,3 +55,45 @@ def test_sweep_removes_orphans_keeps_registered(tmp_path):
 
 def test_sweep_handles_missing_clones_root(tmp_path):
     sweep_orphaned_clones(tmp_path / "no-such-dir", tmp_path)  # must not raise
+
+
+# --- Windows-safe deletion of git trees ----------------------------------
+# Git marks object files read-only and Windows refuses to unlink those, so
+# rmtree with a log-only onexc handler left ephemeral clones behind. Both
+# entry points must clear the read-only bit and retry (via
+# shared_repo.remove_clone_dir). The windows_unlink_semantics fixture makes
+# the failure reproducible on POSIX.
+
+
+def _make_readonly_git_object(clone_dir: Path) -> Path:
+    objects = clone_dir / ".git" / "objects" / "09"
+    objects.mkdir(parents=True)
+    blob = objects / "deadbeef"
+    blob.write_bytes(b"x")
+    blob.chmod(0o444)
+    return blob
+
+
+def test_delete_ephemeral_clone_clears_readonly_git_objects(
+    tmp_path, windows_unlink_semantics
+):
+    clones_root = tmp_path / "clones"
+    project_uuid = "abc-123"
+    _make_readonly_git_object(clones_root / project_uuid)
+
+    delete_ephemeral_clone(clones_root, project_uuid)
+
+    assert not (clones_root / project_uuid).exists()
+
+
+def test_sweep_clears_readonly_git_objects_in_orphans(
+    tmp_path, windows_unlink_semantics
+):
+    clones_root = tmp_path / "clones"
+    reports_root = tmp_path / "reports"
+    reports_root.mkdir()
+    _make_readonly_git_object(clones_root / "orphan-uuid")
+
+    sweep_orphaned_clones(clones_root, reports_root)
+
+    assert not (clones_root / "orphan-uuid").exists()


### PR DESCRIPTION
Two pre-existing delete paths for git clone directories fail on Windows because git object files are read-only (WinError 5 on delete, POSIX unaffected):

- `_ephemeral_cleanup.py`: `delete_ephemeral_clone` and `sweep_orphaned_clones` used `shutil.rmtree` with a log-only `onexc` handler, leaving ephemeral clone debris under `~/.quodeq/clones/`.
- `_fs_clone.py`: the shallow-to-full clone fallback used `rmtree(ignore_errors=True)`, so a leftover partial dest turned the retry into a bogus `dest_exists` failure.

Both now route through `shared_repo.remove_clone_dir` (added in #828), which clears the read-only bit and retries. Same layer, so no import gate changes needed.

Tests: new `windows_unlink_semantics` fixture in `tests/services/conftest.py` makes `os.unlink` refuse read-only files like Windows does, so the three new regression tests fail on the old code even on POSIX. Full suite passes (4794 passed, 8 skipped).