### PR TITLE
fix(analysis): isolate claude scan subprocess with --strict-mcp-config

### DIFF
--- a/src/quodeq/analysis/_command.py
+++ b/src/quodeq/analysis/_command.py
@@ -113,6 +113,10 @@ def _build_mcp_args(
     mcp_flag = provider_cfg.get("mcp_config_flag", "--mcp-config")
     mcp_prefix = provider_cfg.get("mcp_config_prefix", "")
     args: list[str] = [mcp_flag, f"{mcp_prefix}{mcp_config_path}"]
+    # Restrict the subprocess to the findings server only. Without this the
+    # CLI also loads the user's own MCP servers (user/project scope), and
+    # bypassPermissions would let the model call them.
+    args.extend(provider_cfg.get("mcp_strict_args", ["--strict-mcp-config"]))
 
     if provider_cfg.get("supports_tools", True):
         allowed = _MCP_TOOL_REPORT_FINDING

--- a/src/quodeq/analysis/_provider_cache.py
+++ b/src/quodeq/analysis/_provider_cache.py
@@ -23,6 +23,7 @@ _PROVIDER_CONFIGS_FALLBACK: dict[str, dict] = {
         "supports_budget": True,
         "supports_turns": True,
         "mcp_permission_args": ["--permission-mode", "bypassPermissions"],
+        "mcp_strict_args": ["--strict-mcp-config"],
         "env_set_if_missing": {"CODEX_SANDBOX": "read-only"},
         "env_remove": ["CLAUDECODE"],
     },

--- a/src/quodeq/data/config/ai_providers.json
+++ b/src/quodeq/data/config/ai_providers.json
@@ -31,6 +31,7 @@
     "supports_budget": true,
     "supports_turns": true,
     "mcp_permission_args": ["--permission-mode", "bypassPermissions"],
+    "mcp_strict_args": ["--strict-mcp-config"],
     "env_set_if_missing": {"CODEX_SANDBOX": "read-only"},
     "env_remove": ["CLAUDECODE"],
     "assistant": {

--- a/tests/analysis/test_command_builder.py
+++ b/tests/analysis/test_command_builder.py
@@ -105,6 +105,25 @@ class TestBuildAiCmdClaude:
         assert "--permission-mode" in args
         assert "bypassPermissions" in args
 
+    def test_strict_mcp_config_when_jsonl_set(self, tmp_path):
+        # Without --strict-mcp-config the CLI also loads the user's own MCP
+        # servers (~/.claude.json etc.) into the analysis subprocess.
+        jsonl = tmp_path / "findings.jsonl"
+        jsonl.touch()
+        config = AnalysisConfig(
+            ai_cmd="claude", ai_model="sonnet-4",
+            jsonl_file=jsonl, compiled_dir=tmp_path, dimension="security",
+        )
+        with _patch_providers(_CLAUDE_CFG):
+            args, _ = _build_ai_cmd("Analyze", config)
+        assert "--strict-mcp-config" in args
+
+    def test_no_strict_mcp_config_without_jsonl(self):
+        config = AnalysisConfig(ai_cmd="claude", ai_model="sonnet-4")
+        with _patch_providers(_CLAUDE_CFG):
+            args, _ = _build_ai_cmd("Analyze", config)
+        assert "--strict-mcp-config" not in args
+
 
 class TestBuildAiCmdCodex:
     """Codex provider command building."""


### PR DESCRIPTION
## Problem

The analysis subprocess spawns `claude -p` with `--mcp-config` for the quodeq findings server, but not `--strict-mcp-config`. The CLI therefore also loads the user's own MCP servers (user and project scope). Since the subprocess runs with `--permission-mode bypassPermissions`, those servers were callable by the model. Isolation was by convention, not enforcement.

## Fix

Add a `mcp_strict_args` provider config key, defaulting to `--strict-mcp-config` for the config-file MCP style, and append it right after `--mcp-config` in `_build_mcp_args`. The key is set explicitly in `ai_providers.json` and the Python fallback.

The assistant path already passes `--strict-mcp-config`, so no new CLI version requirement is introduced.

Gemini (`cli-register`, gated by `--allowed-mcp-server-names`) and codex (`config-arg`, inline `-c` config) return earlier in `_build_mcp_args` and are unaffected.

## Testing

- New tests: flag present when the findings server is configured, absent otherwise.
- Full suite: 4929 passed, 8 skipped.