### PR TITLE
feat(ui): read-only assistant sessions on remote projects

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -174,15 +174,6 @@ export function isSharedSource(selectedSource) {
   return selectedSource === 'shared';
 }
 
-// Exported for tests. On a shared project only the ASSISTANT panel closes:
-// its dismiss/verify tools write to the local store, which can collide with
-// the shared project's id. The terminal is machine-local (PTY in ~) and must
-// stay open — closing the whole drawer here is the bug that made the
-// terminal unopenable on shared projects.
-export function shouldCloseAssistantForSource(selectedSource, openPanels) {
-  return selectedSource === 'shared' && openPanels.includes('assistant');
-}
-
 // Project-data tabs (overview/violations/map/history) — module scope so both
 // the App component and the exported shouldBounceToEvaluate helper below
 // share one definition.
@@ -755,27 +746,21 @@ export default function App() {
   // active assistant provider/model.
   const assistantGate = useAssistantProvider();
   const assistantCtx = deriveAssistantContext(state, assistantGate);
-  const { isOpen: assistantOpen, activeTab: drawerTab, openPanels: drawerPanels,
-          startSession: startAssistantSession, closePanel: closeDrawerPanel } = useAssistantDrawer();
-  const { provider: asstProvider, model: asstModel, projectId: asstProjectId, runId: asstRunId } = assistantCtx;
+  const { isOpen: assistantOpen, activeTab: drawerTab, startSession: startAssistantSession } = useAssistantDrawer();
+  const { provider: asstProvider, model: asstModel, projectId: asstProjectId, runId: asstRunId, source: asstSource } = assistantCtx;
   // Start (or re-start) the assistant session when the drawer is open and on
   // any provider/model/project/run change while it stays open. startSession
   // dedupes by context key, so re-runs with an unchanged context no-op; a
   // real project/run switch produces a fresh session. We deliberately do NOT
   // start a session while the drawer is closed — sends only originate from the
   // open drawer, so first-open is early enough and avoids needless sessions.
-  // Shared projects have no mutation routes on the backend, so close the
-  // ASSISTANT panel when switching to a shared project; the terminal is
-  // machine-local and stays open.
+  // Shared projects get READ-ONLY sessions: the backend roots their reads in
+  // the shared clone and registers no mutating tools, so the drawer no longer
+  // closes on a source switch; the source-keyed session context re-keys instead.
   useEffect(() => {
-    if (shouldCloseAssistantForSource(state.selectedSource, drawerPanels)) {
-      closeDrawerPanel('assistant');
-      return;
-    }
-    if (state.selectedSource === 'shared') return;
     if (!assistantOpen || drawerTab !== 'assistant') return;
-    startAssistantSession({ provider: asstProvider, model: asstModel, projectId: asstProjectId, runId: asstRunId });
-  }, [assistantOpen, drawerTab, drawerPanels, state.selectedSource, asstProvider, asstModel, asstProjectId, asstRunId, startAssistantSession, closeDrawerPanel]);
+    startAssistantSession({ provider: asstProvider, model: asstModel, projectId: asstProjectId, runId: asstRunId, source: asstSource });
+  }, [assistantOpen, drawerTab, asstProvider, asstModel, asstProjectId, asstRunId, asstSource, startAssistantSession]);
 
   // Sync the client-side grade-label thresholds with the server formula at
   // boot so every gauge/badge agrees with the applied Q² parameters. The

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -634,6 +634,12 @@ export function shouldWallEmptyProjects({ page, projects, selectedSource }) {
   return !projects || projects.length === 0;
 }
 
+// Exported for tests: the session-start payload must carry the selected
+// source so remote projects get read-only sessions server-side.
+export function buildAssistantSessionPayload({ provider, model, projectId, runId, source }) {
+  return { provider, model, projectId, runId, source };
+}
+
 /**
  * @param {{ activePage: { page: string }, props: Object }} params
  * @returns {JSX.Element|null}
@@ -759,7 +765,9 @@ export default function App() {
   // closes on a source switch; the source-keyed session context re-keys instead.
   useEffect(() => {
     if (!assistantOpen || drawerTab !== 'assistant') return;
-    startAssistantSession({ provider: asstProvider, model: asstModel, projectId: asstProjectId, runId: asstRunId, source: asstSource });
+    startAssistantSession(buildAssistantSessionPayload({
+      provider: asstProvider, model: asstModel, projectId: asstProjectId, runId: asstRunId, source: asstSource,
+    }));
   }, [assistantOpen, drawerTab, asstProvider, asstModel, asstProjectId, asstRunId, asstSource, startAssistantSession]);
 
   // Sync the client-side grade-label thresholds with the server formula at

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom/vitest';
 import {
   buildEvalPrincipal, ROUTE_RENDERERS, isSharedSource, shouldBounceToEvaluate, shouldShowEvaluateButton,
   resolveSelectionAfterSharedDisconnect, shouldAutoOpenOnboardingWizard, shouldShowProjectTabs,
-  buildNavigationBundle, shouldWallEmptyProjects, buildWizardHandlers, shouldCloseAssistantForSource,
+  buildNavigationBundle, shouldWallEmptyProjects, buildWizardHandlers,
 } from './App.jsx';
 import Sidebar from './components/Sidebar.jsx';
 
@@ -449,23 +449,5 @@ describe('resolveSelectionAfterSharedDisconnect', () => {
   it('clears the selection to the app\'s no-project state when there are no local projects', () => {
     expect(resolveSelectionAfterSharedDisconnect({ selectedSource: 'shared', projects: [] }))
       .toEqual({ id: '', source: 'local' });
-  });
-});
-
-// Regression lock for the shared-project drawer guard: it must close ONLY the
-// assistant panel. The old guard closed the whole drawer, which made the
-// terminal unopenable on shared projects (it closed itself the instant the
-// launcher opened it).
-describe('shouldCloseAssistantForSource', () => {
-  it('closes the assistant panel on a shared project', () => {
-    expect(shouldCloseAssistantForSource('shared', ['assistant'])).toBe(true);
-    expect(shouldCloseAssistantForSource('shared', ['assistant', 'terminal'])).toBe(true);
-  });
-  it('leaves a terminal-only drawer alone on a shared project', () => {
-    expect(shouldCloseAssistantForSource('shared', ['terminal'])).toBe(false);
-    expect(shouldCloseAssistantForSource('shared', [])).toBe(false);
-  });
-  it('never fires for local projects', () => {
-    expect(shouldCloseAssistantForSource('local', ['assistant', 'terminal'])).toBe(false);
   });
 });

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom/vitest';
 import {
   buildEvalPrincipal, ROUTE_RENDERERS, isSharedSource, shouldBounceToEvaluate, shouldShowEvaluateButton,
   resolveSelectionAfterSharedDisconnect, shouldAutoOpenOnboardingWizard, shouldShowProjectTabs,
-  buildNavigationBundle, shouldWallEmptyProjects, buildWizardHandlers,
+  buildNavigationBundle, shouldWallEmptyProjects, buildWizardHandlers, buildAssistantSessionPayload,
 } from './App.jsx';
 import Sidebar from './components/Sidebar.jsx';
 
@@ -373,6 +373,30 @@ describe('shouldWallEmptyProjects', () => {
 
   it('does not wall once local projects exist', () => {
     expect(shouldWallEmptyProjects({ page: 'file', projects: [{ id: 'p1' }], selectedSource: 'local' })).toBe(false);
+  });
+});
+
+// Pins the session-start effect's payload shape: `source` must reach
+// startAssistantSession so remote (shared) projects get read-only sessions
+// server-side. Regression: this used to be an inline object literal in the
+// effect with no test coverage of the `source` field specifically.
+describe('buildAssistantSessionPayload', () => {
+  it('passes source through unchanged', () => {
+    expect(buildAssistantSessionPayload({ provider: 'p', source: 'shared' }).source).toBe('shared');
+  });
+
+  it('includes all five keys', () => {
+    const payload = buildAssistantSessionPayload({
+      provider: 'claude', model: 'sonnet', projectId: 'p1', runId: 'r1', source: 'local',
+    });
+    expect(Object.keys(payload).sort()).toEqual(['model', 'projectId', 'provider', 'runId', 'source'].sort());
+    expect(payload).toEqual({ provider: 'claude', model: 'sonnet', projectId: 'p1', runId: 'r1', source: 'local' });
+  });
+
+  it('leaves an absent source as undefined (API applies its own local default)', () => {
+    const payload = buildAssistantSessionPayload({ provider: 'p' });
+    expect(payload.source).toBeUndefined();
+    expect('source' in payload).toBe(true);
   });
 });
 

--- a/src/quodeq/ui/src/components/AssistantLauncherButton.jsx
+++ b/src/quodeq/ui/src/components/AssistantLauncherButton.jsx
@@ -2,7 +2,7 @@ import { useAssistantDrawer } from '../features/assistant/AssistantDrawerProvide
 import useAssistantProvider from '../features/settings/hooks/useAssistantProvider.js';
 import { SparkleIcon } from './CopyButton.jsx';
 
-export function AssistantLauncherButton({ sharedSource = false }) {
+export function AssistantLauncherButton() {
   const { openPanels, toggleTopbar } = useAssistantDrawer();
   const { enabled } = useAssistantProvider();
 
@@ -13,21 +13,14 @@ export function AssistantLauncherButton({ sharedSource = false }) {
   // Highlighted whenever the assistant panel is open/selected (both launchers
   // can be highlighted at once when both panels are open).
   const on = openPanels.includes('assistant');
-  // Remote (team repo) projects are read-only: keep the button visible so its
-  // absence doesn't read as a bug, but disable it and say why. aria-disabled
-  // instead of disabled so the explanatory tooltip still shows on hover.
-  const label = sharedSource
-    ? 'Assistant is unavailable on remote projects (read-only)'
-    : 'Assistant (Ctrl+`)';
   return (
     <button
       type="button"
       className={`topbar-btn topbar-btn--icon topbar-btn--assistant${on ? ' topbar-btn--assistant--open' : ''}`}
       aria-pressed={on}
-      aria-disabled={sharedSource || undefined}
-      aria-label={label}
-      title={label}
-      onClick={() => { if (!sharedSource) toggleTopbar('assistant'); }}
+      aria-label="Assistant (Ctrl+`)"
+      title="Assistant (Ctrl+`)"
+      onClick={() => toggleTopbar('assistant')}
     >
       <SparkleIcon />
     </button>

--- a/src/quodeq/ui/src/components/AssistantLauncherButton.test.jsx
+++ b/src/quodeq/ui/src/components/AssistantLauncherButton.test.jsx
@@ -56,18 +56,3 @@ it('is NOT highlighted when only the terminal panel is open', () => {
   expect(btn).not.toHaveClass('topbar-btn--assistant--open');
   expect(btn).toHaveAttribute('aria-pressed', 'false');
 });
-
-it('on a remote project: visible but disabled, tooltip explains why, click is a no-op', () => {
-  render(<AssistantLauncherButton sharedSource />);
-  const btn = screen.getByRole('button', { name: /assistant is unavailable on remote projects/i });
-  expect(btn).toHaveAttribute('aria-disabled', 'true');
-  expect(btn).toHaveAttribute('title', 'Assistant is unavailable on remote projects (read-only)');
-  fireEvent.click(btn);
-  expect(toggleTopbar).not.toHaveBeenCalled();
-});
-
-it('sharedSource does not override the Settings kill switch', () => {
-  localStorage.setItem('cc-assistant-enabled', 'false');
-  const { container } = render(<AssistantLauncherButton sharedSource />);
-  expect(container).toBeEmptyDOMElement();
-});

--- a/src/quodeq/ui/src/components/TopBar.jsx
+++ b/src/quodeq/ui/src/components/TopBar.jsx
@@ -104,9 +104,9 @@ export default function TopBar({
      next click will flip to dark). */
   effectiveDark = false,
   onToggleTheme,
-  /* 'local' | 'shared' — shared projects are read-only: the assistant
-     launcher renders disabled with an explanatory tooltip for them since
-     the assistant can take write actions like dismiss/verify. */
+  /* 'local' | 'shared' — shared projects get read-only assistant sessions
+     server-side, so this no longer gates the assistant launcher; it still
+     gates the Evaluate button (see App.jsx's shouldShowEvaluateButton). */
   selectedSource = 'local',
 }) {
   return (
@@ -166,7 +166,7 @@ export default function TopBar({
           </button>
         )}
 
-        <AssistantLauncherButton sharedSource={selectedSource === 'shared'} />
+        <AssistantLauncherButton />
         <TerminalLauncherButton />
 
         {(provider || model) && (

--- a/src/quodeq/ui/src/components/TopBar.test.jsx
+++ b/src/quodeq/ui/src/components/TopBar.test.jsx
@@ -43,20 +43,21 @@ describe('TopBar mobile project label', () => {
   });
 });
 
-// Shared projects are read-only: the assistant launcher is disabled with an
-// explanatory tooltip since the assistant can take write actions (dismiss/verify).
-// The Evaluate button's own gating lives in App.jsx (shouldShowEvaluateButton),
-// not here — TopBar just renders whatever onEvaluate it's handed.
+// Shared projects get read-only assistant sessions server-side (the backend
+// roots reads in the shared clone and registers no mutating tools), so the
+// launcher is never disabled here. The Evaluate button's own gating lives in
+// App.jsx (shouldShowEvaluateButton), not here — TopBar just renders
+// whatever onEvaluate it's handed.
 describe('TopBar source gating', () => {
   it('renders the assistant launcher when selectedSource is local (default)', () => {
     renderTopBar({ selectedSource: 'local' });
     expect(screen.getByRole('button', { name: /Assistant/i })).toBeInTheDocument();
   });
 
-  it('disables (but keeps) the assistant launcher when selectedSource is shared', () => {
+  it('renders the assistant launcher enabled when selectedSource is shared (read-only session)', () => {
     renderTopBar({ selectedSource: 'shared' });
-    const btn = screen.getByRole('button', { name: /assistant is unavailable/i });
-    expect(btn).toHaveAttribute('aria-disabled', 'true');
+    const btn = screen.getByRole('button', { name: /^Assistant \(Ctrl\+`\)$/ });
+    expect(btn).not.toHaveAttribute('aria-disabled');
   });
 
   it('defaults to local (assistant shown) when selectedSource is not passed', () => {

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawer.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawer.jsx
@@ -26,8 +26,8 @@ export function AssistantPane({ uiState }) {
   const [menuDismissed, setMenuDismissed] = useState(false);
 
   const suggestions = useMemo(
-    () => (streaming ? [] : matchCommands(catalog, draft)),
-    [catalog, draft, streaming],
+    () => (streaming ? [] : matchCommands(catalog, draft, { readOnly })),
+    [catalog, draft, streaming, readOnly],
   );
   const menuVisible = suggestions.length > 0 && !menuDismissed;
 
@@ -41,10 +41,10 @@ export function AssistantPane({ uiState }) {
     if (!text || streaming) return;
     const meta = parseMetaCommand(text);
     if (meta === 'clear') { resetConversation(); setDraft(''); return; }
-    if (meta) { addLocalExchange(text, buildMetaResponse(meta, catalog)); setDraft(''); return; }
+    if (meta) { addLocalExchange(text, buildMetaResponse(meta, catalog, { readOnly })); setDraft(''); return; }
     sendMessage(text, uiState);
     setDraft('');
-  }, [draft, streaming, sendMessage, uiState, catalog, addLocalExchange, resetConversation]);
+  }, [draft, streaming, sendMessage, uiState, catalog, addLocalExchange, resetConversation, readOnly]);
 
   const handleKeyDown = useCallback((event) => {
     if (menuVisible) {

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawer.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawer.jsx
@@ -19,7 +19,7 @@ import { StopIcon } from '../../components/CopyButton.jsx';
 export function AssistantPane({ uiState }) {
   const {
     messages, streaming, error, sendMessage, stopTurn,
-    catalog, addLocalExchange, resetConversation,
+    catalog, addLocalExchange, resetConversation, readOnly,
   } = useAssistantDrawer();
   const [draft, setDraft] = useState('');
   const [menuIndex, setMenuIndex] = useState(0);
@@ -69,7 +69,7 @@ export function AssistantPane({ uiState }) {
   return (
     <>
       {messages.length === 0
-        ? <AssistantWelcome catalog={catalog} view={uiState?.view} onPick={setDraft} />
+        ? <AssistantWelcome catalog={catalog} view={uiState?.view} onPick={setDraft} readOnly={readOnly} />
         : <MessageList messages={messages} streaming={streaming} />}
       {error && <div className="assistant-drawer-error" role="alert">{error}</div>}
       <div className="assistant-drawer-input-row">

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawer.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawer.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 
@@ -13,7 +13,7 @@ const state = {
     { role: 'tool', name: 'get_report', argsSummary: '{"dimension":"security"}' },
   ],
   streaming: false, error: null, sendMessage: vi.fn(), stopTurn: vi.fn(),
-  catalog: null, addLocalExchange: vi.fn(), resetConversation: vi.fn(),
+  catalog: null, addLocalExchange: vi.fn(), resetConversation: vi.fn(), readOnly: false,
 };
 vi.mock('./AssistantDrawerProvider.jsx', () => ({ useAssistantDrawer: () => state }));
 vi.mock('./ActionPreviewCard.jsx', () => ({ ActionPreviewCard: ({ action }) => <div>card:{action.actionId}</div> }));
@@ -104,4 +104,71 @@ it('shows a Stop control while a turn is streaming and it stops the turn', () =>
 it('hides the Stop control when no turn is running', () => {
   render(<AssistantPane uiState={{}} />);
   expect(screen.queryByRole('button', { name: /stop/i })).toBeNull();
+});
+
+describe('read-only sessions (source: shared)', () => {
+  const writeCatalog = {
+    commands: [],
+    skills: [
+      { name: 'explain-score', description: 'Explain a dimension score', argumentHint: '' },
+      { name: 'verify-finding', description: 'Verify a finding', argumentHint: '', requiresWrite: true },
+      { name: 'create-standard', description: 'Draft a custom standard', argumentHint: '', requiresWrite: true },
+    ],
+    actions: [],
+  };
+  const prevCatalog = state.catalog;
+
+  beforeEach(() => { state.catalog = writeCatalog; state.readOnly = true; });
+  afterEach(() => { state.catalog = prevCatalog; state.readOnly = false; });
+
+  it('autocomplete hides requiresWrite skills', () => {
+    render(<AssistantPane uiState={{}} />);
+    const input = screen.getByPlaceholderText(/ask/i);
+    fireEvent.change(input, { target: { value: '/' } });
+    expect(screen.getByText('/explain-score')).toBeInTheDocument();
+    expect(screen.queryByText('/verify-finding')).toBeNull();
+    expect(screen.queryByText('/create-standard')).toBeNull();
+  });
+
+  it('/skills hides requiresWrite skills and /help uses the read-only line', () => {
+    render(<AssistantPane uiState={{}} />);
+    const input = screen.getByPlaceholderText(/ask/i);
+    fireEvent.change(input, { target: { value: '/skills' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    let response = state.addLocalExchange.mock.calls.at(-1)[1];
+    expect(response).toContain('/explain-score');
+    expect(response).not.toContain('/verify-finding');
+    expect(response).not.toContain('/create-standard');
+
+    fireEvent.change(input, { target: { value: '/help' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    response = state.addLocalExchange.mock.calls.at(-1)[1];
+    expect(response).toContain('I can explain scores and dig into findings for this remote project.');
+    expect(response).not.toContain('draft standards');
+  });
+});
+
+describe('default (non-read-only) sessions', () => {
+  it('autocomplete still offers write-shaped skills', () => {
+    const prevCatalog = state.catalog;
+    state.catalog = {
+      commands: [],
+      skills: [{ name: 'create-standard', description: 'Draft a custom standard', argumentHint: '', requiresWrite: true }],
+      actions: [],
+    };
+    render(<AssistantPane uiState={{}} />);
+    const input = screen.getByPlaceholderText(/ask/i);
+    fireEvent.change(input, { target: { value: '/' } });
+    expect(screen.getByText('/create-standard')).toBeInTheDocument();
+    state.catalog = prevCatalog;
+  });
+
+  it('/help keeps the default "draft standards" line', () => {
+    render(<AssistantPane uiState={{}} />);
+    const input = screen.getByPlaceholderText(/ask/i);
+    fireEvent.change(input, { target: { value: '/help' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    const response = state.addLocalExchange.mock.calls.at(-1)[1];
+    expect(response).toContain('I can explain scores, dig into findings, and draft standards for this project.');
+  });
 });

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.jsx
@@ -9,29 +9,6 @@ const DEFAULT_HEIGHT = 320;
 const MIN_HEIGHT = 160;
 const MAX_HEIGHT = 640;
 
-// useProjectState's SOURCE_STORAGE_KEY (hooks/useProjectState.js). Not
-// imported directly: this provider mounts at the app root (main.jsx), above
-// App and the useProjectState hook that owns `selectedSource`, so it has no
-// React state to read the current source from. Every source change is
-// paired with a synchronous write to this key (persistSource), which makes
-// it the synchronous source of truth available at keydown time.
-const SOURCE_STORAGE_KEY = 'quodeq_selected_source';
-
-// True when the persisted project source is the read-only shared-repo
-// mirror. The assistant's dismiss/verify tools mutate the local store, and a
-// shared project can collide with a local project id, so the drawer must not
-// open (via shortcut or programmatic open()) while a shared project is
-// selected. Reads default to 'local' (i.e. this returns false) on any storage
-// failure (private browsing, disabled storage), matching the app's other
-// defensive storage reads.
-function isSharedSourceActive() {
-  try {
-    return localStorage.getItem(SOURCE_STORAGE_KEY) === 'shared';
-  } catch {
-    return false;
-  }
-}
-
 function clampHeight(px) {
   return Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, px));
 }
@@ -200,7 +177,6 @@ export function AssistantDrawerProvider({ children }) {
   // Defense in depth: open() is exposed on the context value, so a future
   // caller besides the keydown handler below could invoke it directly.
   const open = useCallback(() => {
-    if (isSharedSourceActive()) return;
     setOpenPanels((prev) => (prev.length ? prev : [activeTabRef.current]));
   }, []);
   const close = useCallback(() => setOpenPanels([]), []);          // close ALL panels
@@ -215,10 +191,9 @@ export function AssistantDrawerProvider({ children }) {
     });
   }, []);
 
-  // Close one SPECIFIC panel, active or not (App uses this to shut only the
-  // assistant when a shared project is selected — the terminal must survive).
-  // If it was the active one, fall back to the most recent remaining panel,
-  // same rule as closeActiveTab.
+  // Close one SPECIFIC panel, active or not, leaving any other open panel
+  // alone. If it was the active one, fall back to the most recent remaining
+  // panel, same rule as closeActiveTab.
   const closePanel = useCallback((tab) => {
     setOpenPanels((prev) => {
       if (!prev.includes(tab)) return prev;
@@ -251,18 +226,13 @@ export function AssistantDrawerProvider({ children }) {
       if (e.code !== 'Backquote' || !(e.ctrlKey || e.metaKey)) return;
       e.preventDefault();
       // Terminal shortcut (Ctrl+Shift+`) is always available, regardless of
-      // project source. Only the assistant shortcut (Ctrl+`) is gated by source.
+      // project source.
       if (e.shiftKey) {
         if (terminalEnabled) toggleTopbar('terminal');
         return;
       }
-      // This provider mounts above App/useProjectState, so it can't read
-      // `selectedSource` as React state; the persisted key is the
-      // synchronous authority instead (see isSharedSourceActive above). The
-      // assistant's dismiss/verify tools act on the local store, which can
-      // collide with a shared project's id, so the shortcut must not open
-      // the drawer while a shared project is selected.
-      if (isSharedSourceActive()) return;
+      // Shared projects get read-only sessions server-side, so the shortcut
+      // opens the drawer for any source.
       if (assistantEnabled) toggleTopbar('assistant');
       else if (terminalEnabled) toggleTopbar('terminal');
     };

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.jsx
@@ -174,8 +174,8 @@ export function AssistantDrawerProvider({ children }) {
   const [maximized, setMaximized] = useState(false);
   const toggleMaximized = useCallback(() => setMaximized((m) => !m), []);
 
-  // Defense in depth: open() is exposed on the context value, so a future
-  // caller besides the keydown handler below could invoke it directly.
+  // Open the drawer with the previously active tab; exposed on the context
+  // for programmatic callers besides the keydown handler below.
   const open = useCallback(() => {
     setOpenPanels((prev) => (prev.length ? prev : [activeTabRef.current]));
   }, []);
@@ -285,6 +285,10 @@ export function AssistantDrawerProvider({ children }) {
 
   const startSession = useCallback(async (ctx) => {
     const key = `${ctx?.provider}:${ctx?.model}:${ctx?.projectId}:${ctx?.runId}:${ctx?.source || 'local'}`;
+    // Re-claim the latest-requested key even when deduping: a superseded
+    // in-flight commit for a DIFFERENT context must not land after the user
+    // returned to this one (rapid source flip-flop race).
+    latestKeyRef.current = key;
     if (key === sessionCtxKey && sessionId) return;
     await commitSession(ctx, key);
   }, [sessionCtxKey, sessionId, commitSession]);

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.jsx
@@ -130,6 +130,10 @@ export function AssistantDrawerProvider({ children }) {
   writeEnabledRef.current = writeEnabled;
   const [repoInfo, setRepoInfo] = useState(null);   // {attached, reason, writeAvailable}
   const [workspace, setWorkspace] = useState(null); // status route's `worktree` object
+  // Whether the active session is read-only (source: 'shared'), from the
+  // create-session response. Reset on every context switch via commitSession,
+  // same as repoInfo — never sticky across sessions.
+  const [readOnly, setReadOnly] = useState(false);
 
   // Tracks the most recently *requested* session context key, set
   // synchronously at startSession call time. Because startSession awaits a
@@ -301,6 +305,7 @@ export function AssistantDrawerProvider({ children }) {
     setWriteEnabled(false);
     setRepoInfo({ attached: !!created.repoAttached, reason: created.repoReason || null,
                   writeAvailable: !!created.writeAvailable });
+    setReadOnly(!!created.readOnly);
     setWorkspace(null);
     setSessionCtxKey(key);
     setSessionId(created.sessionId);
@@ -309,7 +314,7 @@ export function AssistantDrawerProvider({ children }) {
   }, []);
 
   const startSession = useCallback(async (ctx) => {
-    const key = `${ctx?.provider}:${ctx?.model}:${ctx?.projectId}:${ctx?.runId}`;
+    const key = `${ctx?.provider}:${ctx?.model}:${ctx?.projectId}:${ctx?.runId}:${ctx?.source || 'local'}`;
     if (key === sessionCtxKey && sessionId) return;
     await commitSession(ctx, key);
   }, [sessionCtxKey, sessionId, commitSession]);
@@ -321,7 +326,12 @@ export function AssistantDrawerProvider({ children }) {
   const resetConversation = useCallback(async () => {
     const ctx = lastCtxRef.current;
     if (!ctx || turnActive) return;
-    const key = `${ctx?.provider}:${ctx?.model}:${ctx?.projectId}:${ctx?.runId}`;
+    // Must match startSession's key format exactly: sessionCtxKey is shared
+    // state between the two, and a mismatched format here would make a
+    // subsequent startSession for the SAME context fail its dedupe check
+    // (stale-format key !== freshly-computed key) and mint a spurious extra
+    // session.
+    const key = `${ctx?.provider}:${ctx?.model}:${ctx?.projectId}:${ctx?.runId}:${ctx?.source || 'local'}`;
     await commitSession(ctx, key);
   }, [turnActive, commitSession]);
 
@@ -374,11 +384,11 @@ export function AssistantDrawerProvider({ children }) {
     sessionReady: sessionId != null,
     provider: sessionMeta.provider, model: sessionMeta.model,
     webEnabled, toggleWebEnabled,
-    writeEnabled, toggleWriteEnabled, repoInfo, workspace, refreshWorkspace,
+    writeEnabled, toggleWriteEnabled, repoInfo, readOnly, workspace, refreshWorkspace,
     sessionId,
     catalog, addLocalExchange,
     startSession, sendMessage, stopTurn, resetConversation,
-  }), [isOpen, open, close, toggle, closeActiveTab, closePanel, openPanels, activeTab, openTab, selectTab, toggleTopbar, terminalEnabled, height, setHeight, maximized, toggleMaximized, messages, turnActive, stream.error, localError, sessionId, sessionMeta, webEnabled, toggleWebEnabled, writeEnabled, toggleWriteEnabled, repoInfo, workspace, refreshWorkspace, catalog, addLocalExchange, startSession, sendMessage, stopTurn, resetConversation]);
+  }), [isOpen, open, close, toggle, closeActiveTab, closePanel, openPanels, activeTab, openTab, selectTab, toggleTopbar, terminalEnabled, height, setHeight, maximized, toggleMaximized, messages, turnActive, stream.error, localError, sessionId, sessionMeta, webEnabled, toggleWebEnabled, writeEnabled, toggleWriteEnabled, repoInfo, readOnly, workspace, refreshWorkspace, catalog, addLocalExchange, startSession, sendMessage, stopTurn, resetConversation]);
 
   return (
     <AssistantDrawerContext.Provider value={value}>

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.test.jsx
@@ -3,7 +3,7 @@ import { render, screen, act } from '@testing-library/react';
 import { AssistantDrawerProvider, useAssistantDrawer } from './AssistantDrawerProvider.jsx';
 
 vi.mock('../../api/assistant.js', () => ({
-  createAssistantSession: vi.fn(async () => ({ sessionId: 's1' })),
+  createAssistantSession: vi.fn(async (payload) => ({ sessionId: 's1', readOnly: payload?.source === 'shared' })),
   postAssistantMessage: vi.fn(async () => ({ accepted: true })),
   stopAssistantTurn: vi.fn(async () => ({ stopping: true })),
   assistantEventsUrl: (id, a) => `/api/assistant/sessions/${id}/events?after=${a}`,
@@ -32,10 +32,12 @@ function Probe() {
       <span data-testid="messages">{JSON.stringify(d.messages)}</span>
       <span data-testid="panels">{JSON.stringify(d.openPanels)}</span>
       <span data-testid="active">{d.activeTab}</span>
+      <span data-testid="readonly">{String(d.readOnly)}</span>
       <button onClick={d.toggleWebEnabled}>web</button>
       <button onClick={() => d.startSession({ provider: 'claude', model: 'sonnet', projectId: 'p', runId: 'r' })}>start</button>
       <button onClick={() => d.startSession({ provider: 'claude', model: 'sonnet', projectId: 'pA', runId: 'r' })}>startA</button>
       <button onClick={() => d.startSession({ provider: 'claude', model: 'sonnet', projectId: 'pB', runId: 'r' })}>startB</button>
+      <button onClick={() => d.startSession({ provider: 'claude', model: 'sonnet', projectId: 'p', runId: 'r', source: 'shared' })}>startShared</button>
       <button onClick={d.toggle}>toggle</button>
       <button onClick={() => d.openTab('assistant')}>openAssistant</button>
       <button onClick={() => d.openTab('terminal')}>openTerminal</button>
@@ -165,6 +167,15 @@ it('exposes the active session provider/model for the drawer header', async () =
   await act(async () => { screen.getByText('start').click(); });
   expect(screen.getByTestId('provider').textContent).toBe('claude');
   expect(screen.getByTestId('model').textContent).toBe('sonnet');
+});
+
+it('same project id local vs shared creates DISTINCT sessions and readOnly tracks the response', async () => {
+  render(<AssistantDrawerProvider><Probe /></AssistantDrawerProvider>);
+  await act(async () => { screen.getByText('start').click(); });
+  expect(screen.getByTestId('readonly').textContent).toBe('false');
+  await act(async () => { screen.getByText('startShared').click(); });
+  expect(createAssistantSession).toHaveBeenCalledTimes(2); // source in the key → no dedupe
+  expect(screen.getByTestId('readonly').textContent).toBe('true');
 });
 
 it('surfaces an error when sendMessage POST fails (not silent)', async () => {

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.test.jsx
@@ -206,6 +206,47 @@ it('startSession race: the latest requested context wins even if it resolves fir
   expect(postAssistantMessage).toHaveBeenCalledWith('sess-pB', { text: 'x', uiState: {}, webEnabled: false, writeEnabled: false });
 });
 
+it('a superseded in-flight commit does not land after the user re-selects the original context (source flip-flop race)', async () => {
+  // Regression for the dedupe early-return NOT re-claiming latestKeyRef:
+  // start A (commits) -> start B (leave create pending) -> start A again
+  // (hits the dedupe path) -> resolve B's stale create. B's resolution must
+  // be invalidated and the committed session must still be A's.
+  const deferred = {};
+  createAssistantSession.mockImplementation((ctx) => new Promise((resolve) => {
+    const key = `${ctx.provider}:${ctx.model}:${ctx.projectId}:${ctx.runId}:${ctx.source || 'local'}`;
+    deferred[key] = () => resolve({ sessionId: `sess-${key}`, readOnly: ctx.source === 'shared' });
+  }));
+  let hookRef;
+  const Grab = () => { hookRef = useAssistantDrawer(); return null; };
+  render(<AssistantDrawerProvider><Probe /><Grab /></AssistantDrawerProvider>);
+
+  const ctxA = { provider: 'claude', model: 'sonnet', projectId: 'p', runId: 'r' };
+  const ctxB = { provider: 'claude', model: 'sonnet', projectId: 'p', runId: 'r', source: 'shared' };
+  const keyA = 'claude:sonnet:p:r:local';
+  const keyB = 'claude:sonnet:p:r:shared';
+
+  // Start A and let it commit.
+  await act(async () => { hookRef.startSession(ctxA); });
+  await act(async () => { deferred[keyA](); await Promise.resolve(); });
+  expect(screen.getByTestId('readonly').textContent).toBe('false');
+
+  // Start B; its create is left pending.
+  await act(async () => { hookRef.startSession(ctxB); });
+
+  // The user flips back to A. Same key as the already-committed session, so
+  // this hits the dedupe early-return — but it must still re-claim
+  // latestKeyRef so B's later resolution can't win.
+  await act(async () => { hookRef.startSession(ctxA); });
+
+  // Now let B's stale create resolve.
+  await act(async () => { deferred[keyB](); await Promise.resolve(); });
+
+  // B's resolution must have been ignored: still on A's session.
+  expect(screen.getByTestId('readonly').textContent).toBe('false');
+  await act(async () => { hookRef.sendMessage('x', {}); });
+  expect(postAssistantMessage).toHaveBeenCalledWith(`sess-${keyA}`, expect.objectContaining({ text: 'x' }));
+});
+
 it('webEnabled toggles, rides the POST body, and resets on a new session', async () => {
   // the race test above swapped in a deferred implementation; clearAllMocks
   // clears calls, not implementations, so restore the default here.

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.test.jsx
@@ -74,12 +74,10 @@ it('toggle flips visibility', () => {
   expect(screen.getByTestId('open').textContent).toBe('true');
 });
 
-describe('Ctrl+` shortcut — source gating', () => {
-  // The provider mounts above App/useProjectState and reads the persisted
-  // 'quodeq_selected_source' key synchronously at keydown time (it can't
-  // read App's state). The assistant's dismiss/verify tools act on the
-  // local store, which can collide with a shared project's id, so the
-  // shortcut must not open the drawer while a shared project is selected.
+describe('Ctrl+` shortcut', () => {
+  // Shared projects get read-only sessions server-side: the backend roots
+  // reads in the shared clone and registers no mutating tools, so the
+  // shortcut opens the drawer for any persisted source.
   const fireCtrlBacktick = () => {
     window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Backquote', ctrlKey: true, cancelable: true }));
   };
@@ -87,11 +85,11 @@ describe('Ctrl+` shortcut — source gating', () => {
     window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Backquote', ctrlKey: true, shiftKey: true, cancelable: true }));
   };
 
-  it('does not open the drawer when the persisted source is shared', () => {
+  it('Ctrl+` opens the assistant even when the persisted source is shared (read-only sessions handle safety)', () => {
     localStorage.setItem('quodeq_selected_source', 'shared');
     render(<AssistantDrawerProvider><Probe /></AssistantDrawerProvider>);
     act(() => fireCtrlBacktick());
-    expect(screen.getByTestId('open').textContent).toBe('false');
+    expect(screen.getByTestId('open').textContent).toBe('true');
   });
 
   it('opens the drawer when the persisted source is local', () => {
@@ -121,19 +119,6 @@ describe('Ctrl+` shortcut — source gating', () => {
     localStorage.setItem('cc-assistant-enabled', 'true');
     localStorage.setItem('cc-terminal-enabled', 'true');
     render(<AssistantDrawerProvider><Probe /></AssistantDrawerProvider>);
-    act(() => fireCtrlShiftBacktick());
-    expect(screen.getByTestId('open').textContent).toBe('true');
-  });
-
-  it('assistant shortcut (Ctrl+`) does not open for shared but terminal shortcut still works', () => {
-    localStorage.setItem('quodeq_selected_source', 'shared');
-    localStorage.setItem('cc-assistant-enabled', 'true');
-    localStorage.setItem('cc-terminal-enabled', 'true');
-    render(<AssistantDrawerProvider><Probe /></AssistantDrawerProvider>);
-    // Ctrl+` (assistant) should not open
-    act(() => fireCtrlBacktick());
-    expect(screen.getByTestId('open').textContent).toBe('false');
-    // Ctrl+Shift+` (terminal) should open
     act(() => fireCtrlShiftBacktick());
     expect(screen.getByTestId('open').textContent).toBe('true');
   });

--- a/src/quodeq/ui/src/features/assistant/AssistantWelcome.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantWelcome.jsx
@@ -7,12 +7,14 @@ import { VISIBLE_META_COMMANDS, pillsForView } from './commands.js';
  * only as pills, never as text lines. Pure UI, never persisted, never sent
  * to the model; reappears on every fresh session.
  */
-export function AssistantWelcome({ catalog, view, onPick }) {
-  const pills = pillsForView(catalog, view);
+export function AssistantWelcome({ catalog, view, onPick, readOnly = false }) {
+  const pills = pillsForView(catalog, view, { readOnly });
   return (
     <div className="assistant-welcome">
       <p className="assistant-welcome-intro">
-        I can explain scores, dig into findings, and draft standards for this project.
+        {readOnly
+          ? 'I can explain scores and dig into findings for this remote project.'
+          : 'I can explain scores, dig into findings, and draft standards for this project.'}
       </p>
       <ul className="assistant-welcome-commands">
         {VISIBLE_META_COMMANDS.map((c) => (

--- a/src/quodeq/ui/src/features/assistant/AssistantWelcome.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantWelcome.test.jsx
@@ -34,3 +34,24 @@ it('renders without a catalog (fetch failed)', () => {
   expect(screen.getByText('/help')).toBeInTheDocument();
   expect(screen.queryByRole('button')).toBeNull(); // no pills without catalog
 });
+
+const RO_CATALOG = { skills: [
+  { name: 'explain-score', description: 'd', views: ['overview'], requiresWrite: false },
+  { name: 'verify-finding', description: 'd', views: ['violations'], requiresWrite: true },
+  { name: 'create-standard', description: 'd', views: ['standards'], requiresWrite: true },
+] };
+
+it('read-only mode hides write-shaped pills and drops the draft-standards line', () => {
+  render(<AssistantWelcome catalog={RO_CATALOG} view="violations" onPick={() => {}} readOnly />);
+  expect(screen.queryByRole('button', { name: /verify finding/i })).toBeNull();
+  expect(screen.queryByRole('button', { name: /create standard/i })).toBeNull();
+  expect(screen.getByRole('button', { name: /explain score/i })).toBeInTheDocument();
+  expect(screen.getByText(/dig into findings for this remote project/i)).toBeInTheDocument();
+  expect(screen.queryByText(/draft standards/i)).toBeNull();
+});
+
+it('default mode keeps every pill and the standard intro', () => {
+  render(<AssistantWelcome catalog={RO_CATALOG} view="violations" onPick={() => {}} />);
+  expect(screen.getByRole('button', { name: /verify finding/i })).toBeInTheDocument();
+  expect(screen.getByText(/draft standards for this project/i)).toBeInTheDocument();
+});

--- a/src/quodeq/ui/src/features/assistant/commands.js
+++ b/src/quodeq/ui/src/features/assistant/commands.js
@@ -54,11 +54,11 @@ export function buildMetaResponse(kind, catalog) {
   return `I can explain scores, dig into findings, and draft standards for this project.\n\n**Commands**\n${commandLines(catalog)}`;
 }
 
-export function pillsForView(catalog, view) {
+export function pillsForView(catalog, view, { readOnly = false } = {}) {
   if (!view) return [];
-  const skills = catalog?.skills ?? [];
-  // View-relevant skills lead; the rest follow so any view with context
-  // offers every skill as a pill (skills appear only here, not as text).
+  // Read-only (remote) sessions have no draft_action server-side, so
+  // write-shaped skills would dead-end; hide their pills entirely.
+  const skills = (catalog?.skills ?? []).filter((s) => !readOnly || !s.requiresWrite);
   const matching = skills.filter((s) => (s.views ?? []).includes(view));
   const rest = skills.filter((s) => !(s.views ?? []).includes(view));
   return [...matching, ...rest]

--- a/src/quodeq/ui/src/features/assistant/commands.js
+++ b/src/quodeq/ui/src/features/assistant/commands.js
@@ -22,27 +22,30 @@ export function parseMetaCommand(text) {
   return META_COMMANDS.some((c) => c.name === name) ? name : null;
 }
 
-export function matchCommands(catalog, draft) {
+export function matchCommands(catalog, draft, { readOnly = false } = {}) {
   if (!draft.startsWith('/') || /\s/.test(draft)) return [];
   const prefix = draft.slice(1).toLowerCase();
-  const skills = (catalog?.skills ?? []).map((s) => ({
-    name: s.name, description: s.description, argumentHint: s.argumentHint || '',
-  }));
+  // Read-only (remote) sessions have no draft_action server-side, so
+  // write-shaped skills would dead-end; hide them from autocomplete too,
+  // same rule as pillsForView.
+  const skills = (catalog?.skills ?? [])
+    .filter((s) => !readOnly || !s.requiresWrite)
+    .map((s) => ({ name: s.name, description: s.description, argumentHint: s.argumentHint || '' }));
   return [...VISIBLE_META_COMMANDS.map((c) => ({ ...c, argumentHint: '' })), ...skills]
     .filter((c) => c.name.startsWith(prefix));
 }
 
-function commandLines(catalog) {
-  const skills = catalog?.skills ?? [];
+function commandLines(catalog, readOnly) {
+  const skills = (catalog?.skills ?? []).filter((s) => !readOnly || !s.requiresWrite);
   return [
     ...VISIBLE_META_COMMANDS.map((c) => `- \`/${c.name}\` ${c.description}`),
     ...skills.map((s) => `- \`/${s.name}${s.argumentHint ? ` ${s.argumentHint}` : ''}\` ${s.description}`),
   ].join('\n');
 }
 
-export function buildMetaResponse(kind, catalog) {
+export function buildMetaResponse(kind, catalog, { readOnly = false } = {}) {
   if (kind === 'skills') {
-    const skills = catalog?.skills ?? [];
+    const skills = (catalog?.skills ?? []).filter((s) => !readOnly || !s.requiresWrite);
     if (!skills.length) return 'No skill packs are installed.';
     return `**Skills**\n${skills.map((s) => `- \`/${s.name}${s.argumentHint ? ` ${s.argumentHint}` : ''}\` ${s.description}`).join('\n')}`;
   }
@@ -51,7 +54,10 @@ export function buildMetaResponse(kind, catalog) {
     if (!actions.length) return 'No draftable actions are available.';
     return `**Actions** (drafted as preview cards, applied only after you approve)\n${actions.map((a) => `- \`${a.type}\` ${a.description}`).join('\n')}`;
   }
-  return `I can explain scores, dig into findings, and draft standards for this project.\n\n**Commands**\n${commandLines(catalog)}`;
+  const intro = readOnly
+    ? 'I can explain scores and dig into findings for this remote project.'
+    : 'I can explain scores, dig into findings, and draft standards for this project.';
+  return `${intro}\n\n**Commands**\n${commandLines(catalog, readOnly)}`;
 }
 
 export function pillsForView(catalog, view, { readOnly = false } = {}) {

--- a/src/quodeq/ui/src/features/assistant/commands.test.js
+++ b/src/quodeq/ui/src/features/assistant/commands.test.js
@@ -14,6 +14,19 @@ const catalog = {
   actions: [{ type: 'create_standard', description: 'Draft a new custom standard.' }],
 };
 
+// requiresWrite-flagged catalog, mirroring what pillsForView already filters
+// on: verify-finding and create-standard dead-end in a read-only session
+// (no draft_action server-side), so the command layer must hide them too.
+const writeCatalog = {
+  commands: META_COMMANDS,
+  skills: [
+    { name: 'explain-score', description: 'Explain a dimension score', argumentHint: '[dimension]', views: ['overview'] },
+    { name: 'verify-finding', description: 'Verify a finding', argumentHint: '', requiresWrite: true },
+    { name: 'create-standard', description: 'Draft a custom standard', argumentHint: '', requiresWrite: true },
+  ],
+  actions: [],
+};
+
 test('parseMetaCommand recognizes reserved names only', () => {
   assert.equal(parseMetaCommand('/help'), 'help');
   assert.equal(parseMetaCommand('  /clear  '), 'clear');
@@ -38,6 +51,37 @@ test('buildMetaResponse renders markdown catalogs', () => {
   assert.match(buildMetaResponse('help', catalog), /\/help/);
   assert.doesNotMatch(buildMetaResponse('help', catalog), /\/actions/); // hidden metas stay out of /help
   assert.match(buildMetaResponse('help', null), /\/help/); // catalog fetch failed: still useful
+});
+
+test('matchCommands hides requiresWrite skills from autocomplete when readOnly', () => {
+  assert.deepEqual(matchCommands(writeCatalog, '/', { readOnly: true }).map((c) => c.name),
+    [...VISIBLE_META_COMMANDS.map((c) => c.name), 'explain-score']);
+  // default (non-readOnly) mode is unchanged: all skills offered
+  assert.deepEqual(matchCommands(writeCatalog, '/', { readOnly: false }).map((c) => c.name),
+    [...VISIBLE_META_COMMANDS.map((c) => c.name), 'explain-score', 'verify-finding', 'create-standard']);
+  assert.deepEqual(matchCommands(writeCatalog, '/').map((c) => c.name),
+    [...VISIBLE_META_COMMANDS.map((c) => c.name), 'explain-score', 'verify-finding', 'create-standard']);
+});
+
+test('buildMetaResponse /skills hides requiresWrite skills when readOnly; /help swaps its intro line', () => {
+  const skillsText = buildMetaResponse('skills', writeCatalog, { readOnly: true });
+  assert.match(skillsText, /\/explain-score/);
+  assert.doesNotMatch(skillsText, /\/verify-finding/);
+  assert.doesNotMatch(skillsText, /\/create-standard/);
+  // default mode unchanged: every skill listed
+  const skillsTextDefault = buildMetaResponse('skills', writeCatalog);
+  assert.match(skillsTextDefault, /\/verify-finding/);
+  assert.match(skillsTextDefault, /\/create-standard/);
+
+  const helpReadOnly = buildMetaResponse('help', writeCatalog, { readOnly: true });
+  assert.match(helpReadOnly, /I can explain scores and dig into findings for this remote project\./);
+  assert.doesNotMatch(helpReadOnly, /draft standards/);
+  assert.doesNotMatch(helpReadOnly, /\/create-standard/);
+  assert.doesNotMatch(helpReadOnly, /\/verify-finding/);
+
+  const helpDefault = buildMetaResponse('help', writeCatalog);
+  assert.match(helpDefault, /I can explain scores, dig into findings, and draft standards for this project\./);
+  assert.match(helpDefault, /\/create-standard/);
 });
 
 test('pillsForView leads with view-matching skills, then the rest, max 4', () => {

--- a/src/quodeq/ui/src/features/assistant/useAssistantContext.js
+++ b/src/quodeq/ui/src/features/assistant/useAssistantContext.js
@@ -7,14 +7,16 @@ import { useAssistantProvider } from '../settings/hooks/useAssistantProvider.js'
  * memoized without mounting the whole app.
  *
  * @param {Object} appState  from useAppState(): activeTab, selectedProject, selectedRun, projects,
- *                            currentOverviewRun, granularity, dailyRuns, overviewRunIndex, activePage
+ *                            currentOverviewRun, granularity, dailyRuns, overviewRunIndex, activePage,
+ *                            selectedSource
  * @param {Object} gate      from useAssistantProvider(): activeProvider, model
- * @returns {{ provider: string, model: string, projectId: string|undefined, runId: string|undefined, uiState: { activeTab: string, selectedProject: string, selectedRun: string, dimension?: string, grouping?: string, overviewDate?: string } }}
+ * @returns {{ provider: string, model: string, projectId: string|undefined, runId: string|undefined, source: 'local'|'shared', uiState: { activeTab: string, selectedProject: string, selectedRun: string, dimension?: string, grouping?: string, overviewDate?: string } }}
  */
 export function deriveAssistantContext(appState, gate) {
   const {
     activeTab, selectedProject, selectedRun, projects,
     currentOverviewRun, granularity, dailyRuns, overviewRunIndex, activePage,
+    selectedSource,
   } = appState || {};
   const dimension = activePage?.dimension;
 
@@ -51,6 +53,7 @@ export function deriveAssistantContext(appState, gate) {
     model: gate?.model,
     projectId,
     runId,
+    source: selectedSource || 'local',
     uiState,
   };
 }

--- a/src/quodeq/ui/src/features/assistant/useAssistantContext.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/useAssistantContext.test.jsx
@@ -19,7 +19,7 @@ it('derives provider/model/project/run/uiState from app + settings', () => {
   const ctx = deriveAssistantContext(appState, gate);
   expect(ctx).toEqual({
     provider: 'claude', model: 'sonnet',
-    projectId: 'selectives', runId: 'run-9',
+    projectId: 'selectives', runId: 'run-9', source: 'local',
     uiState: {
       view: 'overview', activeTab: 'overview', selectedProject: 'selectives',
       selectedRun: 'run-9', currentOverviewRun: 'run-9',
@@ -98,4 +98,11 @@ it('omits grouping, overviewDate and dimension when absent', () => {
   expect('grouping' in ctx.uiState).toBe(false);
   expect('overviewDate' in ctx.uiState).toBe(false);
   expect('dimension' in ctx.uiState).toBe(false);
+});
+
+it('emits the selected source, defaulting to local', () => {
+  const gate = { activeProvider: 'ollama', model: 'm' };
+  expect(deriveAssistantContext({ selectedSource: 'shared' }, gate).source).toBe('shared');
+  expect(deriveAssistantContext({ selectedSource: 'local' }, gate).source).toBe('local');
+  expect(deriveAssistantContext({}, gate).source).toBe('local');
 });

--- a/src/quodeq/ui/src/features/drawer/BottomDrawer.jsx
+++ b/src/quodeq/ui/src/features/drawer/BottomDrawer.jsx
@@ -28,7 +28,7 @@ export function BottomDrawer({ uiState }) {
           maximized, toggleMaximized, setMaximized, provider, model,
           streaming, webEnabled, toggleWebEnabled,
           writeEnabled, toggleWriteEnabled, repoInfo, workspace, refreshWorkspace,
-          sessionId, sessionReady, resetConversation } = useAssistantDrawer();
+          sessionId, sessionReady, resetConversation, readOnly } = useAssistantDrawer();
   const { addWindow } = useSidePane();
   const dragRef = useRef(null);
 
@@ -88,6 +88,11 @@ export function BottomDrawer({ uiState }) {
         {active === 'assistant' && modelLabel && (
           <Badge variant="tag" tone="accent" className="drawer-model-chip" title={modelLabel}>
             {modelLabel}
+          </Badge>
+        )}
+        {active === 'assistant' && readOnly && (
+          <Badge variant="tag" tone="info" title="Remote project session: read tools only">
+            read-only
           </Badge>
         )}
         {/* Repo attachment is the NORMAL case — only the exception is worth a

--- a/src/quodeq/ui/src/features/drawer/BottomDrawer.test.jsx
+++ b/src/quodeq/ui/src/features/drawer/BottomDrawer.test.jsx
@@ -9,7 +9,7 @@ const drawer = {
   provider: 'ollama', model: 'm', messages: [], streaming: false, error: null, sendMessage: vi.fn(),
   webEnabled: false, toggleWebEnabled: vi.fn(),
   sessionReady: true, resetConversation: vi.fn(),
-  repoInfo: null,
+  repoInfo: null, readOnly: false,
 };
 vi.mock('../assistant/AssistantDrawerProvider.jsx', () => ({ useAssistantDrawer: () => drawer }));
 vi.mock('../terminal/TerminalPane.jsx', () => ({ default: () => <div data-testid="tty" /> }));
@@ -151,4 +151,18 @@ it('warns with "no repo access" and the server reason when not attached', () => 
 it('the model chip is an accent Badge', () => {
   render(<BottomDrawer uiState={{}} />);
   expect(screen.getByTitle('Ollama · m')).toHaveClass('badge', 'badge--tag', 'badge--accent', 'drawer-model-chip');
+});
+
+it('shows a read-only info badge when the session is read-only', () => {
+  drawer.readOnly = true;
+  render(<BottomDrawer uiState={{}} />);
+  const chip = screen.getByText('read-only');
+  expect(chip).toHaveClass('badge', 'badge--tag', 'badge--info');
+  expect(chip).toHaveAttribute('title', 'Remote project session: read tools only');
+  drawer.readOnly = false;
+});
+
+it('shows NO read-only badge for normal sessions', () => {
+  render(<BottomDrawer uiState={{}} />);
+  expect(screen.queryByText('read-only')).toBeNull();
 });


### PR DESCRIPTION
UI half of the read-only assistant (stacked on #835 — do not merge before it;
retarget to develop after #835 lands). On remote (shared) projects the
assistant now opens instead of being blocked:

- context carries source; sessions are keyed and flagged by it (same
  project id local vs shared = distinct sessions); superseded in-flight
  session commits are invalidated (race hardening + regression test)
- the three block-gates (App force-close, provider open()/Ctrl+`,
  disabled launcher) are removed; the backend's read-only session is the
  safety mechanism now
- drawer shows a read-only info Badge; welcome copy, /help, /skills, and
  autocomplete are read-only aware; Verify finding / Create standard
  disappear via the catalog's requiresWrite flag
- local projects: byte-identical behavior, regression-locked

Verification: 165 test files / 1203 tests green; live E2E on a seeded dev
server (enabled launcher, badge, filtered pills, readOnly wire contract,
local default path unchanged) plus a real-world exercise against a live
shared team repo: session created with source=shared, get_overview tool
call ok, streamed answer, clean done frame. Whole-branch review: ready to
merge. Deferred follow-ups (minor): drop TopBar's now-unused selectedSource
prop; hide draftable actions from the /actions meta-response in read-only
sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)