### PR TITLE
test: deflake shared clone-lock tests on slow Windows CI

### DIFF
--- a/tests/services/test_shared_repo_lock.py
+++ b/tests/services/test_shared_repo_lock.py
@@ -16,6 +16,14 @@ from quodeq.services import shared_publish, shared_repo
 from quodeq.services.shared_publish import publish_project
 from quodeq.services.shared_repo import clone_lock, ensure_shared_clone, refresh_shared_clone
 
+# The thread join()/wait() calls below are deadlock guards, not performance
+# assertions: a genuine clone-lock deadlock hangs forever, so any generous
+# ceiling still trips on a real hang. 5s was too tight for the real git
+# clone/commit/push subprocesses these tests spawn over file://, which flaked
+# on loaded Windows CI runners. A large budget keeps the deadlock signal while
+# removing the timing sensitivity.
+_DEADLOCK_GUARD_TIMEOUT = 60.0
+
 
 def _bare_origin(tmp_path: Path, name: str = "origin.git") -> str:
     origin = tmp_path / name
@@ -114,11 +122,13 @@ def test_refresh_waits_for_publish(tmp_path, monkeypatch):
     refresh_thread = threading.Thread(target=_fire_refresh, name="refresh")
 
     publish_thread.start()
-    assert commit_reached.wait(timeout=5), "publish never reached its commit step"
+    assert commit_reached.wait(timeout=_DEADLOCK_GUARD_TIMEOUT), (
+        "publish never reached its commit step"
+    )
     refresh_thread.start()
 
-    publish_thread.join(timeout=5)
-    refresh_thread.join(timeout=5)
+    publish_thread.join(timeout=_DEADLOCK_GUARD_TIMEOUT)
+    refresh_thread.join(timeout=_DEADLOCK_GUARD_TIMEOUT)
 
     assert not publish_thread.is_alive(), "publish_project deadlocked"
     assert not refresh_thread.is_alive(), "refresh_shared_clone deadlocked"
@@ -153,7 +163,7 @@ def test_clone_lock_is_reentrant_for_publish_internal_refresh(tmp_path):
 
     thread = threading.Thread(target=_do_publish, name="publish")
     thread.start()
-    thread.join(timeout=5)
+    thread.join(timeout=_DEADLOCK_GUARD_TIMEOUT)
 
     assert not thread.is_alive(), (
         "publish_project deadlocked acquiring its own clone lock reentrantly "


### PR DESCRIPTION
## Problem

`test (windows-latest, 3.13)` intermittently fails on `test_clone_lock_is_reentrant_for_publish_internal_refresh` with:

> `AssertionError: publish_project deadlocked acquiring its own clone lock reentrantly`

This is **not a real deadlock** and is unrelated to whatever PR happens to trip it (most recently [#857](https://github.com/quodeq/quodeq/pull/857), which only touches perf hot paths):

- The clone lock is a correct `threading.RLock` ([`shared_repo.py`](../blob/develop/src/quodeq/services/shared_repo.py)), so the reentrant acquire genuinely succeeds. A true deadlock would hang forever **and** fail identically on macOS and Ubuntu — both passed.
- The failure is really a **wall-clock timeout**: the test spawns a thread doing real `git` clone/commit/push subprocesses over `file://` and asserts `thread.join(timeout=5)` finished. On a loaded `windows-latest` runner (the suite took ~12 min vs ~3 min on macOS), those subprocesses just didn't finish inside 5s, so the still-running thread got misreported as a deadlock.

## Fix

The `join()`/`wait()` calls in these tests are **deadlock guards, not performance assertions** — a genuine deadlock hangs forever, so any generous ceiling still trips on a real hang. Hoist the guard timeout to a shared `_DEADLOCK_GUARD_TIMEOUT = 60.0` constant and apply it to all three guards in the file. This keeps the deadlock signal intact while removing the timing sensitivity.

No production code changes.

## Verification

`pytest tests/services/test_shared_repo_lock.py` → 3 passed.