### PR TITLE
Release v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.7.1] - 2026-07-23
+
+Same features as 1.7.0 (see below). 1.7.0 did not reach PyPI or Homebrew because a publish-time test was flaky under a git race; pip and Homebrew users should install 1.7.1.
+
+### Fixes
+- **Release plumbing**: a shared-publish idempotency test monkeypatched the clock with a fixed two-value iterator, which a legitimate rebase-retry under a git push/fetch race could exhaust (StopIteration), failing the publish workflow non-deterministically. The test now uses a monotonic clock. No change to shipped code from 1.7.0.
+
 ## [1.7.0] - 2026-07-23
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,26 @@
 
 ## [1.7.1] - 2026-07-23
 
-Same features as 1.7.0 (see below). 1.7.0 did not reach PyPI or Homebrew because a publish-time test was flaky under a git race; pip and Homebrew users should install 1.7.1.
+This is the first 1.7 release to reach PyPI and Homebrew. 1.7.0 shipped desktop builds but a flaky publish-time test blocked its PyPI and Homebrew steps, so pip and Homebrew users install 1.7.1. The full 1.7 feature set is below; there is no change to shipped code between 1.7.0 and 1.7.1 beyond the release-plumbing fix.
+
+### Features
+- **Shared evaluations (share the code)**: publish a project's results to a git repository your team controls, and browse teammates' evaluations read-only from the same Repositories page. Publishing is additive and syncs only completed runs. There is no server, the shared repo is your own git remote and auth is your existing git access.
+- **Semantic precedent matching**: when you dismiss a finding, Quodeq now recognizes the same issue on later runs by meaning, not just by exact fingerprint, so a false positive you already judged stops coming back after small code or wording changes.
+- **Assistant on remote projects**: the AI assistant now opens on shared (remote) projects in read-only mode, so you can ask it to explain scores and dig into findings on a teammate's results without a local copy. Its mutating actions stay disabled there.
+- **Projects page redesign**: local and shared projects live in one unified, filterable list with sync-state badges (local / published / remote) and a single badge system that follows your theme in light and dark.
+- **Grade formula responsiveness**: changing a grade threshold invalidates the cached scores immediately, so the dashboard reflects your new formula without a manual refresh.
+- **macOS Help menu**: a native Help menu on the desktop app.
+
+### Improvements
+- **Projects page**: newly added projects appear instantly, a location filter (local / published / remote), and cards flip to their published state right after publishing instead of waiting for a background refresh.
 
 ### Fixes
-- **Release plumbing**: a shared-publish idempotency test monkeypatched the clock with a fixed two-value iterator, which a legitimate rebase-retry under a git push/fetch race could exhaust (StopIteration), failing the publish workflow non-deterministically. The test now uses a monotonic clock. No change to shipped code from 1.7.0.
+- **Security**: hardened error-detail handling in confidentiality checks, tightened SSRF path and shell-argument handling on clone, and a batch of security and reliability findings from the audit.
+- **Terminal on remote projects**: the terminal now opens on shared projects (it is a local shell and never needed a project mutation path).
+- **Remote project title**: the topbar and sidebar show the project name (clickable) on remote projects instead of only the page name.
+- **Shared repositories**: consistent online and offline project states, safe clone cleanup on Windows with read-only git objects, shallow-clone handling for online repos, and correct sidebar tabs, empty states, and navigation for shared selections.
+- **Onboarding**: the setup-incomplete state resolves correctly once a project has runs.
+- **Release plumbing**: a shared-publish idempotency test monkeypatched the clock with a fixed two-value iterator, which a legitimate rebase-retry under a git push/fetch race could exhaust (StopIteration) and fail the publish workflow non-deterministically; the test now uses a monotonic clock.
 
 ## [1.7.0] - 2026-07-23
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <h2 align="center">AI-powered code quality and security scanner</h2>
-<p align="center"><strong>v1.7.0</strong></p>
+<p align="center"><strong>v1.7.1</strong></p>
 <p align="center">
   <a href="https://github.com/quodeq/quodeq/actions/workflows/test.yml"><img src="https://github.com/quodeq/quodeq/actions/workflows/test.yml/badge.svg" alt="Tests" /></a>
   <a href="https://github.com/quodeq/quodeq/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>

--- a/packaging/macos/launcher.sh
+++ b/packaging/macos/launcher.sh
@@ -63,7 +63,7 @@ if [ -z "$QUODEQ" ]; then
         # ranges. The release skill bumps this on every cut (see
         # .claude/skills/release/SKILL.md).
         # TODO: ship requirements.txt with hashes in the .app bundle.
-        python3 -m pip install --user --only-binary :all: --no-deps "quodeq==1.7.0" 2>&1
+        python3 -m pip install --user --only-binary :all: --no-deps "quodeq==1.7.1" 2>&1
     fi
     export PATH="$PATH:$(python3 -m site --user-base)/bin"
     QUODEQ=$(command -v quodeq 2>/dev/null)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quodeq"
-version = "1.7.0"
+version = "1.7.1"
 description = "Source code quality evaluation platform powered by AI"
 readme = "README.md"
 license = "MIT"

--- a/tests/services/test_shared_publish_git.py
+++ b/tests/services/test_shared_publish_git.py
@@ -12,6 +12,22 @@ from quodeq.services.shared_publish import PublishError, publish_project
 from quodeq.services.shared_repo import ensure_shared_clone, shared_repo_path
 
 
+def _monotonic_clock(start: float = 1_000_000.0, step: float = 50.0):
+    """A stand-in for time.time() that returns a strictly increasing value on
+    every call. Used instead of a finite iterator so a publish that reads the
+    clock more than once (the rebase-retry path under a git race) can never
+    exhaust it -- the tests that use it assert on commit count / timestamp
+    ordering, both of which a monotonic clock satisfies deterministically.
+    """
+    state = {"t": start - step}
+
+    def clock() -> float:
+        state["t"] += step
+        return state["t"]
+
+    return clock
+
+
 def _bare_origin(tmp_path: Path) -> str:
     origin = tmp_path / "origin.git"
     subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
@@ -76,8 +92,12 @@ def test_publish_is_idempotent_no_empty_commit(tmp_path, monkeypatch):
     """
     url = _bare_origin(tmp_path)
     root = _local_project(tmp_path)
-    times = iter([1_000_000.0, 1_000_050.0])
-    monkeypatch.setattr(shared_publish.time, "time", lambda: next(times))
+    # A monotonic clock, not a finite iterator: the publish path may legitimately
+    # read time.time() more than once per call (e.g. the rebase-retry loop under
+    # a git push/fetch race), and this test asserts idempotency by COMMIT COUNT,
+    # not by a frozen timestamp -- so a clock that keeps ticking is both correct
+    # and more faithful to "regardless of wall-clock ticks between publishes".
+    monkeypatch.setattr(shared_publish.time, "time", _monotonic_clock())
     publish_project("proj-uuid-1", url, evaluations_root=root)
     publish_project("proj-uuid-1", url, evaluations_root=root)  # must not raise
     repo = shared_repo_path(url)
@@ -93,8 +113,10 @@ def test_publish_after_real_change_commits_and_advances_published_at(tmp_path, m
     advances -- the idempotency fix must not suppress real updates."""
     url = _bare_origin(tmp_path)
     root = _local_project(tmp_path)
-    times = iter([1_000_000.0, 1_000_100.0])
-    monkeypatch.setattr(shared_publish.time, "time", lambda: next(times))
+    # Monotonic clock (see the idempotency test): every read is strictly greater
+    # than the last, so the "second publishedAt > first" assertion holds no
+    # matter how many times the publish path reads the clock.
+    monkeypatch.setattr(shared_publish.time, "time", _monotonic_clock())
 
     publish_project("proj-uuid-1", url, evaluations_root=root)
     repo = shared_repo_path(url)

--- a/tests/shared/test_run_heartbeat.py
+++ b/tests/shared/test_run_heartbeat.py
@@ -15,8 +15,17 @@ def test_starts_and_touches_file(tmp_path: Path) -> None:
         time.sleep(0.2)
         assert (tmp_path / HEARTBEAT_FILENAME).exists()
         first_mtime = (tmp_path / HEARTBEAT_FILENAME).stat().st_mtime
-        time.sleep(0.2)
-        second_mtime = (tmp_path / HEARTBEAT_FILENAME).stat().st_mtime
+        # Poll for the next touch instead of a fixed sleep: a loaded CI runner
+        # can starve the heartbeat thread so no touch lands inside a 0.2s
+        # window, leaving both reads on the same mtime (a false failure). This
+        # mirrors the deadline-poll pattern in test_swallows_oserror below.
+        second_mtime = first_mtime
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            second_mtime = (tmp_path / HEARTBEAT_FILENAME).stat().st_mtime
+            if second_mtime > first_mtime:
+                break
+            time.sleep(0.02)
         assert second_mtime > first_mtime, "heartbeat should advance mtime between intervals"
     finally:
         hb.stop()

--- a/uv.lock
+++ b/uv.lock
@@ -821,7 +821,7 @@ wheels = [
 
 [[package]]
 name = "quodeq"
-version = "1.7.0"
+version = "1.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
Cuts v1.7.1. Same features as 1.7.0 (full notes in the 1.7.0 CHANGELOG entry, kept below the 1.7.1 entry).

1.7.0 did not reach PyPI or Homebrew: a shared-publish idempotency test monkeypatched the clock with a fixed two-value iterator that a legitimate rebase-retry under a git push/fetch race could exhaust (StopIteration), failing the publish workflow. This PR fixes the test (monotonic clock) plus the version bump. No shipped code changed from 1.7.0.

Pre-flight: Python 4918 passed; the previously-flaky file passes 3/3 deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)