### PR TITLE
ci: speed up the Windows test job (xdist + Defender exclusion)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,10 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     # Cap the whole job so a hanging test fails fast instead of burning
-    # runner minutes. Ubuntu + macOS finish in ~1 min, Windows in ~2-3 min.
+    # runner minutes. Ubuntu + macOS run in ~2-3 min. Windows is far slower
+    # per test (no fork(), slow git-subprocess startup, NTFS small-file I/O,
+    # Defender scanning), so it runs under pytest-xdist (-n auto) with a
+    # Defender exclusion to stay well within this budget.
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -38,9 +41,25 @@ jobs:
         # tolerable. PR CI should be fast and deterministic.
         run: uv run pytest tests/ -q --tb=short -m "not integration" --cov=quodeq --cov-report=term-missing
 
+      - name: Speed up Windows file I/O (exclude churn paths from Defender)
+        if: runner.os == 'Windows'
+        # The suite spawns thousands of git/python subprocesses and writes
+        # thousands of tiny temp files. Defender's real-time scan of every new
+        # process image and file write is a large, invisible tax on
+        # windows-latest. Exclude the churn dirs and the two hot executables.
+        # Best effort: never let a Defender hiccup block the gate.
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          Add-MpPreference -ExclusionPath $env:RUNNER_TEMP, $env:TEMP, $env:GITHUB_WORKSPACE
+          Add-MpPreference -ExclusionProcess "git.exe", "python.exe"
+
       - name: Run tests (Windows)
         if: runner.os == 'Windows'
+        # -n auto (pytest-xdist): the suite is process- and file-I/O-bound on
+        # Windows, and every test is state-isolated by the autouse
+        # _isolate_quodeq_home fixture (tests/conftest.py), so distributing
+        # across cores cuts wall time roughly linearly (~12 min -> a few).
         # Verbose + -ra so per-test names and the FAILED summary survive
-        # GitHub's log truncation, making any Windows-specific failure easy
-        # to pinpoint now that Windows is a blocking gate.
-        run: uv run pytest tests/ -v -ra --tb=short -m "not integration"
+        # GitHub's log truncation, keeping this blocking gate easy to triage.
+        run: uv run pytest tests/ -v -ra --tb=short -m "not integration" -n auto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
     "pytest-timeout==2.4.0",
+    "pytest-xdist==3.8.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -195,6 +195,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "flask"
 version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -755,6 +764,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "pythonnet"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -839,6 +861,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -858,6 +881,7 @@ dev = [
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-timeout", specifier = "==2.4.0" },
+    { name = "pytest-xdist", specifier = "==3.8.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The Windows leg of the Tests workflow has drifted to **~12 min** (vs ~2-3 min on Ubuntu/macOS) and is one slow run away from the **15-min job cap**. The stale comment in the workflow still claimed *"Windows in ~2-3 min."*

The slowness is Windows-specific and inherent to this suite, not the CI config — in fact the Windows leg does *less* (no coverage). Four taxes stack:

1. **No `fork()`** — every subprocess is a full `CreateProcess`.
2. **Slow git startup** — Git for Windows routes each call through the MSYS layer.
3. **NTFS small-file I/O** — constant tiny create/delete from temp dirs and `.git` objects/locks.
4. **Defender real-time scanning** — every spawned image and written file is scanned.

This suite pays all four heavily: **200** `subprocess.run/Popen` call sites, **37** files shelling out to `git`, **352** `tmp_path`-based tests. The symptom was the clone-lock test blowing a 5s wall-clock budget (deflaked separately in #859); this PR attacks the root cause — the wall time itself.

## Changes

- **Run the Windows leg under `pytest-xdist` (`-n auto`).** Every test is state-isolated by the autouse `_isolate_quodeq_home` fixture in [`tests/conftest.py`](../blob/develop/tests/conftest.py) (redirects every Quodeq state path to a per-test temp dir), so distributing across cores is safe. Added `pytest-xdist==3.8.0` as a dev dep.
- **Exclude the churn dirs + hot executables from Defender** (`RUNNER_TEMP`, `TEMP`, `GITHUB_WORKSPACE`, `git.exe`, `python.exe`) before the run. Best effort — `continue-on-error: true` so a Defender hiccup never blocks the gate.
- **Refresh the stale timing comment.**

Linux/macOS legs are unchanged (they already finish fast and keep coverage reporting).

## Validation

Parallel-safety verified locally (macOS):
- Full non-integration suite under `-n auto`: **4923 passed, 1 skipped** (~18s wall, ~9 cores busy).
- Git-heavy `tests/services/` suite under `-n auto`, 3 consecutive runs: **1088 passed** each — no cross-worker flakes on the subprocess/git path.

The real payoff (Windows wall time) will show on this PR's own `test (windows-latest, 3.13)` run.