### PR TITLE
chore: add .mailmap to canonicalize contributor identity

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+# Canonical contributor identities.
+# Maps every commit to the author's personal identity; the persgroep.net
+# address was used by accident on a handful of commits.
+Victor Purcallas Marchesi <vpurcallas@gmail.com> <victor.purcallas.marchesi@persgroep.net>


### PR DESCRIPTION
A handful of commits were accidentally authored with my persgroep.net work address instead of my personal address. This adds a `.mailmap` mapping them to the personal identity, so `git` tooling and GitHub (contributor graph, commit lists, blame) show one consistent author across the whole history.

No history rewrite: commit objects are untouched, SHAs unchanged, no force-push, no re-tag. Purely additive.