### PR TITLE
fix(history): cancelled run no longer shows as 'running' while draining

### DIFF
--- a/src/quodeq/data/fs/report_parser/runs.py
+++ b/src/quodeq/data/fs/report_parser/runs.py
@@ -164,6 +164,18 @@ def _read_run_status(run_dir: Path) -> str | None:
     return state if isinstance(state, str) else None
 
 
+# Terminal status.json states → History status vocabulary. A terminal state is
+# authoritative even when the run's PID is still alive: the cancel path flips
+# status.json to ``cancelled`` immediately, but the subprocess keeps draining
+# its subagents for a few seconds before it exits. Without this, a cancelled
+# run reappears as "running" in History for the length of that drain.
+_TERMINAL_STATE_TO_STATUS = {
+    "done": "complete",
+    "failed": "failed",
+    "cancelled": "cancelled",
+}
+
+
 def list_runs(reports_root: Path, project: str, *, limit: int = _DEFAULT_RUN_LIMIT) -> list[RunInfo]:
     """Return runs for a project, sorted newest-first by date.
 
@@ -186,16 +198,19 @@ def list_runs(reports_root: Path, project: str, *, limit: int = _DEFAULT_RUN_LIM
         if not manifest_exists:
             continue
         # Status precedence:
-        #   1. Live process holding the PID → "in_progress" (dimmed "Running…" in UI)
-        #   2. status.json state in {cancelled, failed} → pass through
+        #   1. status.json state is terminal (done/failed/cancelled) → honor it,
+        #      even over a still-live PID (a cancelled run keeps draining after
+        #      its state flips; it must not resurface as "running").
+        #   2. Live process holding the PID → "in_progress" (dimmed "Running…" in UI)
         #   3. Otherwise → "complete" (historical, crashed, pre-.pid-era runs)
-        from quodeq.services._external_jobs import resolve_external_pid  # noqa: PLC0415
-        pid = resolve_external_pid(project_dir.name, entry.name, reports_root)
-        if pid is not None:
-            status = "in_progress"
+        raw_state = _read_run_status(run_dir)
+        terminal_status = _TERMINAL_STATE_TO_STATUS.get(raw_state or "")
+        if terminal_status is not None:
+            status = terminal_status
         else:
-            raw_state = _read_run_status(run_dir)
-            status = raw_state if raw_state in ("cancelled", "failed") else "complete"
+            from quodeq.services._external_jobs import resolve_external_pid  # noqa: PLC0415
+            pid = resolve_external_pid(project_dir.name, entry.name, reports_root)
+            status = "in_progress" if pid is not None else "complete"
         cached = index_dates.get(entry.name)
         if cached is not None:
             date_iso, date_label = cached

--- a/tests/data/fs/test_runs.py
+++ b/tests/data/fs/test_runs.py
@@ -57,6 +57,66 @@ def test_list_runs_marks_in_progress_when_pid_is_live(tmp_path: Path) -> None:
     assert runs[0].status == "in_progress"
 
 
+def test_list_runs_cancelled_state_overrides_live_pid(tmp_path: Path) -> None:
+    """A run cancelled while its process is still draining shows as cancelled.
+
+    The cancel path writes ``state: cancelled`` to status.json immediately, but
+    the subprocess keeps running for a few seconds while it reaps its subagents.
+    During that window a live PID must NOT override the explicit terminal state,
+    or the History table shows a cancelled run as "running".
+    """
+    from quodeq.data.fs.report_parser.runs import list_runs
+
+    project_uuid = "proj-cancel"
+    run_dir = tmp_path / project_uuid / "run-draining"
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "evidence" / "manifest.json").write_text("{}")
+    # status.json already flipped to cancelled by the cancel path...
+    (run_dir / "status.json").write_text(json.dumps({"state": "cancelled"}))
+    # ...but the process is still alive (our own PID passes the liveness probe).
+    (run_dir / ".pid").write_text(str(os.getpid()))
+
+    runs = list_runs(tmp_path, project_uuid)
+    assert len(runs) == 1
+    assert runs[0].status == "cancelled"
+
+
+def test_list_runs_failed_state_overrides_live_pid(tmp_path: Path) -> None:
+    """A failed terminal state also wins over a lingering live PID."""
+    from quodeq.data.fs.report_parser.runs import list_runs
+
+    project_uuid = "proj-failed"
+    run_dir = tmp_path / project_uuid / "run-failing"
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "evidence" / "manifest.json").write_text("{}")
+    (run_dir / "status.json").write_text(json.dumps({"state": "failed"}))
+    (run_dir / ".pid").write_text(str(os.getpid()))
+
+    runs = list_runs(tmp_path, project_uuid)
+    assert len(runs) == 1
+    assert runs[0].status == "failed"
+
+
+def test_list_runs_running_state_with_live_pid_stays_in_progress(tmp_path: Path) -> None:
+    """A genuinely running run (non-terminal state + live PID) stays in_progress.
+
+    Guards the fix from over-reaching: only *terminal* states short-circuit the
+    live-PID check.
+    """
+    from quodeq.data.fs.report_parser.runs import list_runs
+
+    project_uuid = "proj-running"
+    run_dir = tmp_path / project_uuid / "run-alive"
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "evidence" / "manifest.json").write_text("{}")
+    (run_dir / "status.json").write_text(json.dumps({"state": "running"}))
+    (run_dir / ".pid").write_text(str(os.getpid()))
+
+    runs = list_runs(tmp_path, project_uuid)
+    assert len(runs) == 1
+    assert runs[0].status == "in_progress"
+
+
 def test_list_runs_marks_historical_runs_as_complete(tmp_path: Path) -> None:
     """A historical run (manifest present, no live PID) shows as complete in History.
 

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -9,8 +9,8 @@ src/quodeq/api/import_project.py:33:data
 src/quodeq/api/llm_bridge_routes.py:8:llm_bridge
 src/quodeq/data/fs/project_resolver.py:17:services
 src/quodeq/data/fs/repo_clone.py:19:context
-src/quodeq/data/fs/report_parser/runs.py:178:services
-src/quodeq/data/fs/report_parser/runs.py:192:services
+src/quodeq/data/fs/report_parser/runs.py:190:services
+src/quodeq/data/fs/report_parser/runs.py:211:services
 src/quodeq/data/projection/grade_projector.py:132:services
 src/quodeq/data/projection/grade_projector.py:20:services
 src/quodeq/data/sqlite/state_store.py:246:services


### PR DESCRIPTION
## The bug

The History table can show **two `running` rows for what is really one evaluation** when you cancel a run and immediately start another. Reported live: the second "running" row was a *cancelled* run, not a second evaluation.

## Root cause

`list_runs` (`src/quodeq/data/fs/report_parser/runs.py`) derived run status with this precedence:

1. **Live PID → `in_progress`** (unconditional)
2. `status.json` state in `{cancelled, failed}` → pass through
3. else → `complete`

When a run is cancelled, the cancel path writes `state: cancelled` to `status.json` **immediately**, but the subprocess keeps draining its subagents for several seconds before it actually exits. During that drain window `resolve_external_pid` still returns a live PID, so step 1 forced the run back to `in_progress` — overriding the explicit terminal state. The History table then rendered the cancelled run as a "running" row (`performing an evaluation…`) next to the genuinely in-progress run.

Timeline from the live repro:

| Time | Run | Outcome |
|---|---|---|
| 2:50:44 PM | `3a095de1` | cancelled at 2:51:04 — **but still shown as "running"** while draining |
| 2:51:33 PM | `6b355cff` | genuinely running |

## The fix

Honor a **terminal** `status.json` state (`done`/`failed`/`cancelled`) *ahead* of the live-PID check. Only non-terminal (or absent) states fall through to the PID probe. Dead-PID behavior is unchanged, and the index-backed path (`_runs_unit.py`) already honored terminal state, so this closes the one path that didn't.

## Tests

TDD — added three cases to `tests/data/fs/test_runs.py` (watched them fail first):
- `test_list_runs_cancelled_state_overrides_live_pid` — cancelled + live PID → `cancelled`
- `test_list_runs_failed_state_overrides_live_pid` — failed + live PID → `failed`
- `test_list_runs_running_state_with_live_pid_stays_in_progress` — guard: running + live PID stays `in_progress`

Full `tests/data/fs`, `tests/services`, `tests/api` suites pass (1747 + 68 green, non-integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)