### PR TITLE
fix(ui): reconcile dashboard after dismiss/restore/delete mutations

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -424,6 +424,7 @@ function renderEvalPrincipleDetail(params, props) {
         const result = await props.dismissFinding(selectedProject, payload);
         props.applyDelta?.(selectedProject, result?.scores, result?.delta);
         props.refreshDashboard?.();
+        props.scheduleDashboardReconcile?.();
         props.bumpDismissRefresh?.();
         return result;
       }}
@@ -522,7 +523,13 @@ function ViolationsRoute({ params, props }) {
           }
         },
         onPrincipleClick: (principleObj) => navigateToPrinciple(principleObj),
-        onRefresh: props.refreshDashboard,
+        // Restore/delete (single + bulk) route through here via
+        // useDismissedFindings' onRefresh. restore-all/delete-all return a
+        // payload applyMutationDelta can't patch (scores:null,
+        // delta.isLatest:false), so this must actively reconcile rather than
+        // just mark the cache stale — see scheduleDashboardReconcile in
+        // useDashboard.js.
+        onRefresh: props.scheduleDashboardReconcile,
         onNavigate: nav,
       }}
       isDirectNav={props.navigation.navStackLength === 1}
@@ -633,6 +640,7 @@ export const ROUTE_RENDERERS = {
         const result = await props.dismissFinding(props.navigation.selectedProject, payload);
         props.applyDelta?.(props.navigation.selectedProject, result?.scores, result?.delta);
         props.refreshDashboard?.();
+        props.scheduleDashboardReconcile?.();
         props.bumpDismissRefresh?.();
         return result;
       }}
@@ -650,6 +658,7 @@ export const ROUTE_RENDERERS = {
         const result = await props.dismissFinding(props.navigation.selectedProject, payload);
         props.applyDelta?.(props.navigation.selectedProject, result?.scores, result?.delta);
         props.refreshDashboard?.();
+        props.scheduleDashboardReconcile?.();
         props.bumpDismissRefresh?.();
         return result;
       }}
@@ -999,6 +1008,14 @@ export default function App() {
     serverHealth: { connected: state.serverConnected, setConnected: state.setServerConnected },
     settings: state.settings,
     refreshDashboard: state.refreshDashboard,
+    // Debounced ACTIVE reconcile for suppression mutations (dismiss/restore/
+    // delete) — see useDashboard.js. refreshDashboard's refetchType:'none'
+    // only marks the cache stale; this actually refetches the always-mounted
+    // Overview observer after the 1200ms window, so restore-all/delete-all
+    // (whose response can't be patched via applyMutationDelta) and every
+    // other suppression mutation converge without waiting for a project
+    // switch.
+    scheduleDashboardReconcile: state.scheduleDashboardReconcile,
     dismissFinding,
     // Patch the dashboard/scores caches from the dismiss response delta so the
     // Overview updates instantly. Additive — the refreshDashboard /

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -523,13 +523,20 @@ function ViolationsRoute({ params, props }) {
           }
         },
         onPrincipleClick: (principleObj) => navigateToPrinciple(principleObj),
-        // Restore/delete (single + bulk) route through here via
-        // useDismissedFindings' onRefresh. restore-all/delete-all return a
-        // payload applyMutationDelta can't patch (scores:null,
-        // delta.isLatest:false), so this must actively reconcile rather than
-        // just mark the cache stale — see scheduleDashboardReconcile in
+        // ViolationsPage fires onRefresh on EVERY mount (its tabKey effect),
+        // including plain drill-down/back navigation with no mutation --
+        // the page remounts on every round trip. onRefresh must stay wired
+        // to the lazy refreshDashboard (mark-stale, refetchType:'none') so
+        // plain navigation never forces an active refetch of the 10-20 MB
+        // dashboard payload. Restore/delete (single + bulk) route through a
+        // SEPARATE onReconcile callback via useDismissedFindings, called
+        // alongside onRefresh from its four mutation handlers.
+        // restore-all/delete-all return a payload applyMutationDelta can't
+        // patch (scores:null, delta.isLatest:false), so those need the
+        // debounced ACTIVE reconcile — see scheduleDashboardReconcile in
         // useDashboard.js.
-        onRefresh: props.scheduleDashboardReconcile,
+        onRefresh: props.refreshDashboard,
+        onReconcile: props.scheduleDashboardReconcile,
         onNavigate: nav,
       }}
       isDirectNav={props.navigation.navStackLength === 1}

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -192,14 +192,17 @@ describe('ROUTE_RENDERERS onDismiss source gating', () => {
   });
 });
 
-// The Dismissed sub-tab's restore/delete (single + bulk) handlers all call
-// the ViolationsRoute-supplied onRefresh (see useDismissedFindings.js).
-// restore-all/delete-all return a payload applyMutationDelta's gates can't
-// patch (scores:null, delta.isLatest:false), so this seam must wire to the
-// debounced ACTIVE scheduleDashboardReconcile, not the lazy refreshDashboard
-// — otherwise a restore-all leaves the Overview showing dismissed counts
-// until the user switches projects.
-describe('ViolationsRoute onRefresh wiring (Dismissed tab reconcile)', () => {
+// ViolationsPage fires its onRefresh on every mount (see
+// ViolationsPage.jsx's tabKey effect) -- including plain drill-down/back
+// navigation with no mutation involved, since the page remounts on every
+// round trip. Wiring onRefresh to scheduleDashboardReconcile (as a prior
+// revision did) turned every such round trip into an ACTIVE refetch of the
+// 10-20 MB dashboard payload -- the exact freeze refetchType:'none' exists
+// to avoid. onRefresh must stay wired to the lazy refreshDashboard; only the
+// four suppression-mutation handlers in useDismissedFindings.js (restore/
+// restore-all/delete/delete-all) get the debounced ACTIVE reconcile, via the
+// separate onReconcile callback threaded down from here.
+describe('ViolationsRoute onRefresh/onReconcile wiring (Dismissed tab reconcile)', () => {
   function renderViolationsRoute(props) {
     const outer = ROUTE_RENDERERS.violations({}, props);
     // ROUTE_RENDERERS.violations returns <ViolationsRoute params props />;
@@ -218,11 +221,17 @@ describe('ViolationsRoute onRefresh wiring (Dismissed tab reconcile)', () => {
     };
   }
 
-  it('wires onRefresh to scheduleDashboardReconcile, not refreshDashboard', () => {
+  it('wires onRefresh to refreshDashboard (lazy mark-stale) so plain navigation never forces an active refetch', () => {
     const props = violationsProps();
     const inner = renderViolationsRoute(props);
-    expect(inner.props.callbacks.onRefresh).toBe(props.scheduleDashboardReconcile);
-    expect(inner.props.callbacks.onRefresh).not.toBe(props.refreshDashboard);
+    expect(inner.props.callbacks.onRefresh).toBe(props.refreshDashboard);
+    expect(inner.props.callbacks.onRefresh).not.toBe(props.scheduleDashboardReconcile);
+  });
+
+  it('wires onReconcile to scheduleDashboardReconcile, for the suppression-mutation handlers to call in addition to onRefresh', () => {
+    const props = violationsProps();
+    const inner = renderViolationsRoute(props);
+    expect(inner.props.callbacks.onReconcile).toBe(props.scheduleDashboardReconcile);
   });
 });
 

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -115,9 +115,10 @@ describe('ROUTE_RENDERERS onDismiss source gating', () => {
   function baseProps(selectedSource) {
     return {
       navigation: { selectedProject: 'proj1', selectedRun: 'latest', selectedSource, projects: [] },
-      dismissFinding: vi.fn(),
+      dismissFinding: vi.fn().mockResolvedValue({ scores: { dimensions: [] }, delta: {} }),
       applyDelta: vi.fn(),
       refreshDashboard: vi.fn(),
+      scheduleDashboardReconcile: vi.fn(),
       bumpDismissRefresh: vi.fn(),
     };
   }
@@ -155,6 +156,73 @@ describe('ROUTE_RENDERERS onDismiss source gating', () => {
   it('eval-principle-detail (alias route) also gates onDismiss for a shared project', () => {
     const el = ROUTE_RENDERERS['eval-principle-detail']({ evalPrincipal: { principle: 'P', dimension: 'Security' } }, baseProps('shared'));
     expect(el.props.onDismiss).toBeUndefined();
+  });
+
+  // The dashboard must eventually reflect a dismiss even though the delta
+  // patch is only best-effort (e.g. it doesn't cover every view). Each
+  // onDismiss success path calls BOTH the existing lazy refreshDashboard
+  // (mark-stale, cheap) AND the new debounced scheduleDashboardReconcile
+  // (active refetch of the always-mounted Overview observer) — see
+  // useDashboard.js. Neither call replaces the other.
+  it('file route onDismiss calls refreshDashboard, scheduleDashboardReconcile, and bumpDismissRefresh on success', async () => {
+    const props = baseProps('local');
+    const el = ROUTE_RENDERERS.file({ file: { path: 'a.py' }, runId: 'r1' }, props);
+    await el.props.onDismiss({ reason: 'test' });
+    expect(props.refreshDashboard).toHaveBeenCalledTimes(1);
+    expect(props.scheduleDashboardReconcile).toHaveBeenCalledTimes(1);
+    expect(props.bumpDismissRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('finding route onDismiss calls refreshDashboard, scheduleDashboardReconcile, and bumpDismissRefresh on success', async () => {
+    const props = baseProps('local');
+    const el = ROUTE_RENDERERS.finding({ finding: {}, principle: 'P', dimension: 'Security' }, props);
+    await el.props.onDismiss({ reason: 'test' });
+    expect(props.refreshDashboard).toHaveBeenCalledTimes(1);
+    expect(props.scheduleDashboardReconcile).toHaveBeenCalledTimes(1);
+    expect(props.bumpDismissRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('evalprinciple route onDismiss calls refreshDashboard, scheduleDashboardReconcile, and bumpDismissRefresh on success', async () => {
+    const props = baseProps('local');
+    const el = ROUTE_RENDERERS.evalprinciple({ evalPrincipal: { principle: 'P', dimension: 'Security' } }, props);
+    await el.props.onDismiss({ reason: 'test' });
+    expect(props.refreshDashboard).toHaveBeenCalledTimes(1);
+    expect(props.scheduleDashboardReconcile).toHaveBeenCalledTimes(1);
+    expect(props.bumpDismissRefresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The Dismissed sub-tab's restore/delete (single + bulk) handlers all call
+// the ViolationsRoute-supplied onRefresh (see useDismissedFindings.js).
+// restore-all/delete-all return a payload applyMutationDelta's gates can't
+// patch (scores:null, delta.isLatest:false), so this seam must wire to the
+// debounced ACTIVE scheduleDashboardReconcile, not the lazy refreshDashboard
+// — otherwise a restore-all leaves the Overview showing dismissed counts
+// until the user switches projects.
+describe('ViolationsRoute onRefresh wiring (Dismissed tab reconcile)', () => {
+  function renderViolationsRoute(props) {
+    const outer = ROUTE_RENDERERS.violations({}, props);
+    // ROUTE_RENDERERS.violations returns <ViolationsRoute params props />;
+    // ViolationsRoute itself has no hooks, so invoking it directly (the way
+    // React would) is safe without mounting a component tree.
+    return outer.type(outer.props);
+  }
+
+  function violationsProps() {
+    return {
+      dashboardData: { latestAccumulated: null, accumulated: null, selectedDisplayName: 'p1', loading: false, isFetching: false },
+      navigation: { selectedProject: 'proj1', selectedSource: 'local', projects: [], projectsLoaded: true, handleNavigate: vi.fn(), navStackLength: 1 },
+      dismissRefreshKey: 0,
+      refreshDashboard: vi.fn(),
+      scheduleDashboardReconcile: vi.fn(),
+    };
+  }
+
+  it('wires onRefresh to scheduleDashboardReconcile, not refreshDashboard', () => {
+    const props = violationsProps();
+    const inner = renderViolationsRoute(props);
+    expect(inner.props.callbacks.onRefresh).toBe(props.scheduleDashboardReconcile);
+    expect(inner.props.callbacks.onRefresh).not.toBe(props.refreshDashboard);
   });
 });
 

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useApi } from "../../../api/ApiContext.jsx";
 import { useProjectScores } from "../../../hooks/useProjectScores.js";
@@ -129,6 +129,31 @@ export function useDashboard({ selectedProject, selectedRun, selectedSource = "l
     });
   }, [queryClient, selectedProject, selectedSource]);
 
+  // Debounced counterpart to refreshDashboardActive, for the high-frequency
+  // suppression mutations (dismiss/restore/delete). refreshDashboard's
+  // refetchType:'none' leaves the Overview's always-mounted observer showing
+  // stale data until the user switches projects and back -- fine for a single
+  // dismiss (the mutation response already patched the visible page's local
+  // scores via applyMutationDelta), but restore-all/delete-all return a
+  // payload the delta gates can't apply (scores:null, delta.isLatest:false),
+  // so the Overview stays wrong indefinitely. The pywebview desktop window
+  // also never fires the focus-refetch a browser tab would get on refocus,
+  // so there's no other path back to fresh data short of an app switch.
+  // Debounce coalesces rapid multi-dismiss/restore bursts into one refetch of
+  // the (potentially 10-20 MB) dashboard payload instead of one per action.
+  const reconcileTimer = useRef(null);
+  const scheduleDashboardReconcile = useCallback(() => {
+    if (reconcileTimer.current) clearTimeout(reconcileTimer.current);
+    reconcileTimer.current = setTimeout(() => {
+      reconcileTimer.current = null;
+      if (!selectedProject) return;
+      queryClient.invalidateQueries({
+        queryKey: projectKeys.project(selectedProject, selectedSource),
+      });
+    }, 1200);
+  }, [queryClient, selectedProject, selectedSource]);
+  useEffect(() => () => clearTimeout(reconcileTimer.current), []);
+
   return {
     dashboard: dashboardWithTrend,
     accumulated: scores?.accumulated || null,
@@ -145,6 +170,7 @@ export function useDashboard({ selectedProject, selectedRun, selectedSource = "l
     availableRuns,
     refreshDashboard,
     refreshDashboardActive,
+    scheduleDashboardReconcile,
     sharedProjectInfo: sharedProjectInfoQuery.data || null,
   };
 }

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -143,6 +143,18 @@ export function useDashboard({ selectedProject, selectedRun, selectedSource = "l
   // the (potentially 10-20 MB) dashboard payload instead of one per action.
   const reconcileTimer = useRef(null);
   const scheduleDashboardReconcile = useCallback(() => {
+    if (!selectedProject) return;
+    // Mark-stale NOW, synchronously, before the timer is (re)armed. The
+    // timer is a single shared ref: a rapid project switch clears it before
+    // the 1200ms elapses, dropping the ACTIVE refetch below. Without this,
+    // a dropped reconcile would leave the cache silently fresh-and-wrong
+    // (no invalidation happened at all); with it, a dropped reconcile
+    // degrades to exactly refreshDashboard's mark-stale-only semantics, so
+    // a remount or Overview-return still self-heals.
+    queryClient.invalidateQueries({
+      queryKey: projectKeys.project(selectedProject, selectedSource),
+      refetchType: 'none',
+    });
     if (reconcileTimer.current) clearTimeout(reconcileTimer.current);
     reconcileTimer.current = setTimeout(() => {
       reconcileTimer.current = null;

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -128,6 +128,72 @@ describe("useDashboard", () => {
       await result.current.refreshDashboardActive();
     });
     await waitFor(() => expect(fakeApi.getDashboard).toHaveBeenCalledTimes(2));
+  });
+});
+
+// After restore-all/delete-all, the mutation response carries scores:null /
+// delta.isLatest:false — applyMutationDelta's gates are a no-op — so
+// refreshDashboard's lazy (refetchType:'none') invalidation is the ONLY
+// signal the Overview ever gets, and its always-mounted observer never
+// refetches on its own (no remount, and the desktop pywebview window never
+// fires a focus refetch). scheduleDashboardReconcile is the debounced ACTIVE
+// counterpart the suppression-mutation handlers call alongside
+// refreshDashboard so restored/deleted findings actually reappear.
+describe("useDashboard scheduleDashboardReconcile (debounced active reconcile)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  function renderWithSpy() {
+    const fakeApi = makeFakeApi();
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    });
+    const spy = vi.spyOn(client, "invalidateQueries");
+    const { result } = renderHook(
+      () => useDashboard({ selectedProject: "p1", selectedRun: null }),
+      {
+        wrapper: ({ children }) => (
+          <QueryClientProvider client={client}>
+            <ApiProvider value={fakeApi}>{children}</ApiProvider>
+          </QueryClientProvider>
+        ),
+      },
+    );
+    return { result, spy };
+  }
+
+  it("invalidates the project subtree with an ACTIVE refetch after the debounce window", () => {
+    const { result, spy } = renderWithSpy();
+    act(() => result.current.scheduleDashboardReconcile());
+    expect(spy).not.toHaveBeenCalled(); // debounced, not immediate
+    act(() => { vi.advanceTimersByTime(1200); });
+    expect(spy).toHaveBeenCalledTimes(1);
+    const arg = spy.mock.calls[0][0];
+    expect(arg.refetchType).toBeUndefined(); // default 'active', NOT 'none'
+    expect(arg.queryKey).toEqual(projectKeys.project("p1", "local"));
+  });
+
+  it("coalesces rapid calls into one invalidation", () => {
+    const { result, spy } = renderWithSpy();
+    act(() => {
+      result.current.scheduleDashboardReconcile();
+      vi.advanceTimersByTime(600);
+      result.current.scheduleDashboardReconcile(); // resets the timer
+      vi.advanceTimersByTime(600);
+      result.current.scheduleDashboardReconcile();
+    });
+    act(() => { vi.advanceTimersByTime(1200); });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression pin: the debounced reconcile is additive, not a replacement.
+  // refreshDashboard must keep its lazy refetchType:'none' contract for its
+  // other callers (evaluation-completion effect, run deletion, etc.).
+  it("refreshDashboard keeps mark-stale-only behavior (regression pin)", () => {
+    const { result, spy } = renderWithSpy();
+    act(() => result.current.refreshDashboard());
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].refetchType).toBe("none");
   });
 });
 

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
@@ -162,18 +162,33 @@ describe("useDashboard scheduleDashboardReconcile (debounced active reconcile)",
     return { result, spy };
   }
 
+  // Schedule-time mark-stale (hardening): if the debounce timer never fires
+  // (e.g. a rapid project switch clears the single shared timer ref before
+  // 1200ms elapses), the mutation must still have left the cache stale --
+  // otherwise a dropped reconcile silently leaves fresh-looking-but-wrong
+  // data cached instead of degrading to refreshDashboard's mark-stale-only
+  // contract. Scheduling call synchronously invalidates with
+  // refetchType:'none' BEFORE the timer is armed, then the timer still does
+  // the ACTIVE invalidation after the debounce window.
+  it("marks the subtree stale (refetchType:'none') synchronously at schedule time, before the timer fires", () => {
+    const { result, spy } = renderWithSpy();
+    act(() => result.current.scheduleDashboardReconcile());
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].refetchType).toBe("none");
+    expect(spy.mock.calls[0][0].queryKey).toEqual(projectKeys.project("p1", "local"));
+  });
+
   it("invalidates the project subtree with an ACTIVE refetch after the debounce window", () => {
     const { result, spy } = renderWithSpy();
     act(() => result.current.scheduleDashboardReconcile());
-    expect(spy).not.toHaveBeenCalled(); // debounced, not immediate
     act(() => { vi.advanceTimersByTime(1200); });
-    expect(spy).toHaveBeenCalledTimes(1);
-    const arg = spy.mock.calls[0][0];
-    expect(arg.refetchType).toBeUndefined(); // default 'active', NOT 'none'
-    expect(arg.queryKey).toEqual(projectKeys.project("p1", "local"));
+    // The ACTIVE (no refetchType) call is the one without refetchType:'none'.
+    const activeCalls = spy.mock.calls.filter(([arg]) => arg.refetchType === undefined);
+    expect(activeCalls).toHaveLength(1);
+    expect(activeCalls[0][0].queryKey).toEqual(projectKeys.project("p1", "local"));
   });
 
-  it("coalesces rapid calls into one invalidation", () => {
+  it("coalesces rapid calls into exactly one ACTIVE invalidation (multiple 'none' pre-marks are fine)", () => {
     const { result, spy } = renderWithSpy();
     act(() => {
       result.current.scheduleDashboardReconcile();
@@ -183,7 +198,8 @@ describe("useDashboard scheduleDashboardReconcile (debounced active reconcile)",
       result.current.scheduleDashboardReconcile();
     });
     act(() => { vi.advanceTimersByTime(1200); });
-    expect(spy).toHaveBeenCalledTimes(1);
+    const activeCalls = spy.mock.calls.filter(([arg]) => arg.refetchType === undefined);
+    expect(activeCalls).toHaveLength(1);
   });
 
   // Regression pin: the debounced reconcile is additive, not a replacement.

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -98,7 +98,7 @@ function FileSubTab({ dimensions, onFileClick, currentPath, setCurrentPath }) {
   );
 }
 
-function useViolationsData({ accumulatedDimensions, selectedProject, onRefresh, initialSubTab, initialFilePath, dismissRefreshKey, selectedSource }) {
+function useViolationsData({ accumulatedDimensions, selectedProject, onRefresh, onReconcile, initialSubTab, initialFilePath, dismissRefreshKey, selectedSource }) {
   const [activeSubTab, _setActiveSubTab] = useState(initialSubTab);
   const setActiveSubTab = (v) => {
     writeCachedState('violations', selectedProject, { activeSubTab: v });
@@ -116,7 +116,7 @@ function useViolationsData({ accumulatedDimensions, selectedProject, onRefresh, 
   // sub-tab reflects new entries without needing the user to re-open the
   // page or switch projects.
   const { dismissed, handleRestore, handleRestoreAll, handleDelete, handleDeleteAll } =
-    useDismissedFindings(selectedProject, onRefresh, setRestoreError, dismissRefreshKey, selectedSource);
+    useDismissedFindings(selectedProject, onRefresh, setRestoreError, dismissRefreshKey, selectedSource, onReconcile);
 
   const visibleDimensions = useMemo(() => {
     const visibleSet = new Set(readVisibleStandardIds());
@@ -194,7 +194,7 @@ export function ViolationsSubTabContent(props) {
 export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 0 }) {
   const { accumulatedDimensions = [], selectedProject, dismissRefreshKey = 0, selectedSource = 'local' } = data;
   const { projects = [], projectsLoaded, projectName, loading, isFetching } = data;
-  const { onNavigate, onRefresh } = callbacks;
+  const { onNavigate, onRefresh, onReconcile } = callbacks;
 
   // Fresh tab click (tabKey changed) drops the cached navigation state so
   // the user lands at the default sub-tab / root path. Round-tripping
@@ -211,6 +211,12 @@ export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 
     fileCurrentPath: '',
   });
 
+  // Fires on every mount, including plain drill-down/back navigation with no
+  // mutation involved (the page remounts on every round trip) -- onRefresh
+  // MUST stay the lazy refreshDashboard (mark-stale only). Do not wire this
+  // to an active-refetching callback (e.g. scheduleDashboardReconcile); that
+  // turns routine navigation into a forced re-download of the dashboard
+  // payload. See App.jsx's ViolationsRoute for the onRefresh/onReconcile split.
   useEffect(() => {
     onRefresh?.();
   }, [tabKey]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -225,6 +231,7 @@ export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 
     accumulatedDimensions,
     selectedProject,
     onRefresh,
+    onReconcile,
     initialSubTab: cached.activeSubTab,
     initialFilePath: cached.fileCurrentPath,
     dismissRefreshKey,

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.test.jsx
@@ -134,6 +134,28 @@ describe('ViolationsPage — teammate persona: shared selection + zero local pro
   });
 });
 
+// Item 1 regression: ViolationsPage fires its mount effect (onRefresh) on
+// EVERY mount, including plain drill-down/back navigation with no mutation
+// -- the page remounts on every round trip through a file/principle detail.
+// A prior revision wired the route's onRefresh to the ACTIVE
+// scheduleDashboardReconcile, turning routine navigation into a forced
+// refetch of the 10-20 MB dashboard payload (the freeze refetchType:'none'
+// exists to avoid). The mount effect must only ever reach onRefresh -- never
+// onReconcile, which is reserved for the Dismissed sub-tab's mutation
+// handlers (see useDismissedFindings.js).
+describe('ViolationsPage — mount-effect onRefresh does not reach onReconcile (Item 1 regression)', () => {
+  it('calls onRefresh on mount but never onReconcile, even though both are supplied', () => {
+    const onRefresh = vi.fn();
+    const onReconcile = vi.fn();
+    renderPage(
+      baseData({ selectedSource: 'local', selectedProject: 'p1', projects: [{ id: 'p1', name: 'p1' }] }),
+      { onRefresh, onReconcile },
+    );
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(onReconcile).not.toHaveBeenCalled();
+  });
+});
+
 describe('ViolationsPage — shared read-only chip (Finding 6)', () => {
   it('shows the chip for a shared project with data', () => {
     renderPage(baseData({

--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
@@ -13,7 +13,10 @@ import { confirmDialog } from '../../../utils/confirmDialog.js';
 
 /**
  * @param {string} selectedProject
- * @param {Function} [onRefresh]
+ * @param {Function} [onRefresh] - Called by every mutation handler below on
+ *   success. This is the lazy refreshDashboard (mark-stale, refetchType:
+ *   'none') threaded from App.jsx via ViolationsPage -- NOT the ACTIVE
+ *   reconcile; see `onReconcile` for that.
  * @param {Function} [setRestoreError]
  * @param {number} [refreshKey=0]
  * @param {'local'|'shared'} [selectedSource='local'] - Shared projects have no
@@ -24,8 +27,16 @@ import { confirmDialog } from '../../../utils/confirmDialog.js';
  *   handlers to the dismissed sub-tab, but this guard protects against a
  *   handler slipping through some other path and corrupting the local cache
  *   with shared-derived deltas (the local id can collide with a shared id).
+ * @param {Function} [onReconcile] - The debounced ACTIVE
+ *   scheduleDashboardReconcile (see useDashboard.js). Called IN ADDITION to
+ *   onRefresh by every mutation handler below, never in place of it.
+ *   restore-all/delete-all return a payload applyMutationDelta's gates can't
+ *   patch (scores:null, delta.isLatest:false), so onRefresh's lazy mark-stale
+ *   alone would leave the always-mounted Overview observer showing stale
+ *   data indefinitely; onReconcile actively refetches it after a short
+ *   debounce window.
  */
-export function useDismissedFindings(selectedProject, onRefresh, setRestoreError, refreshKey = 0, selectedSource = 'local') {
+export function useDismissedFindings(selectedProject, onRefresh, setRestoreError, refreshKey = 0, selectedSource = 'local', onReconcile) {
   const [dismissed, setDismissed] = useState([]);
   const queryClient = useQueryClient();
   const isShared = selectedSource === 'shared';
@@ -33,7 +44,7 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
   // Fold the mutation-delta from a restore/delete response into the React Query
   // caches so dimension scores/grades update instantly and the run-detail
   // violation lists get invalidated for a lazy refetch. Additive — the local
-  // setDismissed splices and onRefresh below still run.
+  // setDismissed splices and the onRefresh/onReconcile calls below still run.
   const applyDelta = useCallback((result) => {
     const delta = result?.delta;
     if (!delta) return;
@@ -60,11 +71,12 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
       applyDelta(result);
       setDismissed((prev) => prev.filter((item) => !(item.req === d.req && item.file === d.file && item.line === d.line)));
       onRefresh?.();
+      onReconcile?.();
     } catch (err) {
       console.error('Failed to restore finding:', err);
       setRestoreError?.('Failed to restore finding. Please try again.');
     }
-  }, [selectedProject, onRefresh, setRestoreError, applyDelta, isShared]);
+  }, [selectedProject, onRefresh, onReconcile, setRestoreError, applyDelta, isShared]);
 
   const handleRestoreAll = useCallback(async () => {
     if (isShared) return;
@@ -73,11 +85,12 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
       applyDelta(result);
       setDismissed([]);
       onRefresh?.();
+      onReconcile?.();
     } catch (err) {
       console.error('Failed to restore all findings:', err);
       setRestoreError?.('Failed to restore all findings. Please try again.');
     }
-  }, [selectedProject, onRefresh, setRestoreError, applyDelta, isShared]);
+  }, [selectedProject, onRefresh, onReconcile, setRestoreError, applyDelta, isShared]);
 
   const handleDelete = useCallback(async (d) => {
     if (isShared) return;
@@ -96,11 +109,12 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
         && item.file === d.file
       )));
       onRefresh?.();
+      onReconcile?.();
     } catch (err) {
       console.error('Failed to delete finding:', err);
       setRestoreError?.('Failed to delete finding. Please try again.');
     }
-  }, [selectedProject, onRefresh, setRestoreError, applyDelta, isShared]);
+  }, [selectedProject, onRefresh, onReconcile, setRestoreError, applyDelta, isShared]);
 
   const handleDeleteAll = useCallback(async () => {
     if (isShared) return;
@@ -118,11 +132,12 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
       applyDelta(result);
       setDismissed([]);
       onRefresh?.();
+      onReconcile?.();
     } catch (err) {
       console.error('Failed to delete all findings:', err);
       setRestoreError?.('Failed to delete all findings. Please try again.');
     }
-  }, [selectedProject, onRefresh, setRestoreError, dismissed.length, applyDelta, isShared]);
+  }, [selectedProject, onRefresh, onReconcile, setRestoreError, dismissed.length, applyDelta, isShared]);
 
   return { dismissed, handleRestore, handleRestoreAll, handleDelete, handleDeleteAll };
 }

--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
@@ -208,6 +208,129 @@ describe('useDismissedFindings — handleDeleteAll', () => {
   });
 });
 
+// Item 1 fix: onRefresh is now the lazy refreshDashboard (mark-stale only) --
+// wiring it to the ACTIVE scheduleDashboardReconcile forced a full refetch of
+// the 10-20 MB dashboard payload on every plain navigation remount (see
+// ViolationsPage's tabKey mount effect). The four mutation handlers below
+// must therefore call a SEPARATE onReconcile callback in addition to
+// onRefresh, so restore/delete still gets the debounced ACTIVE reconcile
+// without plain navigation triggering it.
+describe('useDismissedFindings — onReconcile (called alongside onRefresh, not instead of it)', () => {
+  it('handleRestore calls both onRefresh and onReconcile on success', async () => {
+    listDismissedFindings.mockResolvedValueOnce([sampleA]);
+    restoreFinding.mockResolvedValueOnce({ ok: true });
+    const onRefresh = vi.fn();
+    const onReconcile = vi.fn();
+    const { result } = renderHook(
+      () => useDismissedFindings('proj', onRefresh, vi.fn(), 0, 'local', onReconcile),
+      withQueryClient(),
+    );
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(1));
+
+    await act(async () => { await result.current.handleRestore(sampleA); });
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(onReconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it('handleRestore does not call onReconcile on failure', async () => {
+    listDismissedFindings.mockResolvedValueOnce([sampleA]);
+    restoreFinding.mockRejectedValueOnce(new Error('boom'));
+    const onReconcile = vi.fn();
+    const { result } = renderHook(
+      () => useDismissedFindings('proj', vi.fn(), vi.fn(), 0, 'local', onReconcile),
+      withQueryClient(),
+    );
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(1));
+
+    await act(async () => { await result.current.handleRestore(sampleA); });
+
+    expect(onReconcile).not.toHaveBeenCalled();
+  });
+
+  it('handleRestoreAll calls both onRefresh and onReconcile on success', async () => {
+    listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
+    restoreAllFindings.mockResolvedValueOnce({ ok: true, restored: 2 });
+    const onRefresh = vi.fn();
+    const onReconcile = vi.fn();
+    const { result } = renderHook(
+      () => useDismissedFindings('proj', onRefresh, vi.fn(), 0, 'local', onReconcile),
+      withQueryClient(),
+    );
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
+
+    await act(async () => { await result.current.handleRestoreAll(); });
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(onReconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it('handleDelete calls both onRefresh and onReconcile on success', async () => {
+    listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
+    deleteFinding.mockResolvedValueOnce({ ok: true, swept: 1 });
+    const onRefresh = vi.fn();
+    const onReconcile = vi.fn();
+    const { result } = renderHook(
+      () => useDismissedFindings('proj', onRefresh, vi.fn(), 0, 'local', onReconcile),
+      withQueryClient(),
+    );
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
+
+    await act(async () => { await result.current.handleDelete(sampleA); });
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(onReconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it('handleDeleteAll calls both onRefresh and onReconcile on success', async () => {
+    listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
+    confirmDialog.mockResolvedValueOnce(true);
+    deleteAllFindings.mockResolvedValueOnce({ ok: true, deleted: 2 });
+    const onRefresh = vi.fn();
+    const onReconcile = vi.fn();
+    const { result } = renderHook(
+      () => useDismissedFindings('proj', onRefresh, vi.fn(), 0, 'local', onReconcile),
+      withQueryClient(),
+    );
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
+
+    await act(async () => { await result.current.handleDeleteAll(); });
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(onReconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it('handleDeleteAll does not call onReconcile when the user cancels', async () => {
+    listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
+    confirmDialog.mockResolvedValueOnce(false);
+    const onReconcile = vi.fn();
+    const { result } = renderHook(
+      () => useDismissedFindings('proj', vi.fn(), vi.fn(), 0, 'local', onReconcile),
+      withQueryClient(),
+    );
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
+
+    await act(async () => { await result.current.handleDeleteAll(); });
+
+    expect(onReconcile).not.toHaveBeenCalled();
+  });
+
+  it('works fine when onReconcile is omitted (optional param, back-compat)', async () => {
+    listDismissedFindings.mockResolvedValueOnce([sampleA]);
+    restoreFinding.mockResolvedValueOnce({ ok: true });
+    const onRefresh = vi.fn();
+    const { result } = renderHook(
+      () => useDismissedFindings('proj', onRefresh, vi.fn()),
+      withQueryClient(),
+    );
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(1));
+
+    await act(async () => { await result.current.handleRestore(sampleA); });
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+});
+
 // Shared projects have no mutation routes on the backend (dismiss/restore/
 // delete are local-only by design, and the same project id can exist in both
 // worlds). The dismissed list must read from the shared-repo mirror endpoint,

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -118,7 +118,7 @@ export function useAppState() {
   // usually nearly identical. The dashboard-refreshing class dims the
   // page during the background refetch so the user sees that something
   // is happening without the jarring full-screen LoadingScreen.
-  const { dashboard, accumulated, latestAccumulated, rescoreLookup, loading, isFetching, error, availableRuns, refreshDashboard, refreshDashboardActive, sharedProjectInfo } = useDashboard({
+  const { dashboard, accumulated, latestAccumulated, rescoreLookup, loading, isFetching, error, availableRuns, refreshDashboard, refreshDashboardActive, scheduleDashboardReconcile, sharedProjectInfo } = useDashboard({
     selectedProject,
     selectedRun: effectiveRun,
     selectedSource,
@@ -165,7 +165,7 @@ export function useAppState() {
     currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect, prefetchHandlers,
     headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId,
     historySelectedRun, setHistorySelectedRun,
-    evalLifecycle, settings, activeTab, showProjectHeader, showRunNav, refreshDashboard,
+    evalLifecycle, settings, activeTab, showProjectHeader, showRunNav, refreshDashboard, scheduleDashboardReconcile,
     granularity, onGranularityChange: handleGranularityChange,
   };
 }

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -1,8 +1,10 @@
 import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useDashboard } from '../features/dashboard/hooks/useDashboard.js';
 import { usePrefetchAdjacentRuns } from '../features/dashboard/hooks/usePrefetchAdjacentRuns.js';
 import { buildPeriodRuns } from '../utils/dailyGrouping.js';
 import { readScoreHistoryGranularity, writeScoreHistoryGranularity } from '../utils/scoreHistoryPrefs.js';
+import { projectKeys } from '../api/queryKeys.js';
 import { useServerHealth } from './useServerHealth.js';
 import { useNavStack } from './useNavStack.js';
 import { useRunNavigator } from './useRunNavigator.js';
@@ -94,6 +96,32 @@ export function formatDayLabel(trend, currentOverviewRun, dailyRuns, overviewRun
   return dailyRuns[overviewRunIndex]?.dateLabel || currentOverviewRun;
 }
 
+// Returning to the Overview from another tab must reconcile any project query
+// a mark-stale-only invalidation left behind (refreshDashboard's
+// refetchType:'none', or ordinary staleTime elapse): the Overview's
+// useDashboard observer is mounted at the app root and never remounts on tab
+// navigation (see the eval-completion effect below), and the desktop
+// pywebview window never fires the focus-refetch a browser tab gets on
+// refocus. `stale: true` keeps this a no-op when nothing is actually stale,
+// so switching tabs doesn't re-download the (potentially 10-20 MB) payload
+// on every visit — only a query already marked stale gets refetched here.
+// Exported (and taking plain values rather than reading nav state itself) so
+// the transition-gating logic is testable without mounting all of useAppState.
+export function useOverviewReturnReconcile({ activeTab, selectedProject, selectedSource }) {
+  const queryClient = useQueryClient();
+  const prevTabRef = useRef(activeTab);
+  useEffect(() => {
+    const cameToOverview = prevTabRef.current !== TAB_OVERVIEW && activeTab === TAB_OVERVIEW;
+    prevTabRef.current = activeTab;
+    if (!cameToOverview || !selectedProject) return;
+    queryClient.refetchQueries({
+      queryKey: projectKeys.project(selectedProject, selectedSource),
+      stale: true,
+      type: 'active',
+    });
+  }, [activeTab, selectedProject, selectedSource, queryClient]);
+}
+
 export function useAppState() {
   const nav = useAppNavigation();
   const { serverConnected, setServerConnected, serverVersion, navStack, activePage, navPop, navGoTo, navReset, navTab, projectBundle, handleNavigate, handleNavigateReplace, handleRunChange, historySelectedRun, setHistorySelectedRun } = nav;
@@ -156,6 +184,8 @@ export function useAppState() {
     : TAB_OVERVIEW;
   const showProjectHeader = PROJECT_TABS.includes(activeTab) && projects.length > 0 && !!selectedProject;
   const showRunNav = activeTab === TAB_OVERVIEW && showProjectHeader && visibleDailyRuns.length > 0 && navStack.length === 1;
+
+  useOverviewReturnReconcile({ activeTab, selectedProject, selectedSource });
 
   return {
     serverConnected, setServerConnected, serverVersion, navStack, activePage, navPop, navGoTo, navTab,

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -105,21 +105,32 @@ export function formatDayLabel(trend, currentOverviewRun, dailyRuns, overviewRun
 // refocus. `stale: true` keeps this a no-op when nothing is actually stale,
 // so switching tabs doesn't re-download the (potentially 10-20 MB) payload
 // on every visit — only a query already marked stale gets refetched here.
+//
+// Gates on `rootTab` (navStack[0].page), NOT the derived `activeTab`.
+// `activeTab`'s fallback bucket defaults any untagged/unknown page to
+// TAB_OVERVIEW -- and drill-down pages pushed without a `sourceTab` (e.g.
+// ExplorerPage's onPrincipleClick -> 'evalprinciple', handleCardNavigate ->
+// 'file') hit that fallback while the user is still mid-triage inside
+// Violations/Map. That would misfire a real refetch of the (potentially
+// 10-20 MB) payload during triage -- exactly the freeze this stack exists to
+// avoid. `navTab()` (useNavStack.js) always resets the stack to a single root
+// entry and `navPush` only appends, so `navStack[0].page` is the true
+// top-level tab regardless of drill-down depth or sourceTab tagging.
 // Exported (and taking plain values rather than reading nav state itself) so
 // the transition-gating logic is testable without mounting all of useAppState.
-export function useOverviewReturnReconcile({ activeTab, selectedProject, selectedSource }) {
+export function useOverviewReturnReconcile({ rootTab, selectedProject, selectedSource }) {
   const queryClient = useQueryClient();
-  const prevTabRef = useRef(activeTab);
+  const prevTabRef = useRef(rootTab);
   useEffect(() => {
-    const cameToOverview = prevTabRef.current !== TAB_OVERVIEW && activeTab === TAB_OVERVIEW;
-    prevTabRef.current = activeTab;
+    const cameToOverview = prevTabRef.current !== TAB_OVERVIEW && rootTab === TAB_OVERVIEW;
+    prevTabRef.current = rootTab;
     if (!cameToOverview || !selectedProject) return;
     queryClient.refetchQueries({
       queryKey: projectKeys.project(selectedProject, selectedSource),
       stale: true,
       type: 'active',
     });
-  }, [activeTab, selectedProject, selectedSource, queryClient]);
+  }, [rootTab, selectedProject, selectedSource, queryClient]);
 }
 
 export function useAppState() {
@@ -185,7 +196,7 @@ export function useAppState() {
   const showProjectHeader = PROJECT_TABS.includes(activeTab) && projects.length > 0 && !!selectedProject;
   const showRunNav = activeTab === TAB_OVERVIEW && showProjectHeader && visibleDailyRuns.length > 0 && navStack.length === 1;
 
-  useOverviewReturnReconcile({ activeTab, selectedProject, selectedSource });
+  useOverviewReturnReconcile({ rootTab: navStack[0]?.page, selectedProject, selectedSource });
 
   return {
     serverConnected, setServerConnected, serverVersion, navStack, activePage, navPop, navGoTo, navTab,

--- a/src/quodeq/ui/src/hooks/useAppState.test.jsx
+++ b/src/quodeq/ui/src/hooks/useAppState.test.jsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useOverviewReturnReconcile, TAB_OVERVIEW } from './useAppState.js';
+import { useDashboard } from '../features/dashboard/hooks/useDashboard.js';
+import { ApiProvider } from '../api/ApiContext.jsx';
+import { projectKeys } from '../api/queryKeys.js';
+
+// Task 2 (stacked on Task 1's scheduleDashboardReconcile): the Overview's
+// useDashboard observer is mounted at the app root and never remounts on tab
+// navigation, and the desktop pywebview window never fires the focus-refetch
+// a browser tab gets on refocus. useOverviewReturnReconcile is the second
+// layer -- an explicit active refetch of already-stale project queries when
+// the user navigates BACK to the Overview, gated so it never re-downloads a
+// fresh (unexpired staleTime) payload on every tab switch.
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  });
+}
+
+function renderReconcile(initialProps) {
+  const client = makeClient();
+  const spy = vi.spyOn(client, 'refetchQueries');
+  const { result, rerender } = renderHook(
+    (props) => useOverviewReturnReconcile(props),
+    {
+      wrapper: ({ children }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>,
+      initialProps,
+    },
+  );
+  return { client, spy, result, rerender };
+}
+
+describe('useOverviewReturnReconcile transition gating', () => {
+  it('calls refetchQueries with {stale:true, type:"active"} and the project key on a transition INTO the overview tab', () => {
+    const { spy, rerender } = renderReconcile({ activeTab: 'violations', selectedProject: 'p1', selectedSource: 'local' });
+    expect(spy).not.toHaveBeenCalled();
+
+    rerender({ activeTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const arg = spy.mock.calls[0][0];
+    expect(arg.stale).toBe(true);
+    expect(arg.type).toBe('active');
+    expect(arg.queryKey).toEqual(projectKeys.project('p1', 'local'));
+  });
+
+  it('does NOT call refetchQueries on initial mount even when the starting tab is overview', () => {
+    const { spy } = renderReconcile({ activeTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call refetchQueries on a transition between two non-overview tabs', () => {
+    const { spy, rerender } = renderReconcile({ activeTab: 'violations', selectedProject: 'p1', selectedSource: 'local' });
+    rerender({ activeTab: 'map', selectedProject: 'p1', selectedSource: 'local' });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call refetchQueries on a transition AWAY from the overview tab', () => {
+    const { spy, rerender } = renderReconcile({ activeTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
+    rerender({ activeTab: 'violations', selectedProject: 'p1', selectedSource: 'local' });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call refetchQueries on a transition into overview when there is no selected project', () => {
+    const { spy, rerender } = renderReconcile({ activeTab: 'violations', selectedProject: '', selectedSource: 'local' });
+    rerender({ activeTab: TAB_OVERVIEW, selectedProject: '', selectedSource: 'local' });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('re-fires on a subsequent transition back into overview after leaving again', () => {
+    const { spy, rerender } = renderReconcile({ activeTab: 'violations', selectedProject: 'p1', selectedSource: 'local' });
+    rerender({ activeTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
+    expect(spy).toHaveBeenCalledTimes(1);
+    rerender({ activeTab: 'violations', selectedProject: 'p1', selectedSource: 'local' });
+    rerender({ activeTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});
+
+// Integration: prove the `stale: true` filter actually does the work end to
+// end against a real useDashboard-mounted query, not just that the right
+// arguments are passed. This is the seam the brief calls out explicitly: a
+// FRESH query (within staleTime) must not trigger a re-download of the
+// (potentially 10-20 MB) dashboard payload on a tab-switch round trip.
+function makeFakeApi() {
+  return {
+    getDashboard: vi.fn(async (project, run) => ({
+      project, run: run || 'latest', trend: [], summary: { score: 75 }, dimensions: [],
+      selectedRun: { runId: 'r1', dateLabel: '2026-05-01' },
+    })),
+    sharedGetDashboard: vi.fn(),
+    getProjectScores: vi.fn(async () => ({ accumulated: { score: 90 }, trend: [], availableRuns: [] })),
+    sharedGetProjectScores: vi.fn(),
+    sharedGetProjectInfo: vi.fn(),
+  };
+}
+
+function useCombined({ activeTab, selectedProject, selectedSource }) {
+  const dash = useDashboard({ selectedProject, selectedRun: null, selectedSource });
+  useOverviewReturnReconcile({ activeTab, selectedProject, selectedSource });
+  return dash;
+}
+
+function renderCombined(client, fakeApi, initialProps) {
+  return renderHook((props) => useCombined(props), {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={client}>
+        <ApiProvider value={fakeApi}>{children}</ApiProvider>
+      </QueryClientProvider>
+    ),
+    initialProps,
+  });
+}
+
+describe('useOverviewReturnReconcile integration with useDashboard (stale gating)', () => {
+  it('does NOT refetch when the project query is still fresh (within staleTime)', async () => {
+    const client = makeClient();
+    const fakeApi = makeFakeApi();
+    const { result, rerender } = renderCombined(client, fakeApi, {
+      activeTab: 'violations', selectedProject: 'p1', selectedSource: 'local',
+    });
+    await waitFor(() => expect(result.current.dashboard).not.toBeNull());
+    expect(fakeApi.getDashboard).toHaveBeenCalledTimes(1);
+
+    rerender({ activeTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
+    // Give any errant refetch a chance to fire, then assert it didn't.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(fakeApi.getDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  it('DOES refetch when the project query was marked stale (refetchType:"none" invalidation, e.g. after a dismiss)', async () => {
+    const client = makeClient();
+    const fakeApi = makeFakeApi();
+    const { result, rerender } = renderCombined(client, fakeApi, {
+      activeTab: 'violations', selectedProject: 'p1', selectedSource: 'local',
+    });
+    await waitFor(() => expect(result.current.dashboard).not.toBeNull());
+    expect(fakeApi.getDashboard).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await client.invalidateQueries({ queryKey: projectKeys.project('p1', 'local'), refetchType: 'none' });
+    });
+
+    rerender({ activeTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
+
+    await waitFor(() => expect(fakeApi.getDashboard).toHaveBeenCalledTimes(2));
+  });
+});

--- a/src/quodeq/ui/src/hooks/useAppState.test.jsx
+++ b/src/quodeq/ui/src/hooks/useAppState.test.jsx
@@ -2,7 +2,8 @@ import { describe, it, expect, vi } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useOverviewReturnReconcile, TAB_OVERVIEW } from './useAppState.js';
+import { useOverviewReturnReconcile, TAB_OVERVIEW, KNOWN_TABS } from './useAppState.js';
+import { useNavStack } from './useNavStack.js';
 import { useDashboard } from '../features/dashboard/hooks/useDashboard.js';
 import { ApiProvider } from '../api/ApiContext.jsx';
 import { projectKeys } from '../api/queryKeys.js';
@@ -14,6 +15,13 @@ import { projectKeys } from '../api/queryKeys.js';
 // layer -- an explicit active refetch of already-stale project queries when
 // the user navigates BACK to the Overview, gated so it never re-downloads a
 // fresh (unexpired staleTime) payload on every tab switch.
+//
+// Gates on `rootTab` (navStack[0].page), NOT the derived `activeTab` --
+// `activeTab` defaults any untagged/unknown drill-down page (e.g.
+// ExplorerPage's onPrincipleClick -> 'evalprinciple', handleCardNavigate ->
+// 'file', both pushed without a `sourceTab`) to TAB_OVERVIEW, which would
+// misfire a real refetch mid-triage inside Violations/Map. `navStack[0].page`
+// is stable across drill-down depth because navPush only appends.
 
 function makeClient() {
   return new QueryClient({
@@ -36,10 +44,10 @@ function renderReconcile(initialProps) {
 
 describe('useOverviewReturnReconcile transition gating', () => {
   it('calls refetchQueries with {stale:true, type:"active"} and the project key on a transition INTO the overview tab', () => {
-    const { spy, rerender } = renderReconcile({ activeTab: 'violations', selectedProject: 'p1', selectedSource: 'local' });
+    const { spy, rerender } = renderReconcile({ rootTab: 'violations', selectedProject: 'p1', selectedSource: 'local' });
     expect(spy).not.toHaveBeenCalled();
 
-    rerender({ activeTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
+    rerender({ rootTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
 
     expect(spy).toHaveBeenCalledTimes(1);
     const arg = spy.mock.calls[0][0];
@@ -49,35 +57,128 @@ describe('useOverviewReturnReconcile transition gating', () => {
   });
 
   it('does NOT call refetchQueries on initial mount even when the starting tab is overview', () => {
-    const { spy } = renderReconcile({ activeTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
+    const { spy } = renderReconcile({ rootTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
     expect(spy).not.toHaveBeenCalled();
   });
 
   it('does NOT call refetchQueries on a transition between two non-overview tabs', () => {
-    const { spy, rerender } = renderReconcile({ activeTab: 'violations', selectedProject: 'p1', selectedSource: 'local' });
-    rerender({ activeTab: 'map', selectedProject: 'p1', selectedSource: 'local' });
+    const { spy, rerender } = renderReconcile({ rootTab: 'violations', selectedProject: 'p1', selectedSource: 'local' });
+    rerender({ rootTab: 'map', selectedProject: 'p1', selectedSource: 'local' });
     expect(spy).not.toHaveBeenCalled();
   });
 
   it('does NOT call refetchQueries on a transition AWAY from the overview tab', () => {
-    const { spy, rerender } = renderReconcile({ activeTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
-    rerender({ activeTab: 'violations', selectedProject: 'p1', selectedSource: 'local' });
+    const { spy, rerender } = renderReconcile({ rootTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
+    rerender({ rootTab: 'violations', selectedProject: 'p1', selectedSource: 'local' });
     expect(spy).not.toHaveBeenCalled();
   });
 
   it('does NOT call refetchQueries on a transition into overview when there is no selected project', () => {
-    const { spy, rerender } = renderReconcile({ activeTab: 'violations', selectedProject: '', selectedSource: 'local' });
-    rerender({ activeTab: TAB_OVERVIEW, selectedProject: '', selectedSource: 'local' });
+    const { spy, rerender } = renderReconcile({ rootTab: 'violations', selectedProject: '', selectedSource: 'local' });
+    rerender({ rootTab: TAB_OVERVIEW, selectedProject: '', selectedSource: 'local' });
     expect(spy).not.toHaveBeenCalled();
   });
 
   it('re-fires on a subsequent transition back into overview after leaving again', () => {
-    const { spy, rerender } = renderReconcile({ activeTab: 'violations', selectedProject: 'p1', selectedSource: 'local' });
-    rerender({ activeTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
+    const { spy, rerender } = renderReconcile({ rootTab: 'violations', selectedProject: 'p1', selectedSource: 'local' });
+    rerender({ rootTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
     expect(spy).toHaveBeenCalledTimes(1);
-    rerender({ activeTab: 'violations', selectedProject: 'p1', selectedSource: 'local' });
-    rerender({ activeTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
+    rerender({ rootTab: 'violations', selectedProject: 'p1', selectedSource: 'local' });
+    rerender({ rootTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
     expect(spy).toHaveBeenCalledTimes(2);
+  });
+});
+
+// Regression (reviewer finding): a drill-down page pushed without a
+// `sourceTab` -- exactly what ExplorerPage.jsx's onPrincipleClick
+// ('evalprinciple') and handleCardNavigate ('file') do -- must NOT be
+// misread as "the user returned to the Overview". The old implementation
+// consumed the derived `activeTab`, whose fallback bucket defaults any
+// untagged/unknown page to TAB_OVERVIEW; drilling from Violations into an
+// untagged 'evalprinciple'/'file' page flipped activeTab to 'overview' while
+// the user was still mid-triage, misfiring a real refetch of the (10-20 MB)
+// payload. This composes the REAL useNavStack with the hook, replaying the
+// exact push sequence from the bug report, and asserts navStack[0].page
+// (rootTab) never leaves 'violations' -- so no refetch fires.
+describe('useOverviewReturnReconcile regression: untagged drill-down pages do not misfire', () => {
+  function fakeHistoryAdapter() {
+    return { pushState: vi.fn(), replaceState: vi.fn(), back: vi.fn(), go: vi.fn() };
+  }
+
+  function useRealNavRootTab() {
+    const { navStack, navTab, navPush } = useNavStack({ historyAdapter: fakeHistoryAdapter() });
+    return { rootTab: navStack[0]?.page, navStack, navTab, navPush };
+  }
+
+  function renderScenario() {
+    const client = makeClient();
+    const spy = vi.spyOn(client, 'refetchQueries');
+    const { result } = renderHook(
+      () => {
+        const nav = useRealNavRootTab();
+        useOverviewReturnReconcile({ rootTab: nav.rootTab, selectedProject: 'p1', selectedSource: 'local' });
+        return nav;
+      },
+      { wrapper: ({ children }) => <QueryClientProvider client={client}>{children}</QueryClientProvider> },
+    );
+    return { result, spy };
+  }
+
+  it('does NOT refetch when drilling from Violations into an untagged evalprinciple page (ExplorerPage.onPrincipleClick)', () => {
+    const { result, spy } = renderScenario();
+
+    act(() => { result.current.navTab('violations'); });
+    expect(result.current.rootTab).toBe('violations');
+
+    // ExplorerPage mounted with sourceTab, as App.jsx wires it.
+    act(() => { result.current.navPush({ page: 'explorer', sourceTab: 'violations', dimension: 'Security' }); });
+    expect(result.current.rootTab).toBe('violations');
+
+    // ExplorerPage.onPrincipleClick -> onNavigate('evalprinciple', { evalPrincipal }) -- NO sourceTab.
+    act(() => { result.current.navPush({ page: 'evalprinciple', evalPrincipal: { principle: 'P' } }); });
+
+    expect(result.current.rootTab).toBe('violations'); // never misclassified as overview
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT refetch when drilling from Violations into an untagged file page (ExplorerPage.handleCardNavigate)', () => {
+    const { result, spy } = renderScenario();
+
+    act(() => { result.current.navTab('violations'); });
+    act(() => { result.current.navPush({ page: 'explorer', sourceTab: 'violations', dimension: 'Security' }); });
+    // ExplorerPage.handleCardNavigate -> onNavigate('file', { file, severityFilter, runId, dateLabel }) -- NO sourceTab.
+    act(() => { result.current.navPush({ page: 'file', file: { path: 'a.py' }, severityFilter: 'all' }); });
+
+    expect(result.current.rootTab).toBe('violations');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  // Documents WHY rootTab (not activeTab) is required: useAppState.js's
+  // activeTab fallback formula, replayed here verbatim against the exact
+  // untagged 'evalprinciple' page ExplorerPage.onPrincipleClick pushes,
+  // resolves to TAB_OVERVIEW -- the misclassification the reviewer flagged.
+  it('the legacy activeTab-fallback formula misclassifies the same untagged page as overview', () => {
+    const activePage = { page: 'evalprinciple', evalPrincipal: { principle: 'P' } };
+    const legacyActiveTab = KNOWN_TABS.includes(activePage.page) ? activePage.page
+      : activePage.sourceTab && KNOWN_TABS.includes(activePage.sourceTab) ? activePage.sourceTab
+      : activePage.page === 'history-run' ? 'history'
+      : TAB_OVERVIEW;
+    expect(legacyActiveTab).toBe(TAB_OVERVIEW);
+  });
+
+  it('still refetches on a genuine return to Overview after the same drill-down', () => {
+    const { result, spy } = renderScenario();
+
+    act(() => { result.current.navTab('violations'); });
+    act(() => { result.current.navPush({ page: 'explorer', sourceTab: 'violations', dimension: 'Security' }); });
+    act(() => { result.current.navPush({ page: 'evalprinciple', evalPrincipal: { principle: 'P' } }); });
+    expect(spy).not.toHaveBeenCalled();
+
+    // User backs out and picks the Overview tab from the sidebar.
+    act(() => { result.current.navTab('overview'); });
+
+    expect(result.current.rootTab).toBe(TAB_OVERVIEW);
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -99,9 +200,9 @@ function makeFakeApi() {
   };
 }
 
-function useCombined({ activeTab, selectedProject, selectedSource }) {
+function useCombined({ rootTab, selectedProject, selectedSource }) {
   const dash = useDashboard({ selectedProject, selectedRun: null, selectedSource });
-  useOverviewReturnReconcile({ activeTab, selectedProject, selectedSource });
+  useOverviewReturnReconcile({ rootTab, selectedProject, selectedSource });
   return dash;
 }
 
@@ -121,12 +222,12 @@ describe('useOverviewReturnReconcile integration with useDashboard (stale gating
     const client = makeClient();
     const fakeApi = makeFakeApi();
     const { result, rerender } = renderCombined(client, fakeApi, {
-      activeTab: 'violations', selectedProject: 'p1', selectedSource: 'local',
+      rootTab: 'violations', selectedProject: 'p1', selectedSource: 'local',
     });
     await waitFor(() => expect(result.current.dashboard).not.toBeNull());
     expect(fakeApi.getDashboard).toHaveBeenCalledTimes(1);
 
-    rerender({ activeTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
+    rerender({ rootTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
     // Give any errant refetch a chance to fire, then assert it didn't.
     await new Promise((r) => setTimeout(r, 50));
     expect(fakeApi.getDashboard).toHaveBeenCalledTimes(1);
@@ -136,7 +237,7 @@ describe('useOverviewReturnReconcile integration with useDashboard (stale gating
     const client = makeClient();
     const fakeApi = makeFakeApi();
     const { result, rerender } = renderCombined(client, fakeApi, {
-      activeTab: 'violations', selectedProject: 'p1', selectedSource: 'local',
+      rootTab: 'violations', selectedProject: 'p1', selectedSource: 'local',
     });
     await waitFor(() => expect(result.current.dashboard).not.toBeNull());
     expect(fakeApi.getDashboard).toHaveBeenCalledTimes(1);
@@ -145,7 +246,7 @@ describe('useOverviewReturnReconcile integration with useDashboard (stale gating
       await client.invalidateQueries({ queryKey: projectKeys.project('p1', 'local'), refetchType: 'none' });
     });
 
-    rerender({ activeTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
+    rerender({ rootTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
 
     await waitFor(() => expect(fakeApi.getDashboard).toHaveBeenCalledTimes(2));
   });


### PR DESCRIPTION
Stacks on #873. Fixes the UI side of the dismiss inconsistencies: after restore-all (and other suppression mutations) the dashboard never pulled the corrected state, and the Overview card lagged behind the dimension detail after a dismiss.

## Why nothing updated

Restore-all sends no run_id, so the server responds `scores: null, delta{runId: null, isLatest: false}` and `applyMutationDelta` no-ops on exactly that shape. The only fallback marked queries stale with `refetchType: 'none'`, but the Overview observer is mounted at the app root and never remounts, and the desktop webview never fires the focus refetch. Net effect: restored findings appeared nowhere until an app switch. The original reason for never refetching (a ~100s recompute) is gone since #873 made it seconds.

## Fix (three layers, delta patching untouched)

1. `scheduleDashboardReconcile`: after dismiss/restore/delete/restore-all/delete-all, mark the project subtree stale immediately, then fire one debounced (1.2s) active invalidation. Rapid multi-dismiss coalesces into a single refetch. Plain navigation stays on mark-stale only (the Dismissed tab's mount-refresh keeps the old lazy behavior; mutations get a dedicated `onReconcile` callback).
2. Returning to the Overview refetches stale project queries (`stale: true`, so fresh data is never re-downloaded). Gated on the nav-stack root, not the derived tab value, so drill-down pages that default into the overview bucket cannot misfire it.
3. Existing instant delta patches keep working as before.

## Verified live (isolated stack, headless chromium)

- Restore-all of 4 dismissed findings: accumulated violations badge updated 894 -> 898 in 5.0s with zero navigation and zero focus events.
- Dismiss from a dimension detail: Overview card updated ~7s after returning (debounce + the cold recompute from #873's residual).
- Zero console errors. Full UI suite 1271 passed (166 files); backend suite unchanged (4997 passed).

## Follow-ups noted

- The assistant-action-applied handler is the same bug class when its delta is inapplicable (pre-existing; one-line wire + test).
- ci report / SARIF summaries still show scan-time scores next to filtered violation lists (backend follow-up from #873).
