### PR TITLE
fix(security): validate SSRF/path/shell inputs across tools and bridges

### DIFF
--- a/src/quodeq/config/_asvs_network.py
+++ b/src/quodeq/config/_asvs_network.py
@@ -10,6 +10,8 @@ import urllib.error
 import urllib.request
 import os
 
+from quodeq.shared.url_validation import validate_url_safe
+
 _logger = logging.getLogger(__name__)
 
 _ASVS_SHA256_ENV = "QUODEQ_ASVS_SHA256"
@@ -27,6 +29,8 @@ def fetch_with_retry(url: str, timeout: int = _DEFAULT_FETCH_TIMEOUT_S, max_retr
     """
     if not url.startswith("https://"):
         raise ValueError(f"Only https:// URLs are allowed, got: {url!r}")
+    # Reject private/loopback/link-local/metadata targets (SSRF).
+    validate_url_safe(url)
     last_exc: Exception | None = None
     for attempt in range(max_retries):
         _logger.info("Fetching %s (attempt %d/%d)", url, attempt + 1, max_retries)

--- a/src/quodeq/llm_bridge/_ollama.py
+++ b/src/quodeq/llm_bridge/_ollama.py
@@ -9,6 +9,8 @@ import subprocess
 import urllib.request
 import urllib.error
 
+from quodeq.shared.url_validation import validate_url_safe
+
 _log = logging.getLogger(__name__)
 
 _OLLAMA_BASE = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
@@ -19,10 +21,21 @@ _NVIDIA_SMI_TIMEOUT_S = 5
 _MIB_TO_BYTES = 1024 * 1024
 
 
+def _safe_request(url: str) -> urllib.request.Request:
+    """Build a Request for *url* after an SSRF check.
+
+    Ollama normally runs on localhost, so loopback is allowed. Private-range
+    IPs (10.x, 192.168.x) and link-local/metadata addresses (169.254.x) are
+    rejected. Raises ``ValueError`` for unsafe URLs.
+    """
+    validate_url_safe(url, allow_loopback=True)
+    return urllib.request.Request(url)
+
+
 def get_ollama_status(base_url: str = _OLLAMA_BASE) -> dict:
     """Check if the Ollama server is running."""
     try:
-        req = urllib.request.Request(f"{base_url}/api/version")
+        req = _safe_request(f"{base_url}/api/version")
         with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
             data = json.loads(resp.read())
             return {
@@ -39,7 +52,7 @@ def get_ollama_status(base_url: str = _OLLAMA_BASE) -> dict:
 def list_ollama_models(base_url: str = _OLLAMA_BASE) -> list[dict]:
     """List installed Ollama models."""
     try:
-        req = urllib.request.Request(f"{base_url}/api/tags")
+        req = _safe_request(f"{base_url}/api/tags")
         with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
             data = json.loads(resp.read())
             models = data.get("models", [])
@@ -61,7 +74,7 @@ def list_ollama_models(base_url: str = _OLLAMA_BASE) -> list[dict]:
 def get_running_model_info(base_url: str = _OLLAMA_BASE) -> dict | None:
     """Get info about the currently loaded model (from /api/ps)."""
     try:
-        req = urllib.request.Request(f"{base_url}/api/ps")
+        req = _safe_request(f"{base_url}/api/ps")
         with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
             data = json.loads(resp.read())
             models = data.get("models", [])

--- a/src/quodeq/terminal/_pty_unix.py
+++ b/src/quodeq/terminal/_pty_unix.py
@@ -13,6 +13,15 @@ import termios
 from quodeq.shared._process_kill import kill_proc_tree
 
 _ALLOWED_SHELL_BASENAMES = frozenset({"zsh", "bash", "fish", "sh", "dash", "tcsh", "ksh"})
+# $SHELL must live in a system-managed bin directory. Validating the basename
+# alone lets `SHELL=/tmp/bash` through; requiring a trusted parent directory
+# blocks an attacker-planted binary while preserving standard locations
+# (system paths + Homebrew).
+_TRUSTED_SHELL_DIRS = frozenset({
+    "/bin", "/sbin", "/usr/bin", "/usr/sbin",
+    "/usr/local/bin", "/usr/local/sbin",
+    "/opt/homebrew/bin", "/opt/homebrew/sbin",
+})
 _READ_TIMEOUT_S = 0.5
 # May be absent on unusual builds; guarded at the call site.
 _TIOCSCTTY = getattr(termios, "TIOCSCTTY", None)
@@ -40,7 +49,12 @@ def resolve_shell(env: dict[str, str] | None = None) -> list[str]:
     src = env if env is not None else os.environ
     shell = src.get("SHELL", "")
     default = "/bin/zsh" if sys.platform == "darwin" else "/bin/bash"
-    if not shell or not os.path.isabs(shell) or os.path.basename(shell) not in _ALLOWED_SHELL_BASENAMES:
+    if (
+        not shell
+        or not os.path.isabs(shell)
+        or os.path.basename(shell) not in _ALLOWED_SHELL_BASENAMES
+        or os.path.dirname(shell) not in _TRUSTED_SHELL_DIRS
+    ):
         shell = default
     return [shell, "-il"]
 

--- a/tools/audit_cwe_abstraction.py
+++ b/tools/audit_cwe_abstraction.py
@@ -19,6 +19,11 @@ import urllib.error
 from datetime import date
 from pathlib import Path
 
+# Allow running from repo root without installing the package (mirrors tools/rescore.py).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from quodeq.shared.url_validation import validate_url_safe
+
 _PROGRESS_LOG_INTERVAL = 20
 _RATE_LIMIT_SLEEP_S = 0.1
 _TERMINAL_WIDTH = 80
@@ -63,7 +68,9 @@ def _fetch_cwe_endpoint(
 ) -> dict | None:
     """Fetch a CWE entity from *endpoint* and return the first item under *collection_key*."""
     url = f"{api_base}/{endpoint}/{cwe_id}"
-    if not url.startswith(("http://", "https://")):
+    try:
+        validate_url_safe(url)
+    except ValueError:
         return None
     try:
         req = urllib.request.Request(url, headers={"Accept": "application/json"})

--- a/tools/rescore.py
+++ b/tools/rescore.py
@@ -25,7 +25,7 @@ sys.path.insert(0, str(repo_root / "src"))
 
 from quodeq.evaluate.lib.scoring import run_scoring
 from quodeq.evaluate.lib.report_json import write_report_json
-from quodeq.shared.validation import validate_path_segment
+from quodeq.shared.validation import validate_path_segment, validate_resolved_within
 
 # Content hashes that identify prompt versions — used to select the correct
 # scoring mode for evidence produced by different prompt revisions.
@@ -157,7 +157,9 @@ def main():
     try:
         dry_run = not args.apply_
         evals_dir = Path(args.evaluations_dir) if args.evaluations_dir else repo_root / "evaluations"
+        validate_path_segment(args.project)
         project_dir = evals_dir / args.project
+        validate_resolved_within(project_dir, evals_dir)
 
         if not project_dir.exists():
             print(f"Project dir not found: {project_dir}")


### PR DESCRIPTION
Fixes 5 authenticity/SSRF findings from the targeted security review. Each reuses the existing validation helpers (`validate_url_safe`, `validate_path_segment`, `validate_resolved_within`); no refactoring.

## Changes

| File | Fix |
|------|-----|
| `tools/rescore.py` | Validate the `project` CLI arg with `validate_path_segment` + `validate_resolved_within` before the path join, blocking `../` escape of the evaluations root. (CWE-22) |
| `tools/audit_cwe_abstraction.py` | Run the `CWE_API_BASE`-derived URL through `validate_url_safe` (private/loopback/link-local block) instead of a scheme-prefix check. Added the `src`-path bootstrap so the standalone tool can import the shared helper. (CWE-918) |
| `src/quodeq/terminal/_pty_unix.py` | `$SHELL` must live in a trusted bin directory, not just have an allowlisted basename. `SHELL=/tmp/bash` falls back to the default; `/bin/*` and `/opt/homebrew/*` still work. (CWE-78) |
| `src/quodeq/config/_asvs_network.py` | Keep the https-only check and add `validate_url_safe` to reject private/metadata hosts. (CWE-918) |
| `src/quodeq/llm_bridge/_ollama.py` | Route all three request builders through a `_safe_request` helper using `validate_url_safe(allow_loopback=True)`, mirroring the omlx sibling. (CWE-918) |

## Not changed (false positive)

The `internal_local_cache` provenance-gate fixture (`tests/analysis/fixtures/.../repo/src/cache/local.py`) is intentionally unguarded. Its `expected.json` states: *do not add guards; `key` is an internal SHA-256 digest, not attacker-controllable.* The fixture exists to verify the provenance gate keeps this internal-provenance path build non-critical. The production `LocalFileBackend` already has the `_SAFE_KEY_RE` guard.

## Notes / risk

- **Defaults preserved.** Ollama's `localhost:11434` default is loopback (allowed); ASVS/CWE default URLs are public.
- **LAN-hosted Ollama:** the Ollama check uses `allow_loopback=True`, which blocks the cloud-metadata endpoint but also blocks a LAN-IP `OLLAMA_BASE_URL` (`10.x`/`192.168.x`). Switch that call to `allow_private=True` if LAN Ollama is needed.
- `tools/rescore.py` has a pre-existing broken import (`quodeq.evaluate` no longer exists), unrelated to this change.

## Test

Full suite: 4900 passed, 8 skipped.