### PR TITLE
fix(dashboard): auto-refresh Overview grade after dismiss

### DIFF
--- a/src/quodeq/services/mutation_rescore.py
+++ b/src/quodeq/services/mutation_rescore.py
@@ -179,50 +179,36 @@ def _resolve_default_run_id(evaluations_dir: str, project: str) -> str | None:
     return selected.run_id
 
 
-def _accumulated_payload(evaluations_dir: str, project: str) -> dict[str, Any] | None:
-    """Return the cache-backed accumulated payload, or None on any failure.
-
-    ``get_project_scores(reports_root, project, None)`` returns a dict with an
-    ``accumulated`` key ({dimensions, summary}); we surface just that so the
-    client can patch the accumulated (cross-run) scores cache.
-    """
-    from quodeq.services.scoring import get_project_scores  # noqa: PLC0415
-
-    reports_root = Path(evaluations_dir).resolve()
-    try:
-        payload = get_project_scores(reports_root, project, None)
-    except Exception:
-        _logger.warning("Accumulated fetch for delta failed for %s", project, exc_info=True)
-        return None
-    if not payload:
-        return None
-    return payload.get("accumulated")
-
-
 def _mutation_envelope(
     evaluations_dir: str, project: str, run_id: str | None, kind: str,
 ) -> dict[str, Any]:
-    """Shared delta scaffold: kind/runId/isLatest/accumulated.
+    """Shared delta scaffold: kind/runId/isLatest.
 
     ``isLatest`` is True when ``run_id`` is the run the Overview lands on by
     default — the exact ``_resolve_default_run_id`` rule shared with the
-    dashboard. ``accumulated`` carries the (cache-backed) cross-run rollup so
-    the Overview's accumulated view updates without a refetch; it is None when
-    no ``run_id`` was supplied (the caller has no run to anchor the rollup to)
-    or when the fetch fails. Per-kind finding fields (``dismissed`` /
-    ``restored`` / ``deleted``) are folded in by the caller — bulk kinds
-    (``restore_all`` / ``delete_all``) carry none.
+    dashboard. Per-kind finding fields (``dismissed`` / ``restored`` /
+    ``deleted``) are folded in by the caller — bulk kinds (``restore_all`` /
+    ``delete_all``) carry none.
+
+    ``accumulated`` is intentionally ALWAYS None. The client derives the
+    Overview's per-dimension grades from the (fast, ~0.1s) single-run rescore
+    returned alongside this delta in ``scores`` — the accumulated entry for a
+    dimension the latest run owns equals that run's rescored dimension. We used
+    to compute the full cross-run rollup here, but that ran ``compute_accumulated``
+    over every run (~100s cold on large projects, and recomputed on EVERY
+    mutation because the dismissed-set hash changes), which blew past the
+    client's 30s timeout. The request then aborted, the client never applied the
+    delta, and the Overview grade only refreshed on a later window-focus
+    refetch. See ``applyMutationDelta`` for the client-side derivation; the
+    weighted overall summary is left to a lazy refetch to avoid duplicating the
+    grade formula on the client.
     """
-    is_latest = False
-    accumulated: dict[str, Any] | None = None
-    if run_id:
-        is_latest = run_id == _resolve_default_run_id(evaluations_dir, project)
-        accumulated = _accumulated_payload(evaluations_dir, project)
+    is_latest = bool(run_id) and run_id == _resolve_default_run_id(evaluations_dir, project)
     return {
         "kind": kind,
         "runId": run_id,
         "isLatest": is_latest,
-        "accumulated": accumulated,
+        "accumulated": None,
     }
 
 
@@ -232,7 +218,8 @@ def dismiss_delta(
     """Describe a dismiss mutation so the client can patch its caches.
 
     The client splices the dismissed finding out of the run-detail violation
-    list locally (it has the full key) and patches scores + accumulated.
+    list locally (it has the full key), patches the per-run scores, and derives
+    the Overview accumulated dimension grades from the rescored ``scores``.
     """
     envelope = _mutation_envelope(evaluations_dir, project, run_id, "dismiss")
     envelope["dismissed"] = {
@@ -255,8 +242,9 @@ def restore_delta(
     """Describe a restore mutation so the client can patch its caches.
 
     Unlike dismiss, the client can't reconstruct the restored violation body,
-    so it patches scores + accumulated and INVALIDATES the run-detail violation
-    source (refetch on next view). ``restored`` carries the finding key.
+    so it patches the per-run scores (deriving the Overview accumulated
+    dimension grades from them) and INVALIDATES the run-detail violation source
+    (refetch on next view). ``restored`` carries the finding key.
     """
     envelope = _mutation_envelope(evaluations_dir, project, run_id, "restore")
     envelope["restored"] = {
@@ -273,8 +261,9 @@ def delete_delta(
     """Describe a delete mutation so the client can patch its caches.
 
     Delete sweeps every finding sharing (dimension, principle, file), so the
-    client can't cheaply mirror the batch removal — it patches scores +
-    accumulated and INVALIDATES the run-detail violation source.
+    client can't cheaply mirror the batch removal — it patches the per-run
+    scores (deriving the Overview accumulated dimension grades from them) and
+    INVALIDATES the run-detail violation source.
     """
     envelope = _mutation_envelope(evaluations_dir, project, run_id, "delete")
     envelope["deleted"] = {

--- a/src/quodeq/ui/src/api/applyMutationDelta.js
+++ b/src/quodeq/ui/src/api/applyMutationDelta.js
@@ -105,9 +105,12 @@ export function applyMutationDelta(queryClient, projectId, delta) {
     }));
   };
 
-  // Accumulated (cross-run) scores cache: the server sent the whole rollup, so
+  // Accumulated (cross-run) scores cache: when the server sent a whole rollup,
   // swap it in wholesale; if absent, invalidate (it's small — a default refetch
-  // is fine).
+  // is fine). The dismiss/restore/delete deltas no longer carry one (computing
+  // it server-side ran compute_accumulated over every run — ~100s cold on large
+  // projects — and blew past the client's 30s timeout, aborting the whole
+  // delta), so this path is only taken by callers that still provide one.
   const patchAccumulated = (key, accumulated) => {
     const prev = queryClient.getQueryData(key);
     if (!accumulated || !prev) {
@@ -115,6 +118,36 @@ export function applyMutationDelta(queryClient, projectId, delta) {
       return;
     }
     queryClient.setQueryData(key, (old) => ({ ...old, accumulated }));
+  };
+
+  // Client-derive the Overview's accumulated dimension grades from the per-run
+  // rescore instead of a server-computed rollup. The accumulated entry for each
+  // dimension the latest run OWNS (``fromRunId === runId``) equals that run's
+  // rescored dimension, so we copy overallScore/overallGrade across — no
+  // cross-run recompute, so the dismiss POST stays ~0.1s and never times out.
+  // The weighted overall summary is deliberately left untouched (a lazy refetch
+  // reconciles it); recomputing it here would duplicate the grade formula.
+  // No-op — crucially NOT an invalidate, which would trigger the slow refetch —
+  // when the entry isn't cached; it fills in on its next fetch.
+  const patchAccumulatedDims = (key) => {
+    const prev = queryClient.getQueryData(key);
+    if (!Array.isArray(prev?.accumulated?.dimensions)) return;
+    queryClient.setQueryData(key, (old) => ({
+      ...old,
+      accumulated: {
+        ...old.accumulated,
+        dimensions: old.accumulated.dimensions.map((dim) => {
+          if (dim?.fromRunId !== runId) return dim;
+          const resc = scoreByDim.get(dim?.dimension);
+          if (!resc) return dim;
+          return {
+            ...dim,
+            overallScore: resc.overallScore ?? dim.overallScore,
+            overallGrade: resc.overallGrade ?? dim.overallGrade,
+          };
+        }),
+      },
+    }));
   };
 
   // Invalidate the run-detail violation source so lists refetch on next view.
@@ -142,6 +175,21 @@ export function applyMutationDelta(queryClient, projectId, delta) {
 
   if (delta.isLatest) {
     patchScores(projectKeys.dashboard(projectId, "latest"), { spliceDismissed: splices });
-    patchAccumulated(projectKeys.scores(projectId, null), delta.accumulated);
+    if (delta.accumulated) {
+      // A caller supplied the authoritative rollup — prefer it.
+      patchAccumulated(projectKeys.scores(projectId, null), delta.accumulated);
+      if (runId) patchAccumulated(projectKeys.scores(projectId, runId), delta.accumulated);
+    } else if (runId) {
+      // Client-derive from the per-run rescore. The Overview's app-root
+      // useDashboard reads `accumulated` from the null "latest" entry OR the
+      // run-scoped scores(projectId, runId) entry (the latter the moment the
+      // user drills into any run / dimension detail — see useProjectScores asOf
+      // resolution). Both are patched: the run-scoped entry has
+      // staleTime:Infinity and refreshDashboard only marks it stale
+      // (refetchType:"none"), so without this the Overview grade cards would sit
+      // stale until a window-focus refetch.
+      patchAccumulatedDims(projectKeys.scores(projectId, null));
+      patchAccumulatedDims(projectKeys.scores(projectId, runId));
+    }
   }
 }

--- a/src/quodeq/ui/src/api/applyMutationDelta.test.jsx
+++ b/src/quodeq/ui/src/api/applyMutationDelta.test.jsx
@@ -174,10 +174,19 @@ describe("applyMutationDelta", () => {
     expect(setDash).toBe(false);
   });
 
-  it("F: invalidates accumulated when delta.accumulated is null", () => {
-    const { client, store, invalidateQueries, setQueryData } = makeClient();
+  it("F: client-derives accumulated dims (does NOT invalidate) when delta.accumulated is null", () => {
+    // The mutation deltas no longer carry a server rollup; the accumulated
+    // dimension grades are derived from the per-run rescore instead. Crucially
+    // this must NOT invalidate the accumulated query — that would trigger the
+    // slow cross-run refetch this whole change exists to avoid.
+    const { client, store, invalidateQueries } = makeClient();
     const scoresKey = projectKeys.scores(PROJECT, null);
-    store.set(JSON.stringify(scoresKey), { accumulated: { dimensions: [] } });
+    store.set(JSON.stringify(scoresKey), {
+      accumulated: {
+        dimensions: [{ dimension: "security", fromRunId: RUN, overallScore: "5.0", overallGrade: "C" }],
+        summary: { overallGrade: "C" },
+      },
+    });
 
     applyMutationDelta(client, PROJECT, {
       kind: "dismiss",
@@ -185,14 +194,18 @@ describe("applyMutationDelta", () => {
       isLatest: true,
       dismissed: { req: "R1", file: "a.py", line: 10 },
       accumulated: null,
-      dimensions: [],
+      dimensions: [{ dimension: "security", overallScore: "6.5", overallGrade: "B" }],
     });
 
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: scoresKey });
-    const setAcc = setQueryData.mock.calls.some(
-      ([k]) => JSON.stringify(k) === JSON.stringify(scoresKey),
+    const acc = store.get(JSON.stringify(scoresKey)).accumulated;
+    // The run-owned dim is derived from the rescore; summary left for a lazy refetch.
+    expect(acc.dimensions[0].overallScore).toBe("6.5");
+    expect(acc.dimensions[0].overallGrade).toBe("B");
+    expect(acc.summary.overallGrade).toBe("C");
+    const invalidated = invalidateQueries.mock.calls.some(
+      ([arg]) => JSON.stringify(arg?.queryKey) === JSON.stringify(scoresKey),
     );
-    expect(setAcc).toBe(false);
+    expect(invalidated).toBe(false);
   });
 
   it("G: isLatest false leaves dashboard('latest') and scores(null) untouched", () => {
@@ -239,6 +252,113 @@ describe("applyMutationDelta", () => {
     // Unknown-dim rescore doesn't touch security; no violation matched either.
     expect(sec.overallScore).toBe("5.0");
     expect(sec.violations).toHaveLength(2);
+  });
+
+  it("J: patches the RUN-SCOPED accumulated when isLatest (Overview reads scores(p, runId).accumulated)", () => {
+    // When the user has drilled into a run, the app-root useDashboard reads
+    // `accumulated` from the run-scoped scores query scores(p, runId), NOT the
+    // null "latest" entry. That query has staleTime:Infinity, so if the dismiss
+    // doesn't patch its accumulated it stays stale until a window-focus refetch.
+    const { client, store, invalidateQueries } = makeClient();
+    const runScopedKey = projectKeys.scores(PROJECT, RUN);
+    const nullKey = projectKeys.scores(PROJECT, null);
+    store.set(JSON.stringify(runScopedKey), {
+      dimensions: [{ dimension: "maintainability", overallScore: "5.3", overallGrade: "C" }],
+      accumulated: { dimensions: [{ dimension: "maintainability", overallGrade: "C" }], summary: {} },
+      summary: {},
+    });
+    store.set(JSON.stringify(nullKey), { accumulated: { dimensions: [], summary: {} } });
+
+    const newAccumulated = {
+      dimensions: [{ dimension: "maintainability", overallGrade: "Good" }],
+      summary: { overallGrade: "Good" },
+    };
+    applyMutationDelta(client, PROJECT, {
+      kind: "dismiss",
+      runId: RUN,
+      isLatest: true,
+      dismissed: { req: "R1", file: "a.py", line: 10 },
+      accumulated: newAccumulated,
+      dimensions: [],
+    });
+
+    // The run-scoped entry the Overview actually reads must get the fresh rollup.
+    expect(store.get(JSON.stringify(runScopedKey)).accumulated).toBe(newAccumulated);
+    // Patched, not invalidated.
+    const runAccInvalidated = invalidateQueries.mock.calls.some(
+      ([arg]) => JSON.stringify(arg?.queryKey) === JSON.stringify(runScopedKey),
+    );
+    expect(runAccInvalidated).toBe(false);
+    // The null "latest" entry is still patched too (unchanged behavior).
+    expect(store.get(JSON.stringify(nullKey)).accumulated).toBe(newAccumulated);
+  });
+
+  it("K: client-derive only rewrites dims the latest run OWNS (fromRunId === runId)", () => {
+    const { client, store } = makeClient();
+    const nullKey = projectKeys.scores(PROJECT, null);
+    const runKey = projectKeys.scores(PROJECT, RUN);
+    const OTHER = "run-old";
+    const seed = () => ({
+      accumulated: {
+        dimensions: [
+          { dimension: "security", fromRunId: RUN, overallScore: "5.0", overallGrade: "C" },
+          { dimension: "maintainability", fromRunId: OTHER, overallScore: "7.0", overallGrade: "B" },
+        ],
+        summary: { overallGrade: "B", numericAverage: 6.0 },
+      },
+    });
+    store.set(JSON.stringify(nullKey), seed());
+    store.set(JSON.stringify(runKey), seed());
+
+    applyMutationDelta(client, PROJECT, {
+      kind: "dismiss",
+      runId: RUN,
+      isLatest: true,
+      dismissed: { req: "R1", file: "a.py", line: 10 },
+      accumulated: null,
+      // The run rescore raises security AND reports maintainability, but the
+      // accumulated maintainability entry belongs to a DIFFERENT run.
+      dimensions: [
+        { dimension: "security", overallScore: "6.5", overallGrade: "B" },
+        { dimension: "maintainability", overallScore: "9.9", overallGrade: "A" },
+      ],
+    });
+
+    for (const key of [nullKey, runKey]) {
+      const acc = store.get(JSON.stringify(key)).accumulated;
+      const sec = acc.dimensions.find((d) => d.dimension === "security");
+      const maint = acc.dimensions.find((d) => d.dimension === "maintainability");
+      // security is owned by RUN → derived from the run rescore.
+      expect(sec.overallScore).toBe("6.5");
+      expect(sec.overallGrade).toBe("B");
+      // maintainability's accumulated entry comes from a different run → untouched
+      // even though the rescore reported a value for it.
+      expect(maint.overallScore).toBe("7.0");
+      expect(maint.overallGrade).toBe("B");
+      // weighted summary is deliberately left for a lazy refetch.
+      expect(acc.summary.overallGrade).toBe("B");
+    }
+  });
+
+  it("L: client-derive is a no-op (no invalidate) when the accumulated entry isn't cached", () => {
+    const { client, setQueryData, invalidateQueries } = makeClient();
+    const nullKey = projectKeys.scores(PROJECT, null);
+    // scores(null) is NOT seeded — patchAccumulatedDims must not create or
+    // invalidate it (an invalidate would trigger the slow cross-run refetch).
+    applyMutationDelta(client, PROJECT, {
+      kind: "dismiss",
+      runId: RUN,
+      isLatest: true,
+      dismissed: { req: "R1", file: "a.py", line: 10 },
+      accumulated: null,
+      dimensions: [{ dimension: "security", overallScore: "6.5", overallGrade: "B" }],
+    });
+    const touched =
+      setQueryData.mock.calls.some(([k]) => JSON.stringify(k) === JSON.stringify(nullKey)) ||
+      invalidateQueries.mock.calls.some(
+        ([arg]) => JSON.stringify(arg?.queryKey) === JSON.stringify(nullKey),
+      );
+    expect(touched).toBe(false);
   });
 
   it("I: untouched dimension keeps referential identity", () => {
@@ -347,10 +467,16 @@ describe("applyMutationDelta — restore/delete/bulk kinds (slice 2)", () => {
       expect(sec.violations).toHaveLength(2);
     });
 
-    it(`${kind}: patches accumulated when isLatest`, () => {
+    it(`${kind}: patches accumulated (null AND run-scoped) when isLatest`, () => {
       const { client, store, invalidateQueries } = makeClient();
       const accKey = projectKeys.scores(PROJECT, null);
+      const runScopedKey = projectKeys.scores(PROJECT, RUN);
       store.set(JSON.stringify(accKey), { accumulated: { dimensions: [], summary: {} } });
+      store.set(JSON.stringify(runScopedKey), {
+        dimensions: [{ dimension: "security", overallScore: "5.0", overallGrade: "C" }],
+        accumulated: { dimensions: [], summary: {} },
+        summary: {},
+      });
 
       const newAccumulated = {
         dimensions: [{ dimension: "security" }],
@@ -365,6 +491,9 @@ describe("applyMutationDelta — restore/delete/bulk kinds (slice 2)", () => {
       });
 
       expect(store.get(JSON.stringify(accKey)).accumulated).toBe(newAccumulated);
+      // The run-scoped entry the Overview reads while drilled into a run must
+      // also get the fresh rollup — see test J.
+      expect(store.get(JSON.stringify(runScopedKey)).accumulated).toBe(newAccumulated);
       const accInvalidated = invalidateQueries.mock.calls.some(
         ([arg]) => JSON.stringify(arg?.queryKey) === JSON.stringify(accKey),
       );

--- a/tests/api/test_routes_findings.py
+++ b/tests/api/test_routes_findings.py
@@ -138,9 +138,9 @@ class TestDismissEndpoint:
         assert delta["runId"] == "run-1"
         assert delta["dismissed"] == {"req": "R1", "file": "a.py", "line": 10}
         assert "isLatest" in delta
-        assert delta["accumulated"] is not None
-        assert "dimensions" in delta["accumulated"]
-        assert "summary" in delta["accumulated"]
+        # The delta no longer carries a server-computed rollup — the client
+        # derives the Overview accumulated dimension grades from ``scores``.
+        assert delta["accumulated"] is None
 
     def test_dismiss_without_run_id_delta_has_null_accumulated(self, client, tmp_path):
         """Without a run_id, the delta still describes the dismissed finding but
@@ -222,7 +222,7 @@ class TestRestoreEndpoint:
         assert delta["runId"] == "run-1"
         assert delta["restored"] == {"req": "R1", "file": "a.py", "line": 10}
         assert "isLatest" in delta
-        assert delta["accumulated"] is not None
+        assert delta["accumulated"] is None
 
     def test_restore_appends_undismiss_event(self, client, tmp_path):
         project_dir = tmp_path / "my-project"

--- a/tests/services/test_mutation_rescore_delta.py
+++ b/tests/services/test_mutation_rescore_delta.py
@@ -59,12 +59,14 @@ class TestDismissDeltaEnvelope:
         assert delta["dismissed"] == {"req": "R1", "file": "a.py", "line": 10}
         assert delta["isLatest"] is False
 
-    def test_accumulated_present_when_run_id(self, tmp_path):
+    def test_accumulated_is_none_client_derives(self, tmp_path):
+        # The delta no longer carries a server-computed rollup: computing it ran
+        # compute_accumulated over every run (~100s cold on large projects) and
+        # tripped the client's 30s timeout. The client now derives the Overview
+        # accumulated dimension grades from the per-run rescore in ``scores``.
         _make_run(tmp_path, "proj", "run-1")
         delta = dismiss_delta(str(tmp_path), "proj", "run-1", dict(_DISMISSED))
-        assert delta["accumulated"] is not None
-        assert "dimensions" in delta["accumulated"]
-        assert "summary" in delta["accumulated"]
+        assert delta["accumulated"] is None
 
 
 class TestDismissDeltaIsLatest:
@@ -101,12 +103,10 @@ class TestRestoreDeltaEnvelope:
         assert "isLatest" in delta
         assert "accumulated" in delta
 
-    def test_accumulated_present_when_run_id(self, tmp_path):
+    def test_accumulated_is_none_client_derives(self, tmp_path):
         _make_run(tmp_path, "proj", "run-1")
         delta = restore_delta(str(tmp_path), "proj", "run-1", dict(_RESTORED))
-        assert delta["accumulated"] is not None
-        assert "dimensions" in delta["accumulated"]
-        assert "summary" in delta["accumulated"]
+        assert delta["accumulated"] is None
 
     def test_without_run_id_accumulated_is_none(self, tmp_path):
         _make_run(tmp_path, "proj", "run-1")
@@ -135,12 +135,10 @@ class TestDeleteDeltaEnvelope:
         assert "isLatest" in delta
         assert "accumulated" in delta
 
-    def test_accumulated_present_when_run_id(self, tmp_path):
+    def test_accumulated_is_none_client_derives(self, tmp_path):
         _make_run(tmp_path, "proj", "run-1")
         delta = delete_delta(str(tmp_path), "proj", "run-1", dict(_DELETED))
-        assert delta["accumulated"] is not None
-        assert "dimensions" in delta["accumulated"]
-        assert "summary" in delta["accumulated"]
+        assert delta["accumulated"] is None
 
     def test_without_run_id_accumulated_is_none(self, tmp_path):
         _make_run(tmp_path, "proj", "run-1")
@@ -168,8 +166,7 @@ class TestBulkDeltaEnvelopes:
         assert delta["kind"] == "restore_all"
         assert delta["runId"] == "run-1"
         assert "isLatest" in delta
-        assert delta["accumulated"] is not None
-        assert "dimensions" in delta["accumulated"]
+        assert delta["accumulated"] is None
         assert "restored" not in delta
         assert "deleted" not in delta
 
@@ -179,8 +176,7 @@ class TestBulkDeltaEnvelopes:
         assert delta["kind"] == "delete_all"
         assert delta["runId"] == "run-1"
         assert "isLatest" in delta
-        assert delta["accumulated"] is not None
-        assert "dimensions" in delta["accumulated"]
+        assert delta["accumulated"] is None
 
     def test_bulk_without_run_id_accumulated_is_none(self, tmp_path):
         _make_run(tmp_path, "proj", "run-1")


### PR DESCRIPTION
## Problem

After dismissing findings (e.g. maintainability false positives), the **Overview per-dimension grade cards did not auto-refresh** — the grade only updated much later, on returning the app to the foreground.

Diagnosed on the real 232-run `quodeq` project via the live app + network trace. **Two independent causes**, both producing the same symptom:

1. **Wrong cache key.** The Overview cards read `accumulated` from the *run-scoped* query `scores(project, <runId>)` (asOf becomes a concrete run id the moment you drill into any run/dimension — confirmed by a live `GET /scores/<runId>`). But the dismiss handler only patched `scores(project, null)`. The run-scoped entry has `staleTime: Infinity` and `refreshDashboard` only marks it stale (`refetchType:'none'`), so it refreshed **only on `refetchOnWindowFocus`**.

2. **Dismiss POST timed out.** The delta synchronously recomputed the full cross-run rollup — `compute_accumulated` runs over *every* run (**~104s cold** on this project, and recomputed on every mutation because the dismissed-set hash busts the cache), exceeding the client's **30s** timeout (`API_TIMEOUT_MS`, no override on dismiss). The POST **aborted**, so the client never applied the delta at all.

## Fix (client-derived)

- **Backend** (`mutation_rescore.py`): the mutation delta no longer computes the rollup (`accumulated: None`) → the dismiss POST is **~0.1s and never times out**.
- **UI** (`applyMutationDelta.js`): the Overview's accumulated dimension grades are **derived from the fast single-run rescore** already in the response — `overallScore`/`overallGrade` copied into each accumulated dim the latest run owns (`fromRunId === runId`), on **both** the `null` and run-scoped scores caches, with **no invalidate** (which would re-trigger the slow refetch).
- The weighted **overall summary** (hero score + totals) is left to a lazy refetch — recomputing it client-side would duplicate the custom grade-formula weights, which this codebase keeps server-side only.

## Verification

- **Live** on the 232-run quodeq project: dismissing a security critical moved the Overview **security card 7.1 → 7.5 instantly** via plain navigation, no window focus. POST returned 200 fast, no abort.
- **Tests:** new red→green UI tests for the client-derived patch + `fromRunId` filtering; updated backend delta/route tests. Full UI suite (1238) and backend services+api+assistant (2055) green.

## Follow-ups (not in this PR)

- The overall **hero score + violation totals** update a beat later (on focus), by design. A lightweight server "accumulated summary" endpoint the UI refreshes in the background could make those instant too.
- `compute_accumulated` being ~104s cold is a standalone perf issue (per-run scalar caching) worth its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)