### PR TITLE
fix(export): cap uncompressed export size to match the import guard

### DIFF
--- a/src/quodeq/api/import_project.py
+++ b/src/quodeq/api/import_project.py
@@ -22,6 +22,7 @@ from flask import Response, jsonify, request
 
 from quodeq.api.helpers import error_response
 from quodeq.api.zip import (
+    _EXTRACT_HEADROOM,
     _MANIFEST_FILENAME,
     _MANIFEST_KIND,
     _MANIFEST_SCHEMA,
@@ -38,11 +39,8 @@ _MAX_MEMBERS = 50_000
 _MAX_PER_MEMBER_BYTES = 1 * 1024 * 1024 * 1024  # 1 GiB uncompressed cap per file
 _MAX_RATIO = 200  # uncompressed/compressed ratio per member (zip-bomb guard)
 _RATIO_GUARD_THRESHOLD = 1024  # only enforce ratio above this uncompressed size
-# The MB cap (QUODEQ_MAX_ZIP_SIZE_MB) applies to the zip bytes, matching the
-# export side. Extraction gets this multiple as headroom: evaluation data is
-# text that deflates ~5x, so a cap-sized archive legitimately inflates past
-# the cap. Total extraction stays bounded at cap * headroom.
-_EXTRACT_HEADROOM = 10
+# _EXTRACT_HEADROOM (imported from quodeq.api.zip) bounds total extraction at
+# cap * headroom; export enforces the same bound so its output always re-imports.
 _MAX_PATH_DEPTH = 64  # limit on path components to bound recursion-style attacks
 
 _ACTION_REPLACE = "replace"

--- a/src/quodeq/api/zip.py
+++ b/src/quodeq/api/zip.py
@@ -20,6 +20,10 @@ _DEFAULT_MAX_ZIP_SIZE_MB = 500
 _MANIFEST_FILENAME = "manifest.json"
 _MANIFEST_KIND = "quodeq-project-export"
 _MANIFEST_SCHEMA = 1
+# Import allows the extracted (uncompressed) archive to reach the MB cap times
+# this multiple (evaluation data is text that deflates ~5x). Export applies the
+# same bound so it never produces an archive that would fail re-import.
+_EXTRACT_HEADROOM = 10
 
 
 def _max_zip_size_bytes(max_mb: int | None = None, env: dict[str, str] | None = None) -> int:
@@ -68,19 +72,27 @@ def _build_manifest(project_path: Path) -> dict[str, object]:
 def _build_project_zip(project_path: Path) -> Path:
     """Create a temporary zip archive of a project directory and return its path.
 
-    The size cap applies to the compressed archive, matching the check on the
-    import side (which reads the zip bytes against the same limit).
+    Two caps mirror the import side so a successful export always re-imports:
+    the compressed archive against the MB limit, and the total uncompressed size
+    against that limit times ``_EXTRACT_HEADROOM``.
     """
     fd, tmp_path = tempfile.mkstemp(suffix=".zip", prefix="quodeq_export_")
     os.close(fd)
     size_limit = _max_zip_size_bytes()
-    limit_error = ValueError(
+    uncompressed_limit = size_limit * _EXTRACT_HEADROOM
+    compressed_error = ValueError(
         f"Project exceeds maximum export size of {size_limit // (1024 * 1024)} MB compressed. "
+        f"Reduce the project size or increase QUODEQ_MAX_ZIP_SIZE_MB."
+    )
+    uncompressed_error = ValueError(
+        f"Project exceeds maximum uncompressed size of "
+        f"{uncompressed_limit // (1024 * 1024)} MB (it would be rejected on re-import). "
         f"Reduce the project size or increase QUODEQ_MAX_ZIP_SIZE_MB."
     )
     try:
         with open(tmp_path, "wb") as fh:
             with zipfile.ZipFile(fh, "w", zipfile.ZIP_DEFLATED) as zf:
+                total_uncompressed = 0
                 for file_entry in project_path.rglob("*"):
                     if file_entry.is_symlink():
                         continue
@@ -90,13 +102,20 @@ def _build_project_zip(project_path: Path) -> Path:
                     if file_entry == project_path / _MANIFEST_FILENAME:
                         continue
                     zf.write(file_entry, file_entry.relative_to(project_path.parent))
+                    total_uncompressed += file_entry.stat().st_size
                     if fh.tell() > size_limit:
-                        raise limit_error
+                        raise compressed_error
+                    if total_uncompressed > uncompressed_limit:
+                        raise uncompressed_error
+                manifest_json = json.dumps(_build_manifest(project_path), indent=2)
                 manifest_arcname = f"{project_path.name}/{_MANIFEST_FILENAME}"
-                zf.writestr(manifest_arcname, json.dumps(_build_manifest(project_path), indent=2))
+                zf.writestr(manifest_arcname, manifest_json)
+                total_uncompressed += len(manifest_json.encode("utf-8"))
+                if total_uncompressed > uncompressed_limit:
+                    raise uncompressed_error
         # The central directory is written on close; re-check the final size.
         if os.path.getsize(tmp_path) > size_limit:
-            raise limit_error
+            raise compressed_error
     except (OSError, zipfile.BadZipFile, ValueError):
         os.unlink(tmp_path)
         raise

--- a/tests/api/test_zip_coverage.py
+++ b/tests/api/test_zip_coverage.py
@@ -77,12 +77,14 @@ class TestBuildProjectZip:
                 _build_project_zip(project)
 
     def test_limit_applies_to_compressed_size(self, tmp_path):
-        # 1 MB of repeated text deflates to ~1 KB. The cap is on the archive
-        # size, so this must export even though the input exceeds the limit.
+        # 500 KB of repeated text deflates to ~1 KB. The compressed cap is what
+        # gates export, so this must succeed even though the uncompressed input
+        # (still under the 640 KB uncompressed headroom) far exceeds the 64 KB
+        # compressed cap.
         from quodeq.api.zip import _build_project_zip
         project = tmp_path / "myproject"
         project.mkdir()
-        (project / "big.txt").write_text("x" * (1024 * 1024))
+        (project / "big.txt").write_text("x" * (500 * 1024))
 
         with patch("quodeq.api.zip._max_zip_size_bytes", return_value=64 * 1024):
             result = _build_project_zip(project)
@@ -98,6 +100,22 @@ class TestBuildProjectZip:
 
         with patch("quodeq.api.zip._max_zip_size_bytes", return_value=64 * 1024):
             with pytest.raises(ValueError, match="exceeds maximum"):
+                _build_project_zip(project)
+
+    def test_uncompressed_size_over_headroom_raises(self, tmp_path):
+        # Highly compressible data can slip under the compressed cap while its
+        # uncompressed size exceeds what import accepts (size_limit *
+        # _EXTRACT_HEADROOM). Export must reject it up front rather than produce
+        # an archive that then fails on re-import. 64 KB cap -> 640 KB
+        # uncompressed headroom; 800 KB of "x" deflates to ~1 KB (under the
+        # compressed cap) but is over the uncompressed cap.
+        from quodeq.api.zip import _build_project_zip
+        project = tmp_path / "myproject"
+        project.mkdir()
+        (project / "big.txt").write_text("x" * (800 * 1024))
+
+        with patch("quodeq.api.zip._max_zip_size_bytes", return_value=64 * 1024):
+            with pytest.raises(ValueError, match="uncompressed"):
                 _build_project_zip(project)
 
 

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -3,9 +3,9 @@
 # Regenerate intentionally: python tools/check_imports.py --update-baseline
 src/quodeq/analysis/subprocess.py:262:llm_bridge
 src/quodeq/api/_evaluation_routes.py:21:analysis
-src/quodeq/api/import_project.py:30:data
 src/quodeq/api/import_project.py:31:data
 src/quodeq/api/import_project.py:32:data
+src/quodeq/api/import_project.py:33:data
 src/quodeq/api/llm_bridge_routes.py:8:llm_bridge
 src/quodeq/data/fs/project_resolver.py:17:services
 src/quodeq/data/fs/repo_clone.py:19:context


### PR DESCRIPTION
## What

Export now enforces an uncompressed size cap (`size_limit * _EXTRACT_HEADROOM`) in addition to the existing compressed cap. Moved `_EXTRACT_HEADROOM` into `zip.py` as the single source of truth (import already imports from `zip.py`).

## Why

Export capped only the compressed archive; import caps both compressed bytes and total uncompressed size. A project whose data deflates more than the 10x headroom (large repetitive SARIF/JSONL is not unusual) could export as a small zip and then fail re-import with `TOO_LARGE`. The two sides are now symmetric: a successful export always re-imports, and the user gets a clear error at export time on their own machine instead of a confusing failure later.

## Test

Added `test_uncompressed_size_over_headroom_raises` (written test-first, failed with "DID NOT RAISE", passes after the change). Updated `test_limit_applies_to_compressed_size` to stay under the new uncompressed headroom while still proving the compressed cap gates export. zip and import suites green (41 passed).

Found during the pre-1.7.2 release review.