### PR TITLE
fix(maintainability): guard non-dict JSONL lines and freeze grade thresholds

### DIFF
--- a/src/quodeq/analysis/cache/_failure_streak.py
+++ b/src/quodeq/analysis/cache/_failure_streak.py
@@ -143,6 +143,8 @@ class FailureStreakWatcher:
                 entry = json.loads(raw)
             except (json.JSONDecodeError, UnicodeDecodeError):
                 continue
+            if not isinstance(entry, dict):
+                continue
             if entry.get("_marker") != "file_done":
                 continue
             status = entry.get("status")

--- a/src/quodeq/ui/src/utils/gradeThresholds.js
+++ b/src/quodeq/ui/src/utils/gradeThresholds.js
@@ -3,12 +3,17 @@
  * Seeded with the backend Q2 defaults; App.jsx overwrites them at boot from
  * GET /api/grade-formula so every surface agrees with the server formula.
  */
-const DEFAULT_THRESHOLDS = [
-  [9, 'Exemplary'], [7, 'Good'], [5, 'Adequate'], [3, 'Poor'],
-];
+const DEFAULT_THRESHOLDS = Object.freeze([
+  Object.freeze([9, 'Exemplary']),
+  Object.freeze([7, 'Good']),
+  Object.freeze([5, 'Adequate']),
+  Object.freeze([3, 'Poor']),
+]);
 
 let thresholds = DEFAULT_THRESHOLDS;
 
+// Returns the shared threshold table by reference. It is frozen so callers
+// (all read-only today) cannot mutate app-wide grading through the reference.
 export function getGradeThresholds() {
   return thresholds;
 }
@@ -17,8 +22,8 @@ export function setGradeThresholds(next) {
   if (!Array.isArray(next) || next.length === 0) return;
   const clean = next
     .filter((e) => Array.isArray(e) && typeof e[0] === 'number' && typeof e[1] === 'string')
-    .map((e) => [e[0], e[1]]);
-  if (clean.length === next.length && clean.length > 0) thresholds = clean;
+    .map((e) => Object.freeze([e[0], e[1]]));
+  if (clean.length === next.length && clean.length > 0) thresholds = Object.freeze(clean);
 }
 
 export function resetGradeThresholds() {

--- a/src/quodeq/ui/src/utils/gradeThresholds.test.js
+++ b/src/quodeq/ui/src/utils/gradeThresholds.test.js
@@ -32,6 +32,23 @@ test('setGradeThresholds changes the mapping', () => {
   assert.equal(scoreToGradeLabel(3.9), 'Critical');
 });
 
+test('getGradeThresholds returns a frozen table that callers cannot mutate', () => {
+  const t = getGradeThresholds();
+  assert.ok(Object.isFrozen(t));
+  assert.ok(Object.isFrozen(t[0]));
+  assert.throws(() => { t.push([1, 'x']); }, TypeError);
+  assert.throws(() => { t[0][0] = 0; }, TypeError);
+  // The shared table is unchanged after the failed mutations.
+  assert.equal(scoreToGradeLabel(9.2), 'Exemplary');
+});
+
+test('setGradeThresholds result is also frozen', () => {
+  setGradeThresholds([[9.5, 'Exemplary'], [8, 'Good'], [6, 'Adequate'], [4, 'Poor']]);
+  const t = getGradeThresholds();
+  assert.ok(Object.isFrozen(t));
+  assert.ok(Object.isFrozen(t[0]));
+});
+
 test('setGradeThresholds ignores junk', () => {
   setGradeThresholds(undefined);
   setGradeThresholds([]);

--- a/tests/analysis/cache/test_failure_streak_breaker.py
+++ b/tests/analysis/cache/test_failure_streak_breaker.py
@@ -56,6 +56,28 @@ class TestFailureStreakBreaker:
         assert len(watcher.trip_event.recent) == 5
         assert watcher.trip_event.recent[0].reason == "token_limit"
 
+    def test_non_dict_json_line_does_not_kill_scan(self, tmp_path: Path):
+        # A JSONL line that decodes to a non-object (array/number/string/null)
+        # must be skipped, not crash the scan thread with AttributeError. If the
+        # thread died on the bad line it would never see the trailing errors and
+        # the breaker would not trip.
+        jsonl = tmp_path / "evidence.jsonl"
+        jsonl.touch()
+        watcher = FailureStreakWatcher(jsonl, threshold=5)
+        watcher.start()
+        with jsonl.open("a") as f:
+            f.write("[1, 2, 3]\n")   # array, not object
+            f.write("42\n")           # bare number
+            f.write('"a string"\n')  # bare string
+            f.write("null\n")         # null
+        for i in range(5):
+            _append(jsonl, {"_marker": "file_done", "file": f"f{i}.py", "status": "error", "reason": "token_limit"})
+        watcher.wait_for_trip(timeout=5.0)
+        watcher.stop_and_join(timeout=5.0)
+        assert cancellation.is_cancelled()
+        assert isinstance(watcher.trip_event, TripEvent)
+        assert watcher.trip_event.streak == 5
+
     def test_threshold_zero_disables(self, tmp_path: Path):
         jsonl = tmp_path / "evidence.jsonl"
         jsonl.touch()


### PR DESCRIPTION
## Maintainability triage — latest self-eval (run \`b5e0f558\`, 2026-07-23)

Triaged the **2 critical + 58 major** maintainability violations shown on the Overview. Verified each against source under quodeq's real deployment model (a local, single-user desktop app). Result:

- **2 real fixes** (this PR)
- **2 real-but-low-priority** left as honest violations (not dismissed, not changed): \`galaxyViewInfo.jsx\` branch repetition, \`rateSampleStore.js\` read-only buffer.
- **56 false-positive / design-appropriate** dismissed in the dashboard (env reads wrapped in monkeypatchable helpers, \`localhost\`/relative same-origin paths for the local dashboard, framework globals like \`flask.request\`/\`window.pywebview\`, Vite build-time config, route/orchestrator coupling just over an arbitrary threshold). Both criticals were FPs: a "syntax error" that was a partial grab of a valid ternary, and a local trusted-env-var "arbitrary file read" mislabeled as maintainability.

## Fixes

**\`analysis/cache/_failure_streak.py\`** — the circuit-breaker scan called \`entry.get()\` on \`json.loads()\` output without checking it was a dict. A non-object JSONL line (array/number/string/null) raised \`AttributeError\`, which was uncaught (only decode errors were) and would kill the breaker's background thread, silently disabling failure-streak cancellation for the rest of the run. Added an \`isinstance(entry, dict)\` guard matching the convention used by sibling JSONL parsers. (M-ANA-12)

**\`ui/src/utils/gradeThresholds.js\`** — \`getGradeThresholds()\` returned the mutable module-level threshold table by reference, so a stray caller mutation could silently corrupt app-wide grade labels. Froze the default table and any table set via \`setGradeThresholds()\`. All consumers are read-only, so this is behavior-preserving and keeps the no-copy return (identity preserved). (M-MOD-13)

## Tests

- \`test_failure_streak_breaker.py\`: new \`test_non_dict_json_line_does_not_kill_scan\` — interleaves array/number/string/null lines before the error markers and asserts the breaker still trips (proving the scan thread survived). 9 passed.
- \`gradeThresholds.test.js\`: new frozen-table assertions on both \`getGradeThresholds\` and \`setGradeThresholds\` output. 7 passed.