### PR TITLE
fix(ui): reconcile the dashboard after an assistant-applied dismiss

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -710,6 +710,75 @@ export function buildAssistantSessionPayload({ provider, model, projectId, runId
 }
 
 /**
+ * Handler for the `quodeq:assistant-action-applied` window event, which the
+ * assistant's ActionPreviewCard dispatches after a successful apply.
+ *
+ * Extracted and exported so the post-dismiss convergence contract can be
+ * pinned without mounting App (which needs ~8 providers). An assistant
+ * dismiss mutates exactly the payloads a manual dismiss does, so it owes the
+ * same three follow-ups — see the inline notes on each.
+ *
+ * @param {{
+ *   applyDelta: (project: string, scores: Object, delta: Object) => void,
+ *   bumpDismissRefresh: () => void,
+ *   refreshDashboard?: () => void,
+ *   scheduleDashboardReconcile?: () => void,
+ *   selectedProject: string,
+ * }} deps
+ * @returns {(event: CustomEvent) => void}
+ */
+export function buildAssistantActionAppliedHandler({
+  applyDelta,
+  bumpDismissRefresh,
+  refreshDashboard,
+  scheduleDashboardReconcile,
+  selectedProject,
+}) {
+  return (event) => {
+    if (event.detail?.actionType !== 'dismiss_finding') return;
+    // Apply the delta first so the currently-visible screen patches in place
+    // immediately; the refresh/reconcile below are the eventual-correctness
+    // path (e.g. for views the delta doesn't cover).
+    // Prefer the delta's own project over the live selectedProject: the
+    // apply POST may resolve after the user switched projects, and the
+    // delta is frozen to the action's project. Keying the patch on the
+    // live selection would write project A's rollup into project B's cache.
+    if (event.detail.delta) {
+      try {
+        applyDelta(
+          event.detail.delta?.project || selectedProject,
+          event.detail.scores,
+          event.detail.delta,
+        );
+      } catch {
+        // Instant patch is best-effort; the refresh/reconcile are the fallback.
+      }
+    }
+    bumpDismissRefresh();
+    // Invalidate the project queries so frozen run views (staleTime Infinity)
+    // refetch on their next mount instead of showing the pre-dismiss counts
+    // forever. Mark-stale only (refetchType:'none'), so this is cheap.
+    refreshDashboard?.();
+    // ...and actively reconcile, exactly as the manual dismiss handlers do
+    // (see useDismissedFindings.js). Mark-stale alone never reaches the
+    // Overview: its useDashboard observer is mounted at the app root and
+    // never remounts, and the pywebview window never fires the focus-refetch
+    // a browser tab gets. So for any view the delta above doesn't cover --
+    // and for an assistant dismiss that returns no delta at all -- the
+    // visible screen would keep showing pre-dismiss numbers indefinitely,
+    // which reads as "nothing updated". Debounced, so a multi-action apply
+    // coalesces into one refetch of the 10-20 MB payload.
+    //
+    // Unlike applyDelta this keys on the LIVE selectedProject rather than the
+    // delta's frozen project, matching refreshDashboard. That is safe here
+    // where it wouldn't be above: reconciling is a refetch, so aiming it at
+    // the wrong project after a mid-flight switch merely re-pulls fresh data;
+    // it never writes one project's rollup into another's cache.
+    scheduleDashboardReconcile?.();
+  };
+}
+
+/**
  * @param {{ activePage: { page: string }, props: Object }} params
  * @returns {JSX.Element|null}
  */
@@ -774,44 +843,27 @@ export default function App() {
   // fetched once on mount.
   const [dismissRefreshKey, setDismissRefreshKey] = useState(0);
   const bumpDismissRefresh = () => setDismissRefreshKey((k) => k + 1);
-  const { refreshDashboard: refreshDashboardForApply, selectedProject } = state;
+  const {
+    refreshDashboard: refreshDashboardForApply,
+    scheduleDashboardReconcile: scheduleReconcileForApply,
+    selectedProject,
+  } = state;
   // Shared with the manual dismiss handlers below (buildDismissPayload
   // callers). Patches the dashboard/scores caches from a dismiss response's
   // delta so the Overview updates instantly instead of waiting on a refetch.
   const applyDelta = (project, scores, delta) =>
     applyMutationDelta(queryClient, project, delta && { ...delta, dimensions: scores?.dimensions });
   useEffect(() => {
-    const handler = (event) => {
-      if (event.detail?.actionType === 'dismiss_finding') {
-        // Apply the delta first so the currently-visible screen patches in
-        // place immediately; the refresh/refetch below is the lazy,
-        // eventual-correctness path (e.g. for views the delta doesn't cover).
-        // Prefer the delta's own project over the live selectedProject: the
-        // apply POST may resolve after the user switched projects, and the
-        // delta is frozen to the action's project. Keying the patch on the
-        // live selection would write project A's rollup into project B's cache.
-        if (event.detail.delta) {
-          try {
-            applyDelta(
-              event.detail.delta?.project || selectedProject,
-              event.detail.scores,
-              event.detail.delta,
-            );
-          } catch {
-            // Instant patch is best-effort; the lazy refresh below is the fallback.
-          }
-        }
-        bumpDismissRefresh();
-        // Assistant-applied dismissals mutate the same payloads manual ones
-        // do; invalidate the project queries so frozen run views (staleTime
-        // Infinity) refetch on their next mount instead of showing the
-        // pre-dismiss counts forever.
-        refreshDashboardForApply?.();
-      }
-    };
+    const handler = buildAssistantActionAppliedHandler({
+      applyDelta,
+      bumpDismissRefresh,
+      refreshDashboard: refreshDashboardForApply,
+      scheduleDashboardReconcile: scheduleReconcileForApply,
+      selectedProject,
+    });
     window.addEventListener('quodeq:assistant-action-applied', handler);
     return () => window.removeEventListener('quodeq:assistant-action-applied', handler);
-  }, [refreshDashboardForApply, selectedProject]);
+  }, [refreshDashboardForApply, scheduleReconcileForApply, selectedProject]);
   // Auto-open is a once-per-session decision. Without this guard, closing the
   // wizard sets wizardEntry → null, which re-fires this effect and re-opens
   // the wizard immediately because projects.length is still 0. The user's

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -5,7 +5,7 @@ import {
   buildEvalPrincipal, ROUTE_RENDERERS, isSharedSource, shouldBounceToEvaluate, shouldShowEvaluateButton,
   resolveSelectionAfterSharedDisconnect, shouldAutoOpenOnboardingWizard, shouldRedirectToRemoteRepositories, shouldShowProjectTabs,
   buildNavigationBundle, shouldWallEmptyProjects, buildWizardHandlers, buildAssistantSessionPayload,
-  resolveProjectDisplayName,
+  buildAssistantActionAppliedHandler, resolveProjectDisplayName,
 } from './App.jsx';
 import Sidebar from './components/Sidebar.jsx';
 
@@ -232,6 +232,93 @@ describe('ViolationsRoute onRefresh/onReconcile wiring (Dismissed tab reconcile)
     const props = violationsProps();
     const inner = renderViolationsRoute(props);
     expect(inner.props.callbacks.onReconcile).toBe(props.scheduleDashboardReconcile);
+  });
+});
+
+// An assistant-applied dismiss mutates exactly the payloads a manual dismiss
+// does, so it owes the same convergence follow-ups the manual paths got: the
+// instant delta patch, the dismissed-list bump, the lazy mark-stale, AND the
+// debounced ACTIVE reconcile. The reconcile is the one that reaches the
+// Overview -- its useDashboard observer is mounted at the app root and never
+// remounts, and pywebview never fires a focus-refetch -- so without it, any
+// view the delta doesn't cover keeps showing pre-dismiss numbers, which is
+// the "nothing updated" symptom the manual paths were fixed for.
+describe('buildAssistantActionAppliedHandler', () => {
+  function deps(overrides = {}) {
+    return {
+      applyDelta: vi.fn(),
+      bumpDismissRefresh: vi.fn(),
+      refreshDashboard: vi.fn(),
+      scheduleDashboardReconcile: vi.fn(),
+      selectedProject: 'proj1',
+      ...overrides,
+    };
+  }
+
+  const dismissEvent = (detail) => ({ detail: { actionType: 'dismiss_finding', ...detail } });
+
+  it('schedules the active dashboard reconcile after a dismiss apply', () => {
+    const d = deps();
+    buildAssistantActionAppliedHandler(d)(dismissEvent({ delta: { project: 'proj1' }, scores: {} }));
+    expect(d.scheduleDashboardReconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls the lazy refresh as well, never one in place of the other', () => {
+    const d = deps();
+    buildAssistantActionAppliedHandler(d)(dismissEvent({ delta: { project: 'proj1' }, scores: {} }));
+    expect(d.refreshDashboard).toHaveBeenCalledTimes(1);
+    expect(d.bumpDismissRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  // The regression this pins: a dismiss whose response carries no delta at
+  // all has NOTHING patching the visible screen, so the reconcile is the only
+  // path back to correct numbers. Skipping it here would be silently wrong.
+  it('still reconciles when the apply response carries no delta to patch', () => {
+    const d = deps();
+    buildAssistantActionAppliedHandler(d)(dismissEvent({}));
+    expect(d.applyDelta).not.toHaveBeenCalled();
+    expect(d.refreshDashboard).toHaveBeenCalledTimes(1);
+    expect(d.scheduleDashboardReconcile).toHaveBeenCalledTimes(1);
+  });
+
+  // applyDelta writes into a project-keyed cache, so it must use the delta's
+  // frozen project rather than the live selection (the apply POST can resolve
+  // after a project switch). The reconcile is only a refetch, so it stays on
+  // the live selection -- aiming it wrong re-pulls data, it never corrupts.
+  it('patches the delta against the delta\'s own project, not the live selection', () => {
+    const d = deps({ selectedProject: 'proj2' });
+    buildAssistantActionAppliedHandler(d)(dismissEvent({ delta: { project: 'proj1' }, scores: { dimensions: [] } }));
+    expect(d.applyDelta).toHaveBeenCalledWith('proj1', { dimensions: [] }, { project: 'proj1' });
+  });
+
+  it('falls back to the live selection when the delta names no project', () => {
+    const d = deps({ selectedProject: 'proj2' });
+    buildAssistantActionAppliedHandler(d)(dismissEvent({ delta: { some: 'delta' }, scores: {} }));
+    expect(d.applyDelta).toHaveBeenCalledWith('proj2', {}, { some: 'delta' });
+  });
+
+  // The patch is best-effort; a throw must not swallow the follow-ups that
+  // are the actual convergence guarantee.
+  it('still refreshes and reconciles when the delta patch throws', () => {
+    const d = deps({ applyDelta: vi.fn(() => { throw new Error('bad delta'); }) });
+    buildAssistantActionAppliedHandler(d)(dismissEvent({ delta: { project: 'proj1' }, scores: {} }));
+    expect(d.refreshDashboard).toHaveBeenCalledTimes(1);
+    expect(d.scheduleDashboardReconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores assistant actions that are not dismissals', () => {
+    const d = deps();
+    buildAssistantActionAppliedHandler(d)({ detail: { actionType: 'verify_finding', delta: {} } });
+    expect(d.applyDelta).not.toHaveBeenCalled();
+    expect(d.bumpDismissRefresh).not.toHaveBeenCalled();
+    expect(d.refreshDashboard).not.toHaveBeenCalled();
+    expect(d.scheduleDashboardReconcile).not.toHaveBeenCalled();
+  });
+
+  it('tolerates an event with no detail at all', () => {
+    const d = deps();
+    expect(() => buildAssistantActionAppliedHandler(d)({})).not.toThrow();
+    expect(d.scheduleDashboardReconcile).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Problem

Every manual dismiss path got the debounced active reconcile in #874. The assistant's `quodeq:assistant-action-applied` handler was missed.

It patched the response delta and called `refreshDashboard` — but that is `refetchType: 'none'`, which only marks the cache stale. Mark-stale never reaches the Overview: its `useDashboard` observer is mounted at the app root and never remounts, and the pywebview window never fires the focus-refetch a browser tab gets on refocus.

So whenever the delta didn't cover the visible screen — or the response carried no delta at all — an assistant dismiss left pre-dismiss numbers on screen indefinitely. That is the same "nothing updated" symptom the manual paths were fixed for.

## Fix

Wire `scheduleDashboardReconcile` alongside the existing `refreshDashboard`, never in place of it — same contract as `useDismissedFindings`' four suppression handlers.

The reconcile keys on the live `selectedProject` rather than the delta's frozen project, matching `refreshDashboard` rather than `applyDelta`. That asymmetry is deliberate and commented: reconciling is a refetch, so aiming it at the wrong project after a mid-flight switch costs a redundant pull. A misaimed *delta patch* would write one project's rollup into another's cache.

The handler was inline in `App()`, untestable without ~8 providers, so it is extracted as `buildAssistantActionAppliedHandler` — the seam-testing pattern the rest of `App.test.jsx` already uses. No behavior change from the extraction itself.

## Tests

8 new tests, including the case that matters most: a dismiss whose response carries **no delta at all**, where the reconcile is the only path back to correct numbers.

Red-green verified — stubbing out the new call fails 3 of the 8; restored, all pass. Full UI suite: 1279 passed across 166 files.

## Not covered

Not verified against a live assistant dismiss on real data — that needs a running app with real findings.