### PR TITLE
perf: fix real hot-path findings from Performance self-eval (memoize stats, O(n^2) MST, hoist backfill query)

### DIFF
--- a/src/quodeq/context/precedent.py
+++ b/src/quodeq/context/precedent.py
@@ -312,8 +312,13 @@ def load_precedent_corpus(
             if try_claim_backfill(conn):
                 try:
                     deadline = time.monotonic() + _BACKFILL_BUDGET_S
+                    # We hold the exclusive backfill claim, so no other writer
+                    # adds fingerprints while we run. Read the stored set once and
+                    # track inserts locally instead of re-querying the whole
+                    # (growing) table on every chunk -- that was an N+1 scan whose
+                    # cost climbed with the corpus size.
+                    stored = stored_fingerprints(conn)
                     while time.monotonic() < deadline:
-                        stored = stored_fingerprints(conn)
                         missing = [fp for fp in texts if fp not in stored]
                         if not missing:
                             break
@@ -327,6 +332,7 @@ def load_precedent_corpus(
                             break
                         if not insert_vectors(conn, model, list(zip(chunk, vecs))):
                             break
+                        stored.update(chunk)
                         embedded_new += len(chunk)
                 finally:
                     release_backfill_claim(conn)

--- a/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
@@ -143,17 +143,23 @@ export default function HistoryChartPanel({ trend = [], selectedRunId = null, on
 
   const data = useMemo(() => buildTrendData(trend, selectedRunId), [trend, selectedRunId]);
 
-  if (!trend || trend.length < 2) return null;
-
   // Stats computed from the full trend (not just the windowed slice), matching
-  // the mockup's LATEST / AVG / MIN / MAX header row.
-  const scores = trend
-    .map((t) => parseFloat(t.runNumericAverage ?? t.numericAverage))
-    .filter((n) => !Number.isNaN(n));
-  const latest = scores[0];
-  const min = scores.length ? Math.min(...scores) : null;
-  const max = scores.length ? Math.max(...scores) : null;
-  const avg = scores.length ? scores.reduce((s, n) => s + n, 0) / scores.length : null;
+  // the mockup's LATEST / AVG / MIN / MAX header row. Memoized on `trend` so the
+  // O(N) scan doesn't re-run on every hover render (hoveredIndex changes fire a
+  // re-render on each mouse move).
+  const { latest, min, max, avg } = useMemo(() => {
+    const scores = trend
+      .map((t) => parseFloat(t.runNumericAverage ?? t.numericAverage))
+      .filter((n) => !Number.isNaN(n));
+    return {
+      latest: scores[0],
+      min: scores.length ? Math.min(...scores) : null,
+      max: scores.length ? Math.max(...scores) : null,
+      avg: scores.length ? scores.reduce((s, n) => s + n, 0) / scores.length : null,
+    };
+  }, [trend]);
+
+  if (!trend || trend.length < 2) return null;
 
   const fmt = (n) => (n == null ? '—' : n.toFixed(1));
 

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyViewLayout.js
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyViewLayout.js
@@ -29,22 +29,39 @@ export function computeClusterPositions(groupKeys) {
  */
 export function buildMSTLines(clusterStars, startIdx) {
   const lines = [];
-  if (clusterStars.length < 2) return lines;
+  const n = clusterStars.length;
+  if (n < 2) return lines;
 
-  const connected = new Set([0]);
-  while (connected.size < clusterStars.length) {
-    let bestA = -1, bestB = -1, bestD = Infinity;
-    for (const ai of connected) {
-      for (let bi = 0; bi < clusterStars.length; bi++) {
-        if (connected.has(bi)) continue;
-        const dx = clusterStars[ai]._ox - clusterStars[bi]._ox;
-        const dy = clusterStars[ai]._oy - clusterStars[bi]._oy;
-        const d = dx * dx + dy * dy;
-        if (d < bestD) { bestD = d; bestA = ai; bestB = bi; }
-      }
+  // Prim's algorithm with a nearest-connected-node cache. For each unconnected
+  // node we track its closest connected node (nearD/nearA); adding a node costs
+  // one O(n) pass to refresh those caches, so the whole tree is O(n^2) instead
+  // of the O(n^3) that re-scanning every connected node per step would cost.
+  const inTree = new Array(n).fill(false);
+  const nearD = new Array(n).fill(Infinity);
+  const nearA = new Array(n).fill(-1);
+  inTree[0] = true;
+  for (let b = 1; b < n; b++) {
+    const dx = clusterStars[0]._ox - clusterStars[b]._ox;
+    const dy = clusterStars[0]._oy - clusterStars[b]._oy;
+    nearD[b] = dx * dx + dy * dy;
+    nearA[b] = 0;
+  }
+
+  for (let step = 1; step < n; step++) {
+    let bestB = -1, bestD = Infinity;
+    for (let b = 0; b < n; b++) {
+      if (!inTree[b] && nearD[b] < bestD) { bestD = nearD[b]; bestB = b; }
     }
-    if (bestB >= 0) { lines.push({ a: startIdx + bestA, b: startIdx + bestB }); connected.add(bestB); }
-    else break;
+    if (bestB < 0) break;
+    lines.push({ a: startIdx + nearA[bestB], b: startIdx + bestB });
+    inTree[bestB] = true;
+    for (let b = 0; b < n; b++) {
+      if (inTree[b]) continue;
+      const dx = clusterStars[bestB]._ox - clusterStars[b]._ox;
+      const dy = clusterStars[bestB]._oy - clusterStars[b]._oy;
+      const d = dx * dx + dy * dy;
+      if (d < nearD[b]) { nearD[b] = d; nearA[b] = bestB; }
+    }
   }
   return lines;
 }


### PR DESCRIPTION
## What

Three genuinely-real performance findings surfaced by the latest self-evaluation's **Performance** dimension (nightly run \`b5e0f558\`, 2026-07-23). Each was verified against the actual code before fixing; several other flagged findings turned out to be already-memoized or context-false-positives and were left alone / triaged separately.

### 1. `HistoryChartPanel` — memoize header stats
`LATEST / AVG / MIN / MAX` were recomputed on **every render**. Because `hoveredIndex` updates on each mouse move over the chart, the O(N) scan over the full trend re-ran on every hover frame. Wrapped in `useMemo([trend])` (placed before the early return to keep hook order stable).

### 2. `galaxyViewLayout.buildMSTLines` — O(n³) → O(n²)
The constellation MST used naive Prim's that re-scanned every connected node against every unconnected node each step (O(n³)). Replaced with the standard nearest-connected-node cache (O(n²)). **Verified identical output** (equal edge count + equal total MST weight) across 500 random trials.

### 3. `context/precedent` — hoist `stored_fingerprints()` out of the backfill loop
The semantic-precedent backfill re-queried the entire (growing) `vectors` table on every chunk iteration. Since the loop holds the exclusive backfill claim, no other writer adds rows, so the stored set is now read once and updated locally as chunks insert. Removes an N+1 scan whose cost climbed with corpus size.

## Testing
- `pytest tests/context/test_precedent.py tests/context/test_precedent_corpus.py tests/data/sqlite/test_precedent_vectors.py` → **35 passed**
- UI `node --test` → **310 passed**
- MST equivalence harness → 500/500 trials match old output

## Note
UI source changes require a `vite build` into `src/quodeq/static/` to ship in the packaged app.