### PR TITLE
feat(ui): unified badge system, theme-correct status pills

### DIFF
--- a/src/quodeq/ui/src/components/AssistantLauncherButton.jsx
+++ b/src/quodeq/ui/src/components/AssistantLauncherButton.jsx
@@ -2,7 +2,7 @@ import { useAssistantDrawer } from '../features/assistant/AssistantDrawerProvide
 import useAssistantProvider from '../features/settings/hooks/useAssistantProvider.js';
 import { SparkleIcon } from './CopyButton.jsx';
 
-export function AssistantLauncherButton() {
+export function AssistantLauncherButton({ sharedSource = false }) {
   const { openPanels, toggleTopbar } = useAssistantDrawer();
   const { enabled } = useAssistantProvider();
 
@@ -13,14 +13,21 @@ export function AssistantLauncherButton() {
   // Highlighted whenever the assistant panel is open/selected (both launchers
   // can be highlighted at once when both panels are open).
   const on = openPanels.includes('assistant');
+  // Remote (team repo) projects are read-only: keep the button visible so its
+  // absence doesn't read as a bug, but disable it and say why. aria-disabled
+  // instead of disabled so the explanatory tooltip still shows on hover.
+  const label = sharedSource
+    ? 'Assistant is unavailable on remote projects (read-only)'
+    : 'Assistant (Ctrl+`)';
   return (
     <button
       type="button"
       className={`topbar-btn topbar-btn--icon topbar-btn--assistant${on ? ' topbar-btn--assistant--open' : ''}`}
       aria-pressed={on}
-      aria-label="Assistant (Ctrl+`)"
-      title="Assistant (Ctrl+`)"
-      onClick={() => toggleTopbar('assistant')}
+      aria-disabled={sharedSource || undefined}
+      aria-label={label}
+      title={label}
+      onClick={() => { if (!sharedSource) toggleTopbar('assistant'); }}
     >
       <SparkleIcon />
     </button>

--- a/src/quodeq/ui/src/components/AssistantLauncherButton.test.jsx
+++ b/src/quodeq/ui/src/components/AssistantLauncherButton.test.jsx
@@ -56,3 +56,18 @@ it('is NOT highlighted when only the terminal panel is open', () => {
   expect(btn).not.toHaveClass('topbar-btn--assistant--open');
   expect(btn).toHaveAttribute('aria-pressed', 'false');
 });
+
+it('on a remote project: visible but disabled, tooltip explains why, click is a no-op', () => {
+  render(<AssistantLauncherButton sharedSource />);
+  const btn = screen.getByRole('button', { name: /assistant is unavailable on remote projects/i });
+  expect(btn).toHaveAttribute('aria-disabled', 'true');
+  expect(btn).toHaveAttribute('title', 'Assistant is unavailable on remote projects (read-only)');
+  fireEvent.click(btn);
+  expect(toggleTopbar).not.toHaveBeenCalled();
+});
+
+it('sharedSource does not override the Settings kill switch', () => {
+  localStorage.setItem('cc-assistant-enabled', 'false');
+  const { container } = render(<AssistantLauncherButton sharedSource />);
+  expect(container).toBeEmptyDOMElement();
+});

--- a/src/quodeq/ui/src/components/Badge.jsx
+++ b/src/quodeq/ui/src/components/Badge.jsx
@@ -1,0 +1,19 @@
+/**
+ * Badge — THE status pill/tag component. Every status chip (card sync state,
+ * setup warnings, read-only markers, drawer chips) renders through this so
+ * shape and tint stay consistent across every theme.
+ *
+ * tone      semantic color family; maps to --color-* tokens in badge.css
+ * variant   'pill' (round micro-uppercase, project-card corners)
+ *           'tag'  (squared mono, page headers and the drawer)
+ * title     tooltip text
+ * className extra class for LAYOUT-only tweaks (margins, ellipsis caps);
+ *           visual identity must come from tone/variant, never the extra class
+ */
+const TONES = new Set(['neutral', 'accent', 'info', 'success', 'warning', 'danger']);
+
+export default function Badge({ tone = 'neutral', variant = 'tag', title, className, children }) {
+  const t = TONES.has(tone) ? tone : 'neutral';
+  const cls = `badge badge--${variant} badge--${t}${className ? ` ${className}` : ''}`;
+  return <span className={cls} title={title}>{children}</span>;
+}

--- a/src/quodeq/ui/src/components/Badge.test.jsx
+++ b/src/quodeq/ui/src/components/Badge.test.jsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import Badge from './Badge.jsx';
+
+describe('Badge', () => {
+  it('renders children with tone and variant classes and a tooltip', () => {
+    render(<Badge tone="info" variant="tag" title="tip">remote · read-only</Badge>);
+    const el = screen.getByText('remote · read-only');
+    expect(el).toHaveClass('badge', 'badge--tag', 'badge--info');
+    expect(el).toHaveAttribute('title', 'tip');
+  });
+  it('defaults to a neutral tag', () => {
+    render(<Badge>x</Badge>);
+    expect(screen.getByText('x')).toHaveClass('badge', 'badge--tag', 'badge--neutral');
+  });
+  it('falls back to neutral on an unknown tone', () => {
+    render(<Badge tone="sparkly">x</Badge>);
+    expect(screen.getByText('x')).toHaveClass('badge--neutral');
+  });
+  it('appends a caller className for layout-only tweaks', () => {
+    render(<Badge className="drawer-model-chip">x</Badge>);
+    expect(screen.getByText('x')).toHaveClass('badge', 'drawer-model-chip');
+  });
+});

--- a/src/quodeq/ui/src/components/SharedReadOnlyBadge.jsx
+++ b/src/quodeq/ui/src/components/SharedReadOnlyBadge.jsx
@@ -1,17 +1,20 @@
+import Badge from './Badge.jsx';
+
 /**
- * SharedReadOnlyBadge — "shared · read-only" chip shown on a shared
- * project's page header, plus (when known) a "published by <name>" sub
- * line. Shared projects have no mutation routes on the backend (dismiss/
- * restore/delete/evaluate are local-only by design), so this is purely
- * informational: it tells the user why the action buttons they'd normally
- * see are gone.
+ * SharedReadOnlyBadge — "remote · read-only" tag shown on a remote (team
+ * repo) project's page headers, plus (when known) a "published by <name>"
+ * sub line. Remote projects have no mutation routes on the backend
+ * (dismiss/restore/delete/evaluate are local-only by design), so this is
+ * purely informational: it tells the user why the action buttons they'd
+ * normally see are gone. Display text says "remote"; the internal source
+ * key stays 'shared'.
  */
 export default function SharedReadOnlyBadge({ publishedBy }) {
   return (
     <span className="badge-shared-readonly-group">
-      <span className="badge-shared-readonly" title="Shared projects are read-only in this app">
-        shared · read-only
-      </span>
+      <Badge variant="tag" tone="info" title="Remote projects are read-only in this app">
+        remote · read-only
+      </Badge>
       {publishedBy && (
         <span className="badge-shared-readonly-pub">published by {publishedBy}</span>
       )}

--- a/src/quodeq/ui/src/components/SharedReadOnlyBadge.test.jsx
+++ b/src/quodeq/ui/src/components/SharedReadOnlyBadge.test.jsx
@@ -4,14 +4,16 @@ import '@testing-library/jest-dom/vitest';
 import SharedReadOnlyBadge from './SharedReadOnlyBadge.jsx';
 
 describe('SharedReadOnlyBadge', () => {
-  it('renders the exact "shared · read-only" chip text', () => {
+  it('renders the exact "remote · read-only" chip as an info Badge', () => {
     render(<SharedReadOnlyBadge />);
-    expect(screen.getByText('shared · read-only')).toBeInTheDocument();
+    const el = screen.getByText('remote · read-only');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('badge', 'badge--tag', 'badge--info');
   });
 
   it('uses a middle dot, not an em-dash', () => {
     render(<SharedReadOnlyBadge />);
-    const text = screen.getByText('shared · read-only').textContent;
+    const text = screen.getByText('remote · read-only').textContent;
     expect(text).not.toMatch(/—|--/);
     expect(text).toContain('·'); // ·
   });

--- a/src/quodeq/ui/src/components/TopBar.jsx
+++ b/src/quodeq/ui/src/components/TopBar.jsx
@@ -104,9 +104,9 @@ export default function TopBar({
      next click will flip to dark). */
   effectiveDark = false,
   onToggleTheme,
-  /* 'local' | 'shared' — shared projects are read-only in this app (no
-     mutation routes exist on the backend), so the assistant (which can take
-     write actions like dismiss/verify) is not offered for them. */
+  /* 'local' | 'shared' — shared projects are read-only: the assistant
+     launcher renders disabled with an explanatory tooltip for them since
+     the assistant can take write actions like dismiss/verify. */
   selectedSource = 'local',
 }) {
   return (
@@ -166,7 +166,7 @@ export default function TopBar({
           </button>
         )}
 
-        {selectedSource !== 'shared' && <AssistantLauncherButton />}
+        <AssistantLauncherButton sharedSource={selectedSource === 'shared'} />
         <TerminalLauncherButton />
 
         {(provider || model) && (

--- a/src/quodeq/ui/src/components/TopBar.test.jsx
+++ b/src/quodeq/ui/src/components/TopBar.test.jsx
@@ -43,19 +43,20 @@ describe('TopBar mobile project label', () => {
   });
 });
 
-// Shared projects are read-only: the assistant can take write actions
-// (dismiss/verify) so it is not offered for them. The Evaluate button's own
-// gating lives in App.jsx (shouldShowEvaluateButton), not here — TopBar just
-// renders whatever onEvaluate it's handed.
+// Shared projects are read-only: the assistant launcher is disabled with an
+// explanatory tooltip since the assistant can take write actions (dismiss/verify).
+// The Evaluate button's own gating lives in App.jsx (shouldShowEvaluateButton),
+// not here — TopBar just renders whatever onEvaluate it's handed.
 describe('TopBar source gating', () => {
   it('renders the assistant launcher when selectedSource is local (default)', () => {
     renderTopBar({ selectedSource: 'local' });
     expect(screen.getByRole('button', { name: /Assistant/i })).toBeInTheDocument();
   });
 
-  it('omits the assistant launcher when selectedSource is shared', () => {
+  it('disables (but keeps) the assistant launcher when selectedSource is shared', () => {
     renderTopBar({ selectedSource: 'shared' });
-    expect(screen.queryByRole('button', { name: /Assistant/i })).toBeNull();
+    const btn = screen.getByRole('button', { name: /assistant is unavailable/i });
+    expect(btn).toHaveAttribute('aria-disabled', 'true');
   });
 
   it('defaults to local (assistant shown) when selectedSource is not passed', () => {

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.test.jsx
@@ -68,7 +68,7 @@ describe('useAccumulatedComputations selectedDayDimNames (multi-run day)', () =>
   });
 });
 
-// Task 19 — the Overview page header shows a "shared · read-only" chip
+// Task 19 — the Overview page header shows a "remote · read-only" chip
 // (+ publisher sub line where available) for shared projects, and nothing
 // extra for local ones.
 describe('AccumulatedHeroSection shared read-only chip', () => {
@@ -84,12 +84,12 @@ describe('AccumulatedHeroSection shared read-only chip', () => {
 
   it('shows the chip for a shared project', () => {
     render(<AccumulatedHeroSection {...baseProps} selectedSource="shared" />);
-    expect(screen.getByText('shared · read-only')).toBeInTheDocument();
+    expect(screen.getByText('remote · read-only')).toBeInTheDocument();
   });
 
   it('omits the chip for a local project', () => {
     render(<AccumulatedHeroSection {...baseProps} selectedSource="local" />);
-    expect(screen.queryByText('shared · read-only')).toBeNull();
+    expect(screen.queryByText('remote · read-only')).toBeNull();
   });
 
   it('shows the publisher sub line when projectInfo.publishedBy is available', () => {

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -30,7 +30,7 @@ function NoCompletedEvalPanel({ availableRuns = [], onNavigate, selectedSource }
     return (
       <EmptyState
         title="No completed evaluation yet"
-        description="no completed evaluation in this shared project yet"
+        description="no completed evaluation in this remote project yet"
       />
     );
   }

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -98,7 +98,7 @@ describe('DashboardPage no-completed-evaluation empty state', () => {
     );
     expect(getByText('No completed evaluation yet')).toBeTruthy();
     expect(getByText('Start evaluation')).toBeTruthy();
-    expect(queryByText('no completed evaluation in this shared project yet')).toBeNull();
+    expect(queryByText('no completed evaluation in this remote project yet')).toBeNull();
   });
 
   it('shared project: hides the Start evaluation CTA and shows shared-specific copy', () => {
@@ -106,7 +106,7 @@ describe('DashboardPage no-completed-evaluation empty state', () => {
       <DashboardPage data={{ ...baseData, selectedSource: 'shared' }} callbacks={{}} runMode={false} />,
     );
     expect(getByText('No completed evaluation yet')).toBeTruthy();
-    expect(getByText('no completed evaluation in this shared project yet')).toBeTruthy();
+    expect(getByText('no completed evaluation in this remote project yet')).toBeTruthy();
     expect(queryByText('Start evaluation')).toBeNull();
   });
 });
@@ -141,7 +141,7 @@ describe('DashboardPage, teammate persona: shared selection + zero local project
     );
     expect(queryByText('No projects yet')).toBeNull();
     expect(queryByText('Add a project')).toBeNull();
-    expect(getByText('no completed evaluation in this shared project yet')).toBeTruthy();
+    expect(getByText('no completed evaluation in this remote project yet')).toBeTruthy();
   });
 
   it('local source with an empty local projects list still shows the Add-a-project wall (unchanged)', () => {

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
@@ -519,6 +519,7 @@ function ProjectsToolbar({ filters = {}, onFiltersChange, configured, lastSynced
           label="location"
           value={location}
           options={['all', 'local', 'shared']}
+          valueLabels={{ shared: 'remote' }}
           onChange={(loc) => set({ location: loc })}
         />
       )}

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
@@ -6,6 +6,7 @@ import { relativeTime } from '../../../components/LastFetchedLine.jsx';
 import { useSharedProjects } from '../hooks/useSharedProjects.js';
 import { usePublish } from '../hooks/usePublish.js';
 import { useMergedProjects } from '../hooks/useMergedProjects.js';
+import Badge from '../../../components/Badge.jsx';
 
 const DISCIPLINE_LABEL = {
   frontend_nextjs: 'Next.js',
@@ -81,13 +82,12 @@ function LanguageNumbers({ stats, filesCount }) {
 // merged entry (see useMergedProjects), which still speaks in locations —
 // the state wording is purely presentational.
 const BADGE_LABELS = { local: 'LOCAL', both: 'PUBLISHED', shared: 'REMOTE' };
+const BADGE_TONES = { local: 'neutral', both: 'success', shared: 'info' };
 
 function ProjectCardChips({ chips }) {
   if (!chips) return null;
   return (
-    <span className={`project-card-badge project-card-badge--${chips}`}>
-      {BADGE_LABELS[chips]}
-    </span>
+    <Badge variant="pill" tone={BADGE_TONES[chips]}>{BADGE_LABELS[chips]}</Badge>
   );
 }
 
@@ -303,9 +303,9 @@ function ProjectPathContent({ id, p, relocateActions, subprojectCount = 0 }) {
         <button type="button" className="project-path-action project-path-action--warn" onClick={(e) => { e.stopPropagation(); startRelocate(id, p.path); }}>Relocate</button>
       )}
       {subprojectCount > 0 && (
-        <span className="project-subprojects-tag">
+        <Badge variant="pill" tone="neutral" className="project-subprojects-tag">
           subprojects <span className="project-subprojects-tag-count">{subprojectCount}</span>
-        </span>
+        </Badge>
       )}
     </div>
   );

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
@@ -141,12 +141,13 @@ function ProjectCard({ project, isSelected, cardProps = {}, children: cardChildr
           <div className="project-card-top-left">
             <span className="project-card-name">{project.displayName || name}</span>
             {project.location === 'online' && (
-              <span
-                className="badge-setup-incomplete"
+              <Badge
+                variant="tag"
+                tone="warning"
                 title="This project was added by URL but has no local copy. Complete setup to evaluate."
               >
                 setup incomplete
-              </span>
+              </Badge>
             )}
             {project.onboardingCompletedAt === null && onResumeSetup && (
               <button

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.test.jsx
@@ -43,6 +43,7 @@ describe('ProjectsPage', () => {
     await waitFor(() => expect(fakeApi.getSharedStatus).toHaveBeenCalled());
     const badges = screen.queryAllByText(/setup incomplete/i);
     expect(badges).toHaveLength(1);
+    expect(badges[0]).toHaveClass('badge', 'badge--tag', 'badge--warning');
   });
 
   it('renders no badge when all projects are local', async () => {

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.test.jsx
@@ -216,6 +216,9 @@ describe('ProjectsPage — merged list, no tabs', () => {
       expect(screen.getByText('LOCAL')).toBeInTheDocument();
       expect(screen.getByText('REMOTE')).toBeInTheDocument();
     });
+    expect(screen.getByText('LOCAL')).toHaveClass('badge', 'badge--pill', 'badge--neutral');
+    expect(screen.getByText('PUBLISHED')).toHaveClass('badge--success');
+    expect(screen.getByText('REMOTE')).toHaveClass('badge--info');
   });
 });
 

--- a/src/quodeq/ui/src/features/drawer/BottomDrawer.jsx
+++ b/src/quodeq/ui/src/features/drawer/BottomDrawer.jsx
@@ -3,6 +3,7 @@ import { useAssistantDrawer } from '../assistant/AssistantDrawerProvider.jsx';
 import { AssistantPane } from '../assistant/AssistantDrawer.jsx';
 import { ChevronDownIcon, GlobeIcon, MaximizeIcon, MinimizeIcon, PencilIcon, RotateCcwIcon } from '../../components/CopyButton.jsx';
 import { useSidePane, workspaceDiffSpec } from '../side-pane/index.js';
+import Badge from '../../components/Badge.jsx';
 
 const TerminalPane = lazy(() => import('../terminal/TerminalPane.jsx'));
 
@@ -79,19 +80,22 @@ export function BottomDrawer({ uiState }) {
           ))}
         </div>
         {active === 'assistant' && modelLabel && (
-          <span className="drawer-model-chip" title={modelLabel}>
+          <Badge variant="tag" tone="accent" className="drawer-model-chip" title={modelLabel}>
             {modelLabel}
-          </span>
+          </Badge>
         )}
-        {active === 'assistant' && repoInfo && (
-          <span className={`drawer-repo-chip${repoInfo.attached ? '' : ' drawer-repo-chip--off'}`}
-            title={repoInfo.attached ? 'Repository attached'
-              : `Repository not attached: ${repoInfo.reason || 'unknown'}`}>
-            {repoInfo.attached ? 'repo' : 'no repo'}
-          </span>
+        {/* Repo attachment is the NORMAL case — only the exception is worth a
+            chip. When the session has no repo the assistant's code-reading
+            tools are dead, so surface that as a warning with the server's
+            reason; stay silent when everything is fine. */}
+        {active === 'assistant' && repoInfo && !repoInfo.attached && (
+          <Badge variant="tag" tone="warning"
+            title={`Repository not attached: ${repoInfo.reason || 'unknown'}`}>
+            no repo access
+          </Badge>
         )}
         {active === 'assistant' && workspace?.filesChanged > 0 && (
-          <button type="button" className="drawer-changes-chip"
+          <button type="button" className="badge badge--tag badge--danger drawer-changes-chip"
             onClick={() => addWindow(workspaceDiffSpec({ sessionId, key: workspace.createdAt, onChanged: refreshWorkspace }))}
             title="Review pending changes">
             {workspace.filesChanged} file{workspace.filesChanged === 1 ? '' : 's'} changed

--- a/src/quodeq/ui/src/features/drawer/BottomDrawer.test.jsx
+++ b/src/quodeq/ui/src/features/drawer/BottomDrawer.test.jsx
@@ -9,6 +9,7 @@ const drawer = {
   provider: 'ollama', model: 'm', messages: [], streaming: false, error: null, sendMessage: vi.fn(),
   webEnabled: false, toggleWebEnabled: vi.fn(),
   sessionReady: true, resetConversation: vi.fn(),
+  repoInfo: null,
 };
 vi.mock('../assistant/AssistantDrawerProvider.jsx', () => ({ useAssistantDrawer: () => drawer }));
 vi.mock('../terminal/TerminalPane.jsx', () => ({ default: () => <div data-testid="tty" /> }));
@@ -128,4 +129,26 @@ it('hides the new-conversation control while the terminal tab is active', () => 
   render(<BottomDrawer uiState={{}} />);
   expect(screen.queryByRole('button', { name: /new conversation/i })).toBeNull();
   drawer.activeTab = 'assistant';
+});
+
+it('shows NO repo chip when the repo is attached (exception-only signal)', () => {
+  drawer.repoInfo = { attached: true, reason: null, writeAvailable: false };
+  render(<BottomDrawer uiState={{}} />);
+  expect(screen.queryByText('repo')).toBeNull();
+  expect(screen.queryByText(/no repo/)).toBeNull();
+  drawer.repoInfo = null;
+});
+
+it('warns with "no repo access" and the server reason when not attached', () => {
+  drawer.repoInfo = { attached: false, reason: 'online_project', writeAvailable: false };
+  render(<BottomDrawer uiState={{}} />);
+  const chip = screen.getByText('no repo access');
+  expect(chip).toHaveClass('badge', 'badge--tag', 'badge--warning');
+  expect(chip).toHaveAttribute('title', 'Repository not attached: online_project');
+  drawer.repoInfo = null;
+});
+
+it('the model chip is an accent Badge', () => {
+  render(<BottomDrawer uiState={{}} />);
+  expect(screen.getByTitle('Ollama · m')).toHaveClass('badge', 'badge--tag', 'badge--accent', 'drawer-model-chip');
 });

--- a/src/quodeq/ui/src/features/drawer/BottomDrawer.write.test.jsx
+++ b/src/quodeq/ui/src/features/drawer/BottomDrawer.write.test.jsx
@@ -33,10 +33,10 @@ vi.mock('../side-pane/index.js', () => ({
 import { BottomDrawer } from './BottomDrawer.jsx';
 
 describe('drawer write affordances', () => {
-  it('renders write toggle, repo chip and pending-changes chip', () => {
+  it('renders write toggle and pending-changes chip; no repo chip when attached (exception-only)', () => {
     render(<BottomDrawer uiState={{}} />);
     expect(screen.getByLabelText('Allow repository edits for this conversation')).toBeTruthy();
-    expect(screen.getByTitle('Repository attached')).toBeTruthy();
+    expect(screen.queryByText('no repo access')).toBeNull();
     expect(screen.getByText('3 files changed')).toBeTruthy();
   });
 

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -518,7 +518,7 @@ export default function HistoryPage({ trend: rawTrend, selection, availableRuns,
         <HistoryEmptyShell sub="no evaluations yet">
           <EmptyState
             title="No completed evaluation yet"
-            description="no completed evaluation in this shared project yet"
+            description="no completed evaluation in this remote project yet"
           />
         </HistoryEmptyShell>
       );

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.test.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.test.jsx
@@ -162,7 +162,7 @@ describe('HistoryPage — teammate persona: shared selection + zero local projec
 describe('HistoryPage — shared read-only chip (Finding 6)', () => {
   it('shows the chip for a shared project with data', () => {
     renderHistoryPageWithData({ trend, availableRuns, selection: { selectedRunId: 'r1' } });
-    expect(screen.getByText('shared · read-only')).toBeInTheDocument();
+    expect(screen.getByText('remote · read-only')).toBeInTheDocument();
   });
 
   it('omits the chip for a local project', () => {
@@ -170,6 +170,6 @@ describe('HistoryPage — shared read-only chip (Finding 6)', () => {
       trend, availableRuns, selection: { selectedRunId: 'r1' },
       selectedSource: 'local', selectedProject: 'p1', projects: [{ id: 'p1', name: 'p1' }],
     });
-    expect(screen.queryByText('shared · read-only')).toBeNull();
+    expect(screen.queryByText('remote · read-only')).toBeNull();
   });
 });

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.test.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.test.jsx
@@ -134,7 +134,7 @@ describe('HistoryPage — evaluate CTA gating for shared (Critical 1)', () => {
   it('shared source, no evaluations yet: no Start evaluation CTA, shared-specific copy', () => {
     renderHistoryPageWithData();
     expect(screen.getByText('No completed evaluation yet')).toBeInTheDocument();
-    expect(screen.getByText('no completed evaluation in this shared project yet')).toBeInTheDocument();
+    expect(screen.getByText('no completed evaluation in this remote project yet')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Start evaluation' })).toBeNull();
   });
 

--- a/src/quodeq/ui/src/features/map/components/MapPage.jsx
+++ b/src/quodeq/ui/src/features/map/components/MapPage.jsx
@@ -209,7 +209,7 @@ export default function MapPage(props) {
         <MapEmpty sub="no evaluations yet">
           <EmptyState
             title="No completed evaluation yet"
-            description="no completed evaluation in this shared project yet"
+            description="no completed evaluation in this remote project yet"
           />
         </MapEmpty>
       );

--- a/src/quodeq/ui/src/features/map/components/MapPage.test.jsx
+++ b/src/quodeq/ui/src/features/map/components/MapPage.test.jsx
@@ -59,11 +59,11 @@ describe('MapPage — shared read-only chip (Finding 6)', () => {
 
   it('shows the chip for a shared project with data', () => {
     renderPage(baseData({ accumulated: { dimensions: DIMS } }));
-    expect(screen.getByText('shared · read-only')).toBeInTheDocument();
+    expect(screen.getByText('remote · read-only')).toBeInTheDocument();
   });
 
   it('omits the chip for a local project', () => {
     renderPage(baseData({ selectedSource: 'local', selectedProject: 'p1', accumulated: { dimensions: DIMS } }));
-    expect(screen.queryByText('shared · read-only')).toBeNull();
+    expect(screen.queryByText('remote · read-only')).toBeNull();
   });
 });

--- a/src/quodeq/ui/src/features/map/components/MapPage.test.jsx
+++ b/src/quodeq/ui/src/features/map/components/MapPage.test.jsx
@@ -31,7 +31,7 @@ describe('MapPage — evaluate CTA gating for shared (Critical 1)', () => {
   it('shared source, no evaluations yet: no Start evaluation CTA, shared-specific copy', () => {
     renderPage(baseData());
     expect(screen.getByText('No completed evaluation yet')).toBeInTheDocument();
-    expect(screen.getByText('no completed evaluation in this shared project yet')).toBeInTheDocument();
+    expect(screen.getByText('no completed evaluation in this remote project yet')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Start evaluation' })).toBeNull();
   });
 

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -275,7 +275,7 @@ export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 
           <TermHeader name="violations" sub="no evaluations yet" />
           <EmptyState
             title="No completed evaluation yet"
-            description="no completed evaluation in this shared project yet"
+            description="no completed evaluation in this remote project yet"
           />
         </div>
       );

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.test.jsx
@@ -107,7 +107,7 @@ describe('ViolationsPage — evaluate CTA gating for shared (Critical 1)', () =>
   it('shared source, no evaluations yet: no Start evaluation CTA, shared-specific copy', () => {
     renderPage(baseData());
     expect(screen.getByText('No completed evaluation yet')).toBeInTheDocument();
-    expect(screen.getByText('no completed evaluation in this shared project yet')).toBeInTheDocument();
+    expect(screen.getByText('no completed evaluation in this remote project yet')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Start evaluation' })).toBeNull();
   });
 

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.test.jsx
@@ -139,7 +139,7 @@ describe('ViolationsPage — shared read-only chip (Finding 6)', () => {
     renderPage(baseData({
       accumulatedDimensions: [{ dimension: 'security', violations: [], compliance: [] }],
     }));
-    expect(screen.getByText('shared · read-only')).toBeInTheDocument();
+    expect(screen.getByText('remote · read-only')).toBeInTheDocument();
   });
 
   it('omits the chip for a local project', () => {
@@ -147,6 +147,6 @@ describe('ViolationsPage — shared read-only chip (Finding 6)', () => {
       selectedSource: 'local', selectedProject: 'p1', projects: [{ id: 'p1', name: 'p1' }],
       accumulatedDimensions: [{ dimension: 'security', violations: [], compliance: [] }],
     }));
-    expect(screen.queryByText('shared · read-only')).toBeNull();
+    expect(screen.queryByText('remote · read-only')).toBeNull();
   });
 });

--- a/src/quodeq/ui/src/styles/assistant.css
+++ b/src/quodeq/ui/src/styles/assistant.css
@@ -450,6 +450,10 @@
 /* Model tag in the drawer header (Assistant tab): a compact squared accent
    tag next to the tabs, integrating the provider/model without a subtitle. */
 .drawer-model-chip {
+  display: inline-block;   /* Badge's base class sets inline-flex, and
+                               text-overflow: ellipsis is inert on a flex
+                               container; inline-block here restores the
+                               ellipsis truncation below over that default */
   align-self: center;
   max-width: 14rem;   /* px-based cap so short model names show in full (a %
                          would resolve against a content-sized flex box and

--- a/src/quodeq/ui/src/styles/assistant.css
+++ b/src/quodeq/ui/src/styles/assistant.css
@@ -454,15 +454,6 @@
   max-width: 14rem;   /* px-based cap so short model names show in full (a %
                          would resolve against a content-sized flex box and
                          ellipsize even short names) */
-  font-family: var(--font-mono);
-  font-size: 0.6875rem;
-  line-height: 1.4;
-  color: var(--color-accent);
-  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-accent) 30%, transparent);
-  border-radius: 4px;
-  padding: 1px 8px;
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/src/quodeq/ui/src/styles/badge.css
+++ b/src/quodeq/ui/src/styles/badge.css
@@ -1,0 +1,44 @@
+/* ── Badge: the one status pill/tag recipe ─────────────────────────────────
+   One tint recipe for every tone: text in the tone color, ~12% tinted fill,
+   ~35% tinted border (the pill variant drops the border: it is a soft fill).
+   Tones reference SEMANTIC tokens only, never a raw hex. Hex fallbacks are
+   exactly the drift this file replaces (the old setup-incomplete and
+   read-only badges pointed at tokens that didn't exist and rendered
+   hardcoded amber/cyan in every theme). */
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  white-space: nowrap;
+  color: var(--badge-tone);
+  background: color-mix(in srgb, var(--badge-tone) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--badge-tone) 35%, transparent);
+}
+
+/* Project-card corner style: round, micro, uppercase, borderless. */
+.badge--pill {
+  border: none;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 9.5px;
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+/* Header/drawer style: squared mono tag. Labels keep their authored case. */
+.badge--tag {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 11px;
+  line-height: 1.4;
+  border-radius: var(--term-radius, 2px);
+  padding: 2px 8px;
+}
+
+.badge--neutral { --badge-tone: var(--color-text-muted); }
+.badge--accent  { --badge-tone: var(--color-accent); }
+.badge--info    { --badge-tone: var(--color-info); }
+.badge--success { --badge-tone: var(--color-success); }
+.badge--warning { --badge-tone: var(--color-warning); }
+.badge--danger  { --badge-tone: var(--color-danger); }

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -2534,30 +2534,6 @@
   gap: var(--space-3);
 }
 
-/* Sync-state badge (top-right of every card): LOCAL / PUBLISHED / REMOTE.
-   Soft-filled pill; muted for local-only, success-tinted once published,
-   accent-tinted for remote-only entries. */
-.project-card-badge {
-  flex-shrink: 0;
-  padding: 2px 8px;
-  border-radius: 999px;
-  font-size: 9.5px;
-  font-weight: var(--weight-medium);
-  letter-spacing: 0.06em;
-  background: color-mix(in srgb, var(--color-text-muted) 12%, transparent);
-  color: var(--color-text-muted);
-}
-
-.project-card-badge--both {
-  background: color-mix(in srgb, var(--color-success) 12%, transparent);
-  color: var(--color-success);
-}
-
-.project-card-badge--shared {
-  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
-  color: var(--color-accent);
-}
-
 .project-card-name {
   font-family: var(--term-font-mono);
   font-size: var(--text-base);
@@ -2746,21 +2722,9 @@
   color: var(--color-text-muted);
 }
 
+/* Layout-only; visual identity comes from .badge--pill. */
 .project-subprojects-tag {
   margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 0.65rem;
-  font-weight: var(--weight-medium);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--color-text-muted);
-  background: var(--color-surface-alt);
-  border: 1px solid var(--color-border);
-  padding: 1px 6px;
-  border-radius: var(--radius-sm);
-  white-space: nowrap;
 }
 
 .project-subprojects-tag-count {

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -3068,7 +3068,7 @@
 }
 
 /* "shared · read-only" chip on a shared project's page header (Overview).
-   Same shape as .badge-setup-incomplete but in the cyan/accent-info family
+   Same squared-tag shape as the Badge tag variant but in the cyan/accent-info family
    so it doesn't read as a warning — a shared project isn't a problem state,
    just a different (read-only) one. */
 .badge-shared-readonly-group {
@@ -3093,7 +3093,7 @@
 }
 
 /* "Complete setup" CTA card on the project view for legacy online projects.
-   Same warning-tinted palette as .badge-setup-incomplete; a banner above
+   Warning-tinted palette matching the setup-incomplete badge; a banner above
    the dashboard panels nudges users to clone the repo locally. */
 .incomplete-setup-card {
   background: color-mix(in srgb, var(--color-warning) 10%, transparent);

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -3055,30 +3055,16 @@
 .resume-setup-badge {
   font-family: var(--term-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
   font-size: 11px;
-  background: color-mix(in srgb, var(--color-warn, #f59e0b) 14%, transparent);
-  color: var(--color-warn, #f59e0b);
-  border: 1px solid color-mix(in srgb, var(--color-warn, #f59e0b) 40%, transparent);
+  background: color-mix(in srgb, var(--color-warning) 14%, transparent);
+  color: var(--color-warning);
+  border: 1px solid color-mix(in srgb, var(--color-warning) 40%, transparent);
   border-radius: var(--term-radius, 2px);
   padding: 2px 8px;
   cursor: pointer;
   transition: background 120ms ease;
 }
 .resume-setup-badge:hover {
-  background: color-mix(in srgb, var(--color-warn, #f59e0b) 22%, transparent);
-}
-
-/* "setup incomplete" badge for legacy location: "online" projects.
-   Surfaces the need to complete clone-on-add setup without blocking. */
-.badge-setup-incomplete {
-  display: inline-block;
-  font-family: var(--term-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: 11px;
-  background: color-mix(in srgb, var(--color-warn, #f59e0b) 14%, transparent);
-  color: var(--color-warn, #f59e0b);
-  border: 1px solid color-mix(in srgb, var(--color-warn, #f59e0b) 40%, transparent);
-  border-radius: var(--term-radius, 2px);
-  padding: 2px 8px;
-  text-transform: lowercase;
+  background: color-mix(in srgb, var(--color-warning) 22%, transparent);
 }
 
 /* "shared · read-only" chip on a shared project's page header (Overview).
@@ -3110,8 +3096,8 @@
    Same warning-tinted palette as .badge-setup-incomplete; a banner above
    the dashboard panels nudges users to clone the repo locally. */
 .incomplete-setup-card {
-  background: color-mix(in srgb, var(--color-warn, #f59e0b) 10%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-warn, #f59e0b) 35%, transparent);
+  background: color-mix(in srgb, var(--color-warning) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-warning) 35%, transparent);
   border-radius: var(--term-radius, 2px);
   padding: 12px 16px;
   margin-bottom: 16px;

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -3067,7 +3067,7 @@
   background: color-mix(in srgb, var(--color-warning) 22%, transparent);
 }
 
-/* "shared · read-only" chip on a shared project's page header (Overview).
+/* "remote · read-only" chip on a shared project's page header (Overview).
    Same squared-tag shape as the Badge tag variant but in the cyan/accent-info family
    so it doesn't read as a warning — a shared project isn't a problem state,
    just a different (read-only) one. */
@@ -3076,16 +3076,6 @@
   align-items: baseline;
   gap: 8px;
   margin-left: 4px;
-}
-.badge-shared-readonly {
-  display: inline-block;
-  font-family: var(--term-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: 11px;
-  background: color-mix(in srgb, var(--color-info, #22d3ee) 14%, transparent);
-  color: var(--color-info, #22d3ee);
-  border: 1px solid color-mix(in srgb, var(--color-info, #22d3ee) 40%, transparent);
-  border-radius: var(--term-radius, 2px);
-  padding: 2px 8px;
 }
 .badge-shared-readonly-pub {
   font-size: 11px;

--- a/src/quodeq/ui/src/styles/drawer.css
+++ b/src/quodeq/ui/src/styles/drawer.css
@@ -79,41 +79,18 @@
   font-family: var(--font-mono, monospace);
 }
 
-/* ── Repo-attachment + pending-changes chips (drawer header) ──────────
-   Same shape as .drawer-model-chip (assistant.css): compact squared tag,
-   font-family/size/padding/radius match; color varies by state. */
-.drawer-repo-chip {
+/* ── Drawer-header chips ──────────────────────────────────────────────
+   Visual identity comes from .badge--tag tones (badge.css); only layout
+   and interactivity live here. */
+.assistant-drawer-header .badge {
   align-self: center;
-  font-family: var(--font-mono);
-  font-size: 0.6875rem;
-  line-height: 1.4;
-  color: var(--color-success, #4caf7d);
-  background: color-mix(in srgb, var(--color-success, #4caf7d) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-success, #4caf7d) 30%, transparent);
-  border-radius: 4px;
-  padding: 1px 8px;
-  white-space: nowrap;
-}
-.drawer-repo-chip--off {
-  color: var(--color-text-muted, inherit);
-  background: color-mix(in srgb, var(--color-text-muted, #8a8279) 10%, transparent);
-  border-color: color-mix(in srgb, var(--color-text-muted, #8a8279) 25%, transparent);
 }
 .drawer-changes-chip {
   align-self: center;
-  font-family: var(--font-mono);
-  font-size: 0.6875rem;
-  line-height: 1.4;
   cursor: pointer;
-  color: var(--color-danger, #c0392b);
-  background: color-mix(in srgb, var(--color-danger, #c0392b) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-danger, #c0392b) 30%, transparent);
-  border-radius: 4px;
-  padding: 1px 8px;
-  white-space: nowrap;
 }
 .drawer-changes-chip:hover {
-  background: color-mix(in srgb, var(--color-danger, #c0392b) 20%, transparent);
+  background: color-mix(in srgb, var(--color-danger) 20%, transparent);
 }
 
 /* Write-access pencil: danger-tinted when ON (editing the repo is a

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2809,7 +2809,7 @@ button.eval-provider-badge--clickable:focus-visible {
   transition: width 0.3s ease;
 }
 .scan-progress__bar-fill--done    { background: var(--color-success, #56d364); }
-.scan-progress__bar-fill--partial { background: var(--color-warn, #d29922); }
+.scan-progress__bar-fill--partial { background: var(--color-warning); }
 .scan-progress__bar-fill--cached  { background: var(--color-accent); opacity: 0.35; }
 
 .scan-progress__meta {
@@ -2926,10 +2926,10 @@ button.eval-provider-badge--clickable:focus-visible {
 }
 .scan-progress__v        { color: var(--color-sev-critical-text, #f85149); }
 .scan-progress__c        { color: var(--color-success, #56d364); }
-.scan-progress__budget   { color: var(--color-warn, #d29922); }
+.scan-progress__budget   { color: var(--color-warning); }
 .scan-progress__budget--overrun { color: var(--color-sev-critical-text, #f85149); }
-.scan-progress__partial  { color: var(--color-warn, #d29922); text-transform: uppercase; font-size: 10px; letter-spacing: 0.05em; }
-.scan-progress__dim-reason { color: var(--color-warn, #d29922); font-style: italic; }
+.scan-progress__partial  { color: var(--color-warning); text-transform: uppercase; font-size: 10px; letter-spacing: 0.05em; }
+.scan-progress__dim-reason { color: var(--color-warning); font-style: italic; }
 
 .eval-countdown {
   font-family: var(--font-mono);

--- a/src/quodeq/ui/src/styles/index.css
+++ b/src/quodeq/ui/src/styles/index.css
@@ -1,5 +1,6 @@
 @import './tokens.css';
 @import './base.css';
+@import './badge.css';
 @import './terminal.css';
 @import './dim-gauge-card.css';
 @import './dashboard.css';

--- a/src/quodeq/ui/src/styles/onboarding.css
+++ b/src/quodeq/ui/src/styles/onboarding.css
@@ -388,12 +388,12 @@
   margin-left: 8px;
   padding: 2px 8px;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--color-warn, #f59e0b) 15%, transparent);
-  border: 1px solid var(--color-warn, #f59e0b);
-  color: var(--color-warn, #f59e0b);
+  background: color-mix(in srgb, var(--color-warning) 15%, transparent);
+  border: 1px solid var(--color-warning);
+  color: var(--color-warning);
   font-size: 0.7rem;
   cursor: pointer;
 }
 .resume-setup-badge:hover {
-  background: color-mix(in srgb, var(--color-warn, #f59e0b) 25%, transparent);
+  background: color-mix(in srgb, var(--color-warning) 25%, transparent);
 }

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1166,8 +1166,8 @@ button.term-sev-badge--clickable:focus-visible {
 .history-row__partial-chip {
   margin-left: 6px;
   background: transparent;
-  border: 1px solid var(--color-warn, #d29922);
-  color: var(--color-warn, #d29922);
+  border: 1px solid var(--color-warning);
+  color: var(--color-warning);
   text-transform: uppercase;
   font-size: 10px;
   letter-spacing: 0.05em;
@@ -1182,7 +1182,7 @@ button.term-sev-badge--clickable:focus-visible {
    without showing the (ugly) raw run UUID that we used to fall back to when
    no dateISO was available yet. */
 .history-table .history-row--in-progress {
-  background: color-mix(in srgb, var(--color-warn, #d29922) 6%, transparent);
+  background: color-mix(in srgb, var(--color-warning) 6%, transparent);
 }
 
 /* Running run with no dimensions scored yet — clicking would land on an
@@ -1194,13 +1194,13 @@ button.term-sev-badge--clickable:focus-visible {
 }
 .history-table .history-row--not-ready:hover {
   /* Don't add the usual hover lift — the row isn't actionable. */
-  background: color-mix(in srgb, var(--color-warn, #d29922) 6%, transparent);
+  background: color-mix(in srgb, var(--color-warning) 6%, transparent);
 }
 .history-row__running {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: var(--color-warn, #d29922);
+  color: var(--color-warning);
   text-transform: lowercase;
   font-size: 12px;
   letter-spacing: 0.04em;
@@ -1209,14 +1209,14 @@ button.term-sev-badge--clickable:focus-visible {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: var(--color-warn, #d29922);
-  box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-warn, #d29922) 50%, transparent);
+  background: var(--color-warning);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-warning) 50%, transparent);
   animation: history-row-running-pulse 1.4s ease-out infinite;
 }
 @keyframes history-row-running-pulse {
-  0%   { box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-warn, #d29922) 55%, transparent); }
-  70%  { box-shadow: 0 0 0 8px color-mix(in srgb, var(--color-warn, #d29922) 0%,  transparent); }
-  100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-warn, #d29922) 0%,  transparent); }
+  0%   { box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-warning) 55%, transparent); }
+  70%  { box-shadow: 0 0 0 8px color-mix(in srgb, var(--color-warning) 0%,  transparent); }
+  100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-warning) 0%,  transparent); }
 }
 @media (prefers-reduced-motion: reduce) {
   .history-row__running-dot { animation: none; }

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -2105,6 +2105,14 @@ button.term-sev-badge--clickable:focus-visible {
   color: var(--color-text);
   background: var(--color-surface-alt);
 }
+.topbar-btn--icon[aria-disabled='true'] {
+  opacity: 0.45;
+  cursor: default;
+}
+.topbar-btn--icon[aria-disabled='true']:hover {
+  background: transparent;
+  border-color: var(--color-border);
+}
 .topbar-btn--icon svg {
   display: block;
 }

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -37,10 +37,6 @@
   --primitive-green-700: #2d7a4f;
   --primitive-green-400: #4caf7d;
 
-  /* Cyan (info) */
-  --primitive-cyan-700: #0e7490;
-  --primitive-cyan-400: #22d3ee;
-
   /* Dark palette (dark-mode neutrals) */
   --primitive-dark-950: #1a1917;
   --primitive-dark-900: #222120;

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -37,6 +37,10 @@
   --primitive-green-700: #2d7a4f;
   --primitive-green-400: #4caf7d;
 
+  /* Cyan (info) */
+  --primitive-cyan-700: #0e7490;
+  --primitive-cyan-400: #22d3ee;
+
   /* Dark palette (dark-mode neutrals) */
   --primitive-dark-950: #1a1917;
   --primitive-dark-900: #222120;
@@ -343,6 +347,7 @@
 
   /* Warning */
   --color-warning:      var(--primitive-amber-700);
+  --color-info:         var(--primitive-cyan-700);
   --color-warning-text: var(--primitive-amber-700);
   --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-700) 8%, transparent);
 
@@ -410,6 +415,7 @@
     --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
 
     --color-warning:      var(--primitive-amber-400);
+    --color-info:         var(--primitive-cyan-400);
     --color-warning-text: var(--primitive-amber-400);
     --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-400) 10%, transparent);
 
@@ -493,6 +499,7 @@ html[data-theme="dark"]:root, [data-theme="dark"] {
   --color-grade-bottom-bg:   color-mix(in srgb, #e6182a 12%, transparent);
 
   --color-warning:      var(--primitive-amber-400);
+  --color-info:         var(--primitive-cyan-400);
   --color-warning-text: var(--primitive-amber-400);
   --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-400) 10%, transparent);
 
@@ -580,6 +587,7 @@ html[data-theme="light"]:root, [data-theme="light"] {
 
   /* Warning */
   --color-warning:      var(--primitive-amber-700);
+  --color-info:         var(--primitive-cyan-700);
   --color-warning-text: var(--primitive-amber-700);
   --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-700) 10%, transparent);
 
@@ -668,6 +676,7 @@ html[data-theme="ifrit-dark"]:root, [data-theme="ifrit-dark"] {
   --color-grade-bottom-bg:   color-mix(in srgb, #ff2820 4%, transparent);
 
   --color-warning:      var(--primitive-amber-400);
+  --color-info:         var(--primitive-cyan-400);
   --color-warning-text: var(--primitive-amber-400);
   --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-400) 10%, transparent);
 
@@ -758,6 +767,7 @@ html[data-theme="galadriel-light"]:root, [data-theme="galadriel-light"] {
   --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-600) 12%, transparent);
 
   --color-warning:      var(--primitive-brown-500);
+  --color-info:         var(--primitive-cyan-700);
   --color-warning-text: var(--primitive-brown-500);
   --color-warning-bg:   color-mix(in srgb, var(--primitive-brown-500) 8%, transparent);
 
@@ -836,6 +846,7 @@ html[data-theme="neo-dark"]:root, [data-theme="neo-dark"] {
   --color-grade-bottom-text: #ff2020;
   --color-grade-bottom-bg:   color-mix(in srgb, #ff2020 4%, transparent);
   --color-warning:      var(--primitive-amber-400);
+  --color-info:         var(--primitive-cyan-400);
   --color-warning-text: var(--primitive-amber-400);
   --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-400) 10%, transparent);
   --color-danger-text:   #ff4040;
@@ -911,6 +922,7 @@ html[data-theme="neo-light"]:root, [data-theme="neo-light"] {
   --color-grade-bottom-text: var(--primitive-crimson-600);
   --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-600) 12%, transparent);
   --color-warning:      var(--primitive-amber-700);
+  --color-info:         var(--primitive-cyan-700);
   --color-warning-text: var(--primitive-amber-700);
   --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-700) 8%, transparent);
   --color-danger-text:   var(--color-danger);
@@ -984,6 +996,7 @@ html[data-theme="galadriel-dark"]:root, [data-theme="galadriel-dark"] {
   --color-grade-bottom-text: var(--primitive-crimson-200);
   --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
   --color-warning:      var(--primitive-amber-400);
+  --color-info:         var(--primitive-cyan-400);
   --color-warning-text: var(--primitive-amber-400);
   --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-400) 10%, transparent);
   --color-danger-text:   var(--primitive-crimson-200);
@@ -1066,6 +1079,7 @@ html[data-theme="ifrit-light"]:root, [data-theme="ifrit-light"] {
   --color-grade-bottom-bg:   color-mix(in srgb, #a01008 12%, transparent);
 
   --color-warning:      var(--primitive-amber-700);
+  --color-info:         var(--primitive-cyan-700);
   --color-warning-text: var(--primitive-amber-700);
   --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-700) 8%, transparent);
 
@@ -1156,6 +1170,8 @@ html[data-theme="deckard-dark"]:root, [data-theme="deckard-dark"] {
   --color-compliance-border: color-mix(in srgb, #00dce0 38%, transparent);
 
   --color-warning:      #f0b428;
+  /* Info is blue here: cyan is deckard's success color. */
+  --color-info:         #6ea8fe;
   --color-warning-text: #f0b428;
   --color-warning-bg:   color-mix(in srgb, #f0b428 10%, transparent);
 
@@ -1244,6 +1260,8 @@ html[data-theme="deckard-light"]:root, [data-theme="deckard-light"] {
   --color-compliance-border: color-mix(in srgb, #0098a8 38%, transparent);
 
   --color-warning:      var(--primitive-amber-700);
+  /* Info is blue here: cyan is deckard's success color. */
+  --color-info:         #2f6fd0;
   --color-warning-text: var(--primitive-amber-700);
   --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-700) 8%, transparent);
 


### PR DESCRIPTION
Every status pill was a hand-rolled one-off; two of them ("setup incomplete",
"shared · read-only") referenced tokens that don't exist (--color-warn,
--color-info) and rendered hardcoded amber/cyan in every theme.

- New `--color-info` semantic token in :root, the dark media block, and all
  10 named theme blocks (deckard uses blue: cyan is its success color).
  Reuses the palette's existing cyan primitives rather than adding new ones.
- New `<Badge>` component (tones: neutral/accent/info/success/warning/danger;
  variants: pill/tag) with one shared tint recipe, semantic tokens only
- Migrated: card sync pills (LOCAL/PUBLISHED/REMOTE), subprojects tag,
  setup-incomplete (now the real --color-warning, plus a repo-wide purge of
  18 more dead --color-warn refs in terminal/onboarding/evaluation css),
  overview/map/history/violations "remote · read-only" header tag, drawer
  model chip
- Vocabulary unified to local/published/remote in display text (internal
  source key stays 'shared'); location filter and the four remote-page empty
  states now say "remote". Settings keeps "shared repository" deliberately:
  it names the team results repo, not a project's location.
- Repo chip is exception-only: silent when attached, "no repo access" warning
  with the server reason when not
- Assistant launcher on remote projects: visible but disabled with an
  explanatory tooltip instead of vanishing (aria-disabled so the tooltip
  still shows; Ctrl+` gating unchanged)

Verification: 165 test files / 1183 tests green; vite build clean; live
visual pass on a seeded dev server (fake shared repo) checked all four card
states, the remote header badge, the disabled launcher, and drawer chips in
light + dark, plus token resolution across ifrit/neo/galadriel/deckard
themes. Whole-branch review: ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)