### PR TITLE
fix: autofocus terminal & assistant inputs when their drawer tab opens

### DIFF
--- a/src/quodeq/ui/src/features/assistant/AssistantDrawer.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawer.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAssistantDrawer } from './AssistantDrawerProvider.jsx';
 import { MessageList } from './MessageList.jsx';
 import { CommandMenu } from './CommandMenu.jsx';
@@ -15,8 +15,12 @@ import { StopIcon } from '../../components/CopyButton.jsx';
  *
  * `uiState` is passed in as a prop (current app view context, e.g. active
  * tab) and forwarded verbatim to `sendMessage` on every send.
+ *
+ * `active` is whether this pane is the frontmost drawer tab. It drives the
+ * autofocus effect below; a backgrounded pane (display:none) must not steal
+ * focus. Defaults to true so a standalone render still focuses its input.
  */
-export function AssistantPane({ uiState }) {
+export function AssistantPane({ uiState, active = true }) {
   const {
     messages, streaming, error, sendMessage, stopTurn,
     catalog, addLocalExchange, resetConversation, readOnly,
@@ -24,6 +28,16 @@ export function AssistantPane({ uiState }) {
   const [draft, setDraft] = useState('');
   const [menuIndex, setMenuIndex] = useState(0);
   const [menuDismissed, setMenuDismissed] = useState(false);
+  const inputRef = useRef(null);
+
+  // Give the prompt keyboard focus when this pane becomes the frontmost tab
+  // (drawer open or tab switch) so the user can type immediately without
+  // clicking in. The parent flips display:none→flex in the same commit, so by
+  // the time this effect runs the textarea is laid out and focusable. Skip
+  // while streaming (the textarea is disabled then); refocus once it ends.
+  useEffect(() => {
+    if (active && !streaming) inputRef.current?.focus();
+  }, [active, streaming]);
 
   const suggestions = useMemo(
     () => (streaming ? [] : matchCommands(catalog, draft, { readOnly })),
@@ -77,6 +91,7 @@ export function AssistantPane({ uiState }) {
           <CommandMenu suggestions={suggestions} selectedIndex={menuIndex} onPick={acceptSuggestion} />
         )}
         <textarea
+          ref={inputRef}
           className="assistant-drawer-input"
           placeholder="Ask the assistant…"
           value={draft}

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawer.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawer.test.jsx
@@ -41,6 +41,16 @@ it('renders the prompt input', () => {
   expect(screen.getByPlaceholderText(/ask/i)).toBeInTheDocument();
 });
 
+it('focuses the prompt input when the pane is the active tab (so you can type without clicking)', () => {
+  render(<AssistantPane uiState={{}} active />);
+  expect(screen.getByPlaceholderText(/ask/i)).toHaveFocus();
+});
+
+it('does not focus the prompt input when the pane is a backgrounded tab', () => {
+  render(<AssistantPane uiState={{}} active={false} />);
+  expect(screen.getByPlaceholderText(/ask/i)).not.toHaveFocus();
+});
+
 it('Enter sends the message with uiState', () => {
   render(<AssistantPane uiState={{ activeTab: 'standards' }} />);
   const input = screen.getByPlaceholderText(/ask/i);

--- a/src/quodeq/ui/src/features/drawer/BottomDrawer.jsx
+++ b/src/quodeq/ui/src/features/drawer/BottomDrawer.jsx
@@ -159,7 +159,7 @@ export function BottomDrawer({ uiState }) {
       </header>
       {openPanels.includes('assistant') && (
         <div className="drawer-panel" style={{ display: active === 'assistant' ? 'flex' : 'none' }}>
-          <AssistantPane uiState={uiState} />
+          <AssistantPane uiState={uiState} active={active === 'assistant'} />
         </div>
       )}
       {openPanels.includes('terminal') && (

--- a/src/quodeq/ui/src/features/terminal/TerminalPane.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.jsx
@@ -176,6 +176,18 @@ export default function TerminalPane({ active }) {
     try { fitRef.current.fit(); resize(termRef.current.cols, termRef.current.rows); } catch { /* noop */ }
   }, [active, resize]);
 
+  // Give xterm keyboard focus when the terminal becomes the frontmost tab
+  // (drawer open or tab switch) so the user can type immediately without
+  // clicking into it. Gated on `active` so a backgrounded pane never steals
+  // focus; `paneLive` is a dep so this runs once the terminal has mounted on
+  // first open (termRef is set by the mount effect declared above). No
+  // isHidden guard: focus() doesn't resize the PTY, and an active tab is
+  // visible by definition.
+  useEffect(() => {
+    if (!active || !paneLive || !termRef.current) return;
+    try { termRef.current.focus(); } catch { /* noop */ }
+  }, [active, paneLive]);
+
   // While the socket is not open, disable xterm input. send() already no-ops
   // when disconnected, so keystrokes would otherwise vanish silently into a
   // dead shell (and buffering them is unsafe — the line would land in a fresh

--- a/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
@@ -36,6 +36,22 @@ it('mounts an xterm terminal when active', async () => {
   expect(fakeTerm.open).toHaveBeenCalled();
 });
 
+it('focuses xterm when it is the active tab so the user can type without clicking in', async () => {
+  socketState.status = 'open';
+  fakeTerm.focus.mockClear();
+  render(<TerminalPane active />);
+  await screen.findByTestId('tty-root');
+  expect(fakeTerm.focus).toHaveBeenCalled();
+});
+
+it('does not focus xterm while backgrounded (active=false)', async () => {
+  socketState.status = 'open';
+  fakeTerm.focus.mockClear();
+  render(<TerminalPane active={false} />);
+  await screen.findByTestId('tty-root');
+  expect(fakeTerm.focus).not.toHaveBeenCalled();
+});
+
 it('mounts xterm even when backgrounded (active=false) so the PTY survives a tab switch', async () => {
   const { Terminal } = await import('@xterm/xterm');
   Terminal.mockClear();


### PR DESCRIPTION
## Problem
Opening the Terminal or Assistant panel left its input unfocused, so you always had to click inside the block before typing.

## Root cause
Neither input was ever focused programmatically:
- **Assistant** (`AssistantDrawer.jsx`): plain `<textarea>` with no autofocus/ref/`.focus()`.
- **Terminal** (`TerminalPane.jsx`): xterm was `open()`ed but `term.focus()` was never called.

Both only grab focus on click.

## Fix
Focus the active tab's input whenever a pane becomes the frontmost tab (drawer open or tab switch), gated on `active` so a backgrounded pane (`display:none`) never steals focus:
- **`AssistantPane`**: new `active` prop + ref + effect focusing when `active && !streaming` (also refocuses when a turn ends; skips while the textarea is disabled).
- **`BottomDrawer`**: passes `active={active === 'assistant'}` down (it already passed `active` to the terminal).
- **`TerminalPane`**: effect calls `term.focus()` keyed on `active` + `paneLive`, so it fires once xterm mounts on first open and again on a tab-switch back. No `isHidden` guard — `focus()` doesn't resize the PTY and an active tab is visible by definition.

## Tests
- Added failing-first tests (assistant `toHaveFocus()`, terminal `fakeTerm.focus` called, plus backgrounded-tab negatives), confirmed red then green.
- Full UI suite: **1232 passed**. Production build compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)