### PR TITLE
fix(ui): topbar/sidebar title blank on remote projects

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -207,6 +207,29 @@ export function shouldShowEvaluateButton(projectsCount, selectedSource) {
 }
 
 /**
+ * The project's friendly name for the topbar/sidebar. A LOCAL selection
+ * resolves from the local projects list (selectedProjectInfo / the
+ * list-derived selectedDisplayName). A SHARED (remote) selection is NOT in
+ * that list, so selectedProjectInfo is null and selectedDisplayName stays
+ * equal to the raw UUID -- the anti-UUID guard below would then blank the
+ * title entirely. For 'shared', fall back to the resolved sharedProjectInfo
+ * payload's name (the same "has data to show" signal shouldShowProjectTabs
+ * uses). Returns null while the lists are still unresolved so the UUID never
+ * flashes. Exported so the source-gating contract is testable without
+ * mounting the whole App.
+ */
+export function resolveProjectDisplayName({
+  selectedProjectInfo, selectedSource, sharedProjectInfo, selectedDisplayName, selectedProject,
+}) {
+  return selectedProjectInfo?.displayName
+    || selectedProjectInfo?.name
+    || (selectedSource === 'shared' ? sharedProjectInfo?.name : null)
+    || (selectedDisplayName && selectedDisplayName !== selectedProject
+          ? selectedDisplayName
+          : null);
+}
+
+/**
  * Whether the sidebar's project-data tabs (overview/violations/map/history)
  * should render. The local signal is the run count from the LOCAL project
  * list -- which is null/zero for a shared selection with no local mirror, so
@@ -915,16 +938,17 @@ export default function App() {
     dismissRefreshKey,
   };
 
-  // Resolve the project's friendly name. Until the /api/projects response
-  // has populated the projects array, selectedDisplayName falls back to the
-  // raw project id (a UUID) — we explicitly filter that case out so the
-  // sidebar and topbar show nothing rather than flashing the UUID.
-  const resolvedDisplayName =
-    selectedProjectInfo?.displayName
-    || selectedProjectInfo?.name
-    || (state.selectedDisplayName && state.selectedDisplayName !== state.selectedProject
-          ? state.selectedDisplayName
-          : null);
+  // Resolve the project's friendly name (see resolveProjectDisplayName): local
+  // selections read the local projects list; shared/remote selections (absent
+  // from that list) fall back to the resolved sharedProjectInfo name. Until the
+  // lists populate this stays null so the raw UUID never flashes.
+  const resolvedDisplayName = resolveProjectDisplayName({
+    selectedProjectInfo,
+    selectedSource: state.selectedSource,
+    sharedProjectInfo: state.sharedProjectInfo,
+    selectedDisplayName: state.selectedDisplayName,
+    selectedProject: state.selectedProject,
+  });
 
   return (
     <>

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -5,6 +5,7 @@ import {
   buildEvalPrincipal, ROUTE_RENDERERS, isSharedSource, shouldBounceToEvaluate, shouldShowEvaluateButton,
   resolveSelectionAfterSharedDisconnect, shouldAutoOpenOnboardingWizard, shouldShowProjectTabs,
   buildNavigationBundle, shouldWallEmptyProjects, buildWizardHandlers, buildAssistantSessionPayload,
+  resolveProjectDisplayName,
 } from './App.jsx';
 import Sidebar from './components/Sidebar.jsx';
 
@@ -301,6 +302,44 @@ describe('Sidebar project-data tabs for a shared-only selection (component)', ()
     for (const tab of DATA_TABS) {
       expect(screen.queryByTitle(tab)).toBeNull();
     }
+  });
+});
+
+// A shared/remote project is NOT in the LOCAL projects list, so
+// selectedProjectInfo (a local-list lookup) is null and selectedDisplayName
+// stays equal to the raw UUID -- the anti-UUID guard then suppressed the
+// topbar/sidebar title entirely for remote projects. The name lives in the
+// resolved sharedProjectInfo payload; resolveProjectDisplayName must fall back
+// to it for shared sources.
+describe('resolveProjectDisplayName', () => {
+  it('uses the local project name when the selection is local', () => {
+    expect(resolveProjectDisplayName({
+      selectedProjectInfo: { name: 'growstuff' }, selectedSource: 'local',
+      sharedProjectInfo: null, selectedDisplayName: 'growstuff', selectedProject: 'uuid-1',
+    })).toBe('growstuff');
+  });
+
+  it('falls back to the shared project name for a remote selection not in the local list', () => {
+    expect(resolveProjectDisplayName({
+      selectedProjectInfo: null, selectedSource: 'shared',
+      sharedProjectInfo: { name: 'selectives-ios' },
+      selectedDisplayName: 'b6e548aa', selectedProject: 'b6e548aa',
+    })).toBe('selectives-ios');
+  });
+
+  it('does not borrow a stale shared name for a local selection', () => {
+    expect(resolveProjectDisplayName({
+      selectedProjectInfo: null, selectedSource: 'local',
+      sharedProjectInfo: { name: 'stale-remote' },
+      selectedDisplayName: 'uuid-2', selectedProject: 'uuid-2',
+    })).toBeNull();
+  });
+
+  it('still suppresses the raw UUID while the lists are unresolved', () => {
+    expect(resolveProjectDisplayName({
+      selectedProjectInfo: null, selectedSource: 'shared', sharedProjectInfo: null,
+      selectedDisplayName: 'uuid-3', selectedProject: 'uuid-3',
+    })).toBeNull();
   });
 });
 


### PR DESCRIPTION
On a remote (shared) project the topbar and sidebar showed only the page
name ("overview"), no project title — while local and published projects
showed "name / page". Reported live on selectives-ios and other REMOTE
cards.

Root cause: `resolvedDisplayName` and the list-derived `selectedDisplayName`
both look the selection up in the LOCAL projects list only. A shared project
is not in that list, so `selectedProjectInfo` is null and
`selectedDisplayName` stays equal to the raw UUID — the anti-UUID-flash guard
then blanks the title entirely. (Same "shared selection resolved against the
local list" class as the sidebar-tabs fix in #818.)

Fix: extract `resolveProjectDisplayName` (exported, pure, tested) and, for
`selectedSource === 'shared'`, fall back to the resolved `sharedProjectInfo`
name — the same signal `shouldShowProjectTabs` already uses. Local behavior
and the UUID-suppression guard are unchanged.

Verified live against the real shared repo: "selectives-ios / overview" now
shows on click and after reload; local projects ("ui / overview") unchanged.
165 test files / 1207 tests green (4 new helper tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)