### PR TITLE
fix(assistant): stream CLI provider text deltas instead of whole messages

### DIFF
--- a/src/quodeq/assistant/adapters/_cli.py
+++ b/src/quodeq/assistant/adapters/_cli.py
@@ -118,7 +118,8 @@ def _run_once(cfg: CliTurnConfig, cli_cfg, *, prompt: str, session_id: str,
         # stop already landed).
         cancel.register_kill(lambda: _kill_proc_tree(proc))
         texts, errors, raw_errors, parsed_sid = [], [], [], spec.session_id
-        last_emitted = None
+        last_full = None  # text of the last complete message, emitted or not
+        partial_buf = ""  # delta text streamed since the last complete message
         saw_result = False
         for line in iter_lines(proc.stdout):
             event = _stream.parse_line(line)
@@ -133,17 +134,27 @@ def _run_once(cfg: CliTurnConfig, cli_cfg, *, prompt: str, session_id: str,
             err = _stream.error_message(event)
             if err:
                 errors.append(err)
-            for t in _stream.assistant_text(event):
-                texts.append(t)
-                # the final `result` event echoes the full text already streamed
-                # via `assistant`/`item.completed` events; skip re-emitting it so
-                # the drawer doesn't show the answer twice. Gate on content, not
-                # presence: a `result` whose text DIFFERS from what was streamed
-                # (or a result-only turn) must still be emitted.
-                if etype == "result" and t == last_emitted:
-                    continue
-                emit({"type": "token", "text": t})
-                last_emitted = t
+            delta = _stream.partial_text(event)
+            if delta:
+                partial_buf += delta
+                emit({"type": "token", "text": delta})
+            event_texts = _stream.assistant_text(event)
+            if event_texts:
+                texts.extend(event_texts)
+                # complete events echo text the drawer already shows: an
+                # `assistant` message repeats its own streamed deltas, and the
+                # final `result` repeats the last assistant message. Gate on
+                # content, not presence: an echo whose text DIFFERS from what
+                # was streamed (or a result-only turn, or a provider without
+                # deltas) must still be emitted.
+                joined = "".join(event_texts)
+                is_echo = (joined == partial_buf
+                           or (etype == "result" and joined == last_full))
+                if not is_echo:
+                    for t in event_texts:
+                        emit({"type": "token", "text": t})
+                last_full = joined
+                partial_buf = ""
             for tu in _stream.tool_use_details(event):
                 frame = {"type": "tool_call", "name": tu["name"]}
                 if tu["args_summary"]:
@@ -157,6 +168,10 @@ def _run_once(cfg: CliTurnConfig, cli_cfg, *, prompt: str, session_id: str,
         except subprocess.TimeoutExpired:
             _kill_proc_tree(proc)
             returncode = proc.wait()
+        # a turn killed mid-message (stop/timeout) streamed deltas that never
+        # got their complete-message echo; they are the answer the user saw.
+        if partial_buf:
+            texts.append(partial_buf)
         # argv-append/result providers (claude) end with a `result` event that
         # echoes the complete answer, so the last text IS the whole reply.
         # streaming-only providers (codex) never send `result`; their answer is

--- a/src/quodeq/assistant/adapters/_linereader.py
+++ b/src/quodeq/assistant/adapters/_linereader.py
@@ -3,25 +3,21 @@ from __future__ import annotations
 
 from typing import Iterator, TextIO
 
-_CHUNK = 1 << 16
 
+def iter_lines(stream: TextIO, *, max_line: int = 1 << 20) -> Iterator[str]:
+    """Yield each line as soon as it arrives, without waiting for EOF.
 
-def iter_lines(stream: TextIO, *, chunk_size: int = _CHUNK, max_line: int = 1 << 20) -> Iterator[str]:
-    buffer = ""
+    readline() returns the moment a newline is decoded, unlike read(n) on a
+    TextIOWrapper, which is greedy (blocks until n chars or EOF) and would
+    hold a live pipe's output hostage until the subprocess exits.
+
+    The size argument bounds a newline-less run: past max_line, readline
+    returns the oversized fragment as its own piece (downstream JSON-parse
+    simply fails it and moves on), so one malformed/huge line can't hang or
+    OOM the reader.
+    """
     while True:
-        chunk = stream.read(chunk_size)
-        if not chunk:
+        line = stream.readline(max_line)
+        if not line:
             break
-        buffer += chunk
-        while "\n" in buffer:
-            line, buffer = buffer.split("\n", 1)
-            yield line
-        # A newline-less stream can't be allowed to grow the buffer forever.
-        # Yield the oversized chunk as a "line" (downstream JSON-parse simply
-        # fails it and moves on) instead of raising, so one malformed/huge
-        # line can't hang or OOM the reader.
-        if len(buffer) > max_line:
-            yield buffer
-            buffer = ""
-    if buffer:
-        yield buffer
+        yield line[:-1] if line.endswith("\n") else line

--- a/src/quodeq/assistant/adapters/_stream.py
+++ b/src/quodeq/assistant/adapters/_stream.py
@@ -26,6 +26,22 @@ def _texts_from_blocks(blocks) -> list[str]:
     return out
 
 
+def partial_text(event: dict) -> str | None:
+    """Incremental text from a `stream_event` wrapper (claude/gemini
+    --include-partial-messages): the Anthropic SSE `content_block_delta`
+    carrying a `text_delta`. Thinking/tool-input deltas are not display text."""
+    if event.get("type") != "stream_event":
+        return None
+    inner = event.get("event")
+    if not isinstance(inner, dict) or inner.get("type") != "content_block_delta":
+        return None
+    delta = inner.get("delta")
+    if not isinstance(delta, dict) or delta.get("type") != "text_delta":
+        return None
+    text = delta.get("text")
+    return text if isinstance(text, str) else None
+
+
 def assistant_text(event: dict) -> list[str]:
     etype = event.get("type")
     if etype == "assistant":

--- a/src/quodeq/ui/src/features/assistant/useAssistantStream.js
+++ b/src/quodeq/ui/src/features/assistant/useAssistantStream.js
@@ -2,6 +2,11 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { assistantEventsUrl } from '../../api/assistant.js';
 
 const INACTIVITY_MS = 60000;
+// Max characters revealed per flush tick. Delta-streaming providers (ollama,
+// claude) send frames smaller than this, so they render unchanged; providers
+// without deltas (codex) deliver a whole message as ONE frame, which sweeps
+// in at a readable rate instead of popping as a block.
+const CHARS_PER_TICK = 60;
 
 export function useAssistantStream(sessionId, { onDone } = {}) {
   const [messages, setMessages] = useState([]);
@@ -9,6 +14,9 @@ export function useAssistantStream(sessionId, { onDone } = {}) {
   const [error, setError] = useState(null);
   const pending = useRef(''); const raf = useRef(null); const timer = useRef(null);
   const inactivity = useRef(null); const onDoneRef = useRef(onDone);
+  // Set when the turn's `done` arrived while text was still being revealed:
+  // the turn ends when the drain empties instead of force-flushing the rest.
+  const endPending = useRef(false);
   // When true, the next flushed token starts a NEW assistant bubble instead of
   // appending to the last one — set on each turn's terminal frame so turn 2's
   // answer doesn't concatenate onto turn 1's ("A"+"B" → "AB"). One SSE stream
@@ -21,13 +29,17 @@ export function useAssistantStream(sessionId, { onDone } = {}) {
   useEffect(() => {
     if (!sessionId) { setStreaming(false); return undefined; }
     setMessages([]); setError(null); setStreaming(true); pending.current = '';
-    turnBoundary.current = false;
+    turnBoundary.current = false; endPending.current = false;
 
-    const flushTokens = () => {
+    const finishTurn = () => { endPending.current = false; setStreaming(false);
+      turnBoundary.current = true; onDoneRef.current?.(); };
+    const drain = (all) => {
       if (raf.current != null) { cancelAnimationFrame(raf.current); raf.current = null; }
       if (timer.current != null) { clearTimeout(timer.current); timer.current = null; }
-      const chunk = pending.current; if (!chunk) return;
-      pending.current = '';
+      const buf = pending.current;
+      if (!buf) { if (endPending.current) finishTurn(); return; }
+      const chunk = all ? buf : buf.slice(0, CHARS_PER_TICK);
+      pending.current = all ? '' : buf.slice(CHARS_PER_TICK);
       const startNewBubble = turnBoundary.current;
       turnBoundary.current = false;
       setMessages((prev) => {
@@ -40,19 +52,28 @@ export function useAssistantStream(sessionId, { onDone } = {}) {
         }
         return next;
       });
+      if (pending.current) scheduleFlush();
+      else if (endPending.current) finishTurn();
     };
+    // Structural frames (tool calls, warnings, errors, stop) force the rest
+    // of the reveal out at once so ordering stays exact and errors are never
+    // delayed behind an animation.
+    const flushTokens = () => drain(true);
     const scheduleFlush = () => {
-      if (raf.current == null) raf.current = requestAnimationFrame(flushTokens);
-      if (timer.current == null) timer.current = setTimeout(flushTokens, 50);
+      if (raf.current == null) raf.current = requestAnimationFrame(() => drain(false));
+      if (timer.current == null) timer.current = setTimeout(() => drain(false), 50);
     };
     const append = (msg) => setMessages((prev) => [...prev, msg]);
     const es = new EventSource(assistantEventsUrl(sessionId, 0));
-    // End the TURN (flush, clear spinner, mark a boundary, notify the
-    // provider) WITHOUT closing the connection — the stream stays open so the
-    // next turn's frames still arrive. The EventSource is only closed in the
-    // effect cleanup (sessionId change / unmount).
-    const endTurn = () => { flushTokens(); setStreaming(false);
-      turnBoundary.current = true; onDoneRef.current?.(); };
+    // End the TURN (clear spinner, mark a boundary, notify the provider)
+    // WITHOUT closing the connection — the stream stays open so the next
+    // turn's frames still arrive. The EventSource is only closed in the
+    // effect cleanup (sessionId change / unmount). If text is still being
+    // revealed, the turn ends when the drain empties.
+    const endTurn = () => {
+      if (pending.current) { endPending.current = true; scheduleFlush(); }
+      else finishTurn();
+    };
     const resetInactivity = () => {
       if (inactivity.current) clearTimeout(inactivity.current);
       // End the turn cleanly (same as any other terminal frame) instead of
@@ -72,7 +93,12 @@ export function useAssistantStream(sessionId, { onDone } = {}) {
       resetInactivity();
       let frame; try { frame = JSON.parse(e.data); } catch { return; }
       if (!frame || typeof frame !== 'object') return;
-      if (frame.type === 'token') { beginContent(); pending.current += frame.text || ''; scheduleFlush(); }
+      if (frame.type === 'token') {
+        // A next-turn token during the previous turn's reveal: close that
+        // turn out first so the new text starts its own bubble.
+        if (endPending.current) drain(true);
+        beginContent(); pending.current += frame.text || ''; scheduleFlush();
+      }
       else if (frame.type === 'tool_call') { beginContent(); flushTokens(); append({ role: 'tool', name: frame.name, argsSummary: frame.argsSummary }); }
       else if (frame.type === 'action_draft') { beginContent(); flushTokens();
         append({ role: 'action', actionId: frame.actionId, actionType: frame.actionType, summary: frame.summary }); }

--- a/src/quodeq/ui/src/features/assistant/useAssistantStream.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/useAssistantStream.test.jsx
@@ -160,6 +160,74 @@ it('a null JSON payload frame is ignored instead of crashing', () => {
   expect(result.current.error).toBe(null);
 });
 
+it('a large token frame is revealed progressively, not in one paint', () => {
+  // Providers without deltas (codex) deliver a whole message as ONE token
+  // frame. The drawer should sweep it in at a readable rate instead of
+  // popping the full block in a single flush.
+  const { result } = renderHook(() => useAssistantStream('s1'));
+  const es = MockES.instances[0];
+  const block = 'x'.repeat(600);
+  act(() => { es.emit('message', { type: 'token', text: block }); });
+  act(() => { vi.advanceTimersByTime(40); });
+  const partial = result.current.messages.find((m) => m.role === 'assistant');
+  expect(partial).toBeTruthy();
+  expect(partial.text.length).toBeGreaterThan(0);
+  expect(partial.text.length).toBeLessThan(600);
+  expect(block.startsWith(partial.text)).toBe(true);
+  act(() => { vi.advanceTimersByTime(2000); });
+  expect(result.current.messages.find((m) => m.role === 'assistant').text).toBe(block);
+});
+
+it('done waits for the progressive reveal to finish before ending the turn', () => {
+  // codex sends its final message and `done` back to back. Ending the turn
+  // immediately would force-flush the block and defeat the reveal.
+  const onDone = vi.fn();
+  const { result } = renderHook(() => useAssistantStream('s1', { onDone }));
+  const es = MockES.instances[0];
+  const block = 'y'.repeat(600);
+  act(() => {
+    es.emit('message', { type: 'token', text: block });
+    es.emit('done', { type: 'done' });
+  });
+  // Turn must still be live while text is draining.
+  expect(result.current.streaming).toBe(true);
+  expect(onDone).not.toHaveBeenCalled();
+  act(() => { vi.advanceTimersByTime(2000); });
+  expect(result.current.messages.find((m) => m.role === 'assistant').text).toBe(block);
+  expect(result.current.streaming).toBe(false);
+  expect(onDone).toHaveBeenCalledTimes(1);
+});
+
+it('a next-turn token during the reveal finishes the old turn into its own bubble', () => {
+  const onDone = vi.fn();
+  const { result } = renderHook(() => useAssistantStream('s1', { onDone }));
+  const es = MockES.instances[0];
+  const block = 'z'.repeat(300);
+  act(() => {
+    es.emit('message', { type: 'token', text: block });
+    es.emit('done', { type: 'done' });
+    // user fires the next turn before the reveal finished
+    es.emit('message', { type: 'token', text: 'next answer' });
+  });
+  act(() => { vi.advanceTimersByTime(2000); });
+  const assistants = result.current.messages.filter((m) => m.role === 'assistant');
+  expect(assistants.map((m) => m.text)).toEqual([block, 'next answer']);
+  expect(onDone).toHaveBeenCalledTimes(1); // second turn has no done yet
+});
+
+it('an error force-flushes pending text immediately, no reveal delay', () => {
+  const { result } = renderHook(() => useAssistantStream('s1'));
+  const es = MockES.instances[0];
+  act(() => {
+    es.emit('message', { type: 'token', text: 'w'.repeat(600) });
+    es.emit('message', { type: 'error', message: 'boom' });
+  });
+  // No timer advance: the full text and the error state land synchronously.
+  expect(result.current.messages.find((m) => m.role === 'assistant').text).toBe('w'.repeat(600));
+  expect(result.current.error).toBe('boom');
+  expect(result.current.streaming).toBe(false);
+});
+
 it('a stopped frame ends the turn with a stop marker, not an error', () => {
   const onDone = vi.fn();
   const { result } = renderHook(() => useAssistantStream('s1', { onDone }));

--- a/tests/assistant/test_cli_adapter.py
+++ b/tests/assistant/test_cli_adapter.py
@@ -108,6 +108,92 @@ def test_result_with_differing_text_is_emitted(tmp_path):
     assert text == "Final answer: X"
 
 
+def _delta(text):
+    return ('{"type": "stream_event", "event": {"type": "content_block_delta", '
+            '"index": 0, "delta": {"type": "text_delta", "text": "%s"}}}' % text)
+
+
+def test_claude_partial_deltas_stream_and_message_echo_is_suppressed(tmp_path):
+    # With --include-partial-messages the CLI streams text_delta chunks, then
+    # echoes the complete message as an `assistant` event, then again as
+    # `result`. The chunks must be emitted as they arrive; neither echo may
+    # repeat text already streamed.
+    repo = _repo(tmp_path)
+    lines = [
+        _delta("Hel"),
+        _delta("lo"),
+        '{"type": "assistant", "message": {"content": [{"type": "text", "text": "Hello"}]}}',
+        '{"type": "result", "result": "Hello", "session_id": "claude-uuid-1"}',
+    ]
+    frames = []
+    text = run_cli_turn(
+        messages=[{"role": "user", "content": "hi"}],
+        config=_config(tmp_path), session_id="s1", prior_session_id=None,
+        repository=repo, emit=frames.append,
+        spawn_fn=lambda argv, *, cwd, env: FakeProc(lines))
+    assert text == "Hello"
+    assert [f["text"] for f in frames if f["type"] == "token"] == ["Hel", "lo"]
+
+
+def test_claude_deltas_reset_per_message_across_tool_use(tmp_path):
+    # A tool-use turn carries several assistant messages, each streamed via its
+    # own deltas. Echo suppression must reset per message, and the final
+    # `result` (which repeats only the LAST message) must stay suppressed.
+    repo = _repo(tmp_path)
+    lines = [
+        _delta("Checking."),
+        '{"type": "assistant", "message": {"content": [{"type": "text", "text": "Checking."}, '
+        '{"type": "tool_use", "name": "get_scores", "input": {}}]}}',
+        _delta("Done"),
+        _delta("."),
+        '{"type": "assistant", "message": {"content": [{"type": "text", "text": "Done."}]}}',
+        '{"type": "result", "result": "Done."}',
+    ]
+    frames = []
+    text = run_cli_turn(
+        messages=[{"role": "user", "content": "hi"}],
+        config=_config(tmp_path), session_id="s1", prior_session_id=None,
+        repository=repo, emit=frames.append,
+        spawn_fn=lambda argv, *, cwd, env: FakeProc(lines))
+    assert text == "Done."
+    assert [f["text"] for f in frames if f["type"] == "token"] == ["Checking.", "Done", "."]
+    assert any(f["type"] == "tool_call" and f["name"] == "get_scores" for f in frames)
+
+
+def test_message_echo_differing_from_deltas_is_still_emitted(tmp_path):
+    # Same content-not-presence gate as the result echo: if the complete
+    # message DIFFERS from what the deltas streamed, it must not be swallowed.
+    repo = _repo(tmp_path)
+    lines = [
+        _delta("Hel"),
+        '{"type": "assistant", "message": {"content": [{"type": "text", "text": "Hello world"}]}}',
+        '{"type": "result", "result": "Hello world"}',
+    ]
+    frames = []
+    run_cli_turn(
+        messages=[{"role": "user", "content": "hi"}],
+        config=_config(tmp_path), session_id="s1", prior_session_id=None,
+        repository=repo, emit=frames.append,
+        spawn_fn=lambda argv, *, cwd, env: FakeProc(lines))
+    assert [f["text"] for f in frames if f["type"] == "token"] == ["Hel", "Hello world"]
+
+
+def test_partial_deltas_without_message_completion_count_as_output(tmp_path):
+    # A killed/stopped turn ends mid-message: deltas streamed but no complete
+    # `assistant` echo ever arrives. The streamed text is the answer the user
+    # saw, so it must survive into the returned/partial text.
+    repo = _repo(tmp_path)
+    lines = [_delta("Par"), _delta("tial")]
+    frames = []
+    text = run_cli_turn(
+        messages=[{"role": "user", "content": "hi"}],
+        config=_config(tmp_path), session_id="s1", prior_session_id=None,
+        repository=repo, emit=frames.append,
+        spawn_fn=lambda argv, *, cwd, env: FakeProc(lines))
+    assert text == "Partial"
+    assert [f["text"] for f in frames if f["type"] == "token"] == ["Par", "tial"]
+
+
 def test_tool_use_emits_frame(tmp_path):
     repo = _repo(tmp_path)
     lines = [

--- a/tests/assistant/test_cli_stream.py
+++ b/tests/assistant/test_cli_stream.py
@@ -1,6 +1,6 @@
 from quodeq.assistant.adapters import _stream
 from quodeq.assistant.adapters._stream import (
-    assistant_text, parse_line, session_id, tool_uses,
+    assistant_text, parse_line, partial_text, session_id, tool_uses,
 )
 
 
@@ -107,6 +107,47 @@ def test_codex_tool_item_not_double_counted_on_completed():
         "type": "mcp_tool_call", "tool": "get_context", "arguments": {},
         "status": "completed"}}
     assert _stream.tool_use_details(mcp_completed) == []
+
+
+def test_partial_text_extracts_text_delta():
+    # Real claude shape with --include-partial-messages: stream_event wrapping
+    # the Anthropic SSE content_block_delta.
+    ev = {"type": "stream_event", "event": {
+        "type": "content_block_delta", "index": 0,
+        "delta": {"type": "text_delta", "text": "hel"}}}
+    assert partial_text(ev) == "hel"
+
+
+def test_partial_text_ignores_non_text_deltas():
+    for delta in ({"type": "thinking_delta", "thinking": "hmm"},
+                  {"type": "input_json_delta", "partial_json": '{"q'}):
+        ev = {"type": "stream_event", "event": {
+            "type": "content_block_delta", "index": 0, "delta": delta}}
+        assert partial_text(ev) is None
+
+
+def test_partial_text_ignores_other_stream_events():
+    for inner in ({"type": "message_start"},
+                  {"type": "content_block_start", "content_block": {"type": "text", "text": ""}},
+                  {"type": "content_block_stop"},
+                  {"type": "message_stop"}):
+        assert partial_text({"type": "stream_event", "event": inner}) is None
+
+
+def test_partial_text_ignores_non_stream_events_and_malformed():
+    assert partial_text({"type": "assistant", "message": {"content": []}}) is None
+    assert partial_text({"type": "stream_event"}) is None
+    assert partial_text({"type": "stream_event", "event": None}) is None
+    assert partial_text({"type": "stream_event", "event": {
+        "type": "content_block_delta", "delta": {"type": "text_delta", "text": 3}}}) is None
+
+
+def test_stream_event_is_not_assistant_text_or_tool_use():
+    ev = {"type": "stream_event", "event": {
+        "type": "content_block_delta", "index": 0,
+        "delta": {"type": "text_delta", "text": "hi"}}}
+    assert assistant_text(ev) == []
+    assert tool_uses(ev) == []
 
 
 def test_codex_agent_message_completed_is_not_a_tool_call():

--- a/tests/assistant/test_linereader.py
+++ b/tests/assistant/test_linereader.py
@@ -1,6 +1,8 @@
 import io
+import os
+import threading
 
-from quodeq.assistant.adapters._linereader import _CHUNK, iter_lines
+from quodeq.assistant.adapters._linereader import iter_lines
 
 
 def test_yields_complete_lines():
@@ -13,13 +15,39 @@ def test_flushes_trailing_partial_line():
     assert list(iter_lines(stream)) == ["a", "b", "no-newline-tail"]
 
 
-def test_handles_lines_split_across_chunks():
-    stream = io.StringIO("hello world\nsecond\n")
-    assert list(iter_lines(stream, chunk_size=4)) == ["hello world", "second"]
-
-
 def test_empty_stream():
     assert list(iter_lines(io.StringIO(""))) == []
+
+
+def test_yields_line_while_stream_still_open():
+    # A live subprocess pipe delivers lines long before EOF. The reader must
+    # yield each complete line as soon as it arrives, NOT block until the
+    # process exits: TextIOWrapper.read(n) is greedy (waits for n chars or
+    # EOF), which turns a whole streamed turn into one end-of-process burst.
+    rfd, wfd = os.pipe()
+    reader = os.fdopen(rfd, "r", encoding="utf-8")
+    writer = os.fdopen(wfd, "w", encoding="utf-8")
+    got = []
+    first_line = threading.Event()
+
+    def consume():
+        for line in iter_lines(reader):
+            got.append(line)
+            first_line.set()
+            return
+
+    t = threading.Thread(target=consume, daemon=True)
+    t.start()
+    try:
+        writer.write('{"type":"token"}\n')
+        writer.flush()
+        assert first_line.wait(timeout=5), \
+            "line was not yielded while the pipe was still open (reader waits for EOF)"
+        assert got == ['{"type":"token"}']
+    finally:
+        writer.close()
+        t.join(timeout=5)
+        reader.close()
 
 
 def test_oversized_newline_less_run_is_bounded_not_hung():
@@ -30,5 +58,5 @@ def test_oversized_newline_less_run_is_bounded_not_hung():
     stream = io.StringIO("x" * total)
     pieces = list(iter_lines(stream, max_line=1 << 20))
     assert pieces  # terminated and yielded something
-    assert all(len(p) <= (1 << 20) + _CHUNK for p in pieces)
+    assert all(len(p) <= (1 << 20) for p in pieces)
     assert sum(len(p) for p in pieces) == total


### PR DESCRIPTION
Cloud assistant providers (claude, codex) showed the whole answer as one block after a long blank wait, while ollama streamed smoothly.

Root cause: the claude CLI already emits `content_block_delta` chunks (we pass `--include-partial-messages`), but the stream parser only extracted text from complete `assistant`/`result` events, so every chunk was dropped until the full message landed. The API adapter (ollama) emits per-chunk deltas, hence the difference.

Changes:
- `_stream.py`: new `partial_text()` extracts `text_delta` chunks from `stream_event` lines. Thinking and tool-input deltas are ignored.
- `_cli.py`: emit each delta as a token frame, suppress the complete-message and `result` echoes by content comparison. A message that differs from its streamed deltas is still emitted.
- Partial text from a turn killed mid-message is kept as the answer. This also stops the empty-output session rebuild from rerunning a turn the user just stopped.

Provider notes:
- codex: `exec --json` emits no delta events (verified on 0.145.0), only complete `item.completed` messages. Unchanged behavior, nothing finer exists to stream.
- gemini: same stream-json shape as claude, picks this up automatically if it emits deltas. Could not verify locally (CLI auth broken, free tier discontinued).

No argv, sandbox or MCP config changes. Verified against a live capture of claude 2.1.218 replayed through the adapter: chunks stream incrementally, no duplicate text. 9 new tests, `tests/api` + `tests/assistant` green (943 passed).