### PR TITLE
Show remote repositories when no local projects exist

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -256,7 +256,7 @@ export function shouldShowProjectTabs({ selectedSource, hasCurrentProjectRuns, s
  * consumed but never forwarded). Exported so producer and consumer can be
  * pinned together in tests without mounting the whole App.
  */
-export function buildNavigationBundle({ state, navTab, navStackLength, isEvaluating, showToast, setWizardEntry }) {
+export function buildNavigationBundle({ state, navTab, navStackLength, isEvaluating, showToast, setWizardEntry, sharedHasContent = false }) {
   return {
     selectedProject: state.selectedProject, selectedSource: state.selectedSource, selectedRun: state.selectedRun, projects: state.projects,
     projectsLoaded: state.projectsLoaded,
@@ -299,6 +299,9 @@ export function buildNavigationBundle({ state, navTab, navStackLength, isEvaluat
         presetProjectId: projectId,
       });
     },
+    // null when the shared repo has no content — consumers use the nullness
+    // to hide their "browse remote repositories" affordance.
+    onBrowseRemote: sharedHasContent ? () => navTab('projects') : null,
     isEvaluating,
   };
 }
@@ -702,6 +705,7 @@ function MainContent({ activePage, props }) {
       <EmptyStateWithTour
         onAdd={() => props.navigation.onAddProject()}
         onTour={() => props.navigation.onTakeTour()}
+        onBrowseRemote={props.navigation.onBrowseRemote}
         isEvaluating={props.navigation.isEvaluating}
       />
     );
@@ -977,6 +981,7 @@ export default function App() {
     navigation: buildNavigationBundle({
       state, navTab, navStackLength: navStack.length,
       isEvaluating, showToast, setWizardEntry,
+      sharedHasContent: sharedSignal.hasContent,
     }),
     evaluation: state.evalLifecycle,
     serverHealth: { connected: state.serverConnected, setConnected: state.setServerConnected },

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useMemo, useState, useEffect, useRef } from 'react';
 import NavBreadcrumb, { labelFor as navLabelFor } from './features/explorer/components/NavBreadcrumb.jsx';
 import UpdateBanner from './features/updates/UpdateBanner.jsx';
+import { useSharedContentSignal } from './features/dashboard/hooks/useSharedProjects.js';
 
 const DashboardPage = lazy(() => import('./features/dashboard/components/DashboardPage.jsx'));
 const ExplorerPage = lazy(() => import('./features/explorer/components/ExplorerPage.jsx'));
@@ -363,14 +364,21 @@ export function resolveSelectionAfterSharedDisconnect({ selectedSource, projects
  * connected to a shared repo and is viewing a shared project also reads as
  * zero local projects (state.projects is always the local list per
  * useProjectState), but they already have a real working view open -- the
- * wizard must not cover it uninvited. Exported so this contract is
- * unit-testable without mounting the whole App (which needs ~8 providers).
+ * wizard must not cover it uninvited. Likewise a shared repo with published
+ * content (sharedHasContent, see useSharedContentSignal) gives the user
+ * remote repositories to browse -- the wizard must not open over those
+ * either. While the shared signal is still resolving (sharedSettled=false)
+ * the decision is DEFERRED: return false but do not latch, same as the
+ * other transient blocks. Exported so this contract is unit-testable
+ * without mounting the whole App (which needs ~8 providers).
  */
-export function shouldAutoOpenOnboardingWizard({ projectsLoaded, projectsCount, selectedSource, isEvaluating }) {
+export function shouldAutoOpenOnboardingWizard({ projectsLoaded, projectsCount, selectedSource, isEvaluating, sharedSettled = true, sharedHasContent = false }) {
   if (!projectsLoaded) return false;
   if ((projectsCount ?? 0) > 0) return false;
   if (selectedSource === 'shared') return false;
   if (isEvaluating) return false;
+  if (!sharedSettled) return false;
+  if (sharedHasContent) return false;
   return true;
 }
 
@@ -711,6 +719,11 @@ export default function App() {
   const { dismissFinding } = useApi();
   const queryClient = useQueryClient();
   const state = useAppState();
+  // Passive shared-repo content signal driving the zero-local-projects flow:
+  // wizard auto-open (below), the one-shot landing redirect, and the
+  // "browse remote repositories" empty-state actions. Same react-query cache
+  // as ProjectsPage/Settings — no extra fetching once those mount.
+  const sharedSignal = useSharedContentSignal();
   const APP_VERSION = state.serverVersion;
   const selectedProjectInfo = state.projects?.find((p) => (p.id || p.name) === state.selectedProject) || null;
   const [sidebarPinned, setSidebarPinned] = useState(false);
@@ -820,12 +833,14 @@ export default function App() {
       projectsCount: state.projects.length,
       selectedSource: state.selectedSource,
       isEvaluating,
+      sharedSettled: sharedSignal.settled,
+      sharedHasContent: sharedSignal.hasContent,
     })) {
       // Blocked for a transient reason (shared selection, an evaluation in
-      // flight) -- do NOT mark autoOpenedRef: once the block lifts (source
-      // switches back to local, the evaluation finishes) while local
-      // projects are still zero, the decision must be reconsidered rather
-      // than permanently skipped.
+      // flight, shared signal still resolving) -- do NOT mark autoOpenedRef:
+      // once the block lifts (source switches back to local, the evaluation
+      // finishes, the signal settles) while local projects are still zero, the
+      // decision must be reconsidered rather than permanently skipped.
       return;
     }
     let skipped = false;
@@ -834,7 +849,7 @@ export default function App() {
     if (!skipped) {
       setWizardEntry({ startStep: 'welcome', isFirstProject: true });
     }
-  }, [state.projectsLoaded, state.projects.length, isEvaluating, state.selectedSource]);
+  }, [state.projectsLoaded, state.projects.length, isEvaluating, state.selectedSource, sharedSignal.settled, sharedSignal.hasContent]);
 
   // Project-data tabs (overview/violations/map/history) only make sense once
   // the selected project has at least one completed evaluation run. Until

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -382,6 +382,25 @@ export function shouldAutoOpenOnboardingWizard({ projectsLoaded, projectsCount, 
   return true;
 }
 
+/**
+ * One-shot initial-landing decision. With zero local projects the default
+ * 'overview' landing is a dead-end empty state; when a configured shared
+ * repo has published content, land on the repositories tab instead so the
+ * remote projects are visible without scanning anything locally. Only the
+ * default 'overview' landing redirects: a user who already navigated
+ * elsewhere (settings, help) before the signals settled keeps their page,
+ * and a restored 'shared' selection is already a working view. The caller
+ * latches the decision once inputs settle, so mid-session deletions or
+ * disconnects never yank the user. Exported for unit tests.
+ */
+export function shouldRedirectToRemoteRepositories({ projectsLoaded, projectsCount, selectedSource, sharedSettled, sharedHasContent, activeTab }) {
+  if (!projectsLoaded || !sharedSettled) return false;
+  if ((projectsCount ?? 0) > 0) return false;
+  if (selectedSource === 'shared') return false;
+  if (!sharedHasContent) return false;
+  return activeTab === 'overview';
+}
+
 function renderEvalPrincipleDetail(params, props) {
   const { selectedProject, selectedRun, selectedSource } = props.navigation;
   const evalPrincipal = {
@@ -886,6 +905,26 @@ export default function App() {
     ? localStorage.getItem(providerKey(sidebarProvider, 'model'))
     : null;
   const { activePage, navStack, navPop, navGoTo, navTab, activeTab } = state;
+  // Initial landing: decided exactly once, the first render after both the
+  // local projects list and the shared signal have settled (whatever the
+  // outcome). Mid-session changes never re-trigger it.
+  const initialLandingDecidedRef = useRef(false);
+  useEffect(() => {
+    if (initialLandingDecidedRef.current) return;
+    if (!state.projectsLoaded || !sharedSignal.settled) return;
+    initialLandingDecidedRef.current = true;
+    if (shouldRedirectToRemoteRepositories({
+      projectsLoaded: state.projectsLoaded,
+      projectsCount: state.projects.length,
+      selectedSource: state.selectedSource,
+      sharedSettled: sharedSignal.settled,
+      sharedHasContent: sharedSignal.hasContent,
+      activeTab,
+    })) {
+      navTab('projects');
+    }
+  }, [state.projectsLoaded, state.projects.length, state.selectedSource, sharedSignal.settled, sharedSignal.hasContent, activeTab, navTab]);
+
   // Native-shell bridge: the macOS Help menu opens tabs by dispatching
   // quodeq:navigate (see _webview_window._install_macos_help_menu).
   useNativeNavBridge(navTab);

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -859,11 +859,22 @@ export default function App() {
       sharedSettled: sharedSignal.settled,
       sharedHasContent: sharedSignal.hasContent,
     })) {
-      // Blocked for a transient reason (shared selection, an evaluation in
-      // flight, shared signal still resolving) -- do NOT mark autoOpenedRef:
-      // once the block lifts (source switches back to local, the evaluation
-      // finishes, the signal settles) while local projects are still zero, the
-      // decision must be reconsidered rather than permanently skipped.
+      // A settled "shared repo has content" outcome is FINAL for this page
+      // load, not transient: if it later flips (repo disconnected in
+      // Settings, background refresh reveals an emptied repo), the wizard
+      // must not pop over the user's working view -- the wall/empty states
+      // are the non-modal fallback. Latch here; the remaining blocks
+      // (unsettled signal, shared selection, evaluation in flight) stay
+      // unlatched so the decision is reconsidered when they lift.
+      if (sharedSignal.settled && sharedSignal.hasContent) {
+        autoOpenedRef.current = true;
+      }
+      // Otherwise blocked for a transient reason (shared selection, an
+      // evaluation in flight, shared signal still resolving) -- do NOT mark
+      // autoOpenedRef: once the block lifts (source switches back to local,
+      // the evaluation finishes, the signal settles) while local projects
+      // are still zero, the decision must be reconsidered rather than
+      // permanently skipped.
       return;
     }
     let skipped = false;

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -977,6 +977,7 @@ export default function App() {
       availableRuns: state.availableRuns, dailyRuns: state.dailyRuns, overviewRunIndex: state.overviewRunIndex,
       selectedDisplayName: state.selectedDisplayName,
       granularity: state.granularity, onGranularityChange: state.onGranularityChange,
+      sharedHasContent: sharedSignal.hasContent,
     },
     navigation: buildNavigationBundle({
       state, navTab, navStackLength: navStack.length,

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -232,6 +232,21 @@ describe('shouldAutoOpenOnboardingWizard', () => {
   it('does not open while an evaluation is running', () => {
     expect(shouldAutoOpenOnboardingWizard({ ...base, isEvaluating: true })).toBe(false);
   });
+
+  // Remote-content awareness: a configured shared repo with published
+  // projects is a working view the user can browse — the wizard must not
+  // open over it (spec 2026-07-23-remote-repos-without-local-projects).
+  it('defers (no open) while the shared-repo signal has not settled', () => {
+    expect(shouldAutoOpenOnboardingWizard({ ...base, sharedSettled: false })).toBe(false);
+  });
+
+  it('does not open when the shared repo has content', () => {
+    expect(shouldAutoOpenOnboardingWizard({ ...base, sharedSettled: true, sharedHasContent: true })).toBe(false);
+  });
+
+  it('opens when the shared repo settled without content', () => {
+    expect(shouldAutoOpenOnboardingWizard({ ...base, sharedSettled: true, sharedHasContent: false })).toBe(true);
+  });
 });
 
 // Sidebar tab gating must be source-aware. hasCurrentProjectRuns is derived

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import {
   buildEvalPrincipal, ROUTE_RENDERERS, isSharedSource, shouldBounceToEvaluate, shouldShowEvaluateButton,
-  resolveSelectionAfterSharedDisconnect, shouldAutoOpenOnboardingWizard, shouldShowProjectTabs,
+  resolveSelectionAfterSharedDisconnect, shouldAutoOpenOnboardingWizard, shouldRedirectToRemoteRepositories, shouldShowProjectTabs,
   buildNavigationBundle, shouldWallEmptyProjects, buildWizardHandlers, buildAssistantSessionPayload,
   resolveProjectDisplayName,
 } from './App.jsx';
@@ -246,6 +246,45 @@ describe('shouldAutoOpenOnboardingWizard', () => {
 
   it('opens when the shared repo settled without content', () => {
     expect(shouldAutoOpenOnboardingWizard({ ...base, sharedSettled: true, sharedHasContent: false })).toBe(true);
+  });
+});
+
+// One-shot landing decision: a fresh start with zero local projects but
+// remote content lands on the repositories tab instead of the dead-end
+// 'overview' empty state. Latched in App once inputs settle — these tests
+// pin the pure decision only.
+describe('shouldRedirectToRemoteRepositories', () => {
+  const base = {
+    projectsLoaded: true, projectsCount: 0, selectedSource: 'local',
+    sharedSettled: true, sharedHasContent: true, activeTab: 'overview',
+  };
+
+  it('redirects a fresh start: zero local projects, remote content, default overview landing', () => {
+    expect(shouldRedirectToRemoteRepositories(base)).toBe(true);
+  });
+
+  it('does not redirect before local projects load', () => {
+    expect(shouldRedirectToRemoteRepositories({ ...base, projectsLoaded: false })).toBe(false);
+  });
+
+  it('does not redirect before the shared signal settles', () => {
+    expect(shouldRedirectToRemoteRepositories({ ...base, sharedSettled: false })).toBe(false);
+  });
+
+  it('does not redirect when local projects exist', () => {
+    expect(shouldRedirectToRemoteRepositories({ ...base, projectsCount: 2 })).toBe(false);
+  });
+
+  it('does not redirect over a restored shared selection (already a working view)', () => {
+    expect(shouldRedirectToRemoteRepositories({ ...base, selectedSource: 'shared' })).toBe(false);
+  });
+
+  it('does not redirect without remote content', () => {
+    expect(shouldRedirectToRemoteRepositories({ ...base, sharedHasContent: false })).toBe(false);
+  });
+
+  it('does not redirect off a non-default tab the user already navigated to', () => {
+    expect(shouldRedirectToRemoteRepositories({ ...base, activeTab: 'settings' })).toBe(false);
   });
 });
 

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -133,7 +133,7 @@ export function selectDashboardProjectInfo({ selectedSource, projects, selectedP
 }
 
 export default function DashboardPage({ data = {}, callbacks = {}, runMode = false }) {
-  const { selectedProject, selectedSource, selectedRun, projects = [], sharedProjectInfo = null, dashboard, accumulated, loading, isFetching, error, availableRuns = [], dailyRuns, overviewRunIndex = 0, granularity = 'day', onGranularityChange } = data;
+  const { selectedProject, selectedSource, selectedRun, projects = [], sharedProjectInfo = null, dashboard, accumulated, loading, isFetching, error, availableRuns = [], dailyRuns, overviewRunIndex = 0, granularity = 'day', onGranularityChange, sharedHasContent = false } = data;
   const projectInfo = selectDashboardProjectInfo({ selectedSource, projects, selectedProject, sharedProjectInfo });
   const { onNavigate, onRunSelect, onProjectsReload } = callbacks;
   // After a successful clone-on-add migration the project's repository_info.json
@@ -177,6 +177,20 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   const { projectsLoaded } = data;
   if (!projectsLoaded) return <LoadingScreen />;
   if (projects.length === 0 && selectedSource !== 'shared') {
+    // Zero local projects. When the connected shared repo has published
+    // content, the useful next step is browsing it (read-only until pulled)
+    // -- not necessarily scanning something locally. Both CTAs land on the
+    // repositories tab; the copy is what differs.
+    if (sharedHasContent) {
+      return (
+        <EmptyState
+          title="No local projects yet"
+          description="Your team's online repository has published projects you can browse without scanning anything locally."
+          actionLabel="Browse remote repositories"
+          onAction={() => onNavigate?.('projects')}
+        />
+      );
+    }
     return (
       <EmptyState
         title="No projects yet"

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -185,7 +185,7 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
       return (
         <EmptyState
           title="No local projects yet"
-          description="Your team's online repository has published projects you can browse without scanning anything locally."
+          description="Your team’s online repository has published projects you can browse without scanning anything locally."
           actionLabel="Browse remote repositories"
           onAction={() => onNavigate?.('projects')}
         />

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -1,4 +1,4 @@
-import { render, act } from '@testing-library/react';
+import { render, act, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import DashboardPage, { selectDashboardProjectInfo } from './DashboardPage.jsx';
 
@@ -153,6 +153,36 @@ describe('DashboardPage, teammate persona: shared selection + zero local project
       />,
     );
     expect(getByText('No projects yet')).toBeTruthy();
+  });
+
+  // Remote-content awareness: zero local projects + a shared repo with
+  // published content must route to the repositories tab, not dead-end on
+  // "Add a project" (spec 2026-07-23-remote-repos-without-local-projects).
+  it('local source, zero local projects, shared content: offers Browse remote repositories', () => {
+    const onNavigate = vi.fn();
+    const { getByText, queryByText } = render(
+      <DashboardPage
+        data={{ ...sharedNoLocalData, selectedSource: 'local', selectedProject: '', sharedProjectInfo: null, sharedHasContent: true }}
+        callbacks={{ onNavigate }}
+        runMode={false}
+      />,
+    );
+    expect(getByText('No local projects yet')).toBeTruthy();
+    expect(queryByText('No projects yet')).toBeNull();
+    fireEvent.click(getByText('Browse remote repositories'));
+    expect(onNavigate).toHaveBeenCalledWith('projects');
+  });
+
+  it('local source, zero local projects, NO shared content: unchanged Add-a-project wall', () => {
+    const { getByText } = render(
+      <DashboardPage
+        data={{ ...sharedNoLocalData, selectedSource: 'local', selectedProject: '', sharedProjectInfo: null, sharedHasContent: false }}
+        callbacks={{}}
+        runMode={false}
+      />,
+    );
+    expect(getByText('No projects yet')).toBeTruthy();
+    expect(getByText('Add a project')).toBeTruthy();
   });
 });
 

--- a/src/quodeq/ui/src/features/dashboard/hooks/useSharedProjects.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useSharedProjects.js
@@ -247,16 +247,25 @@ export function useSharedProjects() {
 export function useSharedContentSignal() {
   const { getSharedStatus, sharedListProjects } = useApi();
 
+  // This signal feeds a one-time startup decision (wizard auto-open,
+  // initial landing). Focus revalidation belongs to the pages that render
+  // the list, not here -- refetching on focus would let hasContent flip
+  // mid-session for users who never open those pages. This is a
+  // per-observer option and does not affect useSharedProjects' own
+  // observers on the same query keys.
   const statusQuery = useQuery({
     queryKey: sharedKeys.status(),
     queryFn: getSharedStatus,
+    refetchOnWindowFocus: false,
   });
   const configured = !!statusQuery.data?.configured;
 
+  // See comment above: same rationale applies to the list query.
   const listQuery = useQuery({
     queryKey: sharedKeys.list(),
     queryFn: () => sharedListProjects({ refresh: false }),
     enabled: configured,
+    refetchOnWindowFocus: false,
   });
 
   const statusSettled = statusQuery.isSuccess || statusQuery.isError;

--- a/src/quodeq/ui/src/features/dashboard/hooks/useSharedProjects.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useSharedProjects.js
@@ -228,3 +228,41 @@ export function useSharedProjects() {
     pull,
   };
 }
+
+/**
+ * useSharedContentSignal — passive "does the shared repo have anything to
+ * show?" signal for App-level flow decisions (wizard auto-open, initial
+ * landing, zero-local empty states). Reads the SAME sharedKeys.status()/
+ * sharedKeys.list() cache entries as useSharedProjects (react-query dedupes
+ * by key, so mounting both costs one fetch each), but deliberately has no
+ * background refresh, no mutations, and no error surface: a failed status
+ * or list load settles as hasContent=false, which falls back to today's
+ * local-only flow.
+ *
+ * settled: the decision inputs are final for this load — status resolved or
+ * errored, and (when configured) the first list fetch resolved or errored.
+ * Consumers defer their decision (without latching) until settled so the
+ * wizard doesn't flash open over a remote list that was about to appear.
+ */
+export function useSharedContentSignal() {
+  const { getSharedStatus, sharedListProjects } = useApi();
+
+  const statusQuery = useQuery({
+    queryKey: sharedKeys.status(),
+    queryFn: getSharedStatus,
+  });
+  const configured = !!statusQuery.data?.configured;
+
+  const listQuery = useQuery({
+    queryKey: sharedKeys.list(),
+    queryFn: () => sharedListProjects({ refresh: false }),
+    enabled: configured,
+  });
+
+  const statusSettled = statusQuery.isSuccess || statusQuery.isError;
+  const listSettled = listQuery.isSuccess || listQuery.isError;
+  const settled = statusSettled && (!configured || listSettled);
+  const hasContent = configured && (listQuery.data?.projects?.length ?? 0) > 0;
+
+  return { settled, hasContent };
+}

--- a/src/quodeq/ui/src/features/dashboard/hooks/useSharedProjects.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useSharedProjects.test.jsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useSharedProjects } from './useSharedProjects.js';
+import { useSharedProjects, useSharedContentSignal } from './useSharedProjects.js';
 import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
 import { ApiProvider } from '../../../api/ApiContext.jsx';
 import { sharedKeys } from '../../../api/queryKeys.js';
@@ -387,5 +387,76 @@ describe('useSharedProjects', () => {
     });
 
     expect(fakeApi.pullSharedProject).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The passive signal App.jsx uses to decide the zero-local-projects flow
+// (wizard auto-open, landing redirect, empty-state copy). Same cache keys as
+// useSharedProjects, but no background refresh — mounting it must never
+// trigger a POST /api/shared/refresh.
+describe('useSharedContentSignal', () => {
+  it('settles with hasContent=false when no shared repo is configured, without listing', async () => {
+    const fakeApi = makeFakeApi({
+      getSharedStatus: vi.fn(async () => ({ configured: false })),
+    });
+    const { result } = renderHook(() => useSharedContentSignal(), {
+      wrapper: ({ children }) => wrap(fakeApi, children),
+    });
+    await waitFor(() => expect(result.current.settled).toBe(true));
+    expect(result.current.hasContent).toBe(false);
+    expect(fakeApi.sharedListProjects).not.toHaveBeenCalled();
+  });
+
+  it('reports hasContent=true when configured and the list has projects', async () => {
+    const fakeApi = makeFakeApi();
+    const { result } = renderHook(() => useSharedContentSignal(), {
+      wrapper: ({ children }) => wrap(fakeApi, children),
+    });
+    await waitFor(() => expect(result.current.settled).toBe(true));
+    expect(result.current.hasContent).toBe(true);
+  });
+
+  it('reports hasContent=false when configured but the list is empty', async () => {
+    const fakeApi = makeFakeApi({
+      sharedListProjects: vi.fn(async () => ({ projects: [], lastSynced: null, stale: false })),
+    });
+    const { result } = renderHook(() => useSharedContentSignal(), {
+      wrapper: ({ children }) => wrap(fakeApi, children),
+    });
+    await waitFor(() => expect(result.current.settled).toBe(true));
+    expect(result.current.hasContent).toBe(false);
+  });
+
+  it('settles with hasContent=false when the status fetch fails (fallback to local-only flow)', async () => {
+    const fakeApi = makeFakeApi({
+      getSharedStatus: vi.fn(async () => { throw new Error('boom'); }),
+    });
+    const { result } = renderHook(() => useSharedContentSignal(), {
+      wrapper: ({ children }) => wrap(fakeApi, children),
+    });
+    await waitFor(() => expect(result.current.settled).toBe(true));
+    expect(result.current.hasContent).toBe(false);
+  });
+
+  it('is not settled while the status fetch is in flight', async () => {
+    const d = deferred();
+    const fakeApi = makeFakeApi({
+      getSharedStatus: vi.fn(() => d.promise),
+    });
+    const { result } = renderHook(() => useSharedContentSignal(), {
+      wrapper: ({ children }) => wrap(fakeApi, children),
+    });
+    expect(result.current.settled).toBe(false);
+    d.resolve({ configured: false });
+    await waitFor(() => expect(result.current.settled).toBe(true));
+  });
+
+  it('never triggers a background refresh on its own', async () => {
+    const fakeApi = makeFakeApi();
+    const { result } = renderHook(() => useSharedContentSignal(), {
+      wrapper: ({ children }) => wrap(fakeApi, children),
+    });
+    await waitFor(() => expect(result.current.settled).toBe(true));
+    expect(fakeApi.refreshShared).not.toHaveBeenCalled();
   });
 });

--- a/src/quodeq/ui/src/features/onboarding/components/EmptyStateWithTour.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/EmptyStateWithTour.jsx
@@ -6,16 +6,29 @@ function clearSkip() {
   try { localStorage.removeItem(SKIPPED_STEPS_KEY); } catch { /* ignore */ }
 }
 
-export default function EmptyStateWithTour({ onAdd, onTour, isEvaluating = false }) {
+export default function EmptyStateWithTour({ onAdd, onTour, onBrowseRemote = null, isEvaluating = false }) {
   const blockedTitle = isEvaluating ? 'Cannot add a project while an evaluation is running' : undefined;
   return (
     <section className="empty-state empty-state--with-tour">
       <TermHeader name="projects" sub="no projects yet" />
-      <p>set up your first repository. quodeq scans it locally and runs an evaluation against the standards you pick.</p>
+      <p>
+        {onBrowseRemote
+          ? "no local projects yet. your team's online repository has published projects you can browse, or set up your own."
+          : 'set up your first repository. quodeq scans it locally and runs an evaluation against the standards you pick.'}
+      </p>
       <div className="empty-state__actions">
+        {onBrowseRemote && (
+          <button
+            type="button"
+            className="term-btn--primary"
+            onClick={onBrowseRemote}
+          >
+            browse remote repositories
+          </button>
+        )}
         <button
           type="button"
-          className={`term-btn--primary${isEvaluating ? ' is-disabled' : ''}`}
+          className={`${onBrowseRemote ? 'term-btn--secondary' : 'term-btn--primary'}${isEvaluating ? ' is-disabled' : ''}`}
           onClick={() => { clearSkip(); onAdd(); }}
           aria-disabled={isEvaluating || undefined}
           title={blockedTitle}

--- a/src/quodeq/ui/src/features/onboarding/components/EmptyStateWithTour.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/EmptyStateWithTour.jsx
@@ -13,7 +13,7 @@ export default function EmptyStateWithTour({ onAdd, onTour, onBrowseRemote = nul
       <TermHeader name="projects" sub="no projects yet" />
       <p>
         {onBrowseRemote
-          ? "no local projects yet. your team's online repository has published projects you can browse, or set up your own."
+          ? 'no local projects yet. your team’s online repository has published projects you can browse, or set up your own.'
           : 'set up your first repository. quodeq scans it locally and runs an evaluation against the standards you pick.'}
       </p>
       <div className="empty-state__actions">

--- a/src/quodeq/ui/src/features/onboarding/components/EmptyStateWithTour.test.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/EmptyStateWithTour.test.jsx
@@ -30,4 +30,26 @@ describe('EmptyStateWithTour', () => {
     expect(onTour).toHaveBeenCalled();
     expect(localStorage.getItem('quodeq_onboarding_skipped')).toBeNull();
   });
+
+  // Remote-content awareness: with a connected shared repo that has
+  // published projects, the wall must offer a path to them, not only
+  // "add a project" (spec 2026-07-23-remote-repos-without-local-projects).
+  it('hides the browse-remote button when onBrowseRemote is not provided', () => {
+    render(<EmptyStateWithTour onAdd={() => {}} onTour={() => {}} />);
+    expect(screen.queryByRole('button', { name: /browse remote repositories/i })).toBeNull();
+  });
+
+  it('shows the browse-remote button and calls onBrowseRemote', () => {
+    const onBrowseRemote = vi.fn();
+    render(<EmptyStateWithTour onAdd={() => {}} onTour={() => {}} onBrowseRemote={onBrowseRemote} />);
+    fireEvent.click(screen.getByRole('button', { name: /browse remote repositories/i }));
+    expect(onBrowseRemote).toHaveBeenCalled();
+  });
+
+  it('browse-remote stays clickable during an evaluation (read-only path)', () => {
+    const onBrowseRemote = vi.fn();
+    render(<EmptyStateWithTour onAdd={() => {}} onTour={() => {}} onBrowseRemote={onBrowseRemote} isEvaluating />);
+    fireEvent.click(screen.getByRole('button', { name: /browse remote repositories/i }));
+    expect(onBrowseRemote).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
With zero local projects and a connected shared repo that has published content, the app now lands on the repositories tab with the remote cards visible and usable. Before, the onboarding wizard covered everything and the empty states only offered "add a project", so remote projects were unreachable until you scanned something locally.

Changes:
- New passive `useSharedContentSignal` hook (same react-query cache entries as `useSharedProjects`, no background refresh, no mutations).
- Wizard auto-open defers until the shared signal settles and never opens when remote content exists. The decision latches, so disconnecting the shared repo mid-session cannot pop the wizard over a working view.
- One-shot landing redirect: a fresh start with only remote content lands on repositories instead of the dead-end overview.
- Welcome wall and overview empty state offer "browse remote repositories" when remote content exists.

No shared repo, or an empty or failing one: behavior unchanged. Settings, publish/pull flows and the shared repo backend untouched.

Two deliberate deviations from the design doc: browse-remote is the primary button on the welcome wall (doc said alongside add/tour), and the overview empty state shows it as the single CTA (EmptyState renders one action; add/import are one click away on the repositories tab).

Tested: vitest 1231/1231, node:test 310/310. Live-verified in an isolated env (scratch QUODEQ_DIR) against news-code-audit with 2 published projects: fresh start lands on repositories with both REMOTE cards, wizard suppressed, read-only drill-in works, reload restores the shared view, zero console errors.