### PR TITLE
fix(ui): terminal opens on shared projects

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -174,6 +174,15 @@ export function isSharedSource(selectedSource) {
   return selectedSource === 'shared';
 }
 
+// Exported for tests. On a shared project only the ASSISTANT panel closes:
+// its dismiss/verify tools write to the local store, which can collide with
+// the shared project's id. The terminal is machine-local (PTY in ~) and must
+// stay open — closing the whole drawer here is the bug that made the
+// terminal unopenable on shared projects.
+export function shouldCloseAssistantForSource(selectedSource, openPanels) {
+  return selectedSource === 'shared' && openPanels.includes('assistant');
+}
+
 // Project-data tabs (overview/violations/map/history) — module scope so both
 // the App component and the exported shouldBounceToEvaluate helper below
 // share one definition.
@@ -746,7 +755,8 @@ export default function App() {
   // active assistant provider/model.
   const assistantGate = useAssistantProvider();
   const assistantCtx = deriveAssistantContext(state, assistantGate);
-  const { isOpen: assistantOpen, activeTab: drawerTab, startSession: startAssistantSession, close: closeDrawer } = useAssistantDrawer();
+  const { isOpen: assistantOpen, activeTab: drawerTab, openPanels: drawerPanels,
+          startSession: startAssistantSession, closePanel: closeDrawerPanel } = useAssistantDrawer();
   const { provider: asstProvider, model: asstModel, projectId: asstProjectId, runId: asstRunId } = assistantCtx;
   // Start (or re-start) the assistant session when the drawer is open and on
   // any provider/model/project/run change while it stays open. startSession
@@ -754,17 +764,18 @@ export default function App() {
   // real project/run switch produces a fresh session. We deliberately do NOT
   // start a session while the drawer is closed — sends only originate from the
   // open drawer, so first-open is early enough and avoids needless sessions.
-  // Shared projects have no mutation routes on the backend, so close the drawer
-  // when switching to a shared project to prevent dismiss/verify from writing
-  // to the local store under the shared project's id.
+  // Shared projects have no mutation routes on the backend, so close the
+  // ASSISTANT panel when switching to a shared project; the terminal is
+  // machine-local and stays open.
   useEffect(() => {
-    if (state.selectedSource === 'shared' && assistantOpen) {
-      closeDrawer();
+    if (shouldCloseAssistantForSource(state.selectedSource, drawerPanels)) {
+      closeDrawerPanel('assistant');
       return;
     }
+    if (state.selectedSource === 'shared') return;
     if (!assistantOpen || drawerTab !== 'assistant') return;
     startAssistantSession({ provider: asstProvider, model: asstModel, projectId: asstProjectId, runId: asstRunId });
-  }, [assistantOpen, drawerTab, state.selectedSource, asstProvider, asstModel, asstProjectId, asstRunId, startAssistantSession, closeDrawer]);
+  }, [assistantOpen, drawerTab, drawerPanels, state.selectedSource, asstProvider, asstModel, asstProjectId, asstRunId, startAssistantSession, closeDrawerPanel]);
 
   // Sync the client-side grade-label thresholds with the server formula at
   // boot so every gauge/badge agrees with the applied Q² parameters. The

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom/vitest';
 import {
   buildEvalPrincipal, ROUTE_RENDERERS, isSharedSource, shouldBounceToEvaluate, shouldShowEvaluateButton,
   resolveSelectionAfterSharedDisconnect, shouldAutoOpenOnboardingWizard, shouldShowProjectTabs,
-  buildNavigationBundle, shouldWallEmptyProjects, buildWizardHandlers,
+  buildNavigationBundle, shouldWallEmptyProjects, buildWizardHandlers, shouldCloseAssistantForSource,
 } from './App.jsx';
 import Sidebar from './components/Sidebar.jsx';
 
@@ -449,5 +449,23 @@ describe('resolveSelectionAfterSharedDisconnect', () => {
   it('clears the selection to the app\'s no-project state when there are no local projects', () => {
     expect(resolveSelectionAfterSharedDisconnect({ selectedSource: 'shared', projects: [] }))
       .toEqual({ id: '', source: 'local' });
+  });
+});
+
+// Regression lock for the shared-project drawer guard: it must close ONLY the
+// assistant panel. The old guard closed the whole drawer, which made the
+// terminal unopenable on shared projects (it closed itself the instant the
+// launcher opened it).
+describe('shouldCloseAssistantForSource', () => {
+  it('closes the assistant panel on a shared project', () => {
+    expect(shouldCloseAssistantForSource('shared', ['assistant'])).toBe(true);
+    expect(shouldCloseAssistantForSource('shared', ['assistant', 'terminal'])).toBe(true);
+  });
+  it('leaves a terminal-only drawer alone on a shared project', () => {
+    expect(shouldCloseAssistantForSource('shared', ['terminal'])).toBe(false);
+    expect(shouldCloseAssistantForSource('shared', [])).toBe(false);
+  });
+  it('never fires for local projects', () => {
+    expect(shouldCloseAssistantForSource('local', ['assistant', 'terminal'])).toBe(false);
   });
 });

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.jsx
@@ -211,6 +211,19 @@ export function AssistantDrawerProvider({ children }) {
     });
   }, []);
 
+  // Close one SPECIFIC panel, active or not (App uses this to shut only the
+  // assistant when a shared project is selected — the terminal must survive).
+  // If it was the active one, fall back to the most recent remaining panel,
+  // same rule as closeActiveTab.
+  const closePanel = useCallback((tab) => {
+    setOpenPanels((prev) => {
+      if (!prev.includes(tab)) return prev;
+      const next = prev.filter((t) => t !== tab);
+      if (next.length && activeTabRef.current === tab) setActiveTab(next[next.length - 1]);
+      return next;
+    });
+  }, []);
+
   // A closed drawer is never "maximized".
   useEffect(() => { if (openPanels.length === 0 && maximized) setMaximized(false); }, [openPanels.length, maximized]);
 
@@ -354,7 +367,7 @@ export function AssistantDrawerProvider({ children }) {
   );
 
   const value = useMemo(() => ({
-    isOpen, open, close, toggle, closeActiveTab,
+    isOpen, open, close, toggle, closeActiveTab, closePanel,
     openPanels, activeTab, openTab, selectTab, toggleTopbar, terminalEnabled,
     height, setHeight, maximized, toggleMaximized, setMaximized,
     messages, streaming: turnActive, error: localError || stream.error,
@@ -365,7 +378,7 @@ export function AssistantDrawerProvider({ children }) {
     sessionId,
     catalog, addLocalExchange,
     startSession, sendMessage, stopTurn, resetConversation,
-  }), [isOpen, open, close, toggle, closeActiveTab, openPanels, activeTab, openTab, selectTab, toggleTopbar, terminalEnabled, height, setHeight, maximized, toggleMaximized, messages, turnActive, stream.error, localError, sessionId, sessionMeta, webEnabled, toggleWebEnabled, writeEnabled, toggleWriteEnabled, repoInfo, workspace, refreshWorkspace, catalog, addLocalExchange, startSession, sendMessage, stopTurn, resetConversation]);
+  }), [isOpen, open, close, toggle, closeActiveTab, closePanel, openPanels, activeTab, openTab, selectTab, toggleTopbar, terminalEnabled, height, setHeight, maximized, toggleMaximized, messages, turnActive, stream.error, localError, sessionId, sessionMeta, webEnabled, toggleWebEnabled, writeEnabled, toggleWriteEnabled, repoInfo, workspace, refreshWorkspace, catalog, addLocalExchange, startSession, sendMessage, stopTurn, resetConversation]);
 
   return (
     <AssistantDrawerContext.Provider value={value}>

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.test.jsx
@@ -30,12 +30,16 @@ function Probe() {
       <span data-testid="web">{String(d.webEnabled)}</span>
       <span data-testid="catalog">{JSON.stringify(d.catalog)}</span>
       <span data-testid="messages">{JSON.stringify(d.messages)}</span>
+      <span data-testid="panels">{JSON.stringify(d.openPanels)}</span>
+      <span data-testid="active">{d.activeTab}</span>
       <button onClick={d.toggleWebEnabled}>web</button>
       <button onClick={() => d.startSession({ provider: 'claude', model: 'sonnet', projectId: 'p', runId: 'r' })}>start</button>
       <button onClick={() => d.startSession({ provider: 'claude', model: 'sonnet', projectId: 'pA', runId: 'r' })}>startA</button>
       <button onClick={() => d.startSession({ provider: 'claude', model: 'sonnet', projectId: 'pB', runId: 'r' })}>startB</button>
       <button onClick={d.toggle}>toggle</button>
       <button onClick={() => d.openTab('assistant')}>openAssistant</button>
+      <button onClick={() => d.openTab('terminal')}>openTerminal</button>
+      <button onClick={() => d.closePanel('assistant')}>closeAssistantPanel</button>
       <button onClick={() => d.sendMessage('hi', { activeTab: 'overview' })}>send</button>
       <button onClick={d.stopTurn}>stop</button>
       <button onClick={d.resetConversation}>reset</button>
@@ -310,4 +314,35 @@ it('stopTurn failure surfaces an error instead of dying silently', async () => {
   await act(async () => { screen.getByText('send').click(); });
   await act(async () => { screen.getByText('stop').click(); });
   expect(screen.getByTestId('error').textContent).toContain('stop failed');
+});
+
+describe('closePanel', () => {
+  it('closes only the named panel; the terminal stays open and becomes active', () => {
+    render(<AssistantDrawerProvider><Probe /></AssistantDrawerProvider>);
+    act(() => screen.getByText('openAssistant').click());
+    act(() => screen.getByText('openTerminal').click());
+    act(() => screen.getByText('openAssistant').click()); // assistant active again
+    expect(screen.getByTestId('panels').textContent).toBe('["assistant","terminal"]');
+    expect(screen.getByTestId('active').textContent).toBe('assistant');
+    act(() => screen.getByText('closeAssistantPanel').click());
+    expect(screen.getByTestId('panels').textContent).toBe('["terminal"]');
+    expect(screen.getByTestId('active').textContent).toBe('terminal');
+    expect(screen.getByTestId('open').textContent).toBe('true'); // drawer stays open
+  });
+
+  it('closing a non-active panel does not steal the active tab', () => {
+    render(<AssistantDrawerProvider><Probe /></AssistantDrawerProvider>);
+    act(() => screen.getByText('openAssistant').click());
+    act(() => screen.getByText('openTerminal').click()); // terminal is active
+    act(() => screen.getByText('closeAssistantPanel').click());
+    expect(screen.getByTestId('panels').textContent).toBe('["terminal"]');
+    expect(screen.getByTestId('active').textContent).toBe('terminal');
+  });
+
+  it('no-ops when the panel is not open', () => {
+    render(<AssistantDrawerProvider><Probe /></AssistantDrawerProvider>);
+    act(() => screen.getByText('openTerminal').click());
+    act(() => screen.getByText('closeAssistantPanel').click());
+    expect(screen.getByTestId('panels').textContent).toBe('["terminal"]');
+  });
 });


### PR DESCRIPTION
The shared-project drawer guard in App.jsx closed the WHOLE drawer whenever a
shared project was selected, but it triggered on any open panel — so clicking
the Terminal launcher on a shared project opened the drawer and the guard
closed it in the same tick. The terminal never appeared.

The guard now closes only the assistant panel (the thing it was protecting:
dismiss/verify writes under a shared project id). The terminal is
machine-local (PTY spawns in ~) and now opens normally on shared projects.

- New `closePanel(tab)` on AssistantDrawerProvider (+ tests)
- Guard extracted to pure `shouldCloseAssistantForSource` (+ regression tests)

Full UI suite: 164 files / 1180 tests green. Branch review: ready to merge;
noted follow-up (not a gate): an integration test locking the effect wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)