### PR TITLE
ci: run the web UI test suite on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,9 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7.0.0
         with:
-          node-version: '20'
+          # 22, not 20: the `test` script runs `node --test` with a glob
+          # pattern, and node only expands glob args to --test on 21+.
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: src/quodeq/ui/package-lock.json
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,3 +63,29 @@ jobs:
         # Verbose + -ra so per-test names and the FAILED summary survive
         # GitHub's log truncation, keeping this blocking gate easy to triage.
         run: uv run pytest tests/ -v -ra --tb=short -m "not integration" -n auto
+
+  ui:
+    # The web UI ships ~1600 tests (vitest .test.jsx + node:test .test.js) that
+    # nothing else in CI runs; production builds only `npm run build` them. They
+    # are jsdom/pure-JS and OS-independent, so one Linux runner is enough. Runs
+    # in parallel with `test`, which is far slower, so it adds no wall time.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: src/quodeq/ui/package-lock.json
+
+      - name: Install UI dependencies
+        working-directory: src/quodeq/ui
+        run: npm ci
+
+      - name: Run UI tests
+        working-directory: src/quodeq/ui
+        # test:all = node --test (.test.js) + vitest run (.test.jsx).
+        run: npm run test:all


### PR DESCRIPTION
## What

Add a `ui` job to `test.yml` that runs `npm run test:all` (node:test `.test.js` + vitest `.test.jsx`) on one Linux runner.

## Why

`test.yml` ran only the Python suite. The ~1600 UI tests ran nowhere in CI: production/publish workflows only `npm run build` the UI, never test it. A UI regression could only be caught by a contributor running the suite locally. Most recent releases (this one included) are UI-heavy, so this is a real gap.

## Cost

Negligible. The tests are ~21s (vitest) + ~0.4s (node runner); the job is dominated by `npm ci` (~30-60s, cached via `setup-node`). It runs in parallel with the Python matrix, which is far slower and stays on the critical path, so time-to-green is effectively unchanged. One Linux runner is enough since the tests are jsdom/pure-JS and OS-independent.

## Verification

Ran `npm run test:all` locally: 330 node-runner + 1239 vitest tests pass. Validated the workflow YAML parses with the new `ui` job.

Companion to the pre-1.7.2 release review. Suggest making `ui` a required status check once it is green on a couple of PRs.