### PR TITLE
chore: add .quodeqignore to exclude benchmark harness from self-eval

### DIFF
--- a/.quodeqignore
+++ b/.quodeqignore
@@ -1,0 +1,11 @@
+# Repo-local exclusions for quodeq's own self-evaluation.
+# One glob per line, relative to the repo root. Naming a directory
+# excludes everything under it. See src/quodeq/analysis/_ignore.py.
+
+# Accuracy benchmark harness: dev/release tooling, not the product.
+# The planted-bug corpus under benchmarks/.corpus/ is already skipped
+# (dot-directory), but the harness source (quodeq_bench/, baselines/,
+# precedent_golden.py) is normal code that would otherwise be scanned
+# into quodeq's self-eval and clutter the map. It's scaffolding, so we
+# keep it out of the self-evaluation on purpose.
+benchmarks/


### PR DESCRIPTION
## What

Adds a root `.quodeqignore` that excludes the `benchmarks/` tree from quodeq's own self-evaluation.

## Why

The benchmark harness under `benchmarks/` is dev/release tooling that measures quodeq's finding accuracy against a labeled corpus. It is **not the product**.

- `benchmarks/.corpus/` (the planted-bug answer keys) is already skipped via the built-in dot-directory rule, on purpose.
- But the harness source itself, `benchmarks/quodeq_bench/`, `benchmarks/baselines/`, and `benchmarks/precedent_golden.py`, is normal Python that the manifest walker scans into the self-eval. That is why `benchmarks/quodeq_bench` shows up in the Code Map.

There are no planted bugs in the harness code, so this is not a correctness fix; it is a focus decision: the self-eval and Code Map are most useful when they reflect the product, not the scaffolding.

## Mechanism

`.quodeqignore` is the existing repo-local exclusion mechanism (`src/quodeq/analysis/_ignore.py`), applied at manifest-build time. Ignored directories are pruned during the walk and never scanned. Effect shows on the **next** evaluation; existing runs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)