### PR TITLE
fix(export): apply zip size cap to compressed archive size

### DIFF
--- a/src/quodeq/api/import_project.py
+++ b/src/quodeq/api/import_project.py
@@ -38,6 +38,11 @@ _MAX_MEMBERS = 50_000
 _MAX_PER_MEMBER_BYTES = 1 * 1024 * 1024 * 1024  # 1 GiB uncompressed cap per file
 _MAX_RATIO = 200  # uncompressed/compressed ratio per member (zip-bomb guard)
 _RATIO_GUARD_THRESHOLD = 1024  # only enforce ratio above this uncompressed size
+# The MB cap (QUODEQ_MAX_ZIP_SIZE_MB) applies to the zip bytes, matching the
+# export side. Extraction gets this multiple as headroom: evaluation data is
+# text that deflates ~5x, so a cap-sized archive legitimately inflates past
+# the cap. Total extraction stays bounded at cap * headroom.
+_EXTRACT_HEADROOM = 10
 _MAX_PATH_DEPTH = 64  # limit on path components to bound recursion-style attacks
 
 _ACTION_REPLACE = "replace"
@@ -371,7 +376,7 @@ def import_zip_stream(stream: Any, reports_dir: str, action: str | None) -> Resp
 
     try:
         with zipfile.ZipFile(io.BytesIO(raw)) as zf:
-            top_dir, members = _validate_archive(zf, max_total_bytes=size_limit)
+            top_dir, members = _validate_archive(zf, max_total_bytes=size_limit * _EXTRACT_HEADROOM)
 
             repo_info_arc = f"{top_dir}/{_REPO_INFO_FILENAME}"
             if repo_info_arc not in members:

--- a/src/quodeq/api/zip.py
+++ b/src/quodeq/api/zip.py
@@ -66,30 +66,37 @@ def _build_manifest(project_path: Path) -> dict[str, object]:
 
 
 def _build_project_zip(project_path: Path) -> Path:
-    """Create a temporary zip archive of a project directory and return its path."""
+    """Create a temporary zip archive of a project directory and return its path.
+
+    The size cap applies to the compressed archive, matching the check on the
+    import side (which reads the zip bytes against the same limit).
+    """
     fd, tmp_path = tempfile.mkstemp(suffix=".zip", prefix="quodeq_export_")
     os.close(fd)
-    total_size = 0
     size_limit = _max_zip_size_bytes()
+    limit_error = ValueError(
+        f"Project exceeds maximum export size of {size_limit // (1024 * 1024)} MB compressed. "
+        f"Reduce the project size or increase QUODEQ_MAX_ZIP_SIZE_MB."
+    )
     try:
-        with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
-            for file_entry in project_path.rglob("*"):
-                if file_entry.is_symlink():
-                    continue
-                if not file_entry.is_file():
-                    continue
-                # Skip any prior manifest so the export-time one is authoritative.
-                if file_entry == project_path / _MANIFEST_FILENAME:
-                    continue
-                total_size += file_entry.stat().st_size
-                if total_size > size_limit:
-                    raise ValueError(
-                        f"Project exceeds maximum export size of {size_limit // (1024 * 1024)} MB. "
-                        f"Reduce the project size or increase QUODEQ_MAX_ZIP_SIZE_MB."
-                    )
-                zf.write(file_entry, file_entry.relative_to(project_path.parent))
-            manifest_arcname = f"{project_path.name}/{_MANIFEST_FILENAME}"
-            zf.writestr(manifest_arcname, json.dumps(_build_manifest(project_path), indent=2))
+        with open(tmp_path, "wb") as fh:
+            with zipfile.ZipFile(fh, "w", zipfile.ZIP_DEFLATED) as zf:
+                for file_entry in project_path.rglob("*"):
+                    if file_entry.is_symlink():
+                        continue
+                    if not file_entry.is_file():
+                        continue
+                    # Skip any prior manifest so the export-time one is authoritative.
+                    if file_entry == project_path / _MANIFEST_FILENAME:
+                        continue
+                    zf.write(file_entry, file_entry.relative_to(project_path.parent))
+                    if fh.tell() > size_limit:
+                        raise limit_error
+                manifest_arcname = f"{project_path.name}/{_MANIFEST_FILENAME}"
+                zf.writestr(manifest_arcname, json.dumps(_build_manifest(project_path), indent=2))
+        # The central directory is written on close; re-check the final size.
+        if os.path.getsize(tmp_path) > size_limit:
+            raise limit_error
     except (OSError, zipfile.BadZipFile, ValueError):
         os.unlink(tmp_path)
         raise

--- a/tests/api/test_project_import.py
+++ b/tests/api/test_project_import.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import uuid
 import zipfile
 from datetime import datetime, timezone
@@ -390,6 +391,20 @@ def test_import_oversize_returns_413(app_client, monkeypatch):
             headers=_ORIGIN,
         )
     assert resp.status_code in (413,)
+
+
+def test_import_uncompressed_over_limit_but_compressed_under_is_accepted(app_client):
+    """The MB cap applies to the zip bytes; extraction gets bounded headroom
+    so text that legitimately compresses well (evaluation data deflates ~5x)
+    can round-trip through export and import."""
+    c, home, _ = app_client
+    # ~3 MiB uncompressed at a ~4x compression ratio -> well under a 1 MiB zip.
+    payload = b"".join(os.urandom(64) + b"x" * 192 for _ in range(12288))
+    data = _make_zip(extra_files={"evidence.jsonl": payload})
+    assert len(data) < 1024 * 1024
+    with patch("quodeq.api.import_project._max_zip_size_bytes", return_value=1024 * 1024), _patch_home(home):
+        resp = _post_zip(c, data)
+    assert resp.status_code == 200, resp.get_json()
 
 
 def test_import_zip_bomb_ratio_rejected(app_client):

--- a/tests/api/test_zip_coverage.py
+++ b/tests/api/test_zip_coverage.py
@@ -76,6 +76,30 @@ class TestBuildProjectZip:
             with pytest.raises(ValueError, match="exceeds maximum"):
                 _build_project_zip(project)
 
+    def test_limit_applies_to_compressed_size(self, tmp_path):
+        # 1 MB of repeated text deflates to ~1 KB. The cap is on the archive
+        # size, so this must export even though the input exceeds the limit.
+        from quodeq.api.zip import _build_project_zip
+        project = tmp_path / "myproject"
+        project.mkdir()
+        (project / "big.txt").write_text("x" * (1024 * 1024))
+
+        with patch("quodeq.api.zip._max_zip_size_bytes", return_value=64 * 1024):
+            result = _build_project_zip(project)
+            assert result.exists()
+            assert result.stat().st_size <= 64 * 1024
+            os.unlink(result)
+
+    def test_incompressible_data_over_limit_raises(self, tmp_path):
+        from quodeq.api.zip import _build_project_zip
+        project = tmp_path / "myproject"
+        project.mkdir()
+        (project / "blob.bin").write_bytes(os.urandom(256 * 1024))
+
+        with patch("quodeq.api.zip._max_zip_size_bytes", return_value=64 * 1024):
+            with pytest.raises(ValueError, match="exceeds maximum"):
+                _build_project_zip(project)
+
 
 class TestExportProjectZip:
     def test_invalid_project_path_traversal(self, tmp_path):


### PR DESCRIPTION
## Problem

Pulling a shared project (and exporting one) fails with "too large" when the project's files total more than `QUODEQ_MAX_ZIP_SIZE_MB` (default 500 MB) uncompressed, even though the actual zip is far smaller. Evaluation data is text that deflates ~5x: selectives-android is 830 MB on disk but a 151 MB zip. The import side already measured the zip bytes, so the export and import checks disagreed: a zip that imports fine could not be created.

## Fix

- `zip.py`: enforce the cap on the compressed archive. Check the temp file position after each member write and the final size after close (central directory).
- `import_project.py`: the byte cap stays on the zip itself; total extraction gets 10x headroom over the cap so a cap-sized archive of well-compressing text can round-trip. Per-member zip-bomb guards (200x ratio, 1 GiB per file, 50k members) are unchanged.

## Verification

- New tests: compressible project over the uncompressed cap exports and imports; incompressible data over the cap still fails.
- Full `tests/api` suite: 627 passed.
- Manual: `_build_project_zip` on the real 830 MB selectives-android project now builds a 150.9 MB zip under the default cap.