### PR TITLE
ci: also run snyk when a release is published

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -11,6 +11,8 @@ name: Snyk
 
 on:
   workflow_dispatch:
+  release:
+    types: [published]
   schedule:
     # Weekly sweep catches newly disclosed CVEs against unchanged deps.
     - cron: '30 6 * * 1'


### PR DESCRIPTION
Follow-up to #852, which merged before this landed on the branch: adds the `release: published` trigger to the Snyk workflow so every release gets a scan in addition to the weekly cron and manual dispatch.