### PR TITLE
fix: security and reliability findings from today's self-scan

### DIFF
--- a/src/quodeq/_cli_resolution.py
+++ b/src/quodeq/_cli_resolution.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from quodeq.config.paths import default_paths
+from quodeq.shared._env import env_int
 from quodeq.shared.utils import is_repo_url, project_name_from_repo, read_json
 from quodeq.shared.validation import validate_path_segment
 from quodeq.analysis.manifest import SourceManifest, build_manifest, detect_language
@@ -28,7 +29,7 @@ _logger = logging.getLogger(__name__)
 _WORKTREE_TIMEOUT_S = 30
 # Branch fetches go over the network; give them the clone budget, not the
 # local worktree one.
-_FETCH_TIMEOUT_S = int(os.environ.get("QUODEQ_GIT_CLONE_TIMEOUT_S", "300"))
+_FETCH_TIMEOUT_S = env_int("QUODEQ_GIT_CLONE_TIMEOUT_S", 300, minimum=1)
 
 
 # ---------------------------------------------------------------------------
@@ -95,10 +96,15 @@ def _create_worktree(repo_dir: Path, branch: str) -> Path | None:
 def _cleanup_worktree(repo_dir: Path, worktree_dir: Path) -> None:
     """Remove a temporary git worktree."""
     try:
-        subprocess.run(
+        result = subprocess.run(
             ["git", "-C", str(repo_dir), "worktree", "remove", str(worktree_dir), "--force"],
             capture_output=True, text=True, encoding="utf-8", timeout=_WORKTREE_TIMEOUT_S,
         )
+        if result.returncode != 0:
+            _logger.warning(
+                "git worktree remove %s exited %d: %s",
+                worktree_dir, result.returncode, (result.stderr or "").strip(),
+            )
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
         _logger.debug("Failed to clean up worktree %s: %s", worktree_dir, exc)
 

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -45,6 +45,10 @@ _OLLAMA_DEFAULT_BASE = "http://localhost:11434/v1"
 _OLLAMA_DEFAULT_API_KEY = "ollama"
 _OPENAI_API_HOST = "api.openai.com"
 _LOCAL_TIMEOUT = httpx.Timeout(connect=10.0, read=500.0, write=30.0, pool=10.0)
+# Cloud calls get a finite timeout too: with max_retries=0 a stalled response
+# would otherwise block the analysis worker forever. Read budget matches the
+# SDK's own 600s default; a timeout lands in the existing lossy-file branch.
+_CLOUD_TIMEOUT = httpx.Timeout(connect=10.0, read=600.0, write=30.0, pool=10.0)
 _SYSTEM_PROMPT = (
     "You are a code quality evaluator. Quote the offending code into "
     "`snippet` VERBATIM from the source, one or a few contiguous lines, "
@@ -284,7 +288,7 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
     if config.max_tokens is not None:
         create_kwargs["max_tokens"] = config.max_tokens
 
-    timeout = None if is_openai else _LOCAL_TIMEOUT
+    timeout = _CLOUD_TIMEOUT if is_openai else _LOCAL_TIMEOUT
     _log.debug("Calling %s model=%s (per-finding parse)", config.api_base, config.model)
     start = time.monotonic()
     with openai.OpenAI(

--- a/src/quodeq/api/_rate_limit_config.py
+++ b/src/quodeq/api/_rate_limit_config.py
@@ -1,8 +1,9 @@
 """Rate-limit configuration constants and environment helpers."""
 from __future__ import annotations
 
-import os
 from pathlib import Path
+
+from quodeq.shared._env import env_int
 
 _DEFAULT_RATE_LIMIT_WINDOW = 60
 # 60/min was too tight for the dashboard's bulk-dismiss UX — burst-dismissing
@@ -17,19 +18,21 @@ _PRUNE_THRESHOLD_MULTIPLIER = 2  # prune per-IP list when it exceeds max_request
 
 
 def _rate_limit_window(env: dict[str, str] | None = None) -> int:
-    """Return the rate-limit window in seconds."""
-    try:
-        return int((env or os.environ).get("QUODEQ_RATE_LIMIT_WINDOW", str(_DEFAULT_RATE_LIMIT_WINDOW)))
-    except (ValueError, TypeError):
-        return _DEFAULT_RATE_LIMIT_WINDOW
+    """Return the rate-limit window in seconds.
+
+    minimum=1: a zero/negative window prunes every recorded timestamp
+    immediately, silently disabling the limiter.
+    """
+    return env_int("QUODEQ_RATE_LIMIT_WINDOW", _DEFAULT_RATE_LIMIT_WINDOW, minimum=1, env=env)
 
 
 def _rate_limit_max(env: dict[str, str] | None = None) -> int:
-    """Return the maximum number of requests per window."""
-    try:
-        return int((env or os.environ).get("QUODEQ_RATE_LIMIT_MAX", str(_DEFAULT_RATE_LIMIT_MAX)))
-    except (ValueError, TypeError):
-        return _DEFAULT_RATE_LIMIT_MAX
+    """Return the maximum number of requests per window.
+
+    minimum=1: a zero/negative maximum makes every request exceed the limit,
+    blocking all clients including the app's own UI.
+    """
+    return env_int("QUODEQ_RATE_LIMIT_MAX", _DEFAULT_RATE_LIMIT_MAX, minimum=1, env=env)
 
 
 def default_rate_limit_path() -> Path:

--- a/src/quodeq/api/_rate_limit_file_store.py
+++ b/src/quodeq/api/_rate_limit_file_store.py
@@ -41,9 +41,12 @@ class FileRateLimitStore:
 
     def _load(self) -> dict[str, list[float]]:
         try:
-            return json.loads(self._path.read_text(encoding="utf-8"))
+            data = json.loads(self._path.read_text(encoding="utf-8"))
         except (FileNotFoundError, json.JSONDecodeError, OSError):
             return {}
+        # The state file is plain user-writable JSON; a valid non-object value
+        # (array, scalar) would crash record()/check() at data.get(...).
+        return data if isinstance(data, dict) else {}
 
     def _save(self, data: dict[str, list[float]]) -> None:
         parent = self._path.parent

--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -253,8 +253,12 @@ import time
 from typing import Iterator
 
 from quodeq.api._sse_log_helpers import sse_line
+from quodeq.shared._env import env_float
 
-_HEARTBEAT_S = float(os.environ.get("QUODEQ_SSE_HEARTBEAT_S", "15"))
+# env_float never raises, so a malformed QUODEQ_SSE_HEARTBEAT_S can't abort
+# module import (it logs and falls back to 15s). minimum=0.1 keeps a bogus
+# tiny/negative value from turning every tick into a keepalive frame.
+_HEARTBEAT_S = env_float("QUODEQ_SSE_HEARTBEAT_S", 15.0, minimum=0.1)
 
 
 def _tick_ms() -> int:

--- a/src/quodeq/api/assistant_routes.py
+++ b/src/quodeq/api/assistant_routes.py
@@ -31,6 +31,14 @@ _running_turns: set[str] = set()
 _cancel_tokens: dict[str, CancelToken] = {}
 _running_lock = threading.Lock()
 
+# Each open assistant SSE stream pins a server worker thread for its whole
+# lifetime, and the global rate limiter exempts GETs — without a cap an
+# authenticated caller can exhaust every worker with idle streams. 16 is
+# generous for the real UI (one stream per open drawer/tab).
+_MAX_SSE_STREAMS = 16
+_open_sse_streams = 0
+_sse_lock = threading.Lock()
+
 
 def _try_claim_turn(sid: str) -> bool:
     """Atomically claim the per-session turn slot for a workspace action so a
@@ -224,6 +232,27 @@ def register_assistant_routes(app: Flask) -> None:
         except ValueError:
             after = 0
 
+        global _open_sse_streams
+        with _sse_lock:
+            if _open_sse_streams >= _MAX_SSE_STREAMS:
+                return jsonify({"error": "too many open event streams"}), 429
+            _open_sse_streams += 1
+
+        released = False
+
+        def _release_stream():
+            # Idempotent: runs from both the generator's finally and the
+            # response's on-close callback (the callback covers the case where
+            # the client drops before the generator is ever started, in which
+            # case a generator finally never executes).
+            nonlocal released
+            global _open_sse_streams
+            with _sse_lock:
+                if released:
+                    return
+                released = True
+                _open_sse_streams -= 1
+
         def _generate():
             # SSE comments (":keepalive") are invisible to EventSource — only
             # DATA frames fire onmessage and reset the browser's inactivity
@@ -232,21 +261,25 @@ def register_assistant_routes(app: Flask) -> None:
             # frame, not just comments. Throttled to ~every 20th idle tick
             # (20 * _POLL_SECONDS == ~5s) so we don't spam a data frame every
             # 0.25s; cheap ":keepalive" comments fill the gaps in between.
-            yield ":keepalive\n\n"
-            idle_ticks = 0
-            for item in event_frames(repo, sid, after):
-                if item is None:
-                    idle_ticks += 1
-                    if idle_ticks % 20 == 0:
-                        yield sse_line(json.dumps({"type": "heartbeat"}))
+            try:
+                yield ":keepalive\n\n"
+                idle_ticks = 0
+                for item in event_frames(repo, sid, after):
+                    if item is None:
+                        idle_ticks += 1
+                        if idle_ticks % 20 == 0:
+                            yield sse_line(json.dumps({"type": "heartbeat"}))
+                        else:
+                            yield ":keepalive\n\n"
                     else:
-                        yield ":keepalive\n\n"
-                else:
-                    idle_ticks = 0
-                    seq, frame = item
-                    yield sse_line(json.dumps(frame, ensure_ascii=False), event_id=seq)
+                        idle_ticks = 0
+                        seq, frame = item
+                        yield sse_line(json.dumps(frame, ensure_ascii=False), event_id=seq)
+            finally:
+                _release_stream()
 
         resp = Response(_generate(), mimetype="text/event-stream")
+        resp.call_on_close(_release_stream)
         resp.headers["Cache-Control"] = "no-cache"
         resp.headers["X-Accel-Buffering"] = "no"
         return resp

--- a/src/quodeq/api/llm_bridge_routes.py
+++ b/src/quodeq/api/llm_bridge_routes.py
@@ -23,6 +23,20 @@ from quodeq.llm_bridge import (
 from quodeq.shared.url_validation import validate_url_safe
 
 
+def _json_body() -> dict | None:
+    """Return the request's JSON body when it is an object, else None.
+
+    A body like ``[1]`` or ``"x"`` parses as valid JSON but crashes the
+    ``data.get(...)`` calls below with an AttributeError (a 500); callers
+    turn None into a 400 instead.
+    """
+    data = request.get_json(silent=True)
+    return data if isinstance(data, dict) else None
+
+
+_BODY_NOT_OBJECT = {"error": "request body must be a JSON object", "code": "INVALID_PARAM"}
+
+
 def register_llm_bridge_routes(app: Flask) -> None:
     """Register all llm_bridge API routes."""
 
@@ -36,7 +50,9 @@ def register_llm_bridge_routes(app: Flask) -> None:
 
     @app.post("/api/ollama/test-concurrency")
     def ollama_test_concurrency() -> Response:
-        data = request.get_json() or {}
+        data = _json_body()
+        if data is None:
+            return jsonify(_BODY_NOT_OBJECT), 400
         model = data.get("model", "")
         if not model or not isinstance(model, str):
             return jsonify({"error": "model is required", "code": "MISSING_PARAM"}), 400
@@ -47,7 +63,9 @@ def register_llm_bridge_routes(app: Flask) -> None:
 
     @app.post("/api/ollama/estimate-agents")
     def ollama_estimate_agents() -> Response:
-        data = request.get_json() or {}
+        data = _json_body()
+        if data is None:
+            return jsonify(_BODY_NOT_OBJECT), 400
         model_size = data.get("model_size", 0)
         gpu_memory = data.get("gpu_memory", 0)
         if (isinstance(model_size, bool) or isinstance(gpu_memory, bool)
@@ -66,7 +84,9 @@ def register_llm_bridge_routes(app: Flask) -> None:
 
     @app.post("/api/llamacpp/test-concurrency")
     def llamacpp_test_concurrency() -> Response:
-        data = request.get_json() or {}
+        data = _json_body()
+        if data is None:
+            return jsonify(_BODY_NOT_OBJECT), 400
         model = data.get("model", "")
         if not isinstance(model, str):
             return jsonify({"error": "model must be a string", "code": "INVALID_PARAM"}), 400
@@ -83,25 +103,35 @@ def register_llm_bridge_routes(app: Flask) -> None:
     @app.get("/api/omlx/models")
     def omlx_models() -> Response:
         base_url = request.args.get("base_url", "").strip() or None
-        api_key = request.args.get("api_key", "").strip() or None
+        # The key rides in a header, never the query string: query params leak
+        # through access logs, browser history, and referrers.
+        api_key = (request.headers.get("X-Api-Key") or "").strip() or None
         return jsonify({"models": list_omlx_models(base_url=base_url, api_key=api_key)})
 
     @app.post("/api/omlx/test-concurrency")
     def omlx_test_concurrency() -> Response:
-        data = request.get_json() or {}
+        data = _json_body()
+        if data is None:
+            return jsonify(_BODY_NOT_OBJECT), 400
         model = data.get("model", "")
         if not isinstance(model, str):
             return jsonify({"error": "model must be a string", "code": "INVALID_PARAM"}), 400
         if "\\" in model or ".." in model or "\0" in model:
             return jsonify({"error": "Invalid model name", "code": "INVALID_PARAM"}), 400
-        base_url = data.get("base_url", "").strip() or None
-        api_key = data.get("api_key", "").strip() or None
+        base_url = data.get("base_url") or ""
+        api_key = data.get("api_key") or ""
+        if not isinstance(base_url, str) or not isinstance(api_key, str):
+            return jsonify({"error": "base_url and api_key must be strings", "code": "INVALID_PARAM"}), 400
+        base_url = base_url.strip() or None
+        api_key = api_key.strip() or None
         result = run_omlx_concurrency_test(model, base_url=base_url, api_key=api_key)
         return jsonify(result)
 
     @app.post("/api/provider/test")
     def provider_test() -> Response:
-        data = request.get_json() or {}
+        data = _json_body()
+        if data is None:
+            return jsonify(_BODY_NOT_OBJECT), 400
         configs = get_provider_configs()
         provider_id = data.get("provider", "")
         provider_cfg = configs.get(provider_id, {}) if provider_id else {}

--- a/src/quodeq/api/llm_bridge_routes.py
+++ b/src/quodeq/api/llm_bridge_routes.py
@@ -37,6 +37,21 @@ def _json_body() -> dict | None:
 _BODY_NOT_OBJECT = {"error": "request body must be a JSON object", "code": "INVALID_PARAM"}
 
 
+def _invalid_base_url(base_url: str | None) -> tuple[Response, int] | None:
+    """Return a 400 response when *base_url* fails SSRF validation, else None.
+
+    Same policy as /api/provider/test: http(s) scheme only, private/LAN
+    addresses allowed (self-hosted omlx servers are the normal case).
+    """
+    if base_url is None:
+        return None
+    try:
+        validate_url_safe(base_url, allow_private=True)
+    except ValueError as exc:
+        return jsonify({"error": str(exc), "code": "INVALID_URL"}), 400
+    return None
+
+
 def register_llm_bridge_routes(app: Flask) -> None:
     """Register all llm_bridge API routes."""
 
@@ -98,11 +113,17 @@ def register_llm_bridge_routes(app: Flask) -> None:
     @app.get("/api/omlx/status")
     def omlx_status() -> Response:
         base_url = request.args.get("base_url", "").strip() or None
+        err = _invalid_base_url(base_url)
+        if err is not None:
+            return err
         return jsonify(get_omlx_status(base_url=base_url))
 
     @app.get("/api/omlx/models")
     def omlx_models() -> Response:
         base_url = request.args.get("base_url", "").strip() or None
+        err = _invalid_base_url(base_url)
+        if err is not None:
+            return err
         # The key rides in a header, never the query string: query params leak
         # through access logs, browser history, and referrers.
         api_key = (request.headers.get("X-Api-Key") or "").strip() or None
@@ -124,6 +145,9 @@ def register_llm_bridge_routes(app: Flask) -> None:
             return jsonify({"error": "base_url and api_key must be strings", "code": "INVALID_PARAM"}), 400
         base_url = base_url.strip() or None
         api_key = api_key.strip() or None
+        err = _invalid_base_url(base_url)
+        if err is not None:
+            return err
         result = run_omlx_concurrency_test(model, base_url=base_url, api_key=api_key)
         return jsonify(result)
 

--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -33,6 +33,32 @@ from quodeq.shared.validation import validate_path_segment
 _logger = logging.getLogger(__name__)
 _MAX_DISMISSED_LIMIT = 5000
 
+def _invalid_body_fields(
+    body: dict[str, Any],
+    str_fields: tuple[str, ...],
+    int_fields: tuple[str, ...] = (),
+) -> str | None:
+    """Return a message naming mistyped body fields, or None when types are fine.
+
+    Missing fields stay the caller's MISSING_PARAM concern; this only rejects
+    present values of the wrong type (str fields must be str, int fields must
+    be a non-bool int) so list/dict/number payloads get a 400 at the API
+    boundary instead of crashing in the persistence layer.
+    """
+    bad: list[str] = []
+    for name in str_fields:
+        value = body.get(name)
+        if value is not None and not isinstance(value, str):
+            bad.append(f"{name} (must be a string)")
+    for name in int_fields:
+        value = body.get(name)
+        if value is not None and (isinstance(value, bool) or not isinstance(value, int)):
+            bad.append(f"{name} (must be an integer)")
+    if bad:
+        return f"invalid fields: {', '.join(bad)}"
+    return None
+
+
 def _project_dir(evaluations_dir: str, project: str) -> Path:
     validate_path_segment(project)
     base = Path(evaluations_dir).resolve()
@@ -80,6 +106,9 @@ def register_findings_routes(app: Flask) -> None:
         run_id = body.get("run_id") or body.get("runId")
         if not project or not req or not file or line is None:
             return jsonify({"error": "project, req, file, and line are required", "code": "MISSING_PARAM"}), 400
+        type_err = _invalid_body_fields(body, ("project", "req", "file"), ("line",))
+        if type_err:
+            return jsonify({"error": type_err, "code": "INVALID_PARAM"}), 400
         dismiss_finding(_project_dir(_eval_dir(), project), body)
         scores = _scores_with_fallback(project, run_id)
         delta = dismiss_delta(
@@ -97,6 +126,9 @@ def register_findings_routes(app: Flask) -> None:
         run_id = body.get("run_id") or body.get("runId")
         if not project or not req or not file or line is None:
             return jsonify({"error": "project, req, file, and line are required", "code": "MISSING_PARAM"}), 400
+        type_err = _invalid_body_fields(body, ("project", "req", "file"), ("line",))
+        if type_err:
+            return jsonify({"error": type_err, "code": "INVALID_PARAM"}), 400
         restore_finding(_project_dir(_eval_dir(), project), body)
         scores = _scores_with_fallback(project, run_id)
         delta = restore_delta(
@@ -126,6 +158,9 @@ def register_findings_routes(app: Flask) -> None:
         run_id = body.get("run_id") or body.get("runId")
         if not project or not dimension or not principle or not file:
             return jsonify({"error": "project, dimension, principle, and file are required", "code": "MISSING_PARAM"}), 400
+        type_err = _invalid_body_fields(body, ("project", "dimension", "principle", "file"))
+        if type_err:
+            return jsonify({"error": type_err, "code": "INVALID_PARAM"}), 400
         swept = delete_finding(_project_dir(_eval_dir(), project), body)
         scores = _scores_with_fallback(project, run_id)
         delta = delete_delta(
@@ -162,5 +197,8 @@ def register_findings_routes(app: Flask) -> None:
         line = body.get("line")
         if not project or not req or not file or line is None:
             return jsonify({"error": "project, req, file, and line are required", "code": "MISSING_PARAM"}), 400
+        type_err = _invalid_body_fields(body, ("project", "req", "file"), ("line",))
+        if type_err:
+            return jsonify({"error": type_err, "code": "INVALID_PARAM"}), 400
         unverify_finding(_project_dir(_eval_dir(), project), body)
         return jsonify({"ok": True}), 200

--- a/src/quodeq/api/routes_project_list.py
+++ b/src/quodeq/api/routes_project_list.py
@@ -22,6 +22,27 @@ _logger = logging.getLogger(__name__)
 _BLOCKED_SCAN_PATHS = ("/proc", "/sys", "/dev", "/etc", "/var/run", "/private/etc", "/private/var/run")
 
 
+def _scan_target_error(target_path: Path, reports_root: str) -> tuple[dict, int] | None:
+    """Validate a resolved directory path against the scan allowlist.
+
+    Shared by /api/scan and create_project's local-repo branch so both enforce
+    the same rules: the path must live under the user's home or the
+    evaluations directory, and must not be a blocked system path. Returns an
+    ``error_response`` tuple on rejection, or None when the path is allowed.
+    """
+    _home = Path.home().resolve()
+    _eval_dir = Path(reports_root).resolve()
+    _allowed_roots = (_home, _eval_dir)
+    if not any(target_path == root or target_path.is_relative_to(root) for root in _allowed_roots):
+        return error_response(
+            "Scan path must be under home directory", HTTPStatus.FORBIDDEN, "FORBIDDEN",
+        )
+    # Block scanning system directories to prevent information disclosure
+    if any(str(target_path).startswith(b) for b in _BLOCKED_SCAN_PATHS):
+        return error_response("Cannot scan system directories", HTTPStatus.FORBIDDEN, "FORBIDDEN")
+    return None
+
+
 def _find_existing_project(reports_root: str, repo: str, scope_path: str | None) -> str | None:
     """Return an existing project UUID matching the given repo identity, or None.
 
@@ -284,6 +305,13 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
                     "INVALID_REPO",
                 )
                 return jsonify(body), status
+            # Same allowlist as /api/scan: registering a project scans it and
+            # persists the file tree, so an unvalidated path here would leak
+            # arbitrary readable directories through project endpoints.
+            err = _scan_target_error(local_candidate.resolve(), reports_root)
+            if err is not None:
+                body, status = err
+                return jsonify(body), status
 
         # Pre-flight: detect duplicates by walking existing project
         # directories. Returns None if no match.
@@ -330,6 +358,9 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
             body, _ = error_response(str(exc), status, code)
             return jsonify(body), status
         except Exception as exc:  # pragma: no cover — unexpected scan/clone failure
+            # error_response swallows the traceback that Flask's own 500
+            # handler would have logged; record it before converting.
+            _logger.exception("Registration failed for repo=%r", repo)
             _rollback_new_dirs(reports_root, before)
             body, status = error_response(
                 f"Registration failed: {exc}",
@@ -370,17 +401,9 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
 
         target_path = Path(target).resolve()
         # Allowlist: only permit paths under user home or the evaluations directory
-        _home = Path.home().resolve()
-        _eval_dir = Path(reports_dir()).resolve()
-        _allowed_roots = (_home, _eval_dir)
-        if not any(target_path == root or target_path.is_relative_to(root) for root in _allowed_roots):
-            body, status = error_response(
-                "Scan path must be under home directory", HTTPStatus.FORBIDDEN, "FORBIDDEN",
-            )
-            return jsonify(body), status
-        # Block scanning system directories to prevent information disclosure
-        if any(str(target_path).startswith(b) for b in _BLOCKED_SCAN_PATHS):
-            body, status = error_response("Cannot scan system directories", HTTPStatus.FORBIDDEN, "FORBIDDEN")
+        err = _scan_target_error(target_path, reports_dir())
+        if err is not None:
+            body, status = err
             return jsonify(body), status
         if not target_path.is_dir():
             body, status = error_response("Path is not a directory", HTTPStatus.BAD_REQUEST, "NOT_DIR")

--- a/src/quodeq/api/terminal_routes.py
+++ b/src/quodeq/api/terminal_routes.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import atexit
 import json
+import logging
 import os
 import struct
 import threading
@@ -15,6 +16,8 @@ from flask_sock import Sock
 
 from quodeq.terminal.gate import terminal_env_reason, terminal_gate_reason
 from quodeq.terminal.manager import TerminalManager
+
+_logger = logging.getLogger(__name__)
 
 
 def _env_reason() -> str | None:
@@ -111,7 +114,10 @@ def register_terminal_routes(app: Flask, manager: TerminalManager | None = None)
                     ws.send("0" + sb)
             except Exception:
                 # Spawn failure or early disconnect must not propagate past
-                # flask-sock (would surface as a 500). Don't close here:
+                # flask-sock (would surface as a 500), but leave a trace for
+                # operators — the client only sees a silently closed terminal.
+                _logger.warning("terminal session setup failed", exc_info=True)
+                # Don't close here:
                 # flask-sock sends the close frame after this handler returns,
                 # i.e. after the outer finally has released _conn_lock, so a
                 # client that reconnects the instant it sees the close finds

--- a/src/quodeq/assistant/cancel.py
+++ b/src/quodeq/assistant/cancel.py
@@ -8,8 +8,11 @@ instead of waiting for the next chunk that may never come.
 """
 from __future__ import annotations
 
+import logging
 import threading
 from typing import Callable
+
+_logger = logging.getLogger(__name__)
 
 
 class TurnCancelled(Exception):
@@ -43,7 +46,7 @@ class CancelToken:
             try:
                 hook()
             except Exception:  # noqa: BLE001 - kill hooks are best-effort
-                pass
+                _logger.warning("kill hook failed", exc_info=True)
 
     def register_kill(self, hook: Callable[[], None]) -> None:
         """Run `hook` when cancelled; immediately if already cancelled (a stop
@@ -56,4 +59,4 @@ class CancelToken:
         try:
             hook()
         except Exception:  # noqa: BLE001 - kill hooks are best-effort
-            pass
+            _logger.warning("kill hook failed", exc_info=True)

--- a/src/quodeq/assistant/skills.py
+++ b/src/quodeq/assistant/skills.py
@@ -58,7 +58,12 @@ def load_skills(skills_dir: Path | None = None) -> dict[str, Skill]:
     if not directory.is_dir():
         return skills
     for path in sorted(directory.glob("*.md")):
-        skill = _parse(path.read_text(encoding="utf-8"))
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            _logger.warning("skipping malformed skill file: %s", path)
+            continue
+        skill = _parse(text)
         if skill is None:
             _logger.warning("skipping malformed skill file: %s", path)
             continue

--- a/src/quodeq/assistant/tools/_read_tools.py
+++ b/src/quodeq/assistant/tools/_read_tools.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import logging
+import re
 
 from quodeq.assistant.tools._context import ToolContext
 from quodeq.assistant.tools._registry import ToolError, ToolRegistry, ToolSpec
@@ -13,6 +15,20 @@ from quodeq.services.deleted import deleted_keys
 from quodeq.services.dismissed import dismissed_keys
 from quodeq.services.scoring import rescore_accumulated, scored_run_dimensions
 from quodeq.services.standards import StandardsService
+
+_logger = logging.getLogger(__name__)
+
+# Dimension ids are simple slugs. The tool-call `dimension` argument is
+# model-controlled text used to build a file path, so anything outside this
+# charset (path separators, dots, absolute paths) is rejected outright.
+_DIMENSION_RE = re.compile(r"[a-z0-9_-]+")
+
+
+def _validate_dimension(dimension: str) -> str:
+    if not isinstance(dimension, str) or not _DIMENSION_RE.fullmatch(dimension):
+        raise ToolError(f"invalid dimension: {dimension!r}")
+    return dimension
+
 
 def _require_run(ctx: ToolContext):
     if ctx.run_dir is None or not ctx.run_dir.exists():
@@ -182,7 +198,9 @@ def finding_keys_in_scope(ctx: ToolContext) -> set[tuple]:
                 for f in SqliteFindingsRepository(ctx.run_dir).list_all():
                     keys.add((str(f.req or ""), str(f.file or ""), _coerce_line(f.line)))
             except Exception:  # noqa: BLE001 - a corrupt db must not block the read
-                pass
+                _logger.warning(
+                    "evaluation.db unreadable in %s; finding keys may be incomplete",
+                    ctx.run_dir, exc_info=True)
     else:
         try:
             # rescored=False: the identity check must keep seeing every finding
@@ -242,6 +260,7 @@ def _get_scores(ctx: ToolContext) -> dict:
 
 
 def _get_report(ctx: ToolContext, dimension: str) -> dict:
+    _validate_dimension(dimension)
     if _has_run(ctx):
         path = ctx.run_dir / "evaluation" / f"{dimension}.json"
         if not path.is_file():
@@ -320,6 +339,7 @@ def _get_violations(ctx: ToolContext, dimension: str | None = None,
 def _violations_from_run(ctx: ToolContext, dimension: str | None):
     eval_dir = ctx.run_dir / "evaluation"
     if dimension:
+        _validate_dimension(dimension)
         path = eval_dir / f"{dimension}.json"
         if not path.is_file():
             raise ToolError(

--- a/src/quodeq/ci/cli.py
+++ b/src/quodeq/ci/cli.py
@@ -1,12 +1,13 @@
 """CLI handler for the `quodeq ci` subcommand."""
 from __future__ import annotations
 
+import argparse
 import os
 import sys
 from pathlib import Path
 
 
-def handle_ci(args) -> int:
+def handle_ci(args: argparse.Namespace) -> int:
     """Handle the `quodeq ci` subcommand. Returns exit code."""
     if args.ci_action == "report":
         return _handle_report(args)
@@ -14,7 +15,7 @@ def handle_ci(args) -> int:
     return 1
 
 
-def _handle_report(args) -> int:
+def _handle_report(args: argparse.Namespace) -> int:
     """Post evaluation results as a GitHub PR review."""
     from quodeq.ci._evidence_reader import load_violations_from_evidence
     from quodeq.ci.reporter import (
@@ -25,6 +26,12 @@ def _handle_report(args) -> int:
     )
     from quodeq.ci.review_builder import classify_violations
 
+    if args.token:
+        print(
+            "Warning: --token exposes the credential in shell history and "
+            "process listings; prefer the GITHUB_TOKEN environment variable.",
+            file=sys.stderr,
+        )
     token = args.token or os.environ.get("GITHUB_TOKEN")
     if not token:
         print("Error: --token or GITHUB_TOKEN environment variable required", file=sys.stderr)

--- a/src/quodeq/cli.py
+++ b/src/quodeq/cli.py
@@ -84,7 +84,9 @@ def maybe_emit_cli_notice(stream=None, env: dict[str, str] | None = None) -> Non
                 file=out,
             )
     except Exception:  # pragma: no cover - defensive
-        pass
+        import logging
+
+        logging.getLogger(__name__).debug("update notice failed", exc_info=True)
 
 
 def _install_broken_pipe_guard() -> None:

--- a/src/quodeq/cli_parser.py
+++ b/src/quodeq/cli_parser.py
@@ -139,7 +139,11 @@ def build_parser() -> argparse.ArgumentParser:
     report_parser.add_argument("--owner", required=True, help="GitHub repository owner")
     report_parser.add_argument("--repo", required=True, help="GitHub repository name")
     report_parser.add_argument("--pr", type=int, required=True, help="Pull request number")
-    report_parser.add_argument("--token", help="GitHub token (default: GITHUB_TOKEN env var)")
+    report_parser.add_argument(
+        "--token",
+        help="GitHub token. Prefer the GITHUB_TOKEN env var: a token passed "
+             "here is visible in shell history and process listings.",
+    )
     report_parser.add_argument("--duration", type=int, help="Evaluation duration in seconds")
     report_parser.add_argument(
         "--baseline-dir",

--- a/src/quodeq/core/events/reader.py
+++ b/src/quodeq/core/events/reader.py
@@ -74,15 +74,17 @@ class EventLogReader:
 
                     yield event
 
+                except json.JSONDecodeError:
+                    # Must precede (ValueError, KeyError): JSONDecodeError is a
+                    # ValueError subclass and would otherwise never match here.
+                    _logger.error(f"Malformed JSON in {self.log_path} at line {line_num}")
+                    continue
                 except (ValueError, KeyError) as e:
                     # Handles invalid Enum values or missing keys in raw_data
                     _logger.error(f"Invalid event structure in {self.log_path} at line {line_num}: {e}")
                     continue
                 except ValidationError as e:
                     _logger.error(f"Schema mismatch in {self.log_path} at line {line_num}: {e}")
-                    continue
-                except json.JSONDecodeError:
-                    _logger.error(f"Malformed JSON in {self.log_path} at line {line_num}")
                     continue
                 except Exception as e:
                     _logger.error(f"Unexpected error reading {self.log_path} at line {line_num}: {e}")

--- a/src/quodeq/core/evidence/_jsonl.py
+++ b/src/quodeq/core/evidence/_jsonl.py
@@ -36,6 +36,9 @@ def parse_jsonl_line(line: str) -> tuple[Judgment, list[str] | None] | None:
     except json.JSONDecodeError as exc:
         _logger.warning("Skipping malformed JSONL line: %s", exc)
         return None
+    if not isinstance(obj, dict):
+        _logger.warning("Skipping non-object JSONL line")
+        return None
 
     practice_id = obj.get("p") or obj.get("req")
     verdict = obj.get("t")

--- a/src/quodeq/core/finding_mappings.py
+++ b/src/quodeq/core/finding_mappings.py
@@ -25,6 +25,14 @@ def _coerce_req_refs(raw: Any) -> list[ReqRef]:
     return refs
 
 
+def _safe_int(value: Any, default: int) -> int:
+    """Coerce a wire value to int, falling back to *default* on junk input."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def wire_dict_to_judgment(d: dict[str, Any]) -> Judgment:
     """Lift a short-key LLM/FindingsRouter wire dict into a Judgment.
 
@@ -38,7 +46,7 @@ def wire_dict_to_judgment(d: dict[str, Any]) -> Judgment:
         verdict=d.get("t") or "",
         dimension=d.get("d") or "",
         file=d.get("file") or "",
-        line=int(d.get("line") or 0),
+        line=_safe_int(d.get("line") or 0, 0),
         end_line=d.get("end_line"),
         snippet=d.get("snippet"),
         severity=d.get("severity") or "medium",
@@ -49,7 +57,7 @@ def wire_dict_to_judgment(d: dict[str, Any]) -> Judgment:
         title=d.get("w"),
         context=d.get("context"),
         scope=d.get("scope"),
-        confidence=int(d.get("confidence") if d.get("confidence") is not None else 100),
+        confidence=_safe_int(d.get("confidence") if d.get("confidence") is not None else 100, 100),
         req=d.get("req"),
         req_refs=_coerce_req_refs(d.get("req_refs")),
         cwe=d.get("cwe"),

--- a/src/quodeq/dashboard/_server.py
+++ b/src/quodeq/dashboard/_server.py
@@ -31,6 +31,22 @@ from quodeq.shared.utils import IS_WIN32
 _HTTP_SCHEME = "http"
 
 
+def _guard_plaintext_http(host: str, allow_plaintext: bool | None = None) -> None:
+    """Refuse plaintext HTTP to a non-local host unless explicitly opted in."""
+    if host in _local_hosts():
+        return
+    if _allow_plaintext_http(allow_plaintext):
+        logging.getLogger(__name__).warning(
+            "API traffic to %s uses plaintext HTTP; use a TLS reverse proxy for remote hosts", host,
+        )
+    else:
+        raise RuntimeError(
+            f"Plaintext HTTP to non-localhost host {host!r} is not allowed. "
+            "Set QUODEQ_ALLOW_PLAINTEXT_HTTP=1 to explicitly opt in, "
+            "or use a TLS reverse proxy."
+        )
+
+
 def _ensure_action_api(
     host: str,
     start_port: int,
@@ -38,17 +54,7 @@ def _ensure_action_api(
     api_config: ApiConfig | None = None,
 ) -> tuple[str, subprocess.Popen | None]:
     cfg = api_config or ApiConfig()
-    if host not in _local_hosts():
-        if _allow_plaintext_http(cfg.allow_plaintext):
-            logging.getLogger(__name__).warning(
-                "API traffic to %s uses plaintext HTTP; use a TLS reverse proxy for remote hosts", host,
-            )
-        else:
-            raise RuntimeError(
-                f"Plaintext HTTP to non-localhost host {host!r} is not allowed. "
-                "Set QUODEQ_ALLOW_PLAINTEXT_HTTP=1 to explicitly opt in, "
-                "or use a TLS reverse proxy."
-            )
+    _guard_plaintext_http(host, cfg.allow_plaintext)
     for port in range(start_port, start_port + max_tries):
         base_url = f"{_HTTP_SCHEME}://{host}:{port}"
         if _is_port_open(host, port):
@@ -65,6 +71,7 @@ def _ensure_action_api_forced(
     static_dist: Path | None = None,
     evaluations_dir: str | None = None,
 ) -> tuple[str, subprocess.Popen | None]:
+    _guard_plaintext_http(host)
     base_url = f"http://{host}:{port}"
     if _is_port_open(host, port):
         if action_api_healthy(base_url):

--- a/src/quodeq/data/fs/_resolution.py
+++ b/src/quodeq/data/fs/_resolution.py
@@ -121,7 +121,14 @@ def _create_project(
     try:
         (project_dir / _REPO_INFO_FILENAME).write_text(json.dumps(info, indent=2), encoding="utf-8")
     except OSError as exc:
-        logging.getLogger(__name__).warning("Could not write repository_info.json: %s", exc)
+        # Fail creation cleanly: indexing a project without its metadata file
+        # would leave a permanently broken entry. The registration route rolls
+        # back the new directory when this propagates.
+        logging.getLogger(__name__).error(
+            "Could not write repository_info.json for %s: %s; aborting project creation",
+            project_dir, exc,
+        )
+        raise
     index = load_fn(reports_dir)
     index[_index_key(identity)] = project_uuid
     save_fn(reports_dir, index)

--- a/src/quodeq/data/projection/grade_projector.py
+++ b/src/quodeq/data/projection/grade_projector.py
@@ -139,9 +139,12 @@ def recompute_grades(run_dir: Path, params: ScoringParams | None = None) -> None
     # dimension label, dimensions.json carries the dimension id.
     from quodeq.shared.dimensions_state import read_dimensions  # noqa: PLC0415
     dim_states = read_dimensions(run_dir).get("dimensions", {})
+    if not isinstance(dim_states, dict):
+        dim_states = {}
     exit_by_dim = {
         str(name).lower(): entry.get("exit_reason")
         for name, entry in dim_states.items()
+        if isinstance(entry, dict)
     }
     for row in dimension_rows:
         row["exit_reason"] = exit_by_dim.get(str(row["dimension"]).lower())

--- a/src/quodeq/data/sqlite/_row_mappers.py
+++ b/src/quodeq/data/sqlite/_row_mappers.py
@@ -7,11 +7,14 @@ module is the only place that knows about both naming conventions.
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 from quodeq.core.events.models import Judgment
 from quodeq.core.types.finding import Finding
 from quodeq.core.types.req_ref import ReqRef
+
+_logger = logging.getLogger(__name__)
 
 
 def _dedup_key(practice_id: str, file: str, line: int, verdict: str) -> str:
@@ -98,7 +101,14 @@ def judgment_to_row(j: Judgment) -> dict[str, Any]:
 def row_to_finding(row: dict[str, Any]) -> Finding:
     """Reconstruct a Finding from a SQL row dict."""
     refs_json = row.get("req_refs_json")
-    raw_refs: list[dict] = json.loads(refs_json) if refs_json else []
+    try:
+        raw_refs: list[dict] = json.loads(refs_json) if refs_json else []
+    except json.JSONDecodeError:
+        _logger.warning(
+            "Malformed req_refs_json for finding %s (%s); dropping references",
+            row.get("practice_id"), row.get("file"),
+        )
+        raw_refs = []
     req_refs = [ReqRef(label=r.get("label", ""), url=r.get("url", "")) for r in raw_refs if isinstance(r, dict)]
     return Finding(
         practice_id=row["practice_id"],

--- a/src/quodeq/llm_bridge/_cloud.py
+++ b/src/quodeq/llm_bridge/_cloud.py
@@ -58,7 +58,6 @@ def check_cloud_connection(
             latency = int((time.monotonic() - start) * 1000)
             return {"success": True, "model": model, "latency_ms": latency}
     except Exception as exc:
-        _log.debug("Cloud connection check failed: %s", exc)
         # Surface the exception type and HTTP status codes without leaking
         # internal details like file paths, stack traces, or server headers.
         error_type = type(exc).__name__
@@ -66,5 +65,8 @@ def check_cloud_connection(
         # Strip potential API key fragments from error messages
         if api_key and len(api_key) > _MIN_KEY_LEN_FOR_REDACTION and api_key in raw:
             raw = raw.replace(api_key, "***")
+        # Log the redacted message, not the raw exception, so the key never
+        # lands in application logs either.
+        _log.debug("Cloud connection check failed: %s: %s", error_type, raw)
         brief = raw[:_MAX_ERROR_BRIEF_LEN] if raw else "unknown error"
         return {"success": False, "error": f"{error_type}: {brief}"}

--- a/src/quodeq/llm_bridge/_ollama.py
+++ b/src/quodeq/llm_bridge/_ollama.py
@@ -30,7 +30,8 @@ def get_ollama_status(base_url: str = _OLLAMA_BASE) -> dict:
                 "version": data.get("version", "unknown"),
                 "address": base_url.replace("http://", ""),
             }
-    except (urllib.error.URLError, ConnectionRefusedError, OSError) as exc:
+    except (urllib.error.URLError, ConnectionRefusedError, OSError,
+            ValueError, KeyError, TypeError, AttributeError) as exc:
         _log.warning("Ollama status check failed: %s", exc)
         return {"running": False, "error": "Connection failed"}
 
@@ -51,7 +52,8 @@ def list_ollama_models(base_url: str = _OLLAMA_BASE) -> list[dict]:
                 }
                 for m in models
             ]
-    except (urllib.error.URLError, ConnectionRefusedError, OSError) as exc:
+    except (urllib.error.URLError, ConnectionRefusedError, OSError,
+            ValueError, KeyError, TypeError, AttributeError) as exc:
         _log.warning("Could not list Ollama models: %s", exc)
         return []
 
@@ -70,7 +72,8 @@ def get_running_model_info(base_url: str = _OLLAMA_BASE) -> dict | None:
                     "size": m.get("size", 0),
                     "size_vram": m.get("size_vram", 0),
                 }
-    except (urllib.error.URLError, ConnectionRefusedError, OSError):
+    except (urllib.error.URLError, ConnectionRefusedError, OSError,
+            ValueError, KeyError, TypeError, AttributeError):
         pass
     return None
 

--- a/src/quodeq/llm_bridge/_omlx.py
+++ b/src/quodeq/llm_bridge/_omlx.py
@@ -67,6 +67,8 @@ def get_omlx_status(base_url: str | None = None) -> dict:
         req = _safe_request(f"{root}/health")
         with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
             data = json.loads(resp.read() or b"{}")
+            if not isinstance(data, dict):
+                data = {}
             return {
                 "running": True,
                 "status": data.get("status", "ok"),
@@ -105,11 +107,11 @@ def list_omlx_models(base_url: str | None = None, api_key: str | None = None) ->
             req.add_header("Authorization", f"Bearer {key}")
         with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
             data = json.loads(resp.read())
-            entries = data.get("data", []) or []
+            entries = (data.get("data") or []) if isinstance(data, dict) else []
             models = [
                 {"name": m.get("id", ""), "size": 0, "quantization": "", "family": ""}
                 for m in entries
-                if m.get("id")
+                if isinstance(m, dict) and m.get("id")
             ]
             if models:
                 return models

--- a/src/quodeq/services/_evaluations_index.py
+++ b/src/quodeq/services/_evaluations_index.py
@@ -10,12 +10,16 @@ delegates to an instance of this class.
 from __future__ import annotations
 
 import json
+import logging
 import shutil
 from pathlib import Path
 
 from quodeq.core.types.job import JobSnapshot
 from quodeq.services import run_index as _run_index
+from quodeq.services._external_jobs import is_safe_run_segment
 from quodeq.services.jobs import JobManager
+
+_logger = logging.getLogger(__name__)
 
 _TERMINAL_STATUS_STATES = {"complete", "completed", "done", "cancelled", "failed", "lost"}
 
@@ -108,13 +112,17 @@ class EvaluationsIndex:
             candidate = reports_dir / snapshot.output_project / run_uuid
             if candidate.is_dir():
                 shutil.rmtree(candidate, ignore_errors=True)
-                removed_dir = True
+                removed_dir = not candidate.exists()
+                if not removed_dir:
+                    _logger.warning("Could not remove run directory %s", candidate)
         if not removed_dir and reports_dir.is_dir():
             for project_dir in reports_dir.iterdir():
                 candidate = project_dir / run_uuid
                 if candidate.is_dir():
                     shutil.rmtree(candidate, ignore_errors=True)
-                    removed_dir = True
+                    removed_dir = not candidate.exists()
+                    if not removed_dir:
+                        _logger.warning("Could not remove run directory %s", candidate)
                     break
         # Remove from index regardless so stale rows get cleaned up. The same
         # on-disk run can be indexed under "ext-<run_uuid>" even when the
@@ -154,6 +162,8 @@ class EvaluationsIndex:
         try:
             if job_id.startswith("ext-"):
                 run_id = job_id[len("ext-"):]
+                if not is_safe_run_segment(run_id):
+                    return None
                 for project_dir in (reports_dir.iterdir() if reports_dir.is_dir() else []):
                     candidate = project_dir / run_id
                     if candidate.is_dir():

--- a/src/quodeq/services/_external_jobs.py
+++ b/src/quodeq/services/_external_jobs.py
@@ -14,26 +14,42 @@ returning False means there was nothing to cancel or signal delivery failed.
 from __future__ import annotations
 
 import logging
-import os
+import re
 import signal
 import time
 from pathlib import Path
 
 from quodeq.analysis._process import _kill_tree
+from quodeq.shared._env import env_float
 
 _logger = logging.getLogger(__name__)
 
 _PID_FILENAME = ".pid"
 
+# Charset of a legitimate project/run directory name (UUIDs in practice).
+# Excludes path separators; "." and ".." are rejected separately below.
+_SAFE_ID_RE = re.compile(r"[A-Za-z0-9._-]+")
+
 # Time to wait for the process to honor SIGTERM before escalating to SIGKILL.
 # Long enough that graceful shutdown (per-dim scoring on cancel, status.json
 # finalize, cache flush) finishes; short enough that the user isn't left
 # waiting on a hung run. Overridable for ops via env var.
-_DEFAULT_GRACE_PERIOD_S = float(os.environ.get("QUODEQ_CANCEL_GRACE_S", "30"))
+_DEFAULT_GRACE_PERIOD_S = env_float("QUODEQ_CANCEL_GRACE_S", 30.0, minimum=0.0)
 _POLL_INTERVAL_S = 0.05
 # SIGKILL on POSIX; Windows has no SIGKILL but _kill_tree treats any signal as
 # "taskkill /F /T" -- the fallback to SIGTERM keeps the call valid.
 _FORCE_KILL_SIGNAL = getattr(signal, "SIGKILL", signal.SIGTERM)
+
+
+def is_safe_run_segment(value: str) -> bool:
+    """True when *value* is safe to use as a single path segment.
+
+    Guards externally-supplied run/project ids (e.g. the tail of an
+    ``ext-<run_id>`` job id from the API) before any filesystem path is
+    built from them. Rejects empty strings, ``.``/``..`` and anything
+    outside ``[A-Za-z0-9._-]``.
+    """
+    return bool(_SAFE_ID_RE.fullmatch(value)) and value not in (".", "..")
 
 
 def resolve_external_pid(project_uuid: str, run_id: str, reports_root: Path) -> int | None:
@@ -42,6 +58,8 @@ def resolve_external_pid(project_uuid: str, run_id: str, reports_root: Path) -> 
     Looks for a `.pid` file written by `quodeq evaluate` at run start. Returns
     None if not found or the process is already gone.
     """
+    if not is_safe_run_segment(project_uuid) or not is_safe_run_segment(run_id):
+        return None
     pid_file = reports_root / project_uuid / run_id / _PID_FILENAME
     if not pid_file.exists():
         return None

--- a/src/quodeq/services/_fs_clone.py
+++ b/src/quodeq/services/_fs_clone.py
@@ -9,10 +9,11 @@ import subprocess as _subprocess
 from pathlib import Path
 
 from quodeq.services.shared_repo import remove_clone_dir
+from quodeq.shared._env import env_int
 
 _logger = logging.getLogger(__name__)
 
-_GIT_CLONE_TIMEOUT_S = int(os.environ.get("QUODEQ_GIT_CLONE_TIMEOUT_S", "300"))
+_GIT_CLONE_TIMEOUT_S = env_int("QUODEQ_GIT_CLONE_TIMEOUT_S", 300, minimum=1)
 
 # One month of slack over the default git churn lookback (git_lookback_months,
 # 3) so the boundary commit is never cut off. Raise QUODEQ_CLONE_SHALLOW_MONTHS

--- a/src/quodeq/services/_fs_projects.py
+++ b/src/quodeq/services/_fs_projects.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextvars
 import json
+import logging
 import shutil
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
@@ -22,6 +23,8 @@ from quodeq.services._fs_project_helpers import (
 from quodeq.services.ports import list_runs, safe_read_dir
 from quodeq.shared.repo_handler import is_valid_repo_url
 from quodeq.shared.utils import is_repo_url
+
+_logger = logging.getLogger(__name__)
 
 _MAX_PROJECT_BUILD_WORKERS = 8
 
@@ -202,14 +205,20 @@ def delete_project(reports_dir: str, project: str) -> bool:
         return False
 
     # Cascade: find and delete children first
+    children_removed = True
     for child_id in find_children(reports_root, project):
-        shutil.rmtree(reports_root / child_id, ignore_errors=True)
+        child_path = reports_root / child_id
+        try:
+            shutil.rmtree(child_path)
+        except OSError:
+            _logger.warning("Could not remove child project directory %s", child_path)
+            children_removed = False
 
     try:
         shutil.rmtree(project_path)
     except OSError:
         return False
-    return True
+    return children_removed
 
 
 def get_project_info(reports_dir: str, project: str) -> dict[str, Any] | None:

--- a/src/quodeq/services/_runs_unit.py
+++ b/src/quodeq/services/_runs_unit.py
@@ -20,8 +20,9 @@ from quodeq.services.run_index import (
 _INDEX_STATE_TO_UI_STATUS = {
     "done": "complete", "complete": "complete", "finished": "complete",
     "running": "in_progress", "in_progress": "in_progress",
+    "pending": "in_progress", "finalizing": "in_progress",
     "cancelled": "cancelled", "canceled": "cancelled",
-    "failed": "failed", "error": "failed",
+    "failed": "failed", "error": "failed", "lost": "failed",
 }
 
 

--- a/src/quodeq/services/_trend_fetcher.py
+++ b/src/quodeq/services/_trend_fetcher.py
@@ -17,6 +17,8 @@ its own module-level references so its monkeypatch-based tests keep working;
 """
 from __future__ import annotations
 
+import logging
+import sqlite3
 from collections import OrderedDict
 from pathlib import Path
 from threading import Lock
@@ -30,6 +32,8 @@ from quodeq.services.dismissed import dismissed_keys as _default_dismissed_keys
 from quodeq.services.ports import read_run_scalars as _default_read_run_scalars
 from quodeq.services.rescore import _rescore_dimension
 from quodeq.services.score_cache import make_cache_backed_fetcher
+
+_logger = logging.getLogger(__name__)
 
 _Fetcher = Callable[[str], list[DimensionResult]]
 
@@ -114,7 +118,8 @@ def make_trend_fetcher(
         try:
             with open_score_cache() as _conn:
                 _keys = load_run_keys(_conn, project)
-        except Exception:
+        except (OSError, sqlite3.Error):
+            _logger.debug("Could not load run keys from score cache for %s", project, exc_info=True)
             _keys = {}
 
         def version_for(run_id: str) -> str:
@@ -126,8 +131,11 @@ def make_trend_fetcher(
                     try:
                         with open_score_cache() as _c:
                             store_run_keys(_c, project, run_id, keys[0], keys[1])
-                    except Exception:
-                        pass
+                    except (OSError, sqlite3.Error):
+                        _logger.debug(
+                            "Could not store run keys in score cache for %s/%s",
+                            project, run_id, exc_info=True,
+                        )
             return run_scoped_version(params, keys[0], keys[1], dismissed, deleted)
 
         is_cacheable = (

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -249,11 +249,13 @@ def _make_status_aware_fetcher(
         # without that anchor we'd evict every test stub that pre-seeds
         # the cache without creating disk state.
         key = (reports_root, project, run_id, version)
-        if key in resolved_cache:
+        with resolved_lock:
+            cached_dims = resolved_cache.get(key)
+        if cached_dims is not None:
             eval_dir = reports_root / project / run_id / "evaluation"
             if eval_dir.is_dir():
                 on_disk = _count_eval_files(reports_root, project, run_id)
-                if len(resolved_cache[key]) != on_disk:
+                if len(cached_dims) != on_disk:
                     with resolved_lock:
                         resolved_cache.pop(key, None)
         return cached(run_id)

--- a/src/quodeq/services/deleted.py
+++ b/src/quodeq/services/deleted.py
@@ -11,7 +11,9 @@ guarded by the same kind of POSIX file lock used by ``dismissed.py``.
 from __future__ import annotations
 
 import json
+import logging
 import os
+import sqlite3
 from contextlib import contextmanager
 from dataclasses import replace
 from datetime import datetime, timezone
@@ -26,6 +28,8 @@ from quodeq.data._file_lock import lock_file, unlock_file
 from quodeq.data.actions_log import ActionLogWriter
 from quodeq.services.dismissed import recount_totals
 
+
+_logger = logging.getLogger(__name__)
 
 _FILENAME = "deleted.json"
 
@@ -175,7 +179,11 @@ def _sweep_dismissed_matching(project_dir: Path, key: tuple) -> int:
                     (dimension, principle, file),
                 ):
                     matching.append((row[0] or "", row[1] or "", int(row[2] or 0)))
-        except Exception:
+        except (sqlite3.Error, OSError):
+            _logger.warning(
+                "Skipping unreadable evaluation.db while undismissing in %s",
+                run_dir, exc_info=True,
+            )
             continue
 
     if not matching:

--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -18,6 +18,7 @@ import subprocess
 from quodeq.core.types import JobSnapshot
 
 from quodeq.analysis._process import _kill_tree, _terminate_process
+from quodeq.shared._env import env_float
 from quodeq.shared.run_log import RunLogWriter
 from quodeq.services._job_model import (
     Job,
@@ -179,8 +180,10 @@ class JobManager:
 
     def _cancel_external(self, job_id: str, reports_root: Path) -> bool:
         """Send SIGTERM to an external run's process."""
-        from quodeq.services._external_jobs import cancel_external_run
+        from quodeq.services._external_jobs import cancel_external_run, is_safe_run_segment
         run_id = job_id[len("ext-"):]
+        if not is_safe_run_segment(run_id):
+            return False
         for project_dir in reports_root.iterdir():
             if not project_dir.is_dir():
                 continue
@@ -398,7 +401,7 @@ class JobManager:
         re-enable a wall-clock cap. Otherwise the watchdog only enforces
         the user-set ``deadline_at`` (with a grace window).
         """
-        return float(os.environ.get("QUODEQ_JOB_TIMEOUT_S", "0"))
+        return env_float("QUODEQ_JOB_TIMEOUT_S", 0.0, minimum=0.0)
 
     def _watchdog_should_kill(self, job_id: str, started_at: float) -> bool:
         """Return True when the watchdog should SIGKILL the job process now."""

--- a/src/quodeq/services/run_index.py
+++ b/src/quodeq/services/run_index.py
@@ -181,18 +181,18 @@ def _sync_one_run(
             try:
                 _upsert_from_status(db, run_dir, project_uuid=project_uuid, run_id=run_id)
             except Exception as exc:
-                _logger.warning("skipping run %s: %s", run_dir, exc)
+                _logger.warning("skipping run %s: %s", run_dir, exc, exc_info=True)
                 return
         # Always check staleness, even on mtime-unchanged runs.
         try:
             _check_stale_and_promote(db, run_dir, project_uuid=project_uuid, run_id=run_id)
         except Exception as exc:
-            _logger.warning("stale-check failed for %s: %s", run_dir, exc)
+            _logger.warning("stale-check failed for %s: %s", run_dir, exc, exc_info=True)
     else:
         try:
             _sync_legacy_run(db, run_dir, project_uuid=project_uuid, run_id=run_id)
         except Exception as exc:
-            _logger.warning("legacy sync failed for %s: %s", run_dir, exc)
+            _logger.warning("legacy sync failed for %s: %s", run_dir, exc, exc_info=True)
 
 
 # ---------------------------------------------------------------------------

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -19,7 +19,6 @@ change.
 from __future__ import annotations
 
 import logging
-import os
 from dataclasses import replace
 from pathlib import Path
 from typing import Any, Callable
@@ -48,13 +47,14 @@ from quodeq.services.score_cache import (
 )
 from quodeq.services.ports import RunInfo, list_runs, read_run_data, read_run_scalars
 from quodeq.services.rescore import _rescore_dimension, rescore_dimensions
+from quodeq.shared._env import env_int
 from quodeq.shared.validation import validate_path_segment
 from quodeq.services.scoring._summary import recompute_summary
 
 
 def _max_history_runs() -> int:
     """Read max history runs from env at call time for lazy configuration."""
-    return int(os.environ.get("QUODEQ_MAX_HISTORY_RUNS", "100"))
+    return env_int("QUODEQ_MAX_HISTORY_RUNS", 100, minimum=1)
 
 
 # ---------------------------------------------------------------------------

--- a/src/quodeq/services/violations_parsing.py
+++ b/src/quodeq/services/violations_parsing.py
@@ -6,7 +6,6 @@ modules are re-exported here for backward compatibility.
 """
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -131,7 +130,8 @@ def parse_violations_from_evidence(evidence_path: Path, ctx: ViolationContext) -
     """Extract violations from a completed evidence JSON file."""
     try:
         data = read_json(evidence_path)
-    except (OSError, json.JSONDecodeError):
+    except (OSError, ValueError):
+        # read_json wraps JSONDecodeError and non-object payloads in ValueError.
         return None
     violations = _extract_violations_from_principles(data.get("principles") or {})
     return _build_violation_response(ctx, violations, [], _ResponseOptions(partial=True))

--- a/src/quodeq/shared/_env.py
+++ b/src/quodeq/shared/_env.py
@@ -36,14 +36,66 @@ def get_ai_model(env: dict[str, str] | None = None) -> str | None:
 
 def _env_int(var: str, default: int, env: dict[str, str] | None = None) -> int:
     """Read an environment variable as an int, warn and return *default* on failure."""
+    return env_int(var, default, env=env)
+
+
+def env_int(
+    var: str,
+    default: int,
+    *,
+    minimum: int | None = None,
+    env: dict[str, str] | None = None,
+) -> int:
+    """Read an env var as an int; warn and return *default* on parse failure.
+
+    When *minimum* is given, parsed values below it also fall back to *default*.
+    """
     raw = (env or os.environ).get(var)
     if raw is not None:
         try:
-            return int(raw)
+            value = int(raw)
         except ValueError:
             logging.getLogger(__name__).warning(
-                "Invalid %s=%r (expected integer), using default", var, raw,
+                "Invalid %s=%r (expected integer), using default %r", var, raw, default,
             )
+        else:
+            if minimum is not None and value < minimum:
+                logging.getLogger(__name__).warning(
+                    "Out-of-range %s=%r (minimum %r), using default %r",
+                    var, raw, minimum, default,
+                )
+            else:
+                return value
+    return default
+
+
+def env_float(
+    var: str,
+    default: float,
+    *,
+    minimum: float | None = None,
+    env: dict[str, str] | None = None,
+) -> float:
+    """Read an env var as a float; warn and return *default* on parse failure.
+
+    When *minimum* is given, parsed values below it also fall back to *default*.
+    """
+    raw = (env or os.environ).get(var)
+    if raw is not None:
+        try:
+            value = float(raw)
+        except ValueError:
+            logging.getLogger(__name__).warning(
+                "Invalid %s=%r (expected number), using default %r", var, raw, default,
+            )
+        else:
+            if minimum is not None and value < minimum:
+                logging.getLogger(__name__).warning(
+                    "Out-of-range %s=%r (minimum %r), using default %r",
+                    var, raw, minimum, default,
+                )
+            else:
+                return value
     return default
 
 

--- a/src/quodeq/shared/_process_kill.py
+++ b/src/quodeq/shared/_process_kill.py
@@ -24,9 +24,12 @@ def kill_proc_tree(proc: Any) -> None:
     if pid is not None:
         if sys.platform == "win32":
             try:
-                subprocess.run(["taskkill", "/F", "/T", "/PID", str(pid)],
-                               capture_output=True, timeout=10)
-                return
+                result = subprocess.run(["taskkill", "/F", "/T", "/PID", str(pid)],
+                                        capture_output=True, timeout=10)
+                # A non-zero exit (access denied, no such process, ...) means
+                # the tree was NOT killed; fall through to proc.kill().
+                if result.returncode == 0:
+                    return
             except (OSError, subprocess.SubprocessError, TypeError):
                 pass
         else:

--- a/src/quodeq/shared/_security.py
+++ b/src/quodeq/shared/_security.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 import re
 
 SENSITIVE_PATTERNS = re.compile(
-    r"(api[_-]?key|token|secret|password|authorization)[=:\s]+\S+",
+    # The optional quote after the keyword catches JSON-shaped credentials
+    # such as `"token": "abc"`; the [=:\s]+ separator keeps the existing
+    # `token=abc` / `token: abc` / `token abc` forms matching.
+    r"(api[_-]?key|token|secret|password|authorization)[\"']?[=:\s]+\S+",
     re.IGNORECASE,
 )
 """Compiled regex for detecting secrets in log/error output."""

--- a/src/quodeq/shared/resource_sampler.py
+++ b/src/quodeq/shared/resource_sampler.py
@@ -112,7 +112,11 @@ class ResourceSampler:
         thread = self._thread
         if thread is not None and thread.is_alive():
             thread.join(timeout=timeout)
-        self._thread = None
+        # Only forget the thread once it actually stopped: dropping a
+        # still-alive thread would let a later start() clear _stop and revive
+        # the old loop alongside the new one (duplicate [resources] lines).
+        if thread is None or not thread.is_alive():
+            self._thread = None
 
     def sample_once(self) -> str:
         """Compute and return a snapshot line without logging it. Useful for tests."""

--- a/src/quodeq/terminal/_pty_unix.py
+++ b/src/quodeq/terminal/_pty_unix.py
@@ -110,7 +110,7 @@ class UnixPty:
             # sends SIGKILL, so this returns promptly; bound it regardless).
             try:
                 self._proc.wait(timeout=2)
-            except Exception:
+            except subprocess.TimeoutExpired:
                 pass
         if self._master_fd is not None:
             try:

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -308,9 +308,11 @@ export function getOmlxStatus(baseUrl) {
 export async function getOmlxModels(baseUrl, apiKey) {
   const params = new URLSearchParams();
   if (baseUrl) params.set('base_url', baseUrl);
-  if (apiKey) params.set('api_key', apiKey);
   const qs = params.toString() ? `?${params}` : '';
-  const data = await request(`/omlx/models${qs}`);
+  // The API key travels in a header, never the query string: query strings
+  // end up in server access logs and browser history.
+  const options = apiKey ? { headers: { 'X-Api-Key': apiKey } } : {};
+  const data = await request(`/omlx/models${qs}`, options);
   return data?.models ?? [];
 }
 
@@ -414,11 +416,22 @@ export function markUpdateDisclosed() {
  * @throws {Error & { status: number, code?: string, existingProjectId?: string }} on non-2xx
  */
 export async function registerProject(payload) {
-  const res = await fetch('/api/projects', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
+  let res;
+  try {
+    res = await fetch('/api/projects', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      // Generous: registration may clone a large repository server-side,
+      // but a hung backend must not leave onboarding pending forever.
+      signal: AbortSignal.timeout(600000), // 10 min
+    });
+  } catch (e) {
+    if (e?.name === 'TimeoutError' || e?.name === 'AbortError') {
+      throw new Error('Project registration timed out. The server may be unresponsive or the clone is taking too long; try again.');
+    }
+    throw e;
+  }
   const body = await res.json().catch(() => ({}));
   if (!res.ok) {
     const err = new Error(body.error || `registerProject failed (${res.status})`);

--- a/src/quodeq/ui/src/api/index.test.jsx
+++ b/src/quodeq/ui/src/api/index.test.jsx
@@ -1,8 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { registerProject } from './index.js';
+import { registerProject, getOmlxModels } from './index.js';
 
 beforeEach(() => {
   global.fetch = vi.fn();
+});
+
+describe('getOmlxModels', () => {
+  it('sends the API key as X-Api-Key header, never in the query string', async () => {
+    global.fetch.mockResolvedValue({ ok: true, json: async () => ({ models: [] }) });
+    await getOmlxModels('http://localhost:1234', 'sk-secret');
+    const [url, opts] = global.fetch.mock.calls[0];
+    expect(url).toContain('base_url=');
+    expect(url).not.toContain('api_key');
+    expect(url).not.toContain('sk-secret');
+    expect(opts.headers['X-Api-Key']).toBe('sk-secret');
+  });
+
+  it('omits the header when no key is given', async () => {
+    global.fetch.mockResolvedValue({ ok: true, json: async () => ({ models: [{ id: 'm' }] }) });
+    const models = await getOmlxModels('', '');
+    const [url, opts] = global.fetch.mock.calls[0];
+    expect(url).not.toContain('api_key');
+    expect(opts.headers['X-Api-Key']).toBeUndefined();
+    expect(models).toEqual([{ id: 'm' }]);
+  });
 });
 
 describe('registerProject', () => {
@@ -56,6 +77,20 @@ describe('registerProject', () => {
     expect(caught).toBeDefined();
     expect(caught.code).toBe('MISSING_CLONE_DEST');
     expect(caught.status).toBe(400);
+  });
+
+  it('passes an abort signal so a hung backend cannot stall onboarding', async () => {
+    global.fetch.mockResolvedValue({ ok: true, json: async () => ({ projectId: 'u', scanData: {} }) });
+    await registerProject({ repo: '/tmp/repo' });
+    const [, opts] = global.fetch.mock.calls[0];
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('maps a timeout to a clear user-facing error', async () => {
+    const timeoutErr = new Error('signal timed out');
+    timeoutErr.name = 'TimeoutError';
+    global.fetch.mockRejectedValue(timeoutErr);
+    await expect(registerProject({ repo: '/tmp/repo' })).rejects.toThrow(/timed out/i);
   });
 });
 

--- a/src/quodeq/ui/src/api/shared.js
+++ b/src/quodeq/ui/src/api/shared.js
@@ -287,11 +287,22 @@ export function publishProject(projectId) {
  */
 export async function pullSharedProject(projectId, action) {
   const body = action ? { action } : {};
-  const res = await fetch(`${BASE}/shared/projects/${encodeURIComponent(projectId)}/pull`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
+  let res;
+  try {
+    res = await fetch(`${BASE}/shared/projects/${encodeURIComponent(projectId)}/pull`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      // Generous: a pull imports a zip stream from the shared repository,
+      // but a stalled connection must not leave the pull pending forever.
+      signal: AbortSignal.timeout(600000), // 10 min
+    });
+  } catch (e) {
+    if (e?.name === 'TimeoutError' || e?.name === 'AbortError') {
+      throw new Error('Pull timed out. Check the shared repository connection and try again.');
+    }
+    throw e;
+  }
   const payload = await res.json().catch(() => ({}));
   if (!res.ok) {
     const err = new Error(payload.error || `pullSharedProject failed (${res.status})`);

--- a/src/quodeq/ui/src/api/shared.test.jsx
+++ b/src/quodeq/ui/src/api/shared.test.jsx
@@ -370,5 +370,14 @@ describe('shared repo API client', () => {
         projectName: 'demo-repo',
       });
     });
+
+    it('pullSharedProject passes an abort signal and maps a timeout to a clear error', async () => {
+      await shared.pullSharedProject('proj1');
+      expect(calls[0].opts.signal).toBeInstanceOf(AbortSignal);
+      const timeoutErr = new Error('signal timed out');
+      timeoutErr.name = 'TimeoutError';
+      globalThis.fetch = vi.fn(async () => { throw timeoutErr; });
+      await expect(shared.pullSharedProject('proj1')).rejects.toThrow(/timed out/i);
+    });
   });
 });

--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -156,10 +156,15 @@ export default function RunHistoryPanel({ trend = [], selectedRunId = null, onBa
   const suffix = GRANULARITY_SUFFIX[granularity] || 'd';
   let stats = null;
   if (hasChart) {
-    const min = Math.min(...data.map((d) => d.numericAverage).filter((n) => !Number.isNaN(n)));
-    const max = Math.max(...data.map((d) => d.numericAverage).filter((n) => !Number.isNaN(n)));
-    const avg = data.reduce((s, d) => s + (Number.isNaN(d.numericAverage) ? 0 : d.numericAverage), 0) / data.length;
-    stats = `MIN ${min.toFixed(1)} / MAX ${max.toFixed(1)} / AVG ${avg.toFixed(1)}`;
+    // All-NaN buckets would make Math.min/max over an empty array yield
+    // Infinity/-Infinity; skip the stats line entirely in that case.
+    const valid = data.map((d) => d.numericAverage).filter((n) => !Number.isNaN(n));
+    if (valid.length > 0) {
+      const min = Math.min(...valid);
+      const max = Math.max(...valid);
+      const avg = valid.reduce((s, n) => s + n, 0) / valid.length;
+      stats = `MIN ${min.toFixed(1)} / MAX ${max.toFixed(1)} / AVG ${avg.toFixed(1)}`;
+    }
   }
 
   return (

--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.test.jsx
@@ -32,4 +32,14 @@ describe('RunHistoryPanel', () => {
     expect(screen.getByLabelText('Group score history by')).toBeInTheDocument();
     expect(screen.queryByText(/MIN /)).not.toBeInTheDocument();
   });
+
+  it('hides the stats line instead of rendering Infinity when no bucket has a numeric score', () => {
+    const nanTrend = [
+      { runId: 'r1', dateISO: '2026-03-25T14:00:00', dateLabel: '25 Mar 2026', numericAverage: 'n/a', overallGrade: 'Good' },
+      { runId: 'r2', dateISO: '2026-03-24T10:00:00', dateLabel: '24 Mar 2026', numericAverage: 'n/a', overallGrade: 'Good' },
+    ];
+    render(<RunHistoryPanel trend={nanTrend} selectedRunId="r1" granularity="day" onGranularityChange={() => {}} />);
+    expect(screen.queryByText(/MIN /)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Infinity/)).not.toBeInTheDocument();
+  });
 });

--- a/src/quodeq/ui/src/features/drawer/BottomDrawer.jsx
+++ b/src/quodeq/ui/src/features/drawer/BottomDrawer.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, lazy, Suspense } from 'react';
+import React, { useCallback, useEffect, useRef, lazy, Suspense } from 'react';
 import { useAssistantDrawer } from '../assistant/AssistantDrawerProvider.jsx';
 import { AssistantPane } from '../assistant/AssistantDrawer.jsx';
 import { ChevronDownIcon, GlobeIcon, MaximizeIcon, MinimizeIcon, PencilIcon, RotateCcwIcon } from '../../components/CopyButton.jsx';
@@ -53,6 +53,12 @@ export function BottomDrawer({ uiState }) {
     window.addEventListener('pointermove', handleDragMove);
     window.addEventListener('pointerup', handleDragEnd);
   }, [height, maximized, setMaximized, handleDragMove, handleDragEnd]);
+  // Unmounting mid-drag would leave the window listeners registered and the
+  // stale handlers calling setHeight until the next pointerup; drop them.
+  useEffect(() => () => {
+    window.removeEventListener('pointermove', handleDragMove);
+    window.removeEventListener('pointerup', handleDragEnd);
+  }, [handleDragMove, handleDragEnd]);
 
   if (!isOpen) return null;
   // Guard against a transient render where activeTab isn't (yet) an open panel.

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -142,7 +142,12 @@ export function useEvaluation() {
         job.dimensions.map((d) =>
           api.getDimensionEval(job.outputProject, job.outputRunId, d)
             .then((data) => (data?.violations || []).map((v) => ({ ...v, dimension: d })))
-            .catch(() => []),
+            // Tolerate not-yet-written dimension evals during live polling,
+            // but leave a diagnostic so a real fetch failure is visible.
+            .catch((err) => {
+              console.warn(`Failed to fetch ${d} evaluation:`, err);
+              return [];
+            }),
         ),
       );
       return results.flat();

--- a/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.js
+++ b/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.js
@@ -138,7 +138,11 @@ export function useExplorerData(project, dimension, runId, refreshSignal, select
     fetchRunScores(project, runId).then((rescored) => {
       const dimData = (rescored.dimensions || []).find((d) => d.dimension === dimension);
       if (dimData) setEvalData((prev) => mergeRescoreIntoEval(prev, dimData));
-    }).catch(() => {});
+    }).catch((err) => {
+      // Non-blocking: the explorer keeps the previous scores on screen, but
+      // log the failure so the silent-stale state is diagnosable.
+      console.warn('Rescore refresh failed:', err);
+    });
   }, [refreshSignal]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Live updates after a dismiss arrive synchronously in the dismiss HTTP

--- a/src/quodeq/ui/src/features/onboarding/components/steps/RepoScanStep.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/steps/RepoScanStep.jsx
@@ -41,7 +41,11 @@ export default function RepoScanStep({ state, actions, createProject, getProject
     try {
       const info = await getProjectInfo(existingProjectId);
       if (info.runsCount > 0) return false;
-      const scanRes = await fetch(`/api/projects/${encodeURIComponent(existingProjectId)}/scan`);
+      // Timeout so a backend that accepts but never responds cannot stall
+      // the resume flow; the catch below falls back to the normal error UI.
+      const scanRes = await fetch(`/api/projects/${encodeURIComponent(existingProjectId)}/scan`, {
+        signal: AbortSignal.timeout(120000),
+      });
       if (!scanRes.ok) return false;
       const scanData = await scanRes.json();
       actions.succeedScan(existingProjectId, scanData);

--- a/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
@@ -72,7 +72,7 @@ export default function CliProviderTab({ providerId, state, update }) {
 
   function persistPower(level) {
     setPower(level);
-    try { localStorage.setItem(POWER_KEY, String(level)); } catch { /* */ }
+    try { localStorage.setItem(POWER_KEY, String(level)); } catch (e) { console.warn('localStorage unavailable:', e); }
   }
 
   const hint = MODEL_HINTS[providerId];

--- a/src/quodeq/ui/src/features/updates/UpdateBanner.jsx
+++ b/src/quodeq/ui/src/features/updates/UpdateBanner.jsx
@@ -10,7 +10,7 @@ export default function UpdateBanner() {
   // First-run disclosure: record that the user has been informed.
   useEffect(() => {
     if (status && status.disclosed === false) {
-      markUpdateDisclosed().catch(() => {});
+      markUpdateDisclosed().catch((e) => console.warn('update-state persist failed:', e));
     }
   }, [status]);
 
@@ -18,7 +18,9 @@ export default function UpdateBanner() {
 
   const onDismiss = () => {
     setDismissed(true);
-    dismissUpdate(status.latest).catch(() => {});
+    // Optimistic dismiss: the banner simply reappears next launch if the
+    // request failed, but log the failure so it is diagnosable.
+    dismissUpdate(status.latest).catch((e) => console.warn('update-state persist failed:', e));
   };
 
   return (

--- a/src/quodeq/ui/src/hooks/useEvaluationLifecycle.js
+++ b/src/quodeq/ui/src/hooks/useEvaluationLifecycle.js
@@ -23,6 +23,13 @@ export function useEvaluationLifecycle({ settings, navigation, projects, selecte
   // (older) evaluation was the one they just launched.
   const [blockedStartError, setBlockedStartError] = useState(null);
 
+  // Storage reads degrade to '' when the backing store throws (private
+  // mode, disabled storage) instead of crashing the caller, matching the
+  // guarded reads below.
+  const safeGetItem = (key) => {
+    try { return storage.getItem(key) || ''; } catch (e) { console.warn('localStorage unavailable:', e); return ''; }
+  };
+
   const [analysisPower, setAnalysisPower] = useState(() => {
     try { return Number(storage.getItem(POWER_KEY)) || DEFAULT_ANALYSIS_POWER; } catch (e) { console.warn('localStorage unavailable:', e); return DEFAULT_ANALYSIS_POWER; }
   });
@@ -69,8 +76,8 @@ export function useEvaluationLifecycle({ settings, navigation, projects, selecte
       return false;
     }
     setBlockedStartError(null);
-    const activeProvider = storage.getItem(ACTIVE_PROVIDER_KEY) || '';
-    const get = (key) => storage.getItem(providerKey(activeProvider, key));
+    const activeProvider = safeGetItem(ACTIVE_PROVIDER_KEY);
+    const get = (key) => safeGetItem(providerKey(activeProvider, key));
     // Ollama uses a single analysis model; CLI providers use tier-based selection.
     // Falls back to the orchestrator model if no analysis-specific model is set.
     const analysisModel = get('model-analysis');
@@ -96,7 +103,7 @@ export function useEvaluationLifecycle({ settings, navigation, projects, selecte
     clearJob();
   }
 
-  const activeProvider = storage.getItem(ACTIVE_PROVIDER_KEY) || '';
+  const activeProvider = safeGetItem(ACTIVE_PROVIDER_KEY);
   const isLocalApi = LOCAL_API_PROVIDERS.has(activeProvider);
 
   return {

--- a/src/quodeq/ui/src/utils/dailyGrouping.js
+++ b/src/quodeq/ui/src/utils/dailyGrouping.js
@@ -35,6 +35,10 @@ export function isoWeekKey(dateISO) {
   const [y, m, d] = datePart.split('-').map(Number);
   if (!y || !m || !d) return '';
   const date = new Date(Date.UTC(y, m - 1, d));
+  // Date.UTC normalizes impossible components (2026-02-31 becomes March);
+  // reject anything that does not round-trip so a malformed date is not
+  // grouped under a week it never specified.
+  if (date.getUTCFullYear() !== y || date.getUTCMonth() !== m - 1 || date.getUTCDate() !== d) return '';
   const dayNum = date.getUTCDay() || 7;           // Mon=1 .. Sun=7
   date.setUTCDate(date.getUTCDate() + 4 - dayNum); // shift to this week's Thursday
   const isoYear = date.getUTCFullYear();

--- a/src/quodeq/ui/src/utils/dailyGrouping.test.js
+++ b/src/quodeq/ui/src/utils/dailyGrouping.test.js
@@ -283,6 +283,15 @@ test('isoWeekKey: year-boundary week belongs to the ISO year of its Thursday', (
   assert.equal(isoWeekKey('2026-01-04T00:00:00'), '2026-W01'); // Sunday, still W01
 });
 
+test('isoWeekKey: impossible calendar components are rejected, not normalized', () => {
+  // Date.UTC would normalize 2026-02-31 to 2026-03-03; the entry must not
+  // be grouped under a week it never specified.
+  assert.equal(isoWeekKey('2026-02-31'), '');
+  assert.equal(isoWeekKey('2026-13-01'), '');
+  // A valid edge day (leap day) still produces a week key.
+  assert.notEqual(isoWeekKey('2028-02-29'), '');
+});
+
 test('isoWeekKey: missing/empty date returns empty string', () => {
   assert.equal(isoWeekKey(''), '');
   assert.equal(isoWeekKey(null), '');

--- a/src/quodeq/update/state.py
+++ b/src/quodeq/update/state.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -53,10 +54,20 @@ def read_state(env: dict[str, str] | None = None) -> UpdateState:
 
 def write_state(state: UpdateState, env: dict[str, str] | None = None) -> None:
     path = Path(get_update_state_path(env))
+    # Write a fresh unique temp file then os.replace() onto the target so
+    # concurrent writers (dashboard, menubar, CLI) never share a temp path
+    # and a reader never sees a half-written file.
+    tmp_name: str | None = None
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(path.suffix + ".tmp")
-        tmp.write_text(json.dumps(asdict(state), indent=2), encoding="utf-8")
-        os.replace(tmp, path)
+        tmp_fd, tmp_name = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps(asdict(state), indent=2))
+        os.replace(tmp_name, path)
     except OSError:
-        pass  # fail-silent: a notice is never worth crashing over
+        # fail-silent: a notice is never worth crashing over
+        if tmp_name is not None:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass

--- a/tests/api/test_assistant_routes.py
+++ b/tests/api/test_assistant_routes.py
@@ -714,3 +714,43 @@ def test_stop_cancels_running_turn_and_frees_the_token(client, monkeypatch):
         pytest.fail("cancel token not cleaned up after the turn ended")
     assert client.post(f"/api/assistant/sessions/{sid}/messages",
                        json={"text": "again"}).status_code == 202
+
+
+# ---------------------------------------------------------------------------
+# SEC-00 -- each open SSE stream pins a worker thread and GETs bypass the
+# global rate limiter, so the events endpoint caps concurrently open streams.
+# ---------------------------------------------------------------------------
+
+def test_events_stream_returns_429_above_cap(client, monkeypatch):
+    from quodeq.api import assistant_routes
+
+    sid = client.post("/api/assistant/sessions",
+                      json={"provider": "ollama", "model": "m"}).get_json()["sessionId"]
+    monkeypatch.setattr(assistant_routes, "_open_sse_streams",
+                        assistant_routes._MAX_SSE_STREAMS)
+    resp = client.get(f"/api/assistant/sessions/{sid}/events?after=0")
+    assert resp.status_code == 429
+    assert "error" in resp.get_json()
+
+
+def test_events_stream_releases_slot_when_stream_ends(client, monkeypatch):
+    from quodeq.api import assistant_routes
+
+    monkeypatch.setattr("quodeq.api._assistant_helpers._POLL_SECONDS", 0.001)
+    monkeypatch.setattr("quodeq.api._assistant_helpers._IDLE_LIMIT", 5)
+    sid = client.post("/api/assistant/sessions",
+                      json={"provider": "ollama", "model": "m"}).get_json()["sessionId"]
+    stream = client.get(f"/api/assistant/sessions/{sid}/events?after=0")
+    assert stream.status_code == 200
+    stream.get_data(as_text=True)  # drain to completion
+    stream.close()
+    assert assistant_routes._open_sse_streams == 0
+
+
+def test_events_stream_404_does_not_consume_slot(client):
+    from quodeq.api import assistant_routes
+
+    before = assistant_routes._open_sse_streams
+    resp = client.get("/api/assistant/sessions/nope/events?after=0")
+    assert resp.status_code == 404
+    assert assistant_routes._open_sse_streams == before

--- a/tests/api/test_llm_bridge_routes.py
+++ b/tests/api/test_llm_bridge_routes.py
@@ -148,3 +148,85 @@ class TestEstimateAgentsValidation:
         )
         assert resp.status_code == 400
         assert resp.get_json()["code"] == "INVALID_PARAM"
+
+
+# ---------------------------------------------------------------------------
+# SEC-13 — the OMLX models route takes the API key from the X-Api-Key header,
+#          never from the query string (query params leak via access logs,
+#          browser history, and referrers).
+# ---------------------------------------------------------------------------
+
+class TestOmlxModels:
+    def test_api_key_read_from_header(self, client):
+        with patch("quodeq.api.llm_bridge_routes.list_omlx_models") as mock:
+            mock.return_value = []
+            resp = client.get(
+                "/api/omlx/models?base_url=http://localhost:10240",
+                headers={"X-Api-Key": " sk-header "},
+            )
+        assert resp.status_code == 200
+        mock.assert_called_once_with(base_url="http://localhost:10240", api_key="sk-header")
+
+    def test_api_key_query_param_no_longer_honored(self, client):
+        with patch("quodeq.api.llm_bridge_routes.list_omlx_models") as mock:
+            mock.return_value = []
+            resp = client.get("/api/omlx/models?api_key=sk-leaky")
+        assert resp.status_code == 200
+        mock.assert_called_once_with(base_url=None, api_key=None)
+
+
+# ---------------------------------------------------------------------------
+# REL-084/085/086/087/088 — POST routes must 400 on a JSON body that parses
+# but is not an object (e.g. [1] or "x"), instead of crashing at data.get.
+# ---------------------------------------------------------------------------
+
+class TestJsonObjectBodyRequired:
+    @pytest.mark.parametrize("route", [
+        "/api/ollama/test-concurrency",
+        "/api/ollama/estimate-agents",
+        "/api/llamacpp/test-concurrency",
+        "/api/omlx/test-concurrency",
+        "/api/provider/test",
+    ])
+    def test_array_body_returns_400(self, client, route):
+        resp = client.post(route, json=[1], headers={"Origin": "http://localhost"})
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "INVALID_PARAM"
+
+    @pytest.mark.parametrize("route", [
+        "/api/ollama/test-concurrency",
+        "/api/omlx/test-concurrency",
+    ])
+    def test_string_body_returns_400(self, client, route):
+        resp = client.post(route, json="x", headers={"Origin": "http://localhost"})
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "INVALID_PARAM"
+
+    def test_omlx_non_string_base_url_returns_400(self, client):
+        resp = client.post(
+            "/api/omlx/test-concurrency",
+            json={"model": "m", "base_url": 123},
+            headers={"Origin": "http://localhost"},
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "INVALID_PARAM"
+
+    def test_omlx_non_string_api_key_returns_400(self, client):
+        resp = client.post(
+            "/api/omlx/test-concurrency",
+            json={"model": "m", "api_key": ["k"]},
+            headers={"Origin": "http://localhost"},
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "INVALID_PARAM"
+
+    def test_omlx_valid_string_fields_pass_through(self, client):
+        with patch("quodeq.api.llm_bridge_routes.run_omlx_concurrency_test") as mock:
+            mock.return_value = {"recommended": 2}
+            resp = client.post(
+                "/api/omlx/test-concurrency",
+                json={"model": "m", "base_url": " http://x ", "api_key": ""},
+                headers={"Origin": "http://localhost"},
+            )
+        assert resp.status_code == 200
+        mock.assert_called_once_with("m", base_url="http://x", api_key=None)

--- a/tests/api/test_llm_bridge_routes.py
+++ b/tests/api/test_llm_bridge_routes.py
@@ -230,3 +230,42 @@ class TestJsonObjectBodyRequired:
             )
         assert resp.status_code == 200
         mock.assert_called_once_with("m", base_url="http://x", api_key=None)
+
+
+# ---------------------------------------------------------------------------
+# base_url on the omlx routes must pass the same SSRF validation as
+# /api/provider/test: http(s) scheme only (private/LAN hosts stay allowed
+# for self-hosted servers).
+# ---------------------------------------------------------------------------
+
+class TestOmlxBaseUrlValidation:
+    def _get(self, client, route, base_url):
+        return client.get(f"{route}?base_url={base_url}")
+
+    @pytest.mark.parametrize("route", ["/api/omlx/status", "/api/omlx/models"])
+    def test_non_http_scheme_rejected(self, client, route):
+        resp = self._get(client, route, "ftp://internal-host/models")
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "INVALID_URL"
+
+    @pytest.mark.parametrize("route", ["/api/omlx/status", "/api/omlx/models"])
+    def test_missing_hostname_rejected(self, client, route):
+        resp = self._get(client, route, "http://")
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "INVALID_URL"
+
+    def test_post_route_rejects_non_http_scheme(self, client):
+        resp = client.post(
+            "/api/omlx/test-concurrency",
+            json={"model": "m", "base_url": "file:///etc/passwd"},
+            headers={"Origin": "http://localhost"},
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "INVALID_URL"
+
+    def test_localhost_base_url_accepted(self, client):
+        with patch("quodeq.api.llm_bridge_routes.get_omlx_status") as mock:
+            mock.return_value = {"running": True}
+            resp = self._get(client, "/api/omlx/status", "http://127.0.0.1:10240")
+        assert resp.status_code == 200
+        mock.assert_called_once_with(base_url="http://127.0.0.1:10240")

--- a/tests/api/test_rate_limit_hardening.py
+++ b/tests/api/test_rate_limit_hardening.py
@@ -68,3 +68,56 @@ def test_validated_path_rejects_dotdot_in_raw_path(tmp_path: Path):
     assert ".." in Path(raw).parts, "precondition: '..' must be in raw parts"
     assert ".." not in Path(raw).resolve().parts, "precondition: resolve() removes '..'"
     assert _validated_rate_limit_path(raw) == _DEFAULT_RATE_LIMIT_FILE
+
+
+# ---------------------------------------------------------------------------
+# REL-082/083 -- window/max env values must be positive; zero, negative, or
+# malformed values fall back to the defaults instead of disabling the limiter
+# (window <= 0) or blocking every client (max <= 0).
+# ---------------------------------------------------------------------------
+
+from quodeq.api._rate_limit_config import (
+    _DEFAULT_RATE_LIMIT_MAX,
+    _DEFAULT_RATE_LIMIT_WINDOW,
+    _rate_limit_max,
+    _rate_limit_window,
+)
+
+
+@pytest.mark.parametrize("raw", ["0", "-5", "abc", ""])
+def test_rate_limit_window_falls_back_on_invalid_env(raw):
+    assert _rate_limit_window(env={"QUODEQ_RATE_LIMIT_WINDOW": raw}) == _DEFAULT_RATE_LIMIT_WINDOW
+
+
+def test_rate_limit_window_accepts_valid_env():
+    assert _rate_limit_window(env={"QUODEQ_RATE_LIMIT_WINDOW": "30"}) == 30
+
+
+@pytest.mark.parametrize("raw", ["0", "-1", "many", ""])
+def test_rate_limit_max_falls_back_on_invalid_env(raw):
+    assert _rate_limit_max(env={"QUODEQ_RATE_LIMIT_MAX": raw}) == _DEFAULT_RATE_LIMIT_MAX
+
+
+def test_rate_limit_max_accepts_valid_env():
+    assert _rate_limit_max(env={"QUODEQ_RATE_LIMIT_MAX": "5"}) == 5
+
+
+# ---------------------------------------------------------------------------
+# REL-078 -- a valid-JSON-but-non-object state file must not crash
+# record()/check(); it is treated as empty state.
+# ---------------------------------------------------------------------------
+
+def test_load_treats_non_dict_json_as_empty(tmp_path: Path):
+    target = tmp_path / "rl.json"
+    target.write_text("[1, 2, 3]", encoding="utf-8")
+    store = FileRateLimitStore(path=target)
+    assert store.check("1.2.3.4", 1000.0) is False
+    store.record("1.2.3.4", 1000.0)  # must not raise
+    assert "1.2.3.4" in json.loads(target.read_text(encoding="utf-8"))
+
+
+def test_load_treats_scalar_json_as_empty(tmp_path: Path):
+    target = tmp_path / "rl.json"
+    target.write_text('"corrupt"', encoding="utf-8")
+    store = FileRateLimitStore(path=target)
+    assert store.check("1.2.3.4", 1000.0) is False

--- a/tests/api/test_routes_findings.py
+++ b/tests/api/test_routes_findings.py
@@ -501,3 +501,63 @@ class TestVerifiedEndpoints:
         assert resp.status_code == 400
         data = resp.get_json()
         assert data["code"] == "MISSING_PARAM"
+
+
+class TestBodyTypeValidation:
+    """REL-038/039/040/041: malformed field types must 400 at the API
+    boundary instead of crashing in the service layer (a 500)."""
+
+    def test_dismiss_rejects_list_req(self, client, tmp_path):
+        (tmp_path / "my-project").mkdir()
+        resp = client.post("/api/findings/dismiss", json={
+            "project": "my-project", "req": ["M-MOD-4"], "file": "foo.js", "line": 4,
+        })
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "INVALID_PARAM"
+
+    def test_dismiss_rejects_string_line(self, client, tmp_path):
+        (tmp_path / "my-project").mkdir()
+        resp = client.post("/api/findings/dismiss", json={
+            "project": "my-project", "req": "M-MOD-4", "file": "foo.js", "line": "4",
+        })
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "INVALID_PARAM"
+
+    def test_dismiss_rejects_bool_line(self, client, tmp_path):
+        (tmp_path / "my-project").mkdir()
+        resp = client.post("/api/findings/dismiss", json={
+            "project": "my-project", "req": "M-MOD-4", "file": "foo.js", "line": True,
+        })
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "INVALID_PARAM"
+
+    def test_restore_rejects_dict_file(self, client, tmp_path):
+        (tmp_path / "my-project").mkdir()
+        resp = client.post("/api/findings/restore", json={
+            "project": "my-project", "req": "M-MOD-4", "file": {"p": "foo.js"}, "line": 4,
+        })
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "INVALID_PARAM"
+
+    def test_delete_rejects_list_dimension(self, client, tmp_path):
+        (tmp_path / "my-project").mkdir()
+        resp = client.post("/api/findings/delete", json={
+            "project": "my-project", "dimension": ["security"],
+            "principle": "Integrity", "file": "foo.js",
+        })
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "INVALID_PARAM"
+
+    def test_unverify_rejects_int_req(self, client, tmp_path):
+        (tmp_path / "my-project").mkdir()
+        resp = client.post("/api/findings/unverify", json={
+            "project": "my-project", "req": 7, "file": "a.py", "line": 3,
+        })
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "INVALID_PARAM"
+
+    def test_missing_fields_still_report_missing_param(self, client):
+        # The MISSING_PARAM contract for absent fields is unchanged.
+        resp = client.post("/api/findings/dismiss", json={"project": "x"})
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "MISSING_PARAM"

--- a/tests/api/test_routes_project_list.py
+++ b/tests/api/test_routes_project_list.py
@@ -251,13 +251,22 @@ class TestCreateProjectLocalPathValidation:
     allowlist as /api/scan (home or evaluations dir, no system paths)."""
 
     def test_local_repo_outside_home_rejected(self, client, tmp_path_factory):
-        # A pytest temp dir is outside the real home and outside the
-        # evaluations root the app fixture points at.
+        # Pin home to its own temp dir: the candidate repo must be outside it
+        # on every platform (on Windows the pytest tmp root lives UNDER the
+        # real home, so relying on the real Path.home() would pass the
+        # allowlist and return 200).
+        fake_home = tmp_path_factory.mktemp("fake-home")
         outside = tmp_path_factory.mktemp("outside-home-repo")
-        resp = client.post("/api/projects", json={"repo": str(outside)})
+        with patch("pathlib.Path.home", return_value=fake_home):
+            resp = client.post("/api/projects", json={"repo": str(outside)})
         assert resp.status_code == 403
         assert resp.get_json()["code"] == "FORBIDDEN"
 
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="blocked paths are POSIX system dirs; /etc does not exist on "
+        "Windows so the existence check 400s before the allowlist",
+    )
     def test_local_repo_system_dir_rejected(self, client):
         # Widen home to "/" so the allowlist passes and the blocked-path
         # check is the branch under test.

--- a/tests/api/test_routes_project_list.py
+++ b/tests/api/test_routes_project_list.py
@@ -42,6 +42,9 @@ class _FakeProvider:
     def get_project_info(self, reports_dir: str, project: str) -> dict:
         return self.project_info or {}
 
+    def invalidate_projects_cache(self) -> None:
+        self.cache_invalidated = True
+
 
 @pytest.fixture()
 def provider():
@@ -241,3 +244,42 @@ class TestScanPath:
              patch("pathlib.Path.home", return_value=tmp_path):
             resp = client.post("/api/scan", json={"path": str(target)})
             assert resp.status_code == 200
+
+
+class TestCreateProjectLocalPathValidation:
+    """SEC-24: the local-repo branch of create_project enforces the same
+    allowlist as /api/scan (home or evaluations dir, no system paths)."""
+
+    def test_local_repo_outside_home_rejected(self, client, tmp_path_factory):
+        # A pytest temp dir is outside the real home and outside the
+        # evaluations root the app fixture points at.
+        outside = tmp_path_factory.mktemp("outside-home-repo")
+        resp = client.post("/api/projects", json={"repo": str(outside)})
+        assert resp.status_code == 403
+        assert resp.get_json()["code"] == "FORBIDDEN"
+
+    def test_local_repo_system_dir_rejected(self, client):
+        # Widen home to "/" so the allowlist passes and the blocked-path
+        # check is the branch under test.
+        with patch("pathlib.Path.home", return_value=Path("/")):
+            resp = client.post("/api/projects", json={"repo": "/etc"})
+        assert resp.status_code == 403
+        assert resp.get_json()["code"] == "FORBIDDEN"
+
+    def test_local_repo_under_evaluations_root_accepted(self, client, tmp_path):
+        repo_dir = tmp_path / "myrepo"
+        repo_dir.mkdir()
+        with patch(
+            "quodeq.services.evaluation_mixin._register_project",
+            return_value="uuid-1",
+        ):
+            resp = client.post("/api/projects", json={"repo": str(repo_dir)})
+        assert resp.status_code == 200
+        assert resp.get_json()["projectId"] == "uuid-1"
+
+    def test_nonexistent_local_repo_still_400(self, client, tmp_path):
+        resp = client.post(
+            "/api/projects", json={"repo": str(tmp_path / "does-not-exist")}
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "INVALID_REPO"

--- a/tests/api/test_run_event_stream.py
+++ b/tests/api/test_run_event_stream.py
@@ -336,3 +336,29 @@ def test_run_events_generator_handles_already_terminal_run(tmp_path: Path):
 # evals. See ``routes_findings.py`` and the API-level tests for the new
 # mutation-returns-scores contract.
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# REL-023 -- a malformed QUODEQ_SSE_HEARTBEAT_S must not raise at module
+# import (that would prevent the API process from starting); it falls back
+# to the 15s default. Out-of-range values fall back too.
+# ---------------------------------------------------------------------------
+
+def test_heartbeat_env_fallback_never_breaks_import(monkeypatch):
+    import importlib
+
+    from quodeq.api import _run_event_stream as mod
+
+    try:
+        monkeypatch.setenv("QUODEQ_SSE_HEARTBEAT_S", "not-a-number")
+        assert importlib.reload(mod)._HEARTBEAT_S == 15.0
+
+        monkeypatch.setenv("QUODEQ_SSE_HEARTBEAT_S", "-3")
+        assert importlib.reload(mod)._HEARTBEAT_S == 15.0
+
+        monkeypatch.setenv("QUODEQ_SSE_HEARTBEAT_S", "2.5")
+        assert importlib.reload(mod)._HEARTBEAT_S == 2.5
+    finally:
+        # Restore the module to its env-clean state for other tests.
+        monkeypatch.delenv("QUODEQ_SSE_HEARTBEAT_S", raising=False)
+        importlib.reload(mod)

--- a/tests/assistant/test_tools_read.py
+++ b/tests/assistant/test_tools_read.py
@@ -206,6 +206,25 @@ def test_get_violations_aggregates_across_dimensions_when_omitted(ctx):
     assert res.get("dimension") in (None, "*")
 
 
+def test_get_report_rejects_traversal_dimension(ctx):
+    """The model-controlled `dimension` argument must never reach the
+    filesystem: traversal and absolute paths are rejected up front."""
+    # Plant a JSON file OUTSIDE the evaluation dir that a traversal would hit.
+    (ctx.run_dir / "secret.json").write_text(json.dumps({"stolen": True}))
+    reg = build_registry(ctx)
+    for evil in ("../secret", "../../other/secrets", "/etc/passwd", "a/b", "UPPER"):
+        out = reg.dispatch("get_report", {"dimension": evil})
+        assert out["ok"] is False
+        assert "invalid dimension" in out["error"]
+
+
+def test_get_violations_rejects_traversal_dimension(ctx):
+    reg = build_registry(ctx)
+    out = reg.dispatch("get_violations", {"dimension": "../secret"})
+    assert out["ok"] is False
+    assert "invalid dimension" in out["error"]
+
+
 def test_get_violations_missing_dimension_errors_helpfully(ctx):
     out = build_registry(ctx).dispatch("get_violations", {"dimension": "nope"})
     assert out["ok"] is False

--- a/tests/core/test_event_log_reader.py
+++ b/tests/core/test_event_log_reader.py
@@ -64,6 +64,22 @@ def test_resilience_to_corruption(writer: EventLogWriter, reader: EventLogReader
     assert events[1].payload.practice_id == "after_corruption"
 
 
+def test_malformed_json_hits_json_specific_handler(
+    writer: EventLogWriter, reader: EventLogReader, log_path: Path, caplog,
+):
+    """Regression: json.JSONDecodeError subclasses ValueError, so the JSON
+    branch must come first or malformed JSON is logged as 'Invalid event
+    structure' instead of 'Malformed JSON'."""
+    with open(log_path, "a") as f:
+        f.write("NOT_A_JSON_LINE\n")
+
+    with caplog.at_level("ERROR"):
+        assert list(reader.stream()) == []
+
+    assert any("Malformed JSON" in r.message for r in caplog.records)
+    assert not any("Invalid event structure" in r.message for r in caplog.records)
+
+
 def test_latest_timestamp(writer: EventLogWriter, reader: EventLogReader):
     payload = JudgmentPayload(practice_id="p1", verdict="compliance", dimension="D1", file="f1", line=1, reason="r1")
     writer.emit(JudgmentCreatedEvent(payload=payload))

--- a/tests/core/test_finding_mappings.py
+++ b/tests/core/test_finding_mappings.py
@@ -60,6 +60,28 @@ class TestWireDictToJudgment:
         )
         assert j.confidence == 50
 
+    def test_malformed_line_falls_back_to_zero(self):
+        """Regression: a non-numeric wire line must not raise -- the function
+        documents that it never raises on malformed input."""
+        j = wire_dict_to_judgment(
+            {"p": "P1", "t": "violation", "line": "not-a-number"})
+        assert j.line == 0
+
+    def test_numeric_string_line_coerced(self):
+        j = wire_dict_to_judgment({"p": "P1", "t": "violation", "line": "7"})
+        assert j.line == 7
+
+    def test_malformed_confidence_falls_back_to_100(self):
+        j = wire_dict_to_judgment(
+            {"p": "P1", "t": "violation", "confidence": "high"})
+        assert j.confidence == 100
+
+    def test_non_scalar_line_and_confidence_fall_back(self):
+        j = wire_dict_to_judgment(
+            {"p": "P1", "t": "violation", "line": [1, 2], "confidence": {"x": 1}})
+        assert j.line == 0
+        assert j.confidence == 100
+
     def test_violation_type_read_from_short_vt_key(self):
         """Regression: the JSONL wire format carries the taxonomy as 'vt'
         (see core/evidence/_jsonl.py); this reader must not silently drop it

--- a/tests/data/fs/test_resolution_fail_clean.py
+++ b/tests/data/fs/test_resolution_fail_clean.py
@@ -1,0 +1,53 @@
+"""_create_project must fail cleanly when the metadata write fails (REL-047)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from quodeq.data.fs._models import ProjectIdentity
+from quodeq.data.fs._resolution import _REPO_INFO_FILENAME, _create_project
+
+
+def _identity() -> ProjectIdentity:
+    return ProjectIdentity(project_name="proj", repo_path="/tmp/proj")
+
+
+def test_metadata_write_failure_propagates_and_skips_index(tmp_path, monkeypatch):
+    saved: list[dict] = []
+
+    def load_fn(reports_dir: Path) -> dict:
+        return {}
+
+    def save_fn(reports_dir: Path, index: dict) -> None:
+        saved.append(dict(index))
+
+    original_write_text = Path.write_text
+
+    def failing_write_text(self, *args, **kwargs):
+        if self.name == _REPO_INFO_FILENAME:
+            raise OSError("disk full")
+        return original_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", failing_write_text)
+
+    with pytest.raises(OSError):
+        _create_project(tmp_path, _identity(), load_fn, save_fn)
+
+    # The identity-to-project index must not record the broken project.
+    assert saved == []
+
+
+def test_successful_create_writes_metadata_and_indexes(tmp_path):
+    saved: list[dict] = []
+
+    def load_fn(reports_dir: Path) -> dict:
+        return {}
+
+    def save_fn(reports_dir: Path, index: dict) -> None:
+        saved.append(dict(index))
+
+    project_uuid = _create_project(tmp_path, _identity(), load_fn, save_fn)
+
+    assert (tmp_path / project_uuid / _REPO_INFO_FILENAME).is_file()
+    assert saved and list(saved[-1].values()) == [project_uuid]

--- a/tests/data/sqlite/test_row_mappers.py
+++ b/tests/data/sqlite/test_row_mappers.py
@@ -209,3 +209,23 @@ def test_judgment_to_row_optional_fields_default():
     assert row["req_refs_json"] == "[]"
     assert row["confidence"] == 100
     assert row["severity"] == "medium"
+
+
+def test_row_to_finding_malformed_refs_json_falls_back_to_empty():
+    row = {
+        "practice_id": "P-TIM-1",
+        "verdict": "violation",
+        "req_refs_json": "{not valid json",
+    }
+    finding = row_to_finding(row)
+    assert finding.req_refs == []
+
+
+def test_row_to_finding_valid_refs_json_still_parses():
+    row = {
+        "practice_id": "P-TIM-1",
+        "verdict": "violation",
+        "req_refs_json": '[{"label": "R1", "url": "https://x"}]',
+    }
+    finding = row_to_finding(row)
+    assert [(r.label, r.url) for r in finding.req_refs] == [("R1", "https://x")]

--- a/tests/engine/test_evidence_parser_line.py
+++ b/tests/engine/test_evidence_parser_line.py
@@ -43,6 +43,13 @@ class TestParseJsonlLine:
     def test_invalid_json(self):
         assert _parse_jsonl_line("not json") is None
 
+    def test_non_object_json_skipped(self):
+        """Regression: valid JSON that is not an object (array, string,
+        number) must be skipped, not raise AttributeError at obj.get."""
+        assert _parse_jsonl_line('["p", "t"]') is None
+        assert _parse_jsonl_line('"just a string"') is None
+        assert _parse_jsonl_line("42") is None
+
 
 class TestProvenanceDowngradeRoundTrip:
     """Issue #656: the provenance_downgrade marker must survive the

--- a/tests/llm_bridge/test_ollama.py
+++ b/tests/llm_bridge/test_ollama.py
@@ -35,6 +35,28 @@ class TestGetOllamaStatus:
         assert result["running"] is False
         assert "error" in result
 
+    def test_malformed_body_reports_not_running(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"<html>gateway error</html>"
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._ollama.urllib.request.urlopen", return_value=mock_resp):
+            result = get_ollama_status()
+
+        assert result["running"] is False
+
+    def test_non_object_body_reports_not_running(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b'["not", "a", "dict"]'
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._ollama.urllib.request.urlopen", return_value=mock_resp):
+            result = get_ollama_status()
+
+        assert result["running"] is False
+
 
 class TestListOllamaModels:
     def test_returns_models(self):
@@ -61,6 +83,30 @@ class TestListOllamaModels:
 
     def test_server_offline(self):
         with patch("quodeq.llm_bridge._ollama.urllib.request.urlopen", side_effect=ConnectionRefusedError):
+            models = list_ollama_models()
+
+        assert models == []
+
+    def test_malformed_body_returns_empty_list(self):
+        """Regression: an invalid /api/tags body used to escape the handler
+        and 500 the models route instead of returning the documented []."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"not json at all"
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._ollama.urllib.request.urlopen", return_value=mock_resp):
+            models = list_ollama_models()
+
+        assert models == []
+
+    def test_entry_missing_name_returns_empty_list(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({"models": [{"size": 1}]}).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._ollama.urllib.request.urlopen", return_value=mock_resp):
             models = list_ollama_models()
 
         assert models == []

--- a/tests/llm_bridge/test_omlx.py
+++ b/tests/llm_bridge/test_omlx.py
@@ -58,6 +58,31 @@ class TestGetOmlxStatus:
         assert result["running"] is False
         assert "error" in result
 
+    def test_non_object_body_still_reports_running(self):
+        """A health body that is valid JSON but not an object must not raise;
+        the server responded, so it is running with the default status."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b'["ok"]'
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", return_value=mock_resp):
+            result = get_omlx_status("http://localhost:8000")
+
+        assert result["running"] is True
+        assert result["status"] == "ok"
+
+    def test_malformed_body_reports_not_running(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"<html>bad gateway</html>"
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", return_value=mock_resp):
+            result = get_omlx_status("http://localhost:8000")
+
+        assert result["running"] is False
+
 
 class TestListOmlxModels:
     def test_returns_models(self):
@@ -125,6 +150,32 @@ class TestListOmlxModels:
         with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", side_effect=ConnectionRefusedError), \
              patch("quodeq.llm_bridge._omlx._list_model_dirs", return_value=dir_models):
             assert list_omlx_models() == dir_models
+
+    def test_non_object_body_falls_back_to_dirs(self):
+        """Regression: a non-object /v1/models body raised AttributeError
+        instead of falling back to the local model directories."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b'["not", "an", "object"]'
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        dir_models = [{"name": "my-model", "size": 0, "quantization": "", "family": ""}]
+
+        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", return_value=mock_resp), \
+             patch("quodeq.llm_bridge._omlx._list_model_dirs", return_value=dir_models):
+            assert list_omlx_models() == dir_models
+
+    def test_non_dict_entries_skipped(self):
+        mock_data = {"data": ["a-bare-string", {"id": "mlx-community/valid-model"}]}
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(mock_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", return_value=mock_resp):
+            models = list_omlx_models()
+
+        assert len(models) == 1
+        assert models[0]["name"] == "mlx-community/valid-model"
 
     def test_sends_auth_header_when_key_available(self):
         mock_data = {"object": "list", "data": [{"id": "gemma-4-26B", "object": "model"}]}

--- a/tests/services/test_env_fallbacks.py
+++ b/tests/services/test_env_fallbacks.py
@@ -1,0 +1,76 @@
+"""Defensive env parsing: malformed values fall back instead of raising.
+
+Covers the P2 fix round's env sites: QUODEQ_JOB_TIMEOUT_S,
+QUODEQ_CANCEL_GRACE_S, QUODEQ_GIT_CLONE_TIMEOUT_S (services._fs_clone and
+_cli_resolution), and QUODEQ_MAX_HISTORY_RUNS. Import-time constants are
+exercised via importlib.reload with the env var set, then restored.
+"""
+from __future__ import annotations
+
+import importlib
+
+from quodeq.services.jobs import JobManager
+from quodeq.services.scoring import _max_history_runs
+
+
+def _reload_attr(monkeypatch, module_name: str, var: str, value: str, attr: str):
+    """Reload *module_name* with ``var=value`` set, return *attr*, then restore."""
+    module = importlib.import_module(module_name)
+    monkeypatch.setenv(var, value)
+    try:
+        importlib.reload(module)
+        return getattr(module, attr)
+    finally:
+        monkeypatch.delenv(var, raising=False)
+        importlib.reload(module)
+
+
+class TestJobTimeoutCap:
+    def test_invalid_value_falls_back_to_no_cap(self, monkeypatch):
+        monkeypatch.setenv("QUODEQ_JOB_TIMEOUT_S", "abc")
+        assert JobManager()._job_timeout_cap_s == 0.0
+
+    def test_negative_value_falls_back_to_no_cap(self, monkeypatch):
+        monkeypatch.setenv("QUODEQ_JOB_TIMEOUT_S", "-5")
+        assert JobManager()._job_timeout_cap_s == 0.0
+
+    def test_valid_value_is_used(self, monkeypatch):
+        monkeypatch.setenv("QUODEQ_JOB_TIMEOUT_S", "120")
+        assert JobManager()._job_timeout_cap_s == 120.0
+
+
+class TestMaxHistoryRuns:
+    def test_invalid_value_falls_back(self, monkeypatch):
+        monkeypatch.setenv("QUODEQ_MAX_HISTORY_RUNS", "lots")
+        assert _max_history_runs() == 100
+
+    def test_zero_falls_back(self, monkeypatch):
+        monkeypatch.setenv("QUODEQ_MAX_HISTORY_RUNS", "0")
+        assert _max_history_runs() == 100
+
+    def test_valid_value_is_used(self, monkeypatch):
+        monkeypatch.setenv("QUODEQ_MAX_HISTORY_RUNS", "7")
+        assert _max_history_runs() == 7
+
+
+class TestImportTimeConstants:
+    def test_cancel_grace_invalid_falls_back(self, monkeypatch):
+        value = _reload_attr(
+            monkeypatch, "quodeq.services._external_jobs",
+            "QUODEQ_CANCEL_GRACE_S", "abc", "_DEFAULT_GRACE_PERIOD_S",
+        )
+        assert value == 30.0
+
+    def test_clone_timeout_invalid_falls_back(self, monkeypatch):
+        value = _reload_attr(
+            monkeypatch, "quodeq.services._fs_clone",
+            "QUODEQ_GIT_CLONE_TIMEOUT_S", "fast", "_GIT_CLONE_TIMEOUT_S",
+        )
+        assert value == 300
+
+    def test_fetch_timeout_invalid_falls_back(self, monkeypatch):
+        value = _reload_attr(
+            monkeypatch, "quodeq._cli_resolution",
+            "QUODEQ_GIT_CLONE_TIMEOUT_S", "fast", "_FETCH_TIMEOUT_S",
+        )
+        assert value == 300

--- a/tests/services/test_evaluations_index_safety.py
+++ b/tests/services/test_evaluations_index_safety.py
@@ -1,0 +1,84 @@
+"""Safety fixes on EvaluationsIndex: id validation and honest delete results.
+
+Covers SEC-05 (traversal ``ext-`` ids never reach path construction in
+``get_status``) and REL-026/REL-027 (``delete`` reports failure when the run
+directory survives ``rmtree``).
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+
+from quodeq.services._evaluations_index import EvaluationsIndex
+from quodeq.services._job_model import InMemoryJobStore
+from quodeq.services.jobs import JobManager
+from quodeq.shared.run_status import RunState, write_status
+
+
+def _make_index(tmp_path: Path, reports_root: Path) -> EvaluationsIndex:
+    jobs = JobManager(job_store=InMemoryJobStore(), reports_root=reports_root)
+    return EvaluationsIndex(
+        jobs=jobs,
+        index_db_path=tmp_path / "index.db",
+        reports_root=reports_root,
+    )
+
+
+def _seed_terminal_run(reports_root: Path, project: str, run_id: str) -> Path:
+    run_dir = reports_root / project / run_id
+    run_dir.mkdir(parents=True)
+    write_status(
+        run_dir,
+        state=RunState.FAILED,
+        job_id=f"ext-{run_id}",
+        started_at="2026-05-22T19:00:00+00:00",
+        dimensions=["security"],
+        phase="done",
+        pid=99999,
+    )
+    return run_dir
+
+
+def test_get_status_rejects_traversal_ext_id(tmp_path: Path) -> None:
+    reports_root = tmp_path / "reports"
+    _seed_terminal_run(reports_root, "proj-a", "run-a")
+    index = _make_index(tmp_path, reports_root)
+
+    assert index.get_status("ext-..", reports_dir=reports_root) is None
+    assert index.get_status("ext-.", reports_dir=reports_root) is None
+    assert index.get_status("ext-", reports_dir=reports_root) is None
+
+
+def test_get_status_still_resolves_valid_ext_id(tmp_path: Path) -> None:
+    reports_root = tmp_path / "reports"
+    _seed_terminal_run(reports_root, "proj-a", "run-a")
+    index = _make_index(tmp_path, reports_root)
+
+    snapshot = index.get_status("ext-run-a", reports_dir=reports_root)
+    assert snapshot is not None
+    assert snapshot.output_run_id == "run-a"
+
+
+def test_delete_reports_failure_when_dir_survives(tmp_path, monkeypatch, caplog) -> None:
+    reports_root = tmp_path / "reports"
+    run_dir = _seed_terminal_run(reports_root, "proj-a", "run-a")
+    index = _make_index(tmp_path, reports_root)
+
+    # Simulate a deletion that silently fails (e.g. Windows file locks):
+    # ignore_errors=True means rmtree itself never raises.
+    monkeypatch.setattr(shutil, "rmtree", lambda *a, **k: None)
+
+    with caplog.at_level(logging.WARNING, logger="quodeq.services._evaluations_index"):
+        assert index.delete("ext-run-a", reports_dir=reports_root) is False
+    assert run_dir.is_dir()
+    assert "Could not remove run directory" in caplog.text
+
+
+def test_delete_reports_success_when_dir_removed(tmp_path) -> None:
+    reports_root = tmp_path / "reports"
+    run_dir = _seed_terminal_run(reports_root, "proj-a", "run-a")
+    index = _make_index(tmp_path, reports_root)
+
+    assert index.delete("ext-run-a", reports_dir=reports_root) is True
+    assert not run_dir.exists()

--- a/tests/services/test_external_jobs.py
+++ b/tests/services/test_external_jobs.py
@@ -268,3 +268,52 @@ def test_cancel_external_run_kills_child_processes_in_same_group(tmp_path):
     finally:
         reaper_stop.set()
         _force_cleanup(proc)
+
+
+# ---------------------------------------------------------------------------
+# Path-segment validation for externally-supplied run/project ids
+# ---------------------------------------------------------------------------
+
+from quodeq.services._external_jobs import is_safe_run_segment, resolve_external_pid  # noqa: E402
+
+
+class TestIsSafeRunSegment:
+    def test_accepts_uuid(self):
+        assert is_safe_run_segment("d5b8a421-8c9f-4e11-9b7a-1f2e3d4c5b6a")
+
+    def test_accepts_dotted_and_underscored_names(self):
+        assert is_safe_run_segment("run_1.backup-2")
+
+    def test_rejects_dot_and_dotdot(self):
+        assert not is_safe_run_segment(".")
+        assert not is_safe_run_segment("..")
+
+    def test_rejects_empty(self):
+        assert not is_safe_run_segment("")
+
+    def test_rejects_separators(self):
+        assert not is_safe_run_segment("a/b")
+        assert not is_safe_run_segment("a\\b")
+        assert not is_safe_run_segment("../etc")
+
+    def test_rejects_other_charset(self):
+        assert not is_safe_run_segment("run id")
+        assert not is_safe_run_segment("run\x00id")
+
+
+class TestResolveExternalPidValidation:
+    def test_traversal_run_id_returns_none(self, tmp_path):
+        # A '..' run_id would otherwise resolve to reports_root/<proj>/../.pid
+        (tmp_path / ".pid").write_text("12345")
+        assert resolve_external_pid("proj", "..", tmp_path) is None
+
+    def test_traversal_project_uuid_returns_none(self, tmp_path):
+        assert resolve_external_pid("..", "run", tmp_path) is None
+
+
+class TestCancelExternalValidation:
+    def test_cancel_job_rejects_traversal_ext_id(self, tmp_path):
+        from quodeq.services.jobs import JobManager
+
+        (tmp_path / ".pid").write_text("12345")
+        assert JobManager().cancel_job("ext-..", reports_root=tmp_path) is False

--- a/tests/services/test_runs_unit.py
+++ b/tests/services/test_runs_unit.py
@@ -17,6 +17,9 @@ def test_ui_status_mapping():
     assert _ui_status("in_progress") == "in_progress"
     assert _ui_status("cancelled") == "cancelled"
     assert _ui_status("failed") == "failed"
+    assert _ui_status("lost") == "failed"
+    assert _ui_status("pending") == "in_progress"
+    assert _ui_status("finalizing") == "in_progress"
     assert _ui_status("weird-unknown") == "complete"
 
 def test_row_to_run_entry_shape_is_camel_and_score_placeholders():

--- a/tests/shared/test_env_numeric.py
+++ b/tests/shared/test_env_numeric.py
@@ -1,0 +1,41 @@
+"""Tests for the shared env_int/env_float defensive parsers."""
+import logging
+
+from quodeq.shared._env import env_float, env_int
+
+
+class TestEnvInt:
+    def test_valid_value(self):
+        assert env_int("X", 5, env={"X": "42"}) == 42
+
+    def test_missing_returns_default(self):
+        assert env_int("X", 5, env={}) == 5
+
+    def test_invalid_returns_default_and_warns(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="quodeq.shared._env"):
+            assert env_int("X", 5, env={"X": "abc"}) == 5
+        assert "Invalid X=" in caplog.text
+
+    def test_below_minimum_returns_default(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="quodeq.shared._env"):
+            assert env_int("X", 5, minimum=1, env={"X": "0"}) == 5
+        assert "Out-of-range X=" in caplog.text
+
+    def test_at_minimum_is_accepted(self):
+        assert env_int("X", 5, minimum=1, env={"X": "1"}) == 1
+
+
+class TestEnvFloat:
+    def test_valid_value(self):
+        assert env_float("X", 1.5, env={"X": "2.5"}) == 2.5
+
+    def test_missing_returns_default(self):
+        assert env_float("X", 1.5, env={}) == 1.5
+
+    def test_invalid_returns_default_and_warns(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="quodeq.shared._env"):
+            assert env_float("X", 1.5, env={"X": "nan-ish"}) == 1.5
+        assert "Invalid X=" in caplog.text
+
+    def test_below_minimum_returns_default(self):
+        assert env_float("X", 1.5, minimum=0.0, env={"X": "-3"}) == 1.5

--- a/tests/shared/test_security.py
+++ b/tests/shared/test_security.py
@@ -1,0 +1,42 @@
+"""Tests for the secret-masking helpers in shared/_security.py."""
+from __future__ import annotations
+
+from quodeq.shared._security import sanitize_sensitive
+
+
+def test_masks_equals_form():
+    assert "hunter2" not in sanitize_sensitive("password=hunter2")
+
+
+def test_masks_colon_form():
+    assert "abc123" not in sanitize_sensitive("token: abc123")
+
+
+def test_masks_whitespace_form():
+    assert "s3cret" not in sanitize_sensitive("api_key s3cret")
+
+
+def test_masks_json_shaped_credentials():
+    """Regression: the closing quote after the keyword in JSON payloads
+    (`"token": "abc"`) used to prevent the pattern from matching."""
+    out = sanitize_sensitive('{"token": "abc123", "other": 1}')
+    assert "abc123" not in out
+
+
+def test_masks_json_shaped_api_key():
+    out = sanitize_sensitive('{"api_key": "sk-verysecret"}')
+    assert "sk-verysecret" not in out
+
+
+def test_masks_json_single_quoted():
+    out = sanitize_sensitive("{'authorization': 'xyz-secret'}")
+    assert "xyz-secret" not in out
+
+
+def test_case_insensitive():
+    assert "topsecret" not in sanitize_sensitive("TOKEN=topsecret")
+
+
+def test_plain_text_untouched():
+    text = "no credentials in this line"
+    assert sanitize_sensitive(text) == text

--- a/tests/test_no_unguarded_posix.py
+++ b/tests/test_no_unguarded_posix.py
@@ -27,7 +27,7 @@ _ALLOWLIST: set[str] = {
     "analysis/_process.py:35",
     # kill_proc_tree POSIX branch, in the else of `if sys.platform == "win32"`
     # (win32 uses taskkill /F /T). Hoisted from assistant to shared.
-    "shared/_process_kill.py:34",
+    "shared/_process_kill.py:37",
     # pgrep / ps are wrapped in `except (OSError, ...)` -> returns _UNKNOWN, so
     # on Windows (FileNotFoundError) resource sampling degrades gracefully.
     "shared/resource_sampler.py:41",

--- a/tests/update/test_state.py
+++ b/tests/update/test_state.py
@@ -1,4 +1,5 @@
 import json
+import tempfile
 from pathlib import Path
 
 from quodeq.update.state import (
@@ -50,3 +51,41 @@ def test_read_corrupt_file_returns_defaults(tmp_path: Path) -> None:
     env = _env(tmp_path)
     Path(env["QUODEQ_UPDATE_STATE_PATH"]).write_text("{ not json")
     assert read_state(env) == UpdateState()
+
+
+def test_write_uses_unique_temp_names(tmp_path: Path, monkeypatch) -> None:
+    """Regression: a fixed `<path>.tmp` name raced between the dashboard,
+    menubar and CLI processes; each write must use its own temp file."""
+    env = _env(tmp_path)
+    names: list[str] = []
+    real_mkstemp = tempfile.mkstemp
+
+    def spy(*args, **kwargs):
+        fd, name = real_mkstemp(*args, **kwargs)
+        names.append(name)
+        return fd, name
+
+    monkeypatch.setattr("quodeq.update.state.tempfile.mkstemp", spy)
+    write_state(UpdateState(latest_version="3.0.0"), env)
+    write_state(UpdateState(latest_version="3.0.1"), env)
+
+    assert len(names) == 2
+    assert names[0] != names[1]
+    # Temp files live next to the target (same-filesystem atomic replace)
+    # and none uses the old predictable update_state.json.tmp name.
+    assert all(Path(n).parent == tmp_path for n in names)
+    assert all(not n.endswith("update_state.json.tmp") for n in names)
+    # No stray temp files left behind; last write wins.
+    assert [p.name for p in tmp_path.iterdir()] == ["update_state.json"]
+    assert read_state(env).latest_version == "3.0.1"
+
+
+def test_write_failure_is_silent_and_cleans_temp(tmp_path: Path, monkeypatch) -> None:
+    env = _env(tmp_path)
+
+    def boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("quodeq.update.state.os.replace", boom)
+    write_state(UpdateState(latest_version="9.9.9"), env)  # must not raise
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
Fixes 78 confirmed findings from today's quodeq self-scan runs (security 8.4/10, 25 violations; reliability 8.5/10, 103 violations). All 128 were triaged against the code; 47 were skipped as intentional patterns, false positives, test fixtures, or dev-only tooling, and 3 are deferred (see below).

## Security (15)
- OMLX model listing no longer accepts the provider API key in the URL query string; it moves to an X-Api-Key header (backend + UI client in this PR).
- create_project's local-repo branch now enforces the same path allowlist as /api/scan.
- External run/project ids are validated before any filesystem path is built (job cancel, PID lookup, evaluations index), and assistant read tools validate the dimension segment.
- Assistant SSE streams are capped at 16 concurrent connections.
- Forced dashboard API startup enforces the non-local plaintext HTTP guard.
- Secret masker now catches JSON-shaped credentials; cloud connection probe logs the redacted message; ci report --token warns and steers to GITHUB_TOKEN.

## Reliability (63)
- Env-var config parses defensively via new shared env_int/env_float helpers; two malformed-env import-time crashes removed.
- All llm-bridge POST routes and the findings dismiss/restore/delete/unverify routes return 400 on malformed JSON bodies instead of 500.
- Cloud LLM calls, project registration, shared pull, and repo scan requests get finite timeouts.
- Update-state writes are atomic with unique temp names (no concurrent-writer races).
- rmtree-based cleanup paths report failure instead of silently claiming success; metadata write failure fails project registration cleanly.
- Malformed provider responses, evidence JSONL, stored reference JSON, and wire line/confidence values are tolerated instead of raising.
- Dozens of silent catches now log (backend logger warnings, UI console.warn); several broad excepts narrowed.

## Deferred
Provider API keys persisted in localStorage (3 findings) need a migration design (server-side storage exists via .quodeq.env); not rushed into this round.

## Tests
- Backend: 4894 passed, 8 skipped (full suite).
- UI: node runner 308 passed; vitest 1186 passed.
- New/extended coverage for every behavior change (traversal rejection, 400 guards, env fallbacks, SSE cap, atomic writes, header-based key).
