### PR TITLE
feat(assistant): read-only sessions on shared projects (backend)

### DIFF
--- a/src/quodeq/api/_assistant_helpers.py
+++ b/src/quodeq/api/_assistant_helpers.py
@@ -12,7 +12,11 @@ from quodeq.assistant import AssistantRepository
 from quodeq.assistant.tools import ToolContext
 from quodeq.assistant import LOCAL_PROVIDERS as _LOCAL_PROVIDERS
 from quodeq.services._fs_projects import get_project_info
-from quodeq.services.shared_repo import shared_evaluations_root, shared_score_cache_path
+from quodeq.services.shared_repo import (
+    read_state,
+    shared_evaluations_root,
+    shared_score_cache_path,
+)
 from quodeq.services.shared_settings import read_settings
 from quodeq.shared._env import get_evaluations_dir
 
@@ -189,6 +193,12 @@ def build_tool_context(app: Flask, session: dict) -> ToolContext:
             # The session outlived the shared-repo connection; the messages
             # route maps this to a 409 rather than a 500.
             raise SharedSourceUnavailable("shared repository not configured")
+        # A format-version bump or a foreign clone pulled in by a background
+        # refresh must stop an already-open session's reads too, same as
+        # every /api/shared/* route enforces at request time.
+        state = read_state(settings.url)
+        if state not in ("ok", "empty"):
+            raise SharedSourceUnavailable(f"shared repository unavailable: {state}")
         reports_dir = shared_evaluations_root(settings.url)
         score_cache_path = shared_score_cache_path(settings.url)
     return ToolContext(

--- a/src/quodeq/api/_assistant_helpers.py
+++ b/src/quodeq/api/_assistant_helpers.py
@@ -12,6 +12,8 @@ from quodeq.assistant import AssistantRepository
 from quodeq.assistant.tools import ToolContext
 from quodeq.assistant import LOCAL_PROVIDERS as _LOCAL_PROVIDERS
 from quodeq.services._fs_projects import get_project_info
+from quodeq.services.shared_repo import shared_evaluations_root, shared_score_cache_path
+from quodeq.services.shared_settings import read_settings
 from quodeq.shared._env import get_evaluations_dir
 
 _logger = logging.getLogger(__name__)
@@ -96,6 +98,28 @@ def resolve_run_location(project_id: str, run_id: str) -> tuple[str | None, str 
     if not run_dir.is_dir():
         return None, None
     return str(run_dir), resolve_repo_root(project_id)
+
+
+def resolve_shared_run_location(project_id: str, run_id: str) -> str | None:
+    """Shared-clone sibling of resolve_run_location: the run dir under the
+    shared repo's evaluations root, jailed the same way (a crafted
+    project_id/run_id must not escape the clone). Returns None when no shared
+    repo is configured or the directory does not exist. Shared sessions never
+    attach a repo root: the clone stores results, not a working copy, so
+    unlike the local resolver this returns only the run dir.
+    """
+    settings = read_settings()
+    if not settings.url:
+        return None
+    root = shared_evaluations_root(settings.url).resolve()
+    run_dir = (root / project_id / run_id).resolve()
+    try:
+        run_dir.relative_to(root)
+    except ValueError:
+        return None
+    if not run_dir.is_dir():
+        return None
+    return str(run_dir)
 
 
 def repo_attach_info(project_id: str | None) -> tuple[str | None, str]:

--- a/src/quodeq/api/_assistant_helpers.py
+++ b/src/quodeq/api/_assistant_helpers.py
@@ -18,6 +18,10 @@ from quodeq.shared._env import get_evaluations_dir
 
 _logger = logging.getLogger(__name__)
 
+
+class SharedSourceUnavailable(RuntimeError):
+    """A shared-source session's clone is gone (repo disconnected)."""
+
 # ~/.quodeq/assistant.db is never pruned otherwise; a session older than this
 # is effectively dead (its worktree, if any, was reaped long before). 0
 # disables. Whole-session delete cascades to its messages/events/actions.
@@ -172,8 +176,21 @@ def build_tool_context(app: Flask, session: dict) -> ToolContext:
     ``runDir`` and ``project_uuid`` holds the UI's ``repoRoot`` — the
     create-session route maps those request fields onto these columns.
     Plan 3 revisits this naming with a schema v2 if needed.
+    Shared-source sessions resolve reports_dir against the shared clone and
+    carry read_only + the per-clone score-cache path.
     """
     run_dir = session.get("run_id")
+    source = session.get("source") or "local"
+    reports_dir = Path(get_evaluations_dir())
+    score_cache_path: Path | None = None
+    if source == "shared":
+        settings = read_settings()
+        if not settings.url:
+            # The session outlived the shared-repo connection; the messages
+            # route maps this to a 409 rather than a 500.
+            raise SharedSourceUnavailable("shared repository not configured")
+        reports_dir = shared_evaluations_root(settings.url)
+        score_cache_path = shared_score_cache_path(settings.url)
     return ToolContext(
         repository=get_repository(app),
         session_id=session["id"],
@@ -183,7 +200,9 @@ def build_tool_context(app: Flask, session: dict) -> ToolContext:
         compiled_dir=Path(app.config["STANDARDS_COMPILED_DIR"]),
         dimensions_file=Path(app.config["STANDARDS_DIMENSIONS_FILE"]),
         project_id=session.get("project_id"),
-        reports_dir=Path(get_evaluations_dir()),
+        reports_dir=reports_dir,
+        read_only=(source == "shared"),
+        score_cache_path=score_cache_path,
     )
 
 

--- a/src/quodeq/api/assistant_routes.py
+++ b/src/quodeq/api/assistant_routes.py
@@ -326,6 +326,13 @@ def register_assistant_routes(app: Flask) -> None:
         action = repo.get_action(action_id)
         if action is None:
             return jsonify({"error": "unknown action"}), 404
+        owner = repo.get_session(action["session_id"])
+        if owner is not None and (owner.get("source") or "local") == "shared":
+            # Defense in depth: read-only sessions never draft actions
+            # (draft_action is not registered), so nothing legitimate reaches
+            # here. Refuse rather than mutate the local store under a shared
+            # project id.
+            return jsonify({"error": "read-only session"}), 403
         if action["status"] != "drafted":
             return jsonify({"error": f"action already {action['status']}"}), 409
         spec = ACTIONS.get(action["action_type"])
@@ -356,6 +363,13 @@ def register_assistant_routes(app: Flask) -> None:
         action = repo.get_action(action_id)
         if action is None:
             return jsonify({"error": "unknown action"}), 404
+        owner = repo.get_session(action["session_id"])
+        if owner is not None and (owner.get("source") or "local") == "shared":
+            # Defense in depth: read-only sessions never draft actions
+            # (draft_action is not registered), so nothing legitimate reaches
+            # here. Refuse rather than mutate the local store under a shared
+            # project id.
+            return jsonify({"error": "read-only session"}), 403
         # Same replay guard as apply, made atomic: an applied action must
         # not flip to rejected on a stale card click, SSE replay, or a race
         # with a concurrent apply. The compare-and-set wins at most once.

--- a/src/quodeq/api/assistant_routes.py
+++ b/src/quodeq/api/assistant_routes.py
@@ -23,6 +23,8 @@ from quodeq.assistant.cancel import CancelToken
 from quodeq.assistant.orchestrator import TurnRequest, run_turn, write_safe_provider
 from quodeq.assistant.skills import RESERVED_COMMANDS, load_skills
 from quodeq.assistant.tools._actions import ACTION_DESCRIPTIONS, ACTION_TYPES, ACTIONS, ActionConflict
+from quodeq.services.shared_repo import read_state
+from quodeq.services.shared_settings import read_settings
 
 _running_turns: set[str] = set()
 # Cancel token per session with a /messages turn in flight; the /stop route
@@ -84,6 +86,17 @@ def register_assistant_routes(app: Flask) -> None:
         provider_cfg = _known_provider(str(body.get("provider", "")))
         if provider_cfg is None:
             return jsonify({"error": "unknown or unsupported provider"}), 400
+        source = str(body.get("source") or "local")
+        if source not in ("local", "shared"):
+            return jsonify({"error": "invalid source"}), 400
+        if source == "shared":
+            settings = read_settings()
+            if not settings.url:
+                return jsonify({"error": "no shared repository configured"}), 409
+            state = read_state(settings.url)
+            if state not in ("ok", "empty"):
+                return jsonify(
+                    {"error": f"shared repository unavailable: {state}"}), 409
         session_id = uuid.uuid4().hex
         # Plan 1 mapping: runDir → run_id column, repoRoot → project_uuid column.
         # Client-supplied runDir/repoRoot are NOT honored: they'd flow to the
@@ -92,7 +105,15 @@ def register_assistant_routes(app: Flask) -> None:
         # never sends these — it sends {projectId, runId} and the server
         # resolves run_dir/repo_root itself via the jailed resolver.
         run_dir, repo_root, repo_reason = None, None, "no_project"
-        if body.get("projectId"):
+        if source == "shared":
+            # Shared sessions never attach a repo (the clone has no working
+            # copy); data reads resolve against the clone's evaluations root
+            # in build_tool_context.
+            repo_reason = "online_project"
+            if body.get("projectId") and body.get("runId"):
+                run_dir = _assistant_helpers.resolve_shared_run_location(
+                    str(body["projectId"]), str(body["runId"]))
+        elif body.get("projectId"):
             repo_root, repo_reason = _assistant_helpers.repo_attach_info(
                 str(body["projectId"]))
             # Only bind a single run when the UI selected a SPECIFIC run. On
@@ -109,13 +130,16 @@ def register_assistant_routes(app: Flask) -> None:
             model=body.get("model"), project_uuid=repo_root,
             run_id=run_dir,
             project_id=str(project_id) if project_id else None,
+            source=source,
         )
-        write_available = (bool(repo_root)
+        write_available = (source == "local"
+                           and bool(repo_root)
                            and (Path(repo_root) / ".git").exists()
                            and write_safe_provider(str(body["provider"])))
         return jsonify({"sessionId": session_id,
                         "repoAttached": repo_root is not None,
                         "repoReason": repo_reason,
+                        "readOnly": source == "shared",
                         "writeAvailable": write_available}), 201
 
     @app.get("/api/assistant/skills")

--- a/src/quodeq/api/assistant_routes.py
+++ b/src/quodeq/api/assistant_routes.py
@@ -11,6 +11,7 @@ from flask import Flask, Response, current_app, jsonify, request
 from quodeq.api import _assistant_helpers
 from quodeq.api._assistant_helpers import (
     _LOCAL_PROVIDERS as _FIXED_ENDPOINT_PROVIDERS,
+    SharedSourceUnavailable,
     build_tool_context,
     event_frames,
     get_repository,
@@ -23,6 +24,7 @@ from quodeq.assistant.cancel import CancelToken
 from quodeq.assistant.orchestrator import TurnRequest, run_turn, write_safe_provider
 from quodeq.assistant.skills import RESERVED_COMMANDS, load_skills
 from quodeq.assistant.tools._actions import ACTION_DESCRIPTIONS, ACTION_TYPES, ACTIONS, ActionConflict
+from quodeq.services.score_cache import score_cache_path_override
 from quodeq.services.shared_repo import read_state
 from quodeq.services.shared_settings import read_settings
 
@@ -210,19 +212,29 @@ def register_assistant_routes(app: Flask) -> None:
                 api_key=api_key, provider=session["provider"],
                 model=body.get("model") or session.get("model") or provider_cfg.get("model", ""),
                 web_enabled=bool(body.get("webEnabled", False)),
-                write_enabled=bool(body.get("writeEnabled", False)),
+                write_enabled=(bool(body.get("writeEnabled", False))
+                               and (session.get("source") or "local") == "local"),
             )
             tool_ctx = build_tool_context(app, session)
 
             def _worker():
                 try:
-                    run_turn(turn, repository=repo, tool_ctx=tool_ctx, cancel=cancel)
+                    if tool_ctx.score_cache_path is not None:
+                        with score_cache_path_override(tool_ctx.score_cache_path):
+                            run_turn(turn, repository=repo, tool_ctx=tool_ctx, cancel=cancel)
+                    else:
+                        run_turn(turn, repository=repo, tool_ctx=tool_ctx, cancel=cancel)
                 finally:
                     with _running_lock:
                         _running_turns.discard(sid)
                         _cancel_tokens.pop(sid, None)
 
             threading.Thread(target=_worker, daemon=True).start()
+        except SharedSourceUnavailable as exc:
+            with _running_lock:
+                _running_turns.discard(sid)
+                _cancel_tokens.pop(sid, None)
+            return jsonify({"error": str(exc)}), 409
         except Exception:
             with _running_lock:
                 _running_turns.discard(sid)

--- a/src/quodeq/api/assistant_routes.py
+++ b/src/quodeq/api/assistant_routes.py
@@ -152,7 +152,8 @@ def register_assistant_routes(app: Flask) -> None:
             "commands": [{"name": n, "description": d} for n, d in RESERVED_COMMANDS],
             "skills": [
                 {"name": s.name, "description": s.description,
-                 "argumentHint": s.argument_hint, "views": list(s.views)}
+                 "argumentHint": s.argument_hint, "views": list(s.views),
+                 "requiresWrite": s.requires_write}
                 for s in load_skills().values()
             ],
             "actions": [

--- a/src/quodeq/assistant/mcp/server.py
+++ b/src/quodeq/assistant/mcp/server.py
@@ -83,6 +83,7 @@ def _build_registry_from_args(ns: argparse.Namespace) -> ToolRegistry:
         project_id=ns.project_id or None,
         reports_dir=reports_dir,
         worktree_dir=Path(ns.worktree_dir) if getattr(ns, "worktree_dir", "") else None,
+        read_only=bool(getattr(ns, "read_only", False)),
     )
     registry = build_registry(ctx)
     if getattr(ns, "enable_write", False) and ctx.worktree_dir is not None:
@@ -103,8 +104,16 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--reports-dir", default="")
     parser.add_argument("--enable-write", action="store_true")
     parser.add_argument("--worktree-dir", default="")
+    parser.add_argument("--read-only", action="store_true")
+    parser.add_argument("--score-cache-override", default="")
     ns = parser.parse_args(argv)
-    serve(_build_registry_from_args(ns), stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr)
+    registry = _build_registry_from_args(ns)
+    if ns.score_cache_override:
+        from quodeq.services.score_cache import score_cache_path_override  # noqa: PLC0415
+        with score_cache_path_override(Path(ns.score_cache_override)):
+            serve(registry, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr)
+    else:
+        serve(registry, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/src/quodeq/assistant/mcp/server.py
+++ b/src/quodeq/assistant/mcp/server.py
@@ -86,7 +86,8 @@ def _build_registry_from_args(ns: argparse.Namespace) -> ToolRegistry:
         read_only=bool(getattr(ns, "read_only", False)),
     )
     registry = build_registry(ctx)
-    if getattr(ns, "enable_write", False) and ctx.worktree_dir is not None:
+    if (getattr(ns, "enable_write", False) and ctx.worktree_dir is not None
+            and not ctx.read_only):
         register_write_tools(registry, ctx)
     return registry
 

--- a/src/quodeq/assistant/orchestrator.py
+++ b/src/quodeq/assistant/orchestrator.py
@@ -85,6 +85,10 @@ def _mcp_server_args(request: TurnRequest, tool_ctx: ToolContext) -> list[str]:
         args += ["--reports-dir", str(tool_ctx.reports_dir)]
     if tool_ctx.worktree_dir is not None:
         args += ["--enable-write", "--worktree-dir", str(tool_ctx.worktree_dir)]
+    if tool_ctx.read_only:
+        args += ["--read-only"]
+    if tool_ctx.score_cache_path is not None:
+        args += ["--score-cache-override", str(tool_ctx.score_cache_path)]
     return args
 
 
@@ -113,7 +117,8 @@ def run_turn(request: TurnRequest, *, repository: AssistantRepository,
         # Server-derived write grant, mirror of web_tools_on: the client flag
         # alone is never enough. Requires an attached LOCAL git repo and a
         # provider whose tool wiring is per-invocation isolated.
-        write_on = (request.write_enabled and tool_ctx.repo_root is not None
+        write_on = (request.write_enabled and not tool_ctx.read_only
+                    and tool_ctx.repo_root is not None
                     and (tool_ctx.repo_root / ".git").exists()
                     and write_safe_provider(request.provider))
         if write_on:

--- a/src/quodeq/assistant/skills.py
+++ b/src/quodeq/assistant/skills.py
@@ -32,6 +32,7 @@ class Skill:
     instructions: str
     argument_hint: str = ""
     views: tuple[str, ...] = ()
+    requires_write: bool = False
 
 
 def _parse(text: str) -> Skill | None:
@@ -49,7 +50,8 @@ def _parse(text: str) -> Skill | None:
         return None
     views = tuple(v.strip() for v in meta.get("views", "").split(",") if v.strip())
     return Skill(meta["name"], meta["description"], body.strip(),
-                 argument_hint=meta.get("argument_hint", ""), views=views)
+                 argument_hint=meta.get("argument_hint", ""), views=views,
+                 requires_write=meta.get("requires_write", "").strip().lower() == "true")
 
 
 def load_skills(skills_dir: Path | None = None) -> dict[str, Skill]:

--- a/src/quodeq/assistant/tools/__init__.py
+++ b/src/quodeq/assistant/tools/__init__.py
@@ -18,5 +18,8 @@ def build_registry(ctx: ToolContext) -> ToolRegistry:
     register_read_tools(registry, ctx)
     register_overview_tools(registry, ctx)
     register_repo_tools(registry, ctx)
-    register_action_tools(registry, ctx)
+    # Read-only (shared) sessions get NO mutation primitive: draft_action is
+    # absent from the registry, so there is nothing to gate downstream.
+    if not ctx.read_only:
+        register_action_tools(registry, ctx)
     return registry

--- a/src/quodeq/assistant/tools/_context.py
+++ b/src/quodeq/assistant/tools/_context.py
@@ -23,3 +23,13 @@ class ToolContext:
     # Set only for write-granted turns: the session's fix worktree. When set,
     # repo reads AND writes are jailed here so the model sees its own edits.
     worktree_dir: Path | None = None
+    # Read-only (shared/remote) session: mutating tools are never registered
+    # and the write grant can never activate. reports_dir/run_dir point at
+    # the shared clone.
+    read_only: bool = False
+    # When set, any code path that DISPATCHES tools must wrap execution in
+    # score_cache_path_override(score_cache_path) so rescoring hits the
+    # per-clone cache DB, never the local one (the routes_shared
+    # _with_shared_root mechanism). Wrapped in the messages-route worker and
+    # the MCP server main.
+    score_cache_path: Path | None = None

--- a/src/quodeq/data/assistant/skills/create-standard.md
+++ b/src/quodeq/data/assistant/skills/create-standard.md
@@ -3,6 +3,7 @@ name: create-standard
 description: Draft a new custom standard from a plain-language description
 argument_hint: [what the standard should enforce]
 views: standards
+requires_write: true
 ---
 The user wants a new standard. Work in this order:
 1. Ask (or infer from the conversation) the standard's goal, and check

--- a/src/quodeq/data/assistant/skills/verify-finding.md
+++ b/src/quodeq/data/assistant/skills/verify-finding.md
@@ -3,6 +3,7 @@ name: verify-finding
 description: Adversarially verify a finding, then dismiss it or mark it verified
 argument_hint: [file:line or search terms]
 views: violations
+requires_write: true
 ---
 The user wants to know whether one finding (usually the one selected in
 `[ui-state]`) is a real defect or a false positive. Work in this order:

--- a/src/quodeq/data/sqlite/_assistant_schema.py
+++ b/src/quodeq/data/sqlite/_assistant_schema.py
@@ -1,9 +1,9 @@
 """DDL for the assistant conversation store (~/.quodeq/assistant.db)."""
 
-ASSISTANT_SCHEMA_VERSION = 3
+ASSISTANT_SCHEMA_VERSION = 4
 
 ASSISTANT_DDL = """
-PRAGMA user_version = 3;
+PRAGMA user_version = 4;
 
 CREATE TABLE IF NOT EXISTS sessions (
     id TEXT PRIMARY KEY,
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     run_id TEXT,
     project_id TEXT,
     cli_session_id TEXT,
+    source TEXT NOT NULL DEFAULT 'local',
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
@@ -74,4 +75,6 @@ ASSISTANT_MIGRATIONS: list[tuple[int, str]] = [
         "    created_at TEXT NOT NULL DEFAULT (datetime('now'))\n"
         ");\n"
         "PRAGMA user_version = 3;"),
+    (4, "ALTER TABLE sessions ADD COLUMN source TEXT NOT NULL DEFAULT 'local';\n"
+        "PRAGMA user_version = 4;"),
 ]

--- a/src/quodeq/data/sqlite/assistant_repository.py
+++ b/src/quodeq/data/sqlite/assistant_repository.py
@@ -57,12 +57,14 @@ class AssistantRepository:
     def create_session(self, *, session_id: str, provider: str,
                        model: str | None = None, project_uuid: str | None = None,
                        run_id: str | None = None,
-                       project_id: str | None = None) -> dict:
+                       project_id: str | None = None,
+                       source: str = "local") -> dict:
         with self._connect() as conn:
             conn.execute(
                 "INSERT INTO sessions (id, provider, model, project_uuid, run_id,"
-                " project_id) VALUES (?, ?, ?, ?, ?, ?)",
-                (session_id, provider, model, project_uuid, run_id, project_id),
+                " project_id, source) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (session_id, provider, model, project_uuid, run_id, project_id,
+                 source),
             )
         return self.get_session(session_id)  # type: ignore[return-value]
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,112 @@
+"""Shared fixtures for tests/api/*.
+
+``shared_clone_fixture`` builds a REAL published shared-repo clone (bare
+origin + publish_project + sync_shared_index) and points settings at it —
+the recipe every shared-clone integration test in this directory needs.
+Moved here from ``test_routes_shared_read.py`` (its original home) so
+``test_assistant_shared_sessions.py`` can reuse it without duplicating the
+fixture (Task 6, Step 0).
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.writer import EventLogWriter
+from quodeq.services.shared_publish import publish_project
+from quodeq.services.shared_repo import (
+    ensure_shared_clone,
+    shared_evaluations_root,
+    shared_repo_path,
+    sync_shared_index,
+)
+from quodeq.services.shared_settings import SharedSettings, write_settings
+
+_VIOLATION = dict(
+    practice_id="P1", verdict="violation", dimension="Security",
+    file="a.py", line=10, reason="weak hash", req="R1", severity="high",
+)
+
+_EVAL_JSON = {
+    "schema_version": 1,
+    "dimension": "Security",
+    "project": "proj-a",
+    "runId": "run-1",
+    "overallScore": "7.0/10",
+    "overallGrade": "Good",
+    "principles": [{"name": "Integrity", "score": "7.0/10", "grade": "Good", "violations": [], "compliance": []}],
+    "violations": [{
+        "principle": "Integrity", "req": "R1", "file": "a.py", "line": 10,
+        "severity": "major", "reason": "bad", "title": "Bad",
+    }],
+    "compliance": [],
+}
+
+
+def _make_origin(tmp_path: Path) -> str:
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    return f"file://{origin}"
+
+
+@pytest.fixture()
+def shared_clone_fixture(tmp_path, monkeypatch):
+    """Build a real published shared-repo clone and point settings at it.
+
+    Follows the same recipe as
+    tests/services/test_shared_repo.py::test_readable_and_index_sync_on_published_clone:
+    bare origin + publish_project + sync_shared_index. ``publish_project``'s
+    staging allowlist (source-of-truth files only) never carries
+    ``evaluation/<dim>.json`` — a real published run always has that
+    directory empty — so a per-dimension eval file is written directly into
+    the clone afterwards to exercise the dashboard/accumulated/dimension-eval/
+    violations read paths (this task's job) against real content, without
+    relitigating the publish allowlist (a prior task's decision).
+    """
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "tester")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "t@t")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "tester")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "t@t")
+
+    url = _make_origin(tmp_path)
+    # published.json's publishedBy comes from `git config user.name` in the
+    # clone (GIT_AUTHOR_NAME/GIT_COMMITTER_NAME above only affect a commit's
+    # recorded identity, not `git config` lookups) -- pin it on the clone's
+    # LOCAL config so the "tester" assertion below is deterministic
+    # regardless of the machine running the test.
+    assert ensure_shared_clone(url) is not None
+    subprocess.run(
+        ["git", "config", "user.name", "tester"],
+        cwd=shared_repo_path(url), check=True, capture_output=True,
+    )
+    local_root = tmp_path / "local-evaluations"
+    project_dir = local_root / "proj-a"
+    run_dir = project_dir / "run-1"
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "evidence" / "manifest.json").write_text("{}", encoding="utf-8")
+    (project_dir / "repository_info.json").write_text(
+        json.dumps({"name": "proj-a", "originUrl": "https://github.com/example/proj-a.git"}), encoding="utf-8",
+    )
+    (run_dir / "status.json").write_text(
+        json.dumps({"state": "done", "schema_version": 2}), encoding="utf-8",
+    )
+    (run_dir / "dimensions.json").write_text("{}", encoding="utf-8")
+
+    writer = EventLogWriter(run_dir / "events.jsonl")
+    writer.emit(JudgmentCreatedEvent(payload=JudgmentPayload(**_VIOLATION)))
+
+    publish_project("proj-a", url, evaluations_root=local_root)
+    sync_shared_index(url)
+
+    repo_run_dir = shared_evaluations_root(url) / "proj-a" / "run-1"
+    (repo_run_dir / "evaluation").mkdir(parents=True, exist_ok=True)
+    (repo_run_dir / "evaluation" / "Security.json").write_text(
+        json.dumps(_EVAL_JSON), encoding="utf-8",
+    )
+
+    write_settings(SharedSettings(url=url))
+    return url

--- a/tests/api/test_assistant_routes.py
+++ b/tests/api/test_assistant_routes.py
@@ -839,3 +839,12 @@ def test_reject_refuses_shared_session_action(client, app):
     resp = client.post("/api/assistant/actions/a-ro/reject")
     assert resp.status_code == 403
     assert _repo(app).get_action("a-ro")["status"] == "drafted"
+
+
+def test_catalog_marks_write_shaped_skills(client):
+    body = client.get("/api/assistant/skills").get_json()
+    flags = {s["name"]: s["requiresWrite"] for s in body["skills"]}
+    assert flags["verify-finding"] is True
+    assert flags["create-standard"] is True
+    assert flags["explain-score"] is False
+    assert flags["explain-finding"] is False

--- a/tests/api/test_assistant_routes.py
+++ b/tests/api/test_assistant_routes.py
@@ -797,3 +797,22 @@ def test_create_session_local_reports_read_only_false(client, app):
     body = resp.get_json()
     assert body["readOnly"] is False
     assert _repo(app).get_session(body["sessionId"])["source"] == "local"
+
+
+def test_message_on_shared_session_without_repo_409s_and_frees_the_slot(client, app, monkeypatch):
+    from quodeq.services.shared_settings import SharedSettings
+    # The session was created while a shared repo was configured; it has
+    # since been disconnected. build_tool_context must surface this as a
+    # 409, and the running-turn slot must be released so the session is
+    # not permanently locked out.
+    _repo(app).create_session(session_id="s-gone", provider="ollama", source="shared")
+    monkeypatch.setattr("quodeq.api._assistant_helpers.read_settings",
+                        lambda: SharedSettings(url=None))
+    first = client.post("/api/assistant/sessions/s-gone/messages", json={"text": "hi"})
+    assert first.status_code == 409
+    assert "shared repository" in first.get_json()["error"]
+    # Slot freed: the next POST must hit the same 409, NOT "a turn is
+    # already running".
+    second = client.post("/api/assistant/sessions/s-gone/messages", json={"text": "hi"})
+    assert second.status_code == 409
+    assert "already running" not in second.get_json()["error"]

--- a/tests/api/test_assistant_routes.py
+++ b/tests/api/test_assistant_routes.py
@@ -773,6 +773,17 @@ def test_create_session_shared_409_when_unconfigured(client, monkeypatch):
     assert resp.status_code == 409
 
 
+def test_create_session_shared_409_when_clone_state_bad(client, monkeypatch):
+    from quodeq.services.shared_settings import SharedSettings
+    monkeypatch.setattr("quodeq.api.assistant_routes.read_settings",
+                        lambda: SharedSettings(url="file:///tmp/fake.git"))
+    monkeypatch.setattr("quodeq.api.assistant_routes.read_state", lambda url: "foreign")
+    resp = client.post("/api/assistant/sessions",
+                       json={"provider": "ollama", "source": "shared"})
+    assert resp.status_code == 409
+    assert "foreign" in resp.get_json()["error"]
+
+
 def test_create_session_shared_persists_source_and_read_only(client, app, monkeypatch):
     from quodeq.services.shared_settings import SharedSettings
     monkeypatch.setattr("quodeq.api.assistant_routes.read_settings",
@@ -814,6 +825,26 @@ def test_message_on_shared_session_without_repo_409s_and_frees_the_slot(client, 
     # Slot freed: the next POST must hit the same 409, NOT "a turn is
     # already running".
     second = client.post("/api/assistant/sessions/s-gone/messages", json={"text": "hi"})
+    assert second.status_code == 409
+    assert "already running" not in second.get_json()["error"]
+
+
+def test_message_on_shared_session_with_bad_clone_state_409s_and_frees_the_slot(client, app, monkeypatch):
+    from quodeq.services.shared_settings import SharedSettings
+    # The session was created while the shared clone was in a servable state;
+    # a background refresh has since pulled a foreign/unsupported clone.
+    # build_tool_context must surface this as a 409, and the running-turn
+    # slot must be released so the session is not permanently locked out.
+    _repo(app).create_session(session_id="s-foreign", provider="ollama", source="shared")
+    monkeypatch.setattr("quodeq.api._assistant_helpers.read_settings",
+                        lambda: SharedSettings(url="file:///tmp/fake.git"))
+    monkeypatch.setattr("quodeq.api._assistant_helpers.read_state", lambda url: "foreign")
+    first = client.post("/api/assistant/sessions/s-foreign/messages", json={"text": "hi"})
+    assert first.status_code == 409
+    assert "foreign" in first.get_json()["error"]
+    # Slot freed: the next POST must hit the same 409, NOT "a turn is
+    # already running".
+    second = client.post("/api/assistant/sessions/s-foreign/messages", json={"text": "hi"})
     assert second.status_code == 409
     assert "already running" not in second.get_json()["error"]
 

--- a/tests/api/test_assistant_routes.py
+++ b/tests/api/test_assistant_routes.py
@@ -816,3 +816,26 @@ def test_message_on_shared_session_without_repo_409s_and_frees_the_slot(client, 
     second = client.post("/api/assistant/sessions/s-gone/messages", json={"text": "hi"})
     assert second.status_code == 409
     assert "already running" not in second.get_json()["error"]
+
+
+def _drafted_action_on_shared_session(app):
+    repo = _repo(app)
+    repo.create_session(session_id="s-ro", provider="ollama", source="shared")
+    return repo.create_action(
+        action_id="a-ro", session_id="s-ro", action_type="dismiss_finding",
+        payload={"project": "proj", "req": "R1", "file": "a.py", "line": 1, "reason": "false positive"}, content_hash="h")
+
+
+def test_apply_refuses_shared_session_action(client, app):
+    _drafted_action_on_shared_session(app)
+    resp = client.post("/api/assistant/actions/a-ro/apply")
+    assert resp.status_code == 403
+    # And the action was NOT claimed: still drafted.
+    assert _repo(app).get_action("a-ro")["status"] == "drafted"
+
+
+def test_reject_refuses_shared_session_action(client, app):
+    _drafted_action_on_shared_session(app)
+    resp = client.post("/api/assistant/actions/a-ro/reject")
+    assert resp.status_code == 403
+    assert _repo(app).get_action("a-ro")["status"] == "drafted"

--- a/tests/api/test_assistant_routes.py
+++ b/tests/api/test_assistant_routes.py
@@ -754,3 +754,46 @@ def test_events_stream_404_does_not_consume_slot(client):
     resp = client.get("/api/assistant/sessions/nope/events?after=0")
     assert resp.status_code == 404
     assert assistant_routes._open_sse_streams == before
+
+
+# ---- source-aware create route ---------------------------------------------
+
+def test_create_session_rejects_unknown_source(client):
+    resp = client.post("/api/assistant/sessions",
+                       json={"provider": "ollama", "source": "cloud"})
+    assert resp.status_code == 400
+
+
+def test_create_session_shared_409_when_unconfigured(client, monkeypatch):
+    from quodeq.services.shared_settings import SharedSettings
+    monkeypatch.setattr("quodeq.api.assistant_routes.read_settings",
+                        lambda: SharedSettings(url=None))
+    resp = client.post("/api/assistant/sessions",
+                       json={"provider": "ollama", "source": "shared"})
+    assert resp.status_code == 409
+
+
+def test_create_session_shared_persists_source_and_read_only(client, app, monkeypatch):
+    from quodeq.services.shared_settings import SharedSettings
+    monkeypatch.setattr("quodeq.api.assistant_routes.read_settings",
+                        lambda: SharedSettings(url="file:///tmp/fake.git"))
+    monkeypatch.setattr("quodeq.api.assistant_routes.read_state", lambda url: "ok")
+    resp = client.post("/api/assistant/sessions",
+                       json={"provider": "ollama", "source": "shared",
+                             "projectId": "proj-a"})
+    assert resp.status_code == 201
+    body = resp.get_json()
+    assert body["readOnly"] is True
+    assert body["writeAvailable"] is False
+    assert body["repoAttached"] is False
+    assert body["repoReason"] == "online_project"
+    row = _repo(app).get_session(body["sessionId"])
+    assert row["source"] == "shared"
+
+
+def test_create_session_local_reports_read_only_false(client, app):
+    resp = client.post("/api/assistant/sessions", json={"provider": "ollama"})
+    assert resp.status_code == 201
+    body = resp.get_json()
+    assert body["readOnly"] is False
+    assert _repo(app).get_session(body["sessionId"])["source"] == "local"

--- a/tests/api/test_assistant_shared_sessions.py
+++ b/tests/api/test_assistant_shared_sessions.py
@@ -1,0 +1,112 @@
+"""Integration locks: assistant sessions with source="shared" target the real
+shared-repo clone end to end -- session creation, tool-context construction,
+tool dispatch (get_scores/search_findings), and the read-only registry.
+
+Reuses the fake-clone recipe (bare origin + publish_project +
+sync_shared_index) via ``shared_clone_fixture``, moved to
+tests/api/conftest.py in Task 6 Step 0 so it isn't duplicated here.
+"""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.api._assistant_helpers import build_tool_context, get_repository
+from quodeq.api.app import create_app
+from quodeq.assistant.tools import build_registry
+from quodeq.services.score_cache import score_cache_path_override
+from quodeq.services.shared_repo import shared_evaluations_root, shared_score_cache_path
+
+
+@pytest.fixture()
+def app():
+    return create_app(test_config={"TESTING": True})
+
+
+@pytest.fixture()
+def client(app):
+    with app.test_client() as c:
+        yield c
+
+
+def _create_shared_session(client, run_id=None):
+    payload = {"provider": "ollama", "source": "shared", "projectId": "proj-a"}
+    if run_id:
+        payload["runId"] = run_id
+    # create_app (unlike the bare-Flask app fixture in test_assistant_routes.py)
+    # wires the real security middleware, which 403s any state-changing
+    # request without an Origin header (see security.py::_check_csrf) --
+    # same Origin-header requirement other create_app-backed POST tests in
+    # this directory already work around (e.g. test_browse_mkdir.py,
+    # test_action_api.py).
+    resp = client.post("/api/assistant/sessions", json=payload,
+                       headers={"Origin": "http://localhost"})
+    assert resp.status_code == 201, resp.get_json()
+    return resp.get_json()
+
+
+def test_shared_session_resolves_clone_run_dir(client, app, shared_clone_fixture):
+    body = _create_shared_session(client, run_id="run-1")
+    row = get_repository(app).get_session(body["sessionId"])
+    assert row["source"] == "shared"
+    expected_root = str(shared_evaluations_root(shared_clone_fixture))
+    assert row["run_id"].startswith(expected_root)
+    assert row["project_uuid"] is None  # never a repo root for shared
+
+
+def test_shared_tool_context_targets_clone(client, app, shared_clone_fixture):
+    body = _create_shared_session(client)
+    with app.app_context():
+        ctx = build_tool_context(app, get_repository(app).get_session(body["sessionId"]))
+    assert ctx.read_only is True
+    assert ctx.reports_dir == shared_evaluations_root(shared_clone_fixture)
+    assert ctx.score_cache_path == shared_score_cache_path(shared_clone_fixture)
+
+
+def test_shared_get_scores_matches_shared_route(client, app, shared_clone_fixture):
+    body = _create_shared_session(client)
+    with app.app_context():
+        ctx = build_tool_context(app, get_repository(app).get_session(body["sessionId"]))
+    registry = build_registry(ctx)
+    with score_cache_path_override(ctx.score_cache_path):
+        tool_result = registry.dispatch("get_scores", {})
+    route = client.get(
+        "/api/shared/projects/proj-a/scores?refresh=1").get_json()
+    assert tool_result.get("ok") is True
+    # Shape adaptation (brief's LOCK: dispatch succeeds AND the dimension set
+    # equals the shared route's -- only the key paths below were adjusted):
+    #   - ToolRegistry.dispatch wraps the handler's return in {"ok", "result"};
+    #     it never itself nests a "dimensions" key, so the tool payload is
+    #     read from tool_result["result"], not tool_result["dimensions"].
+    #   - _get_scores (tools/_read_tools.py) returns a dict KEYED BY dimension
+    #     name (`{"Security": {"score": ..., "grade": ..., "fromRun": ...}}`),
+    #     not a list of {"dimension": ...} objects -- so the tool's dimension
+    #     set is the dict's keys.
+    #   - GET /api/shared/projects/<project>/scores (get_project_scores) nests
+    #     its dimension list under "accumulated" (`{"accumulated": {"dimensions":
+    #     [...]}, "trend": [...], "availableRuns": [...]}`), not at the
+    #     response's top level.
+    tool_dims = set(tool_result.get("result", {}).keys())
+    route_dims = {d.get("dimension") for d in route.get("accumulated", {}).get("dimensions", [])}
+    assert tool_dims == route_dims and "Security" in tool_dims
+    # Score-cache isolation: rescoring under the override hits the per-clone
+    # cache DB, and nothing appears at the local default cache location.
+    assert shared_score_cache_path(shared_clone_fixture).exists()
+
+
+def test_shared_search_findings_builds_projection_in_clone(client, app, shared_clone_fixture):
+    body = _create_shared_session(client, run_id="run-1")
+    with app.app_context():
+        ctx = build_tool_context(app, get_repository(app).get_session(body["sessionId"]))
+    registry = build_registry(ctx)
+    with score_cache_path_override(ctx.score_cache_path):
+        result = registry.dispatch("search_findings", {"query": "hash"})
+    assert result.get("ok") is True
+    assert (ctx.run_dir / "evaluation.db").exists()  # projection built in-clone
+
+
+def test_shared_registry_has_no_draft_action(client, app, shared_clone_fixture):
+    body = _create_shared_session(client)
+    with app.app_context():
+        ctx = build_tool_context(app, get_repository(app).get_session(body["sessionId"]))
+    names = {t["function"]["name"] for t in build_registry(ctx).openai_tools()}
+    assert "draft_action" not in names

--- a/tests/api/test_assistant_shared_sessions.py
+++ b/tests/api/test_assistant_shared_sessions.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 
 import pytest
 
+from pathlib import Path
+
 from quodeq.api._assistant_helpers import build_tool_context, get_repository
 from quodeq.api.app import create_app
 from quodeq.assistant.tools import build_registry
-from quodeq.services.score_cache import score_cache_path_override
+from quodeq.services.score_cache import get_score_cache_path, score_cache_path_override
 from quodeq.services.shared_repo import shared_evaluations_root, shared_score_cache_path
 
 
@@ -91,6 +93,7 @@ def test_shared_get_scores_matches_shared_route(client, app, shared_clone_fixtur
     # Score-cache isolation: rescoring under the override hits the per-clone
     # cache DB, and nothing appears at the local default cache location.
     assert shared_score_cache_path(shared_clone_fixture).exists()
+    assert not Path(get_score_cache_path()).exists()
 
 
 def test_shared_search_findings_builds_projection_in_clone(client, app, shared_clone_fixture):

--- a/tests/api/test_assistant_shared_sessions.py
+++ b/tests/api/test_assistant_shared_sessions.py
@@ -20,14 +20,34 @@ from quodeq.services.shared_repo import shared_evaluations_root, shared_score_ca
 
 
 @pytest.fixture()
-def app():
-    return create_app(test_config={"TESTING": True})
+def app(tmp_path):
+    # create_app only defaults ASSISTANT_DB_PATH when absent from
+    # test_config -- to the developer's REAL ~/.quodeq/assistant.db (see
+    # api/app.py). This suite POSTs to /api/assistant/sessions, so without
+    # an explicit override those calls write real rows into (and migrate)
+    # the developer's actual assistant store. Always pin it to an isolated
+    # tmp path; see test_app_fixture_isolates_assistant_db below for the
+    # regression lock.
+    return create_app(test_config={
+        "TESTING": True,
+        "ASSISTANT_DB_PATH": str(tmp_path / "assistant.db"),
+    })
 
 
 @pytest.fixture()
 def client(app):
     with app.test_client() as c:
         yield c
+
+
+def test_app_fixture_isolates_assistant_db(app, tmp_path):
+    # create_app defaults ASSISTANT_DB_PATH to the developer's real
+    # ~/.quodeq/assistant.db; tests must always override it. `app` and this
+    # test both request the (function-scoped) `tmp_path` fixture within the
+    # same test node, so pytest hands them the identical directory -- the
+    # `app` fixture's override is provably rooted under this test's own
+    # `tmp_path`, not just "somewhere outside home".
+    assert Path(app.config["ASSISTANT_DB_PATH"]).is_relative_to(tmp_path)
 
 
 def _create_shared_session(client, run_id=None):

--- a/tests/api/test_routes_shared_read.py
+++ b/tests/api/test_routes_shared_read.py
@@ -22,44 +22,21 @@ from pathlib import Path
 import pytest
 
 from quodeq.api.app import create_app
-from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
-from quodeq.core.events.writer import EventLogWriter
-from quodeq.services.shared_publish import publish_project
 from quodeq.services.shared_repo import (
     FORMAT_NAME,
     MARKER_FILENAME,
     ensure_shared_clone,
     shared_evaluations_root,
     shared_repo_path,
-    sync_shared_index,
 )
 from quodeq.services.shared_settings import SharedSettings, write_settings
+from tests.api.conftest import _make_origin
 
-_VIOLATION = dict(
-    practice_id="P1", verdict="violation", dimension="Security",
-    file="a.py", line=10, reason="weak hash", req="R1", severity="high",
-)
-
-_EVAL_JSON = {
-    "schema_version": 1,
-    "dimension": "Security",
-    "project": "proj-a",
-    "runId": "run-1",
-    "overallScore": "7.0/10",
-    "overallGrade": "Good",
-    "principles": [{"name": "Integrity", "score": "7.0/10", "grade": "Good", "violations": [], "compliance": []}],
-    "violations": [{
-        "principle": "Integrity", "req": "R1", "file": "a.py", "line": 10,
-        "severity": "major", "reason": "bad", "title": "Bad",
-    }],
-    "compliance": [],
-}
-
-
-def _make_origin(tmp_path: Path) -> str:
-    origin = tmp_path / "origin.git"
-    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
-    return f"file://{origin}"
+# _VIOLATION, _EVAL_JSON, _make_origin and shared_clone_fixture moved to
+# tests/api/conftest.py (Task 6, Step 0) so test_assistant_shared_sessions.py
+# can reuse the fake-clone recipe without duplicating it. _make_origin is
+# imported back here because empty_shared_clone_fixture (below) still needs
+# it and is not itself part of the move.
 
 
 @pytest.fixture()
@@ -71,65 +48,6 @@ def app():
 def client(app):
     with app.test_client() as c:
         yield c
-
-
-@pytest.fixture()
-def shared_clone_fixture(tmp_path, monkeypatch):
-    """Build a real published shared-repo clone and point settings at it.
-
-    Follows the same recipe as
-    tests/services/test_shared_repo.py::test_readable_and_index_sync_on_published_clone:
-    bare origin + publish_project + sync_shared_index. ``publish_project``'s
-    staging allowlist (source-of-truth files only) never carries
-    ``evaluation/<dim>.json`` — a real published run always has that
-    directory empty — so a per-dimension eval file is written directly into
-    the clone afterwards to exercise the dashboard/accumulated/dimension-eval/
-    violations read paths (this task's job) against real content, without
-    relitigating the publish allowlist (a prior task's decision).
-    """
-    monkeypatch.setenv("GIT_AUTHOR_NAME", "tester")
-    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "t@t")
-    monkeypatch.setenv("GIT_COMMITTER_NAME", "tester")
-    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "t@t")
-
-    url = _make_origin(tmp_path)
-    # published.json's publishedBy comes from `git config user.name` in the
-    # clone (GIT_AUTHOR_NAME/GIT_COMMITTER_NAME above only affect a commit's
-    # recorded identity, not `git config` lookups) -- pin it on the clone's
-    # LOCAL config so the "tester" assertion below is deterministic
-    # regardless of the machine running the test.
-    assert ensure_shared_clone(url) is not None
-    subprocess.run(
-        ["git", "config", "user.name", "tester"],
-        cwd=shared_repo_path(url), check=True, capture_output=True,
-    )
-    local_root = tmp_path / "local-evaluations"
-    project_dir = local_root / "proj-a"
-    run_dir = project_dir / "run-1"
-    (run_dir / "evidence").mkdir(parents=True)
-    (run_dir / "evidence" / "manifest.json").write_text("{}", encoding="utf-8")
-    (project_dir / "repository_info.json").write_text(
-        json.dumps({"name": "proj-a", "originUrl": "https://github.com/example/proj-a.git"}), encoding="utf-8",
-    )
-    (run_dir / "status.json").write_text(
-        json.dumps({"state": "done", "schema_version": 2}), encoding="utf-8",
-    )
-    (run_dir / "dimensions.json").write_text("{}", encoding="utf-8")
-
-    writer = EventLogWriter(run_dir / "events.jsonl")
-    writer.emit(JudgmentCreatedEvent(payload=JudgmentPayload(**_VIOLATION)))
-
-    publish_project("proj-a", url, evaluations_root=local_root)
-    sync_shared_index(url)
-
-    repo_run_dir = shared_evaluations_root(url) / "proj-a" / "run-1"
-    (repo_run_dir / "evaluation").mkdir(parents=True, exist_ok=True)
-    (repo_run_dir / "evaluation" / "Security.json").write_text(
-        json.dumps(_EVAL_JSON), encoding="utf-8",
-    )
-
-    write_settings(SharedSettings(url=url))
-    return url
 
 
 @pytest.fixture()

--- a/tests/assistant/test_orchestrator.py
+++ b/tests/assistant/test_orchestrator.py
@@ -364,3 +364,21 @@ def test_run_turn_threads_cancel_token_to_adapter(setup):
     run_turn(_request(), repository=repo, tool_ctx=ctx, turn_fn=fake_turn2,
              capability_fn=lambda *a, **k: True, cancel=token)
     assert seen["explicit"] is token
+
+
+def test_mcp_args_carry_read_only_and_cache_override(tmp_path):
+    from quodeq.assistant import AssistantRepository
+    from quodeq.assistant.orchestrator import TurnRequest, _mcp_server_args
+    from quodeq.assistant.tools import ToolContext
+    ctx = ToolContext(
+        repository=AssistantRepository(tmp_path / "assistant.db"),
+        session_id="s", run_dir=None, repo_root=None,
+        evaluators_dir=tmp_path, compiled_dir=tmp_path,
+        dimensions_file=tmp_path / "dims.json",
+        read_only=True, score_cache_path=tmp_path / "score_cache.db")
+    req = TurnRequest(session_id="s", text="hi", ui_state=None, api_base="",
+                      api_key=None, provider="claude", model="m")
+    args = _mcp_server_args(req, ctx)
+    assert "--read-only" in args
+    assert "--score-cache-override" in args
+    assert str(tmp_path / "score_cache.db") in args

--- a/tests/assistant/test_registry.py
+++ b/tests/assistant/test_registry.py
@@ -49,3 +49,30 @@ def test_openai_tools_shape_and_duplicate_rejected():
         raise AssertionError("expected ValueError")
     except ValueError:
         pass
+
+
+from pathlib import Path
+
+from quodeq.assistant import AssistantRepository
+from quodeq.assistant.tools import ToolContext, build_registry
+
+
+def _ctx(tmp_path, **kw):
+    return ToolContext(
+        repository=AssistantRepository(tmp_path / "assistant.db"),
+        session_id="s", run_dir=None, repo_root=None,
+        evaluators_dir=tmp_path, compiled_dir=tmp_path,
+        dimensions_file=tmp_path / "dims.json", **kw)
+
+
+def test_read_only_registry_has_no_draft_action(tmp_path):
+    names = {t["function"]["name"]
+             for t in build_registry(_ctx(tmp_path, read_only=True)).openai_tools()}
+    assert "draft_action" not in names
+    assert {"get_scores", "get_violations", "get_overview", "get_context"} <= names
+
+
+def test_default_registry_keeps_draft_action(tmp_path):
+    names = {t["function"]["name"]
+             for t in build_registry(_ctx(tmp_path)).openai_tools()}
+    assert "draft_action" in names

--- a/tests/assistant/test_worktree_rows.py
+++ b/tests/assistant/test_worktree_rows.py
@@ -1,6 +1,7 @@
 import sqlite3
 import time
 
+from quodeq.data.sqlite._assistant_schema import ASSISTANT_SCHEMA_VERSION
 from quodeq.data.sqlite.assistant_repository import AssistantRepository
 
 
@@ -41,7 +42,7 @@ def test_get_worktree_missing(tmp_path):
     assert _store(tmp_path).get_worktree("nope") is None
 
 
-def test_migration_v2_to_v3(tmp_path):
+def test_migration_from_v2_reaches_current_schema(tmp_path):
     # simulate an on-disk v2 db (sessions only is enough for the migration path)
     db = tmp_path / "assistant.db"
     conn = sqlite3.connect(db)
@@ -51,10 +52,15 @@ def test_migration_v2_to_v3(tmp_path):
         " model TEXT, project_uuid TEXT, run_id TEXT, project_id TEXT,"
         " cli_session_id TEXT, created_at TEXT NOT NULL DEFAULT (datetime('now')));"
     )
+    conn.execute("INSERT INTO sessions (id, provider) VALUES ('old', 'ollama')")
     conn.commit()
     conn.close()
     store = AssistantRepository(db)
     assert store.get_worktree("x") is None  # forces connect + migration
     conn = sqlite3.connect(db)
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == 3
+    # migration chain should reach current schema version
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == ASSISTANT_SCHEMA_VERSION
+    # v2 db should have source column backfilled with 'local'
+    row = conn.execute("SELECT source FROM sessions WHERE id = 'old'").fetchone()
+    assert row[0] == 'local'
     conn.close()

--- a/tests/data/sqlite/test_assistant_repository.py
+++ b/tests/data/sqlite/test_assistant_repository.py
@@ -146,3 +146,35 @@ def test_prune_sessions_ttl_zero_is_a_noop(tmp_path):
     repo.create_session(session_id="s1", provider="ollama")
     assert repo.prune_sessions_older_than(days=0) == 0
     assert repo.get_session("s1") is not None
+
+
+def test_create_session_persists_source(tmp_path):
+    repo = _repo(tmp_path)
+    row = repo.create_session(session_id="s-shared", provider="ollama", source="shared")
+    assert row["source"] == "shared"
+
+
+def test_create_session_source_defaults_to_local(tmp_path):
+    repo = _repo(tmp_path)
+    row = repo.create_session(session_id="s-local", provider="ollama")
+    assert row["source"] == "local"
+
+
+def test_v3_db_migrates_to_v4_with_local_source(tmp_path):
+    import sqlite3
+    db = tmp_path / "assistant.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        "PRAGMA user_version = 3;"
+        "CREATE TABLE sessions (id TEXT PRIMARY KEY, provider TEXT NOT NULL,"
+        " model TEXT, project_uuid TEXT, run_id TEXT, project_id TEXT,"
+        " cli_session_id TEXT, created_at TEXT NOT NULL DEFAULT (datetime('now')));"
+        "INSERT INTO sessions (id, provider) VALUES ('old', 'ollama');"
+    )
+    conn.commit(); conn.close()
+    repo = AssistantRepository(db)
+    row = repo.get_session("old")
+    assert row["source"] == "local"
+    conn = sqlite3.connect(db)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 4
+    conn.close()


### PR DESCRIPTION
Backend half of the read-only assistant for remote (shared) projects. Inert
until the UI sends source=shared (next PR): local sessions are byte-identical.

- sessions schema v4: source column ('local' default, migration backfills)
- POST /api/assistant/sessions accepts source: shared → run_dir resolved
  under the shared clone (jailed), no repo attach, readOnly: true; 409 when
  the shared repo is unconfigured or its clone state is not ok/empty
- ToolContext gains read_only + score_cache_path; shared contexts point
  reports_dir at the clone; clone state re-validated at message time (a
  format-version bump stops an open session the same way it stops the
  shared routes); tool dispatch wraps in score_cache_path_override on both
  execution paths (worker thread + MCP subprocess argv)
- build_registry omits draft_action for read-only contexts — the model's
  only mutation primitive is structurally absent; the write grant is
  triple-dead (route forcing, run_turn guard, no repo root)
- Action apply/reject return 403 for shared-owned sessions before the
  drafted-status claim (defense in depth)
- Skills declare requires_write; catalog surfaces requiresWrite for the UI
- Integration tests against a real fake shared clone: clone-jailed run_dir,
  tool/route score parity, in-clone findings-projection build, per-clone
  score-cache isolation (positive + negative), 409/slot-release locks

Backend suite: 4913 passed / 1 skipped. Whole-branch review: ready to merge.
Deferred follow-ups (minor): revalidate stored run_dir after a shared-repo
URL switch (UI PR re-keys sessions per source); test-fixture import hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)