### PR TITLE
fix(assistant): set SQLite synchronous=NORMAL for the assistant DB

### DIFF
--- a/src/quodeq/data/sqlite/assistant_repository.py
+++ b/src/quodeq/data/sqlite/assistant_repository.py
@@ -34,6 +34,10 @@ class AssistantRepository:
         conn = sqlite3.connect(self._db_path)
         try:
             conn.execute("PRAGMA journal_mode = WAL")
+            # NORMAL is durable against app crashes under WAL and skips the
+            # per-commit fsync. CLI streaming writes one event row per text
+            # delta, so a FULL fsync per commit would pace the reader thread.
+            conn.execute("PRAGMA synchronous = NORMAL")
             conn.execute("PRAGMA foreign_keys = ON")
             conn.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
             version = conn.execute("PRAGMA user_version").fetchone()[0]

--- a/tests/data/sqlite/test_assistant_repository.py
+++ b/tests/data/sqlite/test_assistant_repository.py
@@ -178,3 +178,13 @@ def test_v3_db_migrates_to_v4_with_local_source(tmp_path):
     conn = sqlite3.connect(db)
     assert conn.execute("PRAGMA user_version").fetchone()[0] == 4
     conn.close()
+
+
+def test_connect_uses_wal_with_normal_sync(tmp_path):
+    # WAL + synchronous=NORMAL is durable against app crashes and avoids an
+    # fsync per commit. CLI streaming now writes one event row per text delta
+    # (~50-200 per answer), so a per-commit fsync would pace the read loop.
+    repo = _repo(tmp_path)
+    with repo._connect() as conn:
+        assert conn.execute("PRAGMA journal_mode").fetchone()["journal_mode"].lower() == "wal"
+        assert conn.execute("PRAGMA synchronous").fetchone()["synchronous"] == 1  # 1 == NORMAL


### PR DESCRIPTION
## What

Set `PRAGMA synchronous = NORMAL` on the assistant SQLite connection (`assistant_repository._connect`).

## Why

CLI streaming now writes one event row per text delta (~50-200 per answer) instead of one per whole message. Each `append_event` opens a fresh connection and commits, and the default `synchronous=FULL` fsyncs on every commit. On slow or network-backed disks that per-delta fsync can pace the reader thread, and it multiplies the cost of full-history replay (the frontend reconnects with `after=0` on every drawer reopen).

`NORMAL` is durable against application crashes under WAL and drops the per-commit fsync. Assistant history is a local event log, so the weaker power-loss guarantee (losing the last transaction on OS crash / power loss) is acceptable.

## Test

Added `test_connect_uses_wal_with_normal_sync`, asserting the connection reports WAL + `synchronous=1` (NORMAL). Written test-first (failed at `assert 2 == 1`, passes after the change). Assistant repository and CLI streaming suites green.

Found during the pre-1.7.2 release review.