### PR TITLE
fix(security): stop leaking internal error detail to callers

### DIFF
--- a/packaging/macos/menubar.py
+++ b/packaging/macos/menubar.py
@@ -282,9 +282,14 @@ class QuodeqApp(rumps.App):
         except OSError:
             err = "unknown error"
         sanitized = err[:_ERROR_DISPLAY_MAX].replace("\n", " ").strip()
+        if sanitized:
+            # Keep the crash detail in the local log for troubleshooting, but
+            # do not surface raw dashboard stderr (which may include tokens or
+            # filesystem paths) in the always-visible menu.
+            _logging.getLogger(__name__).warning(
+                "Dashboard crashed (exit code %s): %s", self._process.returncode, sanitized,
+            )
         self._set_error(
-            f"Dashboard stopped unexpectedly (exit code {self._process.returncode}). "
-            f"Try restarting. Details: {sanitized}" if sanitized else
             f"Dashboard stopped unexpectedly (exit code {self._process.returncode}). Try restarting."
         )
         self._status_item.title = "Stopped"

--- a/src/quodeq/api/routes_project_list.py
+++ b/src/quodeq/api/routes_project_list.py
@@ -362,8 +362,11 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
             # handler would have logged; record it before converting.
             _logger.exception("Registration failed for repo=%r", repo)
             _rollback_new_dirs(reports_root, before)
+            # Return a generic message; the exception detail (which can carry
+            # filesystem paths or backend internals) is logged above, not sent
+            # to the remote caller.
             body, status = error_response(
-                f"Registration failed: {exc}",
+                "Registration failed due to an internal error.",
                 HTTPStatus.INTERNAL_SERVER_ERROR,
                 "REGISTRATION_FAILED",
             )

--- a/src/quodeq/assistant/mcp/server.py
+++ b/src/quodeq/assistant/mcp/server.py
@@ -61,7 +61,10 @@ def serve(registry: ToolRegistry, *, stdin: TextIO, stdout: TextIO, stderr: Text
             stderr.write(f"assistant mcp dispatch error: {exc}\n")
             stderr.flush()
             if req_id is not None:  # notifications have no id and expect no response
-                _jsonrpc.send(_jsonrpc.err(req_id, -32603, f"internal error: {exc}"), stdout)
+                # The exception detail is written to stderr above; the client
+                # frame carries only a generic message so internal failure
+                # detail is not exposed to MCP callers.
+                _jsonrpc.send(_jsonrpc.err(req_id, -32603, "internal error"), stdout)
 
 
 def _build_registry_from_args(ns: argparse.Namespace) -> ToolRegistry:

--- a/tests/assistant/test_mcp_server.py
+++ b/tests/assistant/test_mcp_server.py
@@ -114,4 +114,7 @@ def test_dispatch_exception_answers_with_error_frame():
     assert len(frames) == 1
     assert frames[0]["id"] == 7
     assert frames[0]["error"]["code"] == -32603
-    assert "kaboom" in frames[0]["error"]["message"]
+    # Client frame carries only a generic message; the raw exception detail
+    # must not leak to MCP callers, but is still written to stderr for ops.
+    assert "kaboom" not in frames[0]["error"]["message"]
+    assert "kaboom" in stderr.getvalue()


### PR DESCRIPTION
## What

Stop three error paths from returning raw exception or stderr text to remote or external consumers. Each now returns a generic message and keeps the full detail in server-side logs.

- **api** (`routes_project_list.py`): the project-registration 500 returned `Registration failed: {exc}`, exposing filesystem paths and backend internals to the caller. Now generic. The traceback is still recorded via `_logger.exception`. (CWE-210)
- **assistant mcp** (`server.py`): the JSON-RPC dispatch error frame returned `internal error: {exc}` to MCP callers. Now `internal error`. Full detail is still written to stderr. (CWE-210)
- **menubar** (`menubar.py`): a dashboard crash put raw stderr (which can carry tokens or paths) in the always-visible menu title. Now logged locally, and the menu shows a generic message. (CWE-200)

Updated the mcp dispatch test to assert the detail is absent from the client frame and present on stderr.

## Not included

These came from the same confidentiality review but are out of scope for a surgical error-handling change:

- Reading `ANTHROPIC_API_KEY` from the environment (`_env.py`) and reading omlx's own `~/.omlx/settings.json` (`_omlx.py`) are how those providers are meant to work. Removing them breaks the integrations.
- API keys in browser `localStorage` (UI hooks) and the `.quodeq.env` write path (`ai_provider.py`, whose key-writing branch is currently unreachable since the only caller passes an empty key) would need an OS keychain or a backend secret store. That is a feature, not a surgical fix. Happy to open a follow-up if we want it.

## Test

Full suite: 4900 passed, 8 skipped.
