### PR TITLE
ci: add CodeQL and Snyk scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop]
+  schedule:
+    # Weekly sweep catches newly published queries against unchanged code.
+    - cron: '30 5 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # tests/ and benchmarks/ contain intentionally vulnerable fixtures
+          # (they exercise the scanner itself); scanning them would bury real
+          # alerts in noise.
+          config: |
+            paths-ignore:
+              - tests
+              - benchmarks
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -37,13 +37,19 @@ jobs:
         if: env.SNYK_TOKEN != ''
         run: uv export --no-dev --no-hashes --no-emit-project -o requirements.txt
 
+      # Snyk's pip scanner resolves the dependency graph from installed
+      # packages, not from the requirements file alone (SNYK-OS-PYTHON-0013).
+      - name: Install requirements into a venv for Snyk
+        if: env.SNYK_TOKEN != ''
+        run: uv venv && uv pip install -r requirements.txt
+
       - name: Install Snyk CLI
         if: env.SNYK_TOKEN != ''
         run: npm install -g snyk
 
       - name: Snyk Open Source, Python dependencies
         if: env.SNYK_TOKEN != ''
-        run: snyk test --file=requirements.txt --package-manager=pip --severity-threshold=high
+        run: snyk test --file=requirements.txt --package-manager=pip --command=.venv/bin/python --severity-threshold=high
 
       - name: Snyk Open Source, UI dependencies
         if: env.SNYK_TOKEN != ''

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,14 +1,16 @@
 name: Snyk
 
 # Snyk Open Source (dependencies) + Snyk Code (SAST) on the shipped source.
-# Requires the SNYK_TOKEN repo secret; without it (e.g. PRs from forks) every
-# scan step skips and the job passes, so external contributors aren't blocked.
+# Requires the SNYK_TOKEN repo secret; without it every scan step skips and
+# the job passes.
+#
+# Weekly + manual only, not per-PR: the free Snyk tier allows a few hundred
+# tests per month and this repo merges ~200 PRs in that time. Per-PR SAST
+# gating is CodeQL's job (codeql.yml, free on public repos); the Snyk GitHub
+# app additionally diff-checks manifests on PRs without spending CLI tests.
 
 on:
-  pull_request:
-    branches: [develop, main]
-  push:
-    branches: [develop]
+  workflow_dispatch:
   schedule:
     # Weekly sweep catches newly disclosed CVEs against unchanged deps.
     - cron: '30 6 * * 1'

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -38,10 +38,14 @@ jobs:
         run: uv export --no-dev --no-hashes --no-emit-project -o requirements.txt
 
       # Snyk's pip scanner resolves the dependency graph from installed
-      # packages, not from the requirements file alone (SNYK-OS-PYTHON-0013).
+      # packages, not from the requirements file alone (SNYK-OS-PYTHON-0013),
+      # and its resolver runs inside the venv's interpreter, which needs
+      # pip and setuptools present (bare uv venvs ship neither).
       - name: Install requirements into a venv for Snyk
         if: env.SNYK_TOKEN != ''
-        run: uv venv && uv pip install -r requirements.txt
+        run: |
+          uv venv --seed
+          uv pip install setuptools -r requirements.txt
 
       - name: Install Snyk CLI
         if: env.SNYK_TOKEN != ''

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,56 @@
+name: Snyk
+
+# Snyk Open Source (dependencies) + Snyk Code (SAST) on the shipped source.
+# Requires the SNYK_TOKEN repo secret; without it (e.g. PRs from forks) every
+# scan step skips and the job passes, so external contributors aren't blocked.
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop]
+  schedule:
+    # Weekly sweep catches newly disclosed CVEs against unchanged deps.
+    - cron: '30 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  snyk:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Notice when SNYK_TOKEN is missing
+        if: env.SNYK_TOKEN == ''
+        run: echo "SNYK_TOKEN not set (fork PR or missing secret), skipping Snyk scans."
+
+      - name: Install uv
+        if: env.SNYK_TOKEN != ''
+        uses: astral-sh/setup-uv@v8.3.2
+
+      - name: Export pinned Python requirements
+        if: env.SNYK_TOKEN != ''
+        run: uv export --no-dev --no-hashes --no-emit-project -o requirements.txt
+
+      - name: Install Snyk CLI
+        if: env.SNYK_TOKEN != ''
+        run: npm install -g snyk
+
+      - name: Snyk Open Source, Python dependencies
+        if: env.SNYK_TOKEN != ''
+        run: snyk test --file=requirements.txt --package-manager=pip --severity-threshold=high
+
+      - name: Snyk Open Source, UI dependencies
+        if: env.SNYK_TOKEN != ''
+        run: snyk test --file=src/quodeq/ui/package-lock.json --package-manager=npm --severity-threshold=high
+
+      - name: Snyk Code, SAST on shipped source
+        if: env.SNYK_TOKEN != ''
+        # Scoped to src/quodeq: tests/ and benchmarks/ hold intentionally
+        # vulnerable fixtures that would always fail a repo-wide SAST scan.
+        run: snyk code test src/quodeq --severity-threshold=high


### PR DESCRIPTION
Adds two security scanning workflows, both built from public defaults (GitHub's CodeQL starter workflow and Snyk's documented CLI setup).

## CodeQL
- Languages: `python` and `javascript-typescript` (dashboard UI), build-mode none.
- Runs on PRs to develop/main, pushes to develop, and a weekly cron.
- `tests/` and `benchmarks/` are excluded: they contain intentionally vulnerable fixtures that exercise the scanner itself and would bury real alerts.

## Snyk
- **Open Source (SCA):** Python deps via `uv export` to pinned requirements, UI deps via `src/quodeq/ui/package-lock.json`. Fails on high severity.
- **Code (SAST):** scoped to `src/quodeq` for the same fixture reason. Fails on high severity.
- Every scan step is gated on the `SNYK_TOKEN` secret. Without it (fork PRs, or before the secret is added) the steps skip and the job passes, so this PR is safe to merge before the token exists.

## Setup after merge
1. Create a free Snyk account and generate an API token.
2. Add it as the `SNYK_TOKEN` repo secret.
3. Code scanning (CodeQL) alerts appear under Security once the first run completes; no setup needed on a public repo.

Validated with actionlint (same as workflow-lint CI) and `uv export` flags verified against the current lockfile.