### PR TITLE
feat(terminal): cmd-click file paths and URLs to open source

### DIFF
--- a/src/quodeq/api/terminal_routes.py
+++ b/src/quodeq/api/terminal_routes.py
@@ -21,6 +21,7 @@ from quodeq.terminal.links import (
     detect_editor,
     resolve_bases,
     resolve_path,
+    safe_editor_path,
 )
 from quodeq.terminal.manager import TerminalManager
 
@@ -141,10 +142,15 @@ def register_terminal_routes(app: Flask, manager: TerminalManager | None = None)
         path = body.get("path")
         if not isinstance(path, str) or not path:
             return jsonify({"error": "path is required"}), 400
+        # Confine the launch to the terminal's own working directories (shell
+        # cwd, server cwd, home) and normalize the untrusted path to its real,
+        # canonical form. Everything below uses this sanitized value, never the
+        # raw client string. Outside the bases -> refuse.
+        safe = safe_editor_path(path, resolve_bases(manager.pid))
         # Never launch on a non-file, even though the client only sends paths it
         # got back as exists=true — the state could have changed, and this is the
         # authoritative check before spawning a process.
-        if not os.path.isfile(path):
+        if safe is None or not os.path.isfile(safe):
             return jsonify({"opened": False, "editor": None})
         editor = detect_editor()
         if editor is None:
@@ -152,15 +158,15 @@ def register_terminal_routes(app: Flask, manager: TerminalManager | None = None)
         line = _coerce_int(body.get("line"))
         col = _coerce_int(body.get("col"))
         try:
-            argv = build_open_argv(editor, path, line, col)
+            argv = build_open_argv(editor, safe, line, col)
             if argv is None:  # Windows startfile sentinel
-                os.startfile(path)  # type: ignore[attr-defined]
+                os.startfile(safe)  # type: ignore[attr-defined]
             else:
                 # Detached: the editor outlives this request; we don't wait on it.
                 subprocess.Popen(argv, start_new_session=True)
             return jsonify({"opened": True, "editor": editor.name})
         except (OSError, ValueError):
-            _logger.warning("failed to open %s in %s", path, editor.name, exc_info=True)
+            _logger.warning("failed to open %s in %s", safe, editor.name, exc_info=True)
             return jsonify({"opened": False, "editor": editor.name})
 
     @sock.route("/api/terminal/ws")

--- a/src/quodeq/api/terminal_routes.py
+++ b/src/quodeq/api/terminal_routes.py
@@ -9,12 +9,19 @@ import json
 import logging
 import os
 import struct
+import subprocess
 import threading
 
 from flask import Flask, current_app, jsonify, request
 from flask_sock import Sock
 
 from quodeq.terminal.gate import terminal_env_reason, terminal_gate_reason
+from quodeq.terminal.links import (
+    build_open_argv,
+    detect_editor,
+    resolve_bases,
+    resolve_path,
+)
 from quodeq.terminal.manager import TerminalManager
 
 _logger = logging.getLogger(__name__)
@@ -47,6 +54,15 @@ def _gate_reason() -> str | None:
 # succeed, so it must not loop — only unexpected drops are retried.
 _WS_CLOSE_BUSY = 4002     # single-connection lock held by another window
 _WS_CLOSE_REFUSED = 4003  # terminal gate refused the handshake
+
+
+def _coerce_int(value) -> int | None:
+    """Line/col from a JSON body: accept ints or numeric strings, else None."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return None
+    return n if n > 0 else None
 
 
 def _clamp_winsize(value: int) -> int:
@@ -91,6 +107,61 @@ def register_terminal_routes(app: Flask, manager: TerminalManager | None = None)
             return jsonify({"error": "forbidden"}), 403
         manager.kill()
         return jsonify({"ok": True})
+
+    @app.post("/api/terminal/resolve")
+    def terminal_resolve():
+        """Resolve candidate path tokens the client detected in a terminal line
+        to absolute paths, reporting which exist. The client makes only the
+        existing ones clickable, so path-shaped text never becomes a dead link.
+        Gated exactly like the other terminal routes (same threat model: a
+        single-user localhost app whose terminal already grants a full shell)."""
+        if _gate_reason() is not None:
+            return jsonify({"error": "forbidden"}), 403
+        body = request.get_json(silent=True) or {}
+        paths = body.get("paths")
+        if not isinstance(paths, list):
+            return jsonify({"error": "paths must be a list"}), 400
+        bases = resolve_bases(manager.pid)
+        resolved = []
+        for token in paths:
+            if not isinstance(token, str) or not token:
+                continue
+            abs_path, exists = resolve_path(token, bases)
+            resolved.append({"input": token, "abs": abs_path, "exists": exists})
+        return jsonify({"resolved": resolved})
+
+    @app.post("/api/terminal/open")
+    def terminal_open():
+        """Open an already-resolved absolute path in the user's editor at an
+        optional line/col. Fail-soft: any error returns opened=false rather than
+        raising, so a missing editor never surfaces as a 500."""
+        if _gate_reason() is not None:
+            return jsonify({"error": "forbidden"}), 403
+        body = request.get_json(silent=True) or {}
+        path = body.get("path")
+        if not isinstance(path, str) or not path:
+            return jsonify({"error": "path is required"}), 400
+        # Never launch on a non-file, even though the client only sends paths it
+        # got back as exists=true — the state could have changed, and this is the
+        # authoritative check before spawning a process.
+        if not os.path.isfile(path):
+            return jsonify({"opened": False, "editor": None})
+        editor = detect_editor()
+        if editor is None:
+            return jsonify({"opened": False, "editor": None})
+        line = _coerce_int(body.get("line"))
+        col = _coerce_int(body.get("col"))
+        try:
+            argv = build_open_argv(editor, path, line, col)
+            if argv is None:  # Windows startfile sentinel
+                os.startfile(path)  # type: ignore[attr-defined]
+            else:
+                # Detached: the editor outlives this request; we don't wait on it.
+                subprocess.Popen(argv, start_new_session=True)
+            return jsonify({"opened": True, "editor": editor.name})
+        except (OSError, ValueError):
+            _logger.warning("failed to open %s in %s", path, editor.name, exc_info=True)
+            return jsonify({"opened": False, "editor": editor.name})
 
     @sock.route("/api/terminal/ws")
     def terminal_ws(ws):

--- a/src/quodeq/terminal/_pty_unix.py
+++ b/src/quodeq/terminal/_pty_unix.py
@@ -117,6 +117,10 @@ class UnixPty:
     def alive(self) -> bool:
         return self._proc is not None and self._proc.poll() is None
 
+    @property
+    def pid(self) -> int | None:
+        return self._proc.pid if self._proc is not None else None
+
     def kill(self) -> None:
         if self._proc is not None:
             kill_proc_tree(self._proc)

--- a/src/quodeq/terminal/_pty_windows.py
+++ b/src/quodeq/terminal/_pty_windows.py
@@ -60,6 +60,10 @@ class WindowsPty:
     def alive(self) -> bool:
         return self._proc is not None and self._proc.isalive()
 
+    @property
+    def pid(self) -> int | None:
+        return getattr(self._proc, "pid", None) if self._proc is not None else None
+
     def kill(self) -> None:
         if self._proc is not None:
             try:

--- a/src/quodeq/terminal/links.py
+++ b/src/quodeq/terminal/links.py
@@ -1,0 +1,180 @@
+"""Path resolution and editor launching for clickable terminal links.
+
+Pure, dependency-injected helpers so the HTTP layer (api/terminal_routes.py)
+stays thin and this logic is unit-testable without a PTY, a real filesystem, or
+a real ``$PATH``. Three concerns:
+
+* ``child_cwd`` — the live working directory of the PTY's shell, so a relative
+  path printed by ``ls``/``grep``/pytest resolves the way the user sees it. The
+  shell starts at ``$HOME`` and the user ``cd``s around, so a fixed base is
+  wrong; the shell's own cwd is the correct primary base.
+* ``resolve_path`` — turn a candidate token into an absolute path + existence.
+* ``detect_editor`` / ``build_open_argv`` — pick an editor and build its argv.
+
+Nothing here raises into a request: callers treat ``None``/``False`` as "no
+link" / "didn't open".
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+
+# Well-known CLI locations to probe IN ADDITION to $PATH. A macOS app launched
+# from Finder/Dock inherits a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin) that
+# usually lacks `code`/`cursor`, so a PATH-only lookup would silently fall back
+# to `open` and lose the line jump. These cover Homebrew and the CLI shipped
+# inside the app bundle.
+_CODE_CANDIDATES = (
+    "/opt/homebrew/bin/code",
+    "/usr/local/bin/code",
+    "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code",
+)
+_CURSOR_CANDIDATES = (
+    "/opt/homebrew/bin/cursor",
+    "/usr/local/bin/cursor",
+    "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
+)
+
+
+@dataclass(frozen=True)
+class Editor:
+    """A resolved editor launcher.
+
+    ``name`` is a stable identifier surfaced to the client (telemetry / "opened
+    in X"). ``path`` is the executable (or the string ``"startfile"`` sentinel
+    on Windows, where launching goes through ``os.startfile`` rather than argv).
+    ``supports_line`` is True only for editors we can send a ``file:line:col``
+    goto to (VS Code / Cursor via ``-g``).
+    """
+
+    name: str
+    path: str
+    supports_line: bool
+
+
+def child_cwd(
+    pid: int | None,
+    *,
+    platform: str = sys.platform,
+    readlink=os.readlink,
+    run=subprocess.run,
+) -> str | None:
+    """Best-effort live cwd of the shell process ``pid`` (None if unknown).
+
+    Linux exposes it as ``/proc/<pid>/cwd``; macOS has no ``/proc`` so we shell
+    out to ``lsof`` (bounded, best-effort). Any failure returns None so the
+    caller falls back to other bases.
+    """
+    if not pid:
+        return None
+    try:
+        if platform.startswith("linux"):
+            return readlink(f"/proc/{pid}/cwd")
+        if platform == "darwin":
+            # -Fn = machine-readable, one field per line; the cwd path is the
+            # 'n'-prefixed line of the 'cwd' fd record.
+            proc = run(
+                ["lsof", "-a", "-p", str(pid), "-d", "cwd", "-Fn"],
+                capture_output=True, text=True, timeout=2,
+            )
+            for line in proc.stdout.splitlines():
+                if line.startswith("n"):
+                    return line[1:]
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return None
+    return None
+
+
+def resolve_bases(pid: int | None, *, getcwd=os.getcwd, home=None) -> list[str]:
+    """Ordered bases for resolving a relative token: shell cwd, then the server's
+    launch dir, then home. Deduped, preserving order."""
+    home = home if home is not None else os.path.expanduser("~")
+    ordered = [child_cwd(pid), _safe(getcwd), home]
+    seen: set[str] = set()
+    out: list[str] = []
+    for b in ordered:
+        if b and b not in seen:
+            seen.add(b)
+            out.append(b)
+    return out
+
+
+def _safe(fn):
+    try:
+        return fn()
+    except OSError:
+        return None
+
+
+def resolve_path(
+    token: str,
+    bases: list[str],
+    *,
+    isabs=os.path.isabs,
+    isfile=os.path.isfile,
+    join=os.path.join,
+    normpath=os.path.normpath,
+    expanduser=os.path.expanduser,
+) -> tuple[str, bool]:
+    """Resolve a candidate path token to ``(abs_path, exists)``.
+
+    Absolute (incl. ``~``) tokens are used as-is. Relative tokens are tried
+    against each base in order; the first that is a regular file wins. When none
+    exist, the first base is used so the client still gets a canonical path
+    (with ``exists=False``, so it never becomes a link).
+    """
+    token = expanduser(token)
+    if isabs(token):
+        p = normpath(token)
+        return p, isfile(p)
+    for base in bases:
+        cand = normpath(join(base, token))
+        if isfile(cand):
+            return cand, True
+    fallback = normpath(join(bases[0], token)) if bases else token
+    return fallback, False
+
+
+def detect_editor(
+    *,
+    which=shutil.which,
+    isfile=os.path.isfile,
+    platform: str = sys.platform,
+) -> Editor | None:
+    """Pick an editor: VS Code, then Cursor (PATH + known locations), then the
+    OS default opener. None only on a platform with no opener at all."""
+    for name, candidates in (("code", _CODE_CANDIDATES), ("cursor", _CURSOR_CANDIDATES)):
+        found = which(name) or next((c for c in candidates if isfile(c)), None)
+        if found:
+            return Editor(name=name, path=found, supports_line=True)
+    if platform == "darwin":
+        return Editor(name="open", path=which("open") or "/usr/bin/open", supports_line=False)
+    if platform == "win32":
+        # No argv — the caller routes this to os.startfile.
+        return Editor(name="startfile", path="startfile", supports_line=False)
+    opener = which("xdg-open")
+    if opener:
+        return Editor(name="xdg-open", path=opener, supports_line=False)
+    return None
+
+
+def build_open_argv(
+    editor: Editor, path: str, line: int | None = None, col: int | None = None
+) -> list[str] | None:
+    """argv to launch ``editor`` on ``path`` (at ``line[:col]`` when supported).
+
+    Returns None for the Windows ``startfile`` sentinel, which has no argv form.
+    """
+    if editor.name == "startfile":
+        return None
+    if editor.supports_line:
+        target = path
+        if line:
+            target += f":{line}"
+            if col:
+                target += f":{col}"
+        return [editor.path, "-g", target]
+    return [editor.path, path]

--- a/src/quodeq/terminal/links.py
+++ b/src/quodeq/terminal/links.py
@@ -109,6 +109,40 @@ def _safe(fn):
         return None
 
 
+def safe_editor_path(
+    path: str,
+    bases: list[str],
+    *,
+    realpath=os.path.realpath,
+    commonpath=os.path.commonpath,
+) -> str | None:
+    """Return the canonical real path of ``path`` iff it lives under one of the
+    terminal's working directories (``bases``); otherwise None.
+
+    Guards the /open launch: the client may send any path, but we only ever hand
+    the editor a file inside the directories the terminal actually operates in
+    (shell cwd, server cwd, home). This both bounds the blast radius and, because
+    the launch sinks consume the *returned* normalized value, sanitizes the
+    untrusted input (a symlink escaping a base resolves out via realpath and is
+    rejected).
+    """
+    try:
+        real = realpath(path)
+    except OSError:
+        return None
+    for base in bases:
+        try:
+            base_real = realpath(base)
+        except OSError:
+            continue
+        try:
+            if commonpath([real, base_real]) == base_real:
+                return real
+        except ValueError:  # mixed abs/rel or different drive (Windows)
+            continue
+    return None
+
+
 def resolve_path(
     token: str,
     bases: list[str],

--- a/src/quodeq/terminal/manager.py
+++ b/src/quodeq/terminal/manager.py
@@ -81,6 +81,13 @@ class TerminalManager:
     def alive(self) -> bool:
         return self._backend is not None and self._backend.alive
 
+    @property
+    def pid(self) -> int | None:
+        """PID of the live shell, or None. Used to read the shell's cwd so
+        clickable relative paths resolve against where the user actually is."""
+        backend = self._backend
+        return backend.pid if backend is not None else None
+
     def _append_scrollback(self, data: str) -> None:
         self._ring.append(data)
         self._ring_size += len(data)

--- a/src/quodeq/ui/src/api/terminal.js
+++ b/src/quodeq/ui/src/api/terminal.js
@@ -13,3 +13,20 @@ export function terminalStatus() {
 export function killTerminal() {
   return request('/terminal/kill', { method: 'POST' });
 }
+
+// Verify which detected path tokens are real files (backend resolves them
+// against the shell's live cwd). Returns [{ input, abs, exists }].
+export function resolveTerminalPaths(paths) {
+  return request('/terminal/resolve', {
+    method: 'POST',
+    body: JSON.stringify({ paths }),
+  }).then((r) => r.resolved || []);
+}
+
+// Open an already-resolved absolute path in the user's editor at line[:col].
+export function openInEditor(path, line, col) {
+  return request('/terminal/open', {
+    method: 'POST',
+    body: JSON.stringify({ path, line, col }),
+  });
+}

--- a/src/quodeq/ui/src/features/terminal/TerminalPane.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.jsx
@@ -3,7 +3,8 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
 import { useTerminalSocket } from './useTerminalSocket.js';
-import { terminalStatus } from '../../api/terminal.js';
+import { terminalStatus, resolveTerminalPaths, openInEditor } from '../../api/terminal.js';
+import { createUrlLinkProvider, createFileLinkProvider } from './terminalLinks.js';
 
 // Two drawer chords are reserved for the host; return false so xterm lets them
 // bubble to the window handler instead of typing into the shell.
@@ -101,6 +102,7 @@ export default function TerminalPane({ active }) {
     let ro = null;
     let mo = null;
     let fitTimer = null;
+    const linkProviders = [];
 
     const setup = () => {
       if (disposed || termRef.current || !rootRef.current) return;
@@ -125,6 +127,23 @@ export default function TerminalPane({ active }) {
       term.attachCustomKeyEventHandler((e) => !isReservedChord(e));
       term.onData((d) => send(d));
       termRef.current = term; fitRef.current = fit;
+
+      // Clickable links: cmd/ctrl-click a URL to open it in the system browser,
+      // or a real file path to open it in the user's editor. The file provider
+      // asks the backend which candidates are real files before lighting them
+      // up (see terminalLinks.js). y is a 1-based buffer line number.
+      const readLine = (y) => term.buffer.active.getLine(y - 1)?.translateToString(true) ?? '';
+      linkProviders.push(
+        term.registerLinkProvider(createUrlLinkProvider({
+          readLine,
+          openUrl: (url) => window.open(url, '_blank', 'noopener,noreferrer'),
+        })),
+        term.registerLinkProvider(createFileLinkProvider({
+          readLine,
+          resolvePaths: resolveTerminalPaths,
+          openFile: (abs, line, col) => { openInEditor(abs, line, col).catch(() => {}); },
+        })),
+      );
       // Fit only when visible. If the pane mounts on a hidden/background tab,
       // fitting measures a 0x0 box (bogus PTY size); the status-open and
       // tab-activation effects both fit once the pane is actually shown.
@@ -162,6 +181,7 @@ export default function TerminalPane({ active }) {
       disposed = true;
       if (fitTimer) clearTimeout(fitTimer);
       ro?.disconnect(); mo?.disconnect();
+      linkProviders.forEach((d) => { try { d.dispose(); } catch { /* noop */ } });
       if (termRef.current) { termRef.current.dispose(); }
       termRef.current = null; fitRef.current = null;
     };

--- a/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
@@ -5,6 +5,8 @@ import '@testing-library/jest-dom/vitest';
 const fakeTerm = { open: vi.fn(), write: vi.fn(), dispose: vi.fn(), loadAddon: vi.fn(),
   onData: vi.fn(), onResize: vi.fn(), focus: vi.fn(), attachCustomKeyEventHandler: vi.fn(),
   reset: vi.fn(),
+  registerLinkProvider: vi.fn(() => ({ dispose: vi.fn() })),
+  buffer: { active: { getLine: () => ({ translateToString: () => '' }) } },
   cols: 80, rows: 24, options: {} };
 // Use `function` (not arrow) implementations so vi.fn() produces a constructible
 // mock: xterm's Terminal/FitAddon are always invoked with `new` in TerminalPane.
@@ -16,6 +18,8 @@ vi.mock('../../api/terminal.js', () => ({
   terminalStatus: vi.fn(async () => ({ enabled: true, running: false, reason: null })),
   killTerminal: vi.fn(async () => ({ ok: true })),
   terminalSocketUrl: () => 'ws://localhost/api/terminal/ws',
+  resolveTerminalPaths: vi.fn(async () => []),
+  openInEditor: vi.fn(async () => ({ opened: true, editor: 'code' })),
 }));
 // Mock the socket hook: jsdom has no real terminal WS to reach, and the
 // overlay tests need to drive each connection status directly. lastSocketOpts

--- a/src/quodeq/ui/src/features/terminal/terminalLinks.js
+++ b/src/quodeq/ui/src/features/terminal/terminalLinks.js
@@ -1,0 +1,110 @@
+// Path detection for clickable terminal links. Pure (no xterm, no DOM) so it is
+// unit-testable with `node --test`. TerminalPane wires the results into an
+// xterm link provider; the backend verifies existence before anything lights up.
+
+// A candidate path token plus its half-open column span [start, end) within the
+// line (0-based), and an optional line:col parsed from a trailing `:N` / `:N:M`.
+// The span covers ONLY the path (never the :line:col suffix) so the underline
+// and click target match what the user reads as the filename.
+
+// Matches:
+//   ./rel/path.js            relative with a leading ./ or ../
+//   src/pkg/mod.py:12:3      relative with at least one slash + optional :line:col
+//   /abs/path.rs             absolute
+//   ~/notes.md               home-relative
+// A bare word like `README` (no slash, no dot-slash) is deliberately NOT matched
+// — too many false positives; the backend existence check is the second gate,
+// but we keep the regex conservative so we rarely even ask.
+const PATH_RE =
+  /(?<![\w./~-])((?:\.{1,2}\/|~\/|\/)?[\w.-]+(?:\/[\w.-]+)+|\.{1,2}\/[\w.-]+|~\/[\w.-]+)(?::(\d+)(?::(\d+))?)?/g;
+
+// Trailing punctuation that commonly hugs a path in prose/tool output but is not
+// part of it: `see src/a.js.` or `(src/a.js)` or `src/a.js,`.
+const TRAILING = /[).,:;'"\]}>]+$/;
+
+// http/https URLs. Kept as its own provider (rather than pulling in
+// @xterm/addon-web-links) so URLs and file paths share the exact same
+// cmd-click gating and there is no xterm peer-dependency to track.
+const URL_RE = /\bhttps?:\/\/[^\s'"`()<>[\]{}]+/g;
+
+export function extractUrlCandidates(line) {
+  if (!line) return [];
+  const out = [];
+  for (const m of line.matchAll(URL_RE)) {
+    const stripped = m[0].replace(TRAILING, '');
+    if (!stripped) continue;
+    out.push({ text: stripped, start: m.index, end: m.index + stripped.length });
+  }
+  return out;
+}
+
+export function extractPathCandidates(line) {
+  if (!line) return [];
+  const out = [];
+  for (const m of line.matchAll(PATH_RE)) {
+    const text = m[1];
+    const matchStart = m.index;
+    // Strip trailing punctuation from the path span, shrinking end accordingly.
+    const stripped = text.replace(TRAILING, '');
+    if (!stripped) continue;
+    const start = matchStart;
+    const end = start + stripped.length;
+    const line1 = m[2] ? Number(m[2]) : undefined;
+    const col1 = m[3] ? Number(m[3]) : undefined;
+    out.push({ text: stripped, start, end, line: line1, col: col1 });
+  }
+  return out;
+}
+
+// Build an xterm ILink. Columns are 1-based: a candidate span [start, end)
+// (0-based, end exclusive) maps to start.x = start+1, end.x = end. Activation is
+// gated on the platform modifier (cmd on macOS, ctrl elsewhere) so a plain click
+// still selects text, matching iTerm / VS Code.
+function makeLink(y, cand, activate) {
+  return {
+    text: cand.text,
+    range: { start: { x: cand.start + 1, y }, end: { x: cand.end, y } },
+    activate: (event) => {
+      if (event && (event.metaKey || event.ctrlKey)) activate();
+    },
+  };
+}
+
+// URL link provider (synchronous). `readLine(y)` returns the text of buffer line
+// y; `openUrl(url)` opens it in the system browser.
+export function createUrlLinkProvider({ readLine, openUrl }) {
+  return {
+    provideLinks(y, callback) {
+      const cands = extractUrlCandidates(readLine(y));
+      callback(cands.length ? cands.map((c) => makeLink(y, c, () => openUrl(c.text))) : undefined);
+    },
+  };
+}
+
+// File-path link provider (async). Extracts candidates, asks `resolvePaths` which
+// exist, and only makes the existing ones clickable. `openFile(abs, line, col)`
+// opens the resolved absolute path in the editor.
+export function createFileLinkProvider({ readLine, resolvePaths, openFile }) {
+  return {
+    provideLinks(y, callback) {
+      const cands = extractPathCandidates(readLine(y));
+      if (!cands.length) {
+        callback(undefined);
+        return;
+      }
+      Promise.resolve(resolvePaths(cands.map((c) => c.text)))
+        .then((resolved) => {
+          const byInput = new Map((resolved || []).map((r) => [r.input, r]));
+          const links = [];
+          for (const c of cands) {
+            const r = byInput.get(c.text);
+            if (r && r.exists) {
+              links.push(makeLink(y, c, () => openFile(r.abs, c.line, c.col)));
+            }
+          }
+          callback(links.length ? links : undefined);
+        })
+        .catch(() => callback(undefined));
+    },
+  };
+}

--- a/src/quodeq/ui/src/features/terminal/terminalLinks.test.js
+++ b/src/quodeq/ui/src/features/terminal/terminalLinks.test.js
@@ -1,0 +1,154 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  extractPathCandidates,
+  extractUrlCandidates,
+  createUrlLinkProvider,
+  createFileLinkProvider,
+} from './terminalLinks.js';
+
+test('relative path with slash', () => {
+  const [c] = extractPathCandidates('editing src/quodeq/api/terminal_routes.py now');
+  assert.equal(c.text, 'src/quodeq/api/terminal_routes.py');
+  assert.equal(c.line, undefined);
+});
+
+test('dot-slash single segment', () => {
+  const [c] = extractPathCandidates('run ./setup.sh');
+  assert.equal(c.text, './setup.sh');
+});
+
+test('absolute path', () => {
+  const [c] = extractPathCandidates('  File "/Users/x/proj/app.py", line 3');
+  assert.equal(c.text, '/Users/x/proj/app.py');
+});
+
+test('home-relative single segment', () => {
+  const [c] = extractPathCandidates('cat ~/notes.md');
+  assert.equal(c.text, '~/notes.md');
+});
+
+test('pytest file:line:col suffix parsed, span excludes it', () => {
+  const line = 'tests/api/test_x.py:42:7: AssertionError';
+  const [c] = extractPathCandidates(line);
+  assert.equal(c.text, 'tests/api/test_x.py');
+  assert.equal(c.line, 42);
+  assert.equal(c.col, 7);
+  // span covers only the path, not :42:7
+  assert.equal(line.slice(c.start, c.end), 'tests/api/test_x.py');
+});
+
+test('grep file:line suffix', () => {
+  const [c] = extractPathCandidates('src/a/b.js:10:  const x = 1');
+  assert.equal(c.text, 'src/a/b.js');
+  assert.equal(c.line, 10);
+  assert.equal(c.col, undefined);
+});
+
+test('trailing punctuation stripped', () => {
+  const [c] = extractPathCandidates('see (src/a/b.js).');
+  assert.equal(c.text, 'src/a/b.js');
+  assert.equal('see (src/a/b.js).'.slice(c.start, c.end), 'src/a/b.js');
+});
+
+test('bare word without slash is not matched', () => {
+  assert.deepEqual(extractPathCandidates('README and Makefile here'), []);
+});
+
+test('url is not captured as a path', () => {
+  // https://... has slashes but the scheme host should not become a file link.
+  // We do not assert zero here (defense is the backend existence check), but the
+  // captured token must not be a plausible local file the backend would open.
+  const cands = extractPathCandidates('visit https://example.com/a/b');
+  for (const c of cands) {
+    assert.ok(!c.text.startsWith('/'), `unexpected absolute token: ${c.text}`);
+  }
+});
+
+test('multiple candidates on one line', () => {
+  const cands = extractPathCandidates('mv src/a.js src/b.js');
+  assert.equal(cands.length, 2);
+  assert.deepEqual(cands.map((c) => c.text), ['src/a.js', 'src/b.js']);
+});
+
+test('empty line yields nothing', () => {
+  assert.deepEqual(extractPathCandidates(''), []);
+});
+
+test('http url captured with correct span', () => {
+  const line = 'open https://example.com/a/b?x=1 in browser';
+  const [u] = extractUrlCandidates(line);
+  assert.equal(u.text, 'https://example.com/a/b?x=1');
+  assert.equal(line.slice(u.start, u.end), 'https://example.com/a/b?x=1');
+});
+
+test('url trailing paren/period stripped', () => {
+  const [u] = extractUrlCandidates('(see http://localhost:7863/app).');
+  assert.equal(u.text, 'http://localhost:7863/app');
+});
+
+test('no url yields nothing', () => {
+  assert.deepEqual(extractUrlCandidates('just some text'), []);
+});
+
+test('url provider: 1-based range and cmd-gated activate', () => {
+  const opened = [];
+  const p = createUrlLinkProvider({
+    readLine: () => 'x https://a.co/p',
+    openUrl: (u) => opened.push(u),
+  });
+  let links;
+  p.provideLinks(3, (l) => { links = l; });
+  assert.equal(links.length, 1);
+  // 'https://a.co/p' starts at index 2 -> start.x 3, y passthrough
+  assert.deepEqual(links[0].range.start, { x: 3, y: 3 });
+  // plain click does nothing; cmd-click opens
+  links[0].activate({});
+  assert.deepEqual(opened, []);
+  links[0].activate({ metaKey: true });
+  assert.deepEqual(opened, ['https://a.co/p']);
+});
+
+test('file provider: only existing files become links, opens abs+line', async () => {
+  const opened = [];
+  let resolveReq;
+  const p = createFileLinkProvider({
+    readLine: () => 'a src/real.js:5 and src/missing.js',
+    resolvePaths: (paths) => {
+      resolveReq = paths;
+      return Promise.resolve([
+        { input: 'src/real.js', abs: '/proj/src/real.js', exists: true },
+        { input: 'src/missing.js', abs: '/proj/src/missing.js', exists: false },
+      ]);
+    },
+    openFile: (abs, line, col) => opened.push([abs, line, col]),
+  });
+  const links = await new Promise((res) => p.provideLinks(2, res));
+  assert.deepEqual(resolveReq, ['src/real.js', 'src/missing.js']);
+  assert.equal(links.length, 1);
+  assert.equal(links[0].text, 'src/real.js');
+  links[0].activate({ ctrlKey: true });
+  assert.deepEqual(opened, [['/proj/src/real.js', 5, undefined]]);
+});
+
+test('file provider: no candidates -> undefined, no backend call', async () => {
+  let called = false;
+  const p = createFileLinkProvider({
+    readLine: () => 'nothing here',
+    resolvePaths: () => { called = true; return Promise.resolve([]); },
+    openFile: () => {},
+  });
+  const links = await new Promise((res) => p.provideLinks(1, res));
+  assert.equal(links, undefined);
+  assert.equal(called, false);
+});
+
+test('file provider: backend error -> undefined (no throw)', async () => {
+  const p = createFileLinkProvider({
+    readLine: () => 'edit src/a.js',
+    resolvePaths: () => Promise.reject(new Error('boom')),
+    openFile: () => {},
+  });
+  const links = await new Promise((res) => p.provideLinks(1, res));
+  assert.equal(links, undefined);
+});

--- a/tests/api/test_terminal_links.py
+++ b/tests/api/test_terminal_links.py
@@ -5,8 +5,6 @@ subprocess) and the /api/terminal/resolve + /open routes.
 """
 from __future__ import annotations
 
-import os
-
 import pytest
 from flask import Flask
 
@@ -21,18 +19,43 @@ from quodeq.terminal.links import (
 )
 
 
+# POSIX-style path primitives injected into the pure helpers so these logic
+# tests are deterministic on every OS (the host's os.path uses \ on Windows,
+# which would break literal "/foo" assertions without exercising real logic).
+def _pjoin(a, b):
+    return a.rstrip("/") + "/" + b
+
+
+def _ident(p):
+    return p
+
+
+def _pisabs(p):
+    return p.startswith("/")
+
+
+def _pcommonpath(paths):
+    a, base = paths
+    b = base.rstrip("/")
+    return base if (a == base or a == b or a.startswith(b + "/")) else "/"
+
+
 # --- resolve_path -----------------------------------------------------------
 
 def test_resolve_absolute_existing():
     abs_path, exists = resolve_path(
         "/proj/a.py", ["/base"], isfile=lambda p: p == "/proj/a.py",
+        isabs=_pisabs, join=_pjoin, normpath=_ident, expanduser=_ident,
     )
     assert abs_path == "/proj/a.py"
     assert exists is True
 
 
 def test_resolve_absolute_missing():
-    abs_path, exists = resolve_path("/nope.py", ["/base"], isfile=lambda p: False)
+    abs_path, exists = resolve_path(
+        "/nope.py", ["/base"], isfile=lambda p: False,
+        isabs=_pisabs, join=_pjoin, normpath=_ident, expanduser=_ident,
+    )
     assert abs_path == "/nope.py"
     assert exists is False
 
@@ -42,6 +65,7 @@ def test_resolve_relative_picks_first_existing_base():
     real = "/second/rel.py"
     abs_path, exists = resolve_path(
         "rel.py", ["/first", "/second"], isfile=lambda p: p == real,
+        isabs=_pisabs, join=_pjoin, normpath=_ident, expanduser=_ident,
     )
     assert abs_path == real
     assert exists is True
@@ -50,6 +74,7 @@ def test_resolve_relative_picks_first_existing_base():
 def test_resolve_relative_none_exist_falls_back_to_first_base():
     abs_path, exists = resolve_path(
         "rel.py", ["/first", "/second"], isfile=lambda p: False,
+        isabs=_pisabs, join=_pjoin, normpath=_ident, expanduser=_ident,
     )
     assert abs_path == "/first/rel.py"
     assert exists is False
@@ -58,12 +83,14 @@ def test_resolve_relative_none_exist_falls_back_to_first_base():
 # --- safe_editor_path -------------------------------------------------------
 
 def test_safe_editor_path_within_base_returns_realpath():
-    got = safe_editor_path("/home/u/proj/a.py", ["/home/u"], realpath=lambda p: p)
+    got = safe_editor_path("/home/u/proj/a.py", ["/home/u"],
+                           realpath=_ident, commonpath=_pcommonpath)
     assert got == "/home/u/proj/a.py"
 
 
 def test_safe_editor_path_outside_bases_is_none():
-    assert safe_editor_path("/etc/passwd", ["/home/u"], realpath=lambda p: p) is None
+    assert safe_editor_path("/etc/passwd", ["/home/u"],
+                            realpath=_ident, commonpath=_pcommonpath) is None
 
 
 def test_safe_editor_path_symlink_escape_rejected():
@@ -71,18 +98,23 @@ def test_safe_editor_path_symlink_escape_rejected():
     def _rp(p):
         return "/etc/shadow" if p == "/home/u/link" else p
 
-    assert safe_editor_path("/home/u/link", ["/home/u"], realpath=_rp) is None
+    assert safe_editor_path("/home/u/link", ["/home/u"],
+                            realpath=_rp, commonpath=_pcommonpath) is None
 
 
 def test_safe_editor_path_normalizes_returned_value():
+    # realpath collapses the `..`; the returned value is the normalized one.
     got = safe_editor_path(
-        "/home/u/../u/proj/a.py", ["/home/u"], realpath=os.path.normpath,
+        "/home/u/../u/proj/a.py", ["/home/u"],
+        realpath=lambda p: "/home/u/proj/a.py" if ".." in p else p,
+        commonpath=_pcommonpath,
     )
     assert got == "/home/u/proj/a.py"
 
 
 def test_safe_editor_path_checks_multiple_bases():
-    got = safe_editor_path("/second/a.py", ["/first", "/second"], realpath=lambda p: p)
+    got = safe_editor_path("/second/a.py", ["/first", "/second"],
+                           realpath=_ident, commonpath=_pcommonpath)
     assert got == "/second/a.py"
 
 

--- a/tests/api/test_terminal_links.py
+++ b/tests/api/test_terminal_links.py
@@ -5,6 +5,8 @@ subprocess) and the /api/terminal/resolve + /open routes.
 """
 from __future__ import annotations
 
+import os
+
 import pytest
 from flask import Flask
 
@@ -15,6 +17,7 @@ from quodeq.terminal.links import (
     child_cwd,
     detect_editor,
     resolve_path,
+    safe_editor_path,
 )
 
 
@@ -50,6 +53,37 @@ def test_resolve_relative_none_exist_falls_back_to_first_base():
     )
     assert abs_path == "/first/rel.py"
     assert exists is False
+
+
+# --- safe_editor_path -------------------------------------------------------
+
+def test_safe_editor_path_within_base_returns_realpath():
+    got = safe_editor_path("/home/u/proj/a.py", ["/home/u"], realpath=lambda p: p)
+    assert got == "/home/u/proj/a.py"
+
+
+def test_safe_editor_path_outside_bases_is_none():
+    assert safe_editor_path("/etc/passwd", ["/home/u"], realpath=lambda p: p) is None
+
+
+def test_safe_editor_path_symlink_escape_rejected():
+    # realpath resolves the link OUT of the base -> rejected (not just lexical).
+    def _rp(p):
+        return "/etc/shadow" if p == "/home/u/link" else p
+
+    assert safe_editor_path("/home/u/link", ["/home/u"], realpath=_rp) is None
+
+
+def test_safe_editor_path_normalizes_returned_value():
+    got = safe_editor_path(
+        "/home/u/../u/proj/a.py", ["/home/u"], realpath=os.path.normpath,
+    )
+    assert got == "/home/u/proj/a.py"
+
+
+def test_safe_editor_path_checks_multiple_bases():
+    got = safe_editor_path("/second/a.py", ["/first", "/second"], realpath=lambda p: p)
+    assert got == "/second/a.py"
 
 
 # --- detect_editor ----------------------------------------------------------
@@ -210,6 +244,9 @@ def test_resolve_route_gated(app):
 
 def test_open_route_launches_editor(app, monkeypatch):
     calls = {}
+    # Bypass containment/realpath so the test is deterministic; safe path == input.
+    monkeypatch.setattr("quodeq.api.terminal_routes.resolve_bases", lambda pid: ["/base"])
+    monkeypatch.setattr("quodeq.api.terminal_routes.safe_editor_path", lambda p, bases: p)
     monkeypatch.setattr("quodeq.api.terminal_routes.os.path.isfile", lambda p: True)
     monkeypatch.setattr("quodeq.api.terminal_routes.detect_editor",
                         lambda: Editor("code", "/usr/bin/code", True))
@@ -230,7 +267,22 @@ def test_open_route_launches_editor(app, monkeypatch):
     assert calls["kw"].get("start_new_session") is True
 
 
+def test_open_route_rejects_path_outside_bases(app, monkeypatch):
+    # safe_editor_path returns None for anything outside the terminal's dirs.
+    monkeypatch.setattr("quodeq.api.terminal_routes.resolve_bases", lambda pid: ["/base"])
+    monkeypatch.setattr("quodeq.api.terminal_routes.safe_editor_path", lambda p, bases: None)
+    launched = []
+    monkeypatch.setattr("quodeq.api.terminal_routes.subprocess.Popen",
+                        lambda *a, **k: launched.append(a))
+    c = app.test_client()
+    r = c.post("/api/terminal/open", json={"path": "/etc/passwd"}, headers=_H, base_url="http://localhost")
+    assert r.get_json() == {"opened": False, "editor": None}
+    assert launched == []
+
+
 def test_open_route_missing_file_not_opened(app, monkeypatch):
+    monkeypatch.setattr("quodeq.api.terminal_routes.resolve_bases", lambda pid: ["/base"])
+    monkeypatch.setattr("quodeq.api.terminal_routes.safe_editor_path", lambda p, bases: p)
     monkeypatch.setattr("quodeq.api.terminal_routes.os.path.isfile", lambda p: False)
     launched = []
     monkeypatch.setattr("quodeq.api.terminal_routes.subprocess.Popen",
@@ -242,6 +294,8 @@ def test_open_route_missing_file_not_opened(app, monkeypatch):
 
 
 def test_open_route_fail_soft_on_launch_error(app, monkeypatch):
+    monkeypatch.setattr("quodeq.api.terminal_routes.resolve_bases", lambda pid: ["/base"])
+    monkeypatch.setattr("quodeq.api.terminal_routes.safe_editor_path", lambda p, bases: p)
     monkeypatch.setattr("quodeq.api.terminal_routes.os.path.isfile", lambda p: True)
     monkeypatch.setattr("quodeq.api.terminal_routes.detect_editor",
                         lambda: Editor("code", "/usr/bin/code", True))

--- a/tests/api/test_terminal_links.py
+++ b/tests/api/test_terminal_links.py
@@ -1,0 +1,262 @@
+"""Tests for clickable-terminal-link resolution and editor launching.
+
+Covers the pure helpers in quodeq.terminal.links (no real filesystem, PATH, or
+subprocess) and the /api/terminal/resolve + /open routes.
+"""
+from __future__ import annotations
+
+import pytest
+from flask import Flask
+
+from quodeq.api.terminal_routes import register_terminal_routes
+from quodeq.terminal.links import (
+    Editor,
+    build_open_argv,
+    child_cwd,
+    detect_editor,
+    resolve_path,
+)
+
+
+# --- resolve_path -----------------------------------------------------------
+
+def test_resolve_absolute_existing():
+    abs_path, exists = resolve_path(
+        "/proj/a.py", ["/base"], isfile=lambda p: p == "/proj/a.py",
+    )
+    assert abs_path == "/proj/a.py"
+    assert exists is True
+
+
+def test_resolve_absolute_missing():
+    abs_path, exists = resolve_path("/nope.py", ["/base"], isfile=lambda p: False)
+    assert abs_path == "/nope.py"
+    assert exists is False
+
+
+def test_resolve_relative_picks_first_existing_base():
+    # Exists only under the second base.
+    real = "/second/rel.py"
+    abs_path, exists = resolve_path(
+        "rel.py", ["/first", "/second"], isfile=lambda p: p == real,
+    )
+    assert abs_path == real
+    assert exists is True
+
+
+def test_resolve_relative_none_exist_falls_back_to_first_base():
+    abs_path, exists = resolve_path(
+        "rel.py", ["/first", "/second"], isfile=lambda p: False,
+    )
+    assert abs_path == "/first/rel.py"
+    assert exists is False
+
+
+# --- detect_editor ----------------------------------------------------------
+
+def test_detect_editor_prefers_code_on_path():
+    ed = detect_editor(which=lambda n: "/usr/bin/code" if n == "code" else None,
+                       isfile=lambda p: False, platform="darwin")
+    assert ed == Editor(name="code", path="/usr/bin/code", supports_line=True)
+
+
+def test_detect_editor_finds_code_via_known_location_when_path_misses():
+    # GUI-launched macOS app: `code` not on PATH, but the bundled CLI exists.
+    bundled = "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code"
+    ed = detect_editor(which=lambda n: None, isfile=lambda p: p == bundled,
+                       platform="darwin")
+    assert ed.name == "code" and ed.path == bundled and ed.supports_line
+
+
+def test_detect_editor_falls_back_to_cursor_then_open():
+    ed = detect_editor(which=lambda n: "/opt/homebrew/bin/cursor" if n == "cursor" else None,
+                       isfile=lambda p: False, platform="darwin")
+    assert ed.name == "cursor"
+
+    ed2 = detect_editor(which=lambda n: None, isfile=lambda p: False, platform="darwin")
+    assert ed2.name == "open" and ed2.supports_line is False
+
+
+def test_detect_editor_none_when_no_opener():
+    ed = detect_editor(which=lambda n: None, isfile=lambda p: False, platform="linux")
+    # No xdg-open either.
+    assert ed is None
+
+
+# --- build_open_argv --------------------------------------------------------
+
+def test_build_argv_code_with_line_col():
+    ed = Editor("code", "/usr/bin/code", True)
+    assert build_open_argv(ed, "/a.py", 12, 4) == ["/usr/bin/code", "-g", "/a.py:12:4"]
+
+
+def test_build_argv_code_line_only():
+    ed = Editor("code", "/usr/bin/code", True)
+    assert build_open_argv(ed, "/a.py", 12, None) == ["/usr/bin/code", "-g", "/a.py:12"]
+
+
+def test_build_argv_code_no_line():
+    ed = Editor("code", "/usr/bin/code", True)
+    assert build_open_argv(ed, "/a.py", None, None) == ["/usr/bin/code", "-g", "/a.py"]
+
+
+def test_build_argv_open_ignores_line():
+    ed = Editor("open", "/usr/bin/open", False)
+    assert build_open_argv(ed, "/a.py", 12, 4) == ["/usr/bin/open", "/a.py"]
+
+
+def test_build_argv_startfile_sentinel_is_none():
+    ed = Editor("startfile", "startfile", False)
+    assert build_open_argv(ed, "/a.py", 1, 1) is None
+
+
+# --- child_cwd --------------------------------------------------------------
+
+def test_child_cwd_linux_readlink():
+    got = child_cwd(123, platform="linux", readlink=lambda p: "/proc-cwd" if p == "/proc/123/cwd" else None)
+    assert got == "/proc-cwd"
+
+
+def test_child_cwd_darwin_parses_lsof():
+    class _Proc:
+        stdout = "p123\nfcwd\nn/Users/x/live\n"
+
+    got = child_cwd(123, platform="darwin", run=lambda *a, **k: _Proc())
+    assert got == "/Users/x/live"
+
+
+def test_child_cwd_none_without_pid():
+    assert child_cwd(None) is None
+
+
+def test_child_cwd_swallows_errors():
+    def _boom(*a, **k):
+        raise OSError("nope")
+
+    assert child_cwd(123, platform="linux", readlink=_boom) is None
+
+
+# --- routes -----------------------------------------------------------------
+
+class _FakeManager:
+    def __init__(self, pid=4321):
+        self.pid = pid
+        self._alive = False
+
+    def ensure_session(self, *, cwd, cols, rows):
+        self._alive = True
+
+    def scrollback(self):
+        return ""
+
+    def read(self, max_bytes=65536):
+        return ""
+
+    def write(self, data):
+        pass
+
+    def resize(self, cols, rows):
+        pass
+
+    def kill(self):
+        self._alive = False
+
+    @property
+    def alive(self):
+        return self._alive
+
+
+@pytest.fixture()
+def app():
+    app = Flask(__name__)
+    app.config["QUODEQ_API_KEY"] = None
+    app.config["QUODEQ_BIND_HOST"] = "127.0.0.1"
+    register_terminal_routes(app, manager=_FakeManager())
+    return app
+
+
+_H = {"Origin": "http://localhost"}
+
+
+def test_resolve_route_reports_existence(app, monkeypatch):
+    monkeypatch.setattr("quodeq.api.terminal_routes.resolve_bases", lambda pid: ["/base"])
+    monkeypatch.setattr(
+        "quodeq.api.terminal_routes.resolve_path",
+        lambda token, bases: (f"/base/{token}", token == "real.py"),
+    )
+    c = app.test_client()
+    r = c.post("/api/terminal/resolve", json={"paths": ["real.py", "ghost.py"]},
+               headers=_H, base_url="http://localhost")
+    assert r.status_code == 200
+    resolved = r.get_json()["resolved"]
+    assert resolved == [
+        {"input": "real.py", "abs": "/base/real.py", "exists": True},
+        {"input": "ghost.py", "abs": "/base/ghost.py", "exists": False},
+    ]
+
+
+def test_resolve_route_rejects_non_list(app):
+    c = app.test_client()
+    r = c.post("/api/terminal/resolve", json={"paths": "x"}, headers=_H, base_url="http://localhost")
+    assert r.status_code == 400
+
+
+def test_resolve_route_gated(app):
+    app.config["QUODEQ_BIND_HOST"] = "0.0.0.0"  # forces gate refusal
+    c = app.test_client()
+    r = c.post("/api/terminal/resolve", json={"paths": []}, headers=_H, base_url="http://localhost")
+    assert r.status_code == 403
+
+
+def test_open_route_launches_editor(app, monkeypatch):
+    calls = {}
+    monkeypatch.setattr("quodeq.api.terminal_routes.os.path.isfile", lambda p: True)
+    monkeypatch.setattr("quodeq.api.terminal_routes.detect_editor",
+                        lambda: Editor("code", "/usr/bin/code", True))
+
+    def _popen(argv, **kw):
+        calls["argv"] = argv
+        calls["kw"] = kw
+        return object()
+
+    monkeypatch.setattr("quodeq.api.terminal_routes.subprocess.Popen", _popen)
+    c = app.test_client()
+    r = c.post("/api/terminal/open", json={"path": "/proj/a.py", "line": 9, "col": 2},
+               headers=_H, base_url="http://localhost")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body == {"opened": True, "editor": "code"}
+    assert calls["argv"] == ["/usr/bin/code", "-g", "/proj/a.py:9:2"]
+    assert calls["kw"].get("start_new_session") is True
+
+
+def test_open_route_missing_file_not_opened(app, monkeypatch):
+    monkeypatch.setattr("quodeq.api.terminal_routes.os.path.isfile", lambda p: False)
+    launched = []
+    monkeypatch.setattr("quodeq.api.terminal_routes.subprocess.Popen",
+                        lambda *a, **k: launched.append(a))
+    c = app.test_client()
+    r = c.post("/api/terminal/open", json={"path": "/gone.py"}, headers=_H, base_url="http://localhost")
+    assert r.get_json() == {"opened": False, "editor": None}
+    assert launched == []
+
+
+def test_open_route_fail_soft_on_launch_error(app, monkeypatch):
+    monkeypatch.setattr("quodeq.api.terminal_routes.os.path.isfile", lambda p: True)
+    monkeypatch.setattr("quodeq.api.terminal_routes.detect_editor",
+                        lambda: Editor("code", "/usr/bin/code", True))
+
+    def _boom(*a, **k):
+        raise OSError("no exec")
+
+    monkeypatch.setattr("quodeq.api.terminal_routes.subprocess.Popen", _boom)
+    c = app.test_client()
+    r = c.post("/api/terminal/open", json={"path": "/proj/a.py"}, headers=_H, base_url="http://localhost")
+    assert r.status_code == 200
+    assert r.get_json() == {"opened": False, "editor": "code"}
+
+
+def test_open_route_requires_path(app):
+    c = app.test_client()
+    r = c.post("/api/terminal/open", json={}, headers=_H, base_url="http://localhost")
+    assert r.status_code == 400

--- a/tests/test_no_unguarded_posix.py
+++ b/tests/test_no_unguarded_posix.py
@@ -32,6 +32,11 @@ _ALLOWLIST: set[str] = {
     # on Windows (FileNotFoundError) resource sampling degrades gracefully.
     "shared/resource_sampler.py:41",
     "shared/resource_sampler.py:57",
+    # child_cwd's macOS branch: only reached when `platform == "darwin"` and
+    # wrapped in `except (..., subprocess.SubprocessError)`, so Windows never
+    # runs it and a missing lsof degrades to None. Used to resolve clickable
+    # terminal links against the shell's live cwd.
+    "terminal/links.py:80",
 }
 
 


### PR DESCRIPTION
## What

The embedded terminal colored file paths and http URLs (ANSI output from the programs), but nothing was clickable, no cmd-click to jump to the source like iTerm/VS Code. This adds it.

- **URLs** open in the system browser.
- **File paths** open in the user's editor at the right `line:col`. Only real files light up: candidates are verified against the shell's live cwd before becoming links, so path-shaped text never becomes a dead link. `pytest`/`grep`/traceback `file:line:col` suffixes are parsed.
- Activation is gated on the platform modifier (⌘ macOS / Ctrl elsewhere) so a plain click still selects text.

## How

Two `xterm` link providers (no `@xterm/addon-web-links` — a custom URL provider avoids the peer-dep vs xterm 6 and lets URLs and paths share the same cmd-click gating). Logic lives in pure, unit-tested modules; the HTTP layer stays thin:

- `ui/src/features/terminal/terminalLinks.js` — path/URL regex + provider factories.
- `terminal/links.py` — cwd / editor / path resolution.
- `POST /api/terminal/resolve` + `/open` in `terminal_routes.py`, gated by the same `_gate_reason()` as `/kill`.

## Design notes (from reading the code)

- The shell starts at `$HOME` and the user `cd`s around, so relative paths resolve against the shell's **live cwd** (Linux `/proc/<pid>/cwd`, macOS `lsof`), with server-cwd and home as fallbacks, not a fixed root. Added a `pid` property to `TerminalManager` and both PTY backends.
- A GUI-launched macOS app inherits a minimal `PATH` that lacks `code`/`cursor`, so `detect_editor` probes Homebrew and the in-`.app` CLI locations in addition to `PATH` (VS Code → Cursor → OS opener). VS Code/Cursor share `-g file:line:col`.
- `/open` is fail-soft: any error returns `opened: false` rather than raising.

## Testing

- 18 JS unit tests (`terminalLinks.test.js`): regex, `file:line:col` parsing, span offsets, provider activation gating, exists-filtering, error handling.
- 24 Python tests (`test_terminal_links.py`): resolve base-fallback, editor detection order, argv building, `child_cwd` parsing, route gating, missing-file guard, fail-soft.
- Existing terminal suite (336 backend + 17 UI) still green; UI builds clean.
- Verified live against the running dashboard: `/resolve` returned correct existence via the multi-base fallback; `/open` detected VS Code and launched it at `terminal_routes.py:96:5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)