### PR TITLE
fix(api): honor QUODEQ_DIR for the assistant DB default path

### DIFF
--- a/src/quodeq/api/app.py
+++ b/src/quodeq/api/app.py
@@ -92,7 +92,7 @@ def create_app(
 
     from pathlib import Path
     from quodeq.services._ephemeral_cleanup import sweep_orphaned_clones
-    from quodeq.shared._env import get_clones_dir, get_evaluations_dir
+    from quodeq.shared._env import get_clones_dir, get_evaluations_dir, get_quodeq_dir
 
     try:
         sweep_orphaned_clones(get_clones_dir(), Path(get_evaluations_dir()))
@@ -110,7 +110,9 @@ def create_app(
         app.config["STANDARDS_DIMENSIONS_FILE"] = str(paths.dimensions_file)
 
     if "ASSISTANT_DB_PATH" not in app.config:
-        app.config["ASSISTANT_DB_PATH"] = str(Path.home() / ".quodeq" / "assistant.db")
+        # QUODEQ_DIR must redirect this like every other state path, else
+        # env-isolated servers write sessions into the real ~/.quodeq store.
+        app.config["ASSISTANT_DB_PATH"] = str(get_quodeq_dir() / "assistant.db")
 
     if api_key is None:
         _logger.warning(

--- a/src/quodeq/shared/_env.py
+++ b/src/quodeq/shared/_env.py
@@ -204,6 +204,18 @@ def score_cache_disabled(env: dict[str, str] | None = None) -> bool:
     return environ.get("QUODEQ_DISABLE_SCORE_CACHE", "").strip().lower() in _SQLITE_DISABLE_TRUTHY
 
 
+def get_quodeq_dir(env: dict[str, str] | None = None) -> Path:
+    """Return the base Quodeq state directory.
+
+    Resolution order: QUODEQ_DIR env var, then ~/.quodeq. Recomputes the
+    default on each call so test monkeypatches of ``Path.home`` are honored.
+    """
+    from_env = (env or os.environ).get("QUODEQ_DIR")
+    if from_env:
+        return Path(from_env)
+    return Path.home() / ".quodeq"
+
+
 _DEFAULT_CLONES_DIR = Path.home() / ".quodeq" / "clones"
 
 

--- a/tests/api/test_assistant_wiring.py
+++ b/tests/api/test_assistant_wiring.py
@@ -15,3 +15,24 @@ def test_assistant_routes_mounted(tmp_path):
 def test_assistant_db_path_defaults(tmp_path):
     app = create_app(test_config={"TESTING": True})
     assert app.config["ASSISTANT_DB_PATH"].endswith("assistant.db")
+
+
+def test_assistant_db_path_honors_quodeq_dir(tmp_path, monkeypatch):
+    """QUODEQ_DIR must redirect the assistant DB default (env isolation).
+
+    Regression: the default was hardcoded to ~/.quodeq/assistant.db, so
+    env-isolated test/dev servers leaked assistant sessions into the
+    developer's real store.
+    """
+    monkeypatch.setenv("QUODEQ_DIR", str(tmp_path))
+    app = create_app(test_config={"TESTING": True})
+    assert app.config["ASSISTANT_DB_PATH"] == str(tmp_path / "assistant.db")
+
+
+def test_assistant_db_path_falls_back_to_home(tmp_path, monkeypatch):
+    monkeypatch.delenv("QUODEQ_DIR", raising=False)
+    monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+    app = create_app(test_config={"TESTING": True})
+    assert app.config["ASSISTANT_DB_PATH"] == str(
+        tmp_path / ".quodeq" / "assistant.db"
+    )


### PR DESCRIPTION
## Problem

`create_app` defaulted `ASSISTANT_DB_PATH` to `Path.home() / ".quodeq" / "assistant.db"` unconditionally. Every other data root (evaluations, cache, index, settings) respects its env isolation variable, so an env-isolated test/dev server still wrote assistant sessions into the developer's REAL store. Observed 2026-07-23: E2E and integration runs leaked ~18 session rows into `~/.quodeq/assistant.db`.

The autouse `_isolate_quodeq_home` fixture in `tests/conftest.py` already exports `QUODEQ_DIR`, and its docstring documents this exact leak class ("defaults in shared/_env.py continued to fall through to Path.home()"). The assistant DB just never consulted it.

## Fix

- Add `get_quodeq_dir()` to `quodeq/shared/_env.py`: `QUODEQ_DIR` env var, else `~/.quodeq`, recomputed per call so `Path.home` monkeypatches are honored (same pattern as `get_clones_dir`).
- Derive the `ASSISTANT_DB_PATH` default in `create_app` from it. Explicit `test_config` overrides still win; no launcher passes an explicit path (verified: only `main()` calls `create_app`, without `test_config`).

## Tests

- `test_assistant_db_path_honors_quodeq_dir`: setting `QUODEQ_DIR` redirects the default (watched fail before the fix, resolving to the real home store).
- `test_assistant_db_path_falls_back_to_home`: without `QUODEQ_DIR` the default stays `~/.quodeq/assistant.db`.
- `pytest tests/api tests/shared -m "not integration"`: 814 passed.

Note: `update/state.py`, `dashboard/_build_npm.py`, and `services/shared_settings.py` each carry their own inline copy of this resolution; consolidating them onto `get_quodeq_dir()` is a possible follow-up, left out to keep this diff focused.