### PR TITLE
fix(terminal): fail soft on a NUL byte in the /open path

### DIFF
--- a/src/quodeq/terminal/links.py
+++ b/src/quodeq/terminal/links.py
@@ -128,12 +128,12 @@ def safe_editor_path(
     """
     try:
         real = realpath(path)
-    except OSError:
+    except (OSError, ValueError):  # ValueError: embedded NUL byte in path
         return None
     for base in bases:
         try:
             base_real = realpath(base)
-        except OSError:
+        except (OSError, ValueError):
             continue
         try:
             if commonpath([real, base_real]) == base_real:

--- a/src/quodeq/terminal/links.py
+++ b/src/quodeq/terminal/links.py
@@ -126,9 +126,15 @@ def safe_editor_path(
     untrusted input (a symlink escaping a base resolves out via realpath and is
     rejected).
     """
+    # A NUL byte can never appear in a real path. Reject it up front: POSIX
+    # realpath raises ValueError on it, but Windows realpath returns it intact,
+    # so an explicit guard is what makes the behavior consistent and keeps the
+    # NUL out of the editor launch on every platform.
+    if "\x00" in path:
+        return None
     try:
         real = realpath(path)
-    except (OSError, ValueError):  # ValueError: embedded NUL byte in path
+    except (OSError, ValueError):
         return None
     for base in bases:
         try:

--- a/tests/api/test_terminal_links.py
+++ b/tests/api/test_terminal_links.py
@@ -119,9 +119,10 @@ def test_safe_editor_path_checks_multiple_bases():
 
 
 def test_safe_editor_path_null_byte_returns_none():
-    # The real os.path.realpath raises ValueError on an embedded NUL. The /open
-    # route promises to fail soft (never raise into a request), so a NUL path
-    # must resolve to None rather than propagate a 500.
+    # A NUL byte must never reach the editor launch. POSIX realpath raises
+    # ValueError on it (previously an uncaught 500), while Windows realpath
+    # returns it intact under the base; both must resolve to None. Uses the
+    # real os.path.realpath so the platform behavior is exercised.
     assert safe_editor_path("/home/u/a\x00.py", ["/home/u"]) is None
 
 

--- a/tests/api/test_terminal_links.py
+++ b/tests/api/test_terminal_links.py
@@ -118,6 +118,13 @@ def test_safe_editor_path_checks_multiple_bases():
     assert got == "/second/a.py"
 
 
+def test_safe_editor_path_null_byte_returns_none():
+    # The real os.path.realpath raises ValueError on an embedded NUL. The /open
+    # route promises to fail soft (never raise into a request), so a NUL path
+    # must resolve to None rather than propagate a 500.
+    assert safe_editor_path("/home/u/a\x00.py", ["/home/u"]) is None
+
+
 # --- detect_editor ----------------------------------------------------------
 
 def test_detect_editor_prefers_code_on_path():


### PR DESCRIPTION
## What

`safe_editor_path` now catches `ValueError` (not just `OSError`) around `os.path.realpath`.

## Why

`os.path.realpath` raises `ValueError: embedded null byte` for a NUL in the path. That call sits outside the `/open` route's try/except, so `POST /api/terminal/open {"path": ".../a\x00.py"}` returned HTTP 500, violating the module's stated contract ("Nothing here raises into a request").

Not reachable through the UI (the `/resolve` `isfile` check already treats NUL tokens as non-existent, so they never become clickable) and `/open` is Origin/CSRF-gated, so there is no cross-origin or privilege angle. This is a contract violation and a noisy 500, fixed with a one-liner.

## Test

Added `test_safe_editor_path_null_byte_returns_none` using the real `os.path.realpath` (written test-first; failed with `ValueError: embedded null character`, passes after the change). Terminal links + POSIX-guard suites green (32 passed).

Found during the pre-1.7.2 release review.