### PR TITLE
chore: drop stale node dependency from Homebrew formula

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -81,7 +81,6 @@ jobs:
             license "MIT"
 
             depends_on "python@3.12"
-            depends_on "node"
 
             def install
               virtualenv_install_with_resources


### PR DESCRIPTION
## Problem

Fresh `brew install quodeq/tap/quodeq` pulls in the entire Node.js + npm toolchain because the generated formula carries `depends_on "node"`. That dependency is stale.

## Why node isn't needed

- The React dashboard is **pre-built into `src/quodeq/static/`** and shipped inside the wheel. `dashboard/_build.py` is explicit: *"the wheel ships a pre-built UI. Never invoke npm here. End users never invoke npm."*
- `shared/prereqs.py` only checks Node/npm for `quodeq dashboard --dev` (dev-mode UI rebuilds), not runtime.
- `depends_on "node"` installs only the Node *runtime*, **not** the AI CLIs (claude-code/codex/gemini-cli) — those come from `npm install -g …`, which `prereqs.py` guides users through separately. So the formula's node dep never actually enabled the CLI-provider path; it was pure install bloat.

## Change

Removes the `depends_on "node"` line from the formula generated by `.github/workflows/update-homebrew.yml`, so future releases stop shipping it. The live tap formula (`quodeq/homebrew-tap`) is being patched directly in parallel so 1.7.1 installs are fixed immediately.