### PR TITLE
fix(ui): scope placeholderData to the project so switching loads clean

### DIFF
--- a/src/quodeq/ui/src/api/queryKeys.js
+++ b/src/quodeq/ui/src/api/queryKeys.js
@@ -35,6 +35,34 @@ export const projectKeys = {
   info: (projectId, source = "local") => ["project", projectId, source, "info"],
 };
 
+/**
+ * placeholderData guard for project-scoped queries.
+ *
+ * React Query's `placeholderData: (prev) => prev` is OBSERVER-scoped, not
+ * key-scoped: it hands back the last data this observer rendered no matter
+ * which key produced it. That's what makes run-to-run Overview navigation feel
+ * instant — but it also means switching PROJECTS leaves the previous project's
+ * payload on screen, with `isLoading` false (status is 'success' on
+ * placeholder data), until the new fetch lands. On a large project that is
+ * several seconds of the wrong project's grades, visually indistinguishable
+ * from the new project's real data.
+ *
+ * Gate the reuse on the key's project+source segments so a placeholder only
+ * survives a change WITHIN one project's subtree (i.e. the run swap it exists
+ * for), and a project or source switch falls through to a real loading state.
+ *
+ *   placeholderData: (prev, prevQuery) =>
+ *     samePlaceholderScope(prevQuery, projectId, source) ? prev : undefined
+ *
+ * Relies on the [scope, projectId, source, ...] layout the factories above
+ * build; keep the two in step.
+ */
+export function samePlaceholderScope(previousQuery, projectId, source = "local") {
+  const key = previousQuery?.queryKey;
+  if (!Array.isArray(key)) return false;
+  return key[1] === projectId && key[2] === source;
+}
+
 export const systemKeys = {
   all: () => ["system"],
   health: () => ["system", "health"],

--- a/src/quodeq/ui/src/components/LoadingScreen.jsx
+++ b/src/quodeq/ui/src/components/LoadingScreen.jsx
@@ -1,4 +1,12 @@
-export default function LoadingScreen() {
+/**
+ * @param {{ message?: string }} props
+ *
+ * `message` labels what is being waited on. Worth passing whenever the wait
+ * follows a user action that swapped the whole page's subject (e.g. switching
+ * projects on the Overview), so the pulsing logo reads as "loading THAT" rather
+ * than an unexplained blank.
+ */
+export default function LoadingScreen({ message }) {
   return (
     <div className="loading-screen" role="status" aria-live="polite">
       <svg className="loading-logo" viewBox="288 209 965 588" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
@@ -9,6 +17,7 @@ export default function LoadingScreen() {
           fillRule="evenodd"
         />
       </svg>
+      {message && <p className="loading-message">{message}</p>}
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -210,8 +210,8 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
       />
     );
   }
+  const projectName = projectInfo?.displayName || projectInfo?.name || selectedProject;
   if (!loading && !isFetching && !dashboard) {
-    const projectName = projectInfo?.displayName || projectInfo?.name || selectedProject;
     return (
       <div className="dashboard-page dashboard-fade dashboard-ready">
         <IncompleteSetupCard projectInfo={projectInfo} onComplete={handleSetupComplete} />
@@ -244,7 +244,12 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
     <div className={`dashboard-page dashboard-fade ${isLoading ? 'dashboard-loading' : 'dashboard-ready'}${isRefreshing ? ' dashboard-refreshing' : ''}`}>
       <IncompleteSetupCard projectInfo={projectInfo} onComplete={handleSetupComplete} />
       {error && <p className="inline-error">Failed to load dashboard data. Please try again.</p>}
-      {isLoading && <LoadingScreen />}
+      {/* Name the project being loaded. A project switch now clears the old
+          payload (placeholderData is project-scoped -- see
+          samePlaceholderScope), so this spinner is what the user sees right
+          after picking a project; saying which one makes the wait legible
+          instead of looking like the page hung. */}
+      {isLoading && <LoadingScreen message={projectName ? `Loading ${projectName}…` : undefined} />}
       {dashboard && (
         <DashboardContent
           runMode={runMode}

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useApi } from "../../../api/ApiContext.jsx";
 import { useProjectScores } from "../../../hooks/useProjectScores.js";
-import { projectKeys } from "../../../api/queryKeys.js";
+import { projectKeys, samePlaceholderScope } from "../../../api/queryKeys.js";
 
 /**
  * @param {{
@@ -32,6 +32,11 @@ export function useDashboard({ selectedProject, selectedRun, selectedSource = "l
   const { getDashboard, sharedGetDashboard, sharedGetProjectInfo } = useApi();
   const fetchDashboard = selectedSource === "shared" ? sharedGetDashboard : getDashboard;
   const queryClient = useQueryClient();
+  const projectKey = selectedProject || "_none_";
+  const keepInScope = useCallback(
+    (prev, prevQuery) => (samePlaceholderScope(prevQuery, projectKey, selectedSource) ? prev : undefined),
+    [projectKey, selectedSource],
+  );
 
   // Shared projects aren't in the LOCAL projects list DashboardPage otherwise
   // reads projectInfo from, and a shared selection's id can collide with an
@@ -40,7 +45,7 @@ export function useDashboard({ selectedProject, selectedRun, selectedSource = "l
   // into a shared Overview. Fetch the shared project's own info instead, keyed
   // by source so switching sources never serves the other source's cache.
   const sharedProjectInfoQuery = useQuery({
-    queryKey: projectKeys.info(selectedProject || "_none_", selectedSource),
+    queryKey: projectKeys.info(projectKey, selectedSource),
     queryFn: () => sharedGetProjectInfo(selectedProject),
     enabled: selectedSource === "shared" && !!selectedProject,
   });
@@ -66,7 +71,7 @@ export function useDashboard({ selectedProject, selectedRun, selectedSource = "l
   const isFrozenRun = !!selectedRun && selectedRun !== "latest" && runStatus !== "in_progress";
 
   const dashboardQuery = useQuery({
-    queryKey: projectKeys.dashboard(selectedProject || "_none_", selectedRun, selectedSource),
+    queryKey: projectKeys.dashboard(projectKey, selectedRun, selectedSource),
     queryFn: () => fetchDashboard(selectedProject, selectedRun),
     enabled: !!selectedProject,
     staleTime: isFrozenRun ? Infinity : 60_000,
@@ -74,7 +79,10 @@ export function useDashboard({ selectedProject, selectedRun, selectedSource = "l
     // perceived navigation. isFetching toggles true during the background
     // fetch, which the page reads to show a subtle indicator.
     // Disabled when keepPlaceholder=false (History run details).
-    placeholderData: keepPlaceholder ? (prev) => prev : undefined,
+    // Scoped to this project+source: a PROJECT switch must fall through to a
+    // real loading state instead of parking the old project's overview on
+    // screen (see samePlaceholderScope).
+    placeholderData: keepPlaceholder ? keepInScope : undefined,
   });
 
   const dashboardWithTrend = useMemo(() => {

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
@@ -469,6 +469,76 @@ describe("useDashboard frozen historical runs", () => {
     expect(result.current.dashboard).toBe(before); // identity stable => no flicker
     expect(result.current.dashboard.trend).toBe(dashTrend);
   });
+
+  // placeholderData is observer-scoped, not key-scoped — an unguarded
+  // (prev) => prev parks the PREVIOUS project's overview on screen (with
+  // loading false, so no loading state either) until the new project's fetch
+  // lands. See samePlaceholderScope in api/queryKeys.js.
+  //
+  // NOTE: build the wrapper ONCE. `wrap()` above calls withQueryClient()
+  // during the wrapper's render, minting a new component type every render;
+  // React remounts the subtree and destroys the observer that carries the
+  // placeholder, so the bug becomes invisible to the test.
+  describe("placeholder scope", () => {
+    function stableWrapper(api) {
+      const QC = withQueryClient();
+      return function Wrapper({ children }) {
+        return (
+          <QC>
+            <ApiProvider value={api}>{children}</ApiProvider>
+          </QC>
+        );
+      };
+    }
+
+    it("drops the previous project's dashboard while the new project loads", async () => {
+      let release;
+      const fakeApi = makeFakeApi();
+      fakeApi.getDashboard = vi.fn(async (project, run) => {
+        if (project === "p1") return makeDashboardPayload({ project, run: run || "latest" });
+        return new Promise((resolve) => {
+          release = () => resolve(makeDashboardPayload({ project, summary: { score: 20 } }));
+        });
+      });
+      const { result, rerender } = renderHook(
+        ({ p }) => useDashboard({ selectedProject: p, selectedRun: null }),
+        { wrapper: stableWrapper(fakeApi), initialProps: { p: "p1" } },
+      );
+      await waitFor(() => expect(result.current.dashboard?.summary?.score).toBe(75));
+
+      rerender({ p: "p2" });
+      // No stale overview, and the page gets a real loading state to render.
+      expect(result.current.dashboard).toBeNull();
+      expect(result.current.loading).toBe(true);
+
+      release();
+      await waitFor(() => expect(result.current.dashboard?.summary?.score).toBe(20));
+    });
+
+    it("keeps the previous run's dashboard while a new run in the SAME project loads", async () => {
+      let release;
+      const fakeApi = makeFakeApi();
+      fakeApi.getDashboard = vi.fn(async (project, run) => {
+        if (!run || run === "latest") return makeDashboardPayload({ project, run: "latest" });
+        return new Promise((resolve) => {
+          release = () => resolve(makeDashboardPayload({ project, run, summary: { score: 33 } }));
+        });
+      });
+      const { result, rerender } = renderHook(
+        ({ run }) => useDashboard({ selectedProject: "p1", selectedRun: run }),
+        { wrapper: stableWrapper(fakeApi), initialProps: { run: null } },
+      );
+      await waitFor(() => expect(result.current.dashboard?.summary?.score).toBe(75));
+
+      rerender({ run: "r_old" });
+      await waitFor(() => expect(fakeApi.getDashboard).toHaveBeenCalledWith("p1", "r_old"));
+      // Instant perceived navigation within a project is preserved.
+      expect(result.current.dashboard?.summary?.score).toBe(75);
+
+      release();
+      await waitFor(() => expect(result.current.dashboard?.summary?.score).toBe(33));
+    });
+  });
 });
 
 // Note: live grade SSE merging used to live here. It was deleted in the

--- a/src/quodeq/ui/src/hooks/useProjectScores.js
+++ b/src/quodeq/ui/src/hooks/useProjectScores.js
@@ -10,7 +10,7 @@
 import { useCallback, useMemo } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useApi } from "../api/ApiContext.jsx";
-import { projectKeys } from "../api/queryKeys.js";
+import { projectKeys, samePlaceholderScope } from "../api/queryKeys.js";
 
 /**
  * @param {{
@@ -31,15 +31,24 @@ export function useProjectScores({ selectedProject, selectedRun, selectedSource 
   const { getProjectScores, sharedGetProjectScores } = useApi();
   const fetchScores = selectedSource === "shared" ? sharedGetProjectScores : getProjectScores;
   const queryClient = useQueryClient();
+  const projectKey = selectedProject || "_none_";
+  // Reuse the previous payload only within the same project+source subtree —
+  // see samePlaceholderScope for why an unguarded (prev) => prev shows the
+  // PREVIOUS project's overview after a project switch.
+  const keepInScope = useCallback(
+    (prev, prevQuery) => (samePlaceholderScope(prevQuery, projectKey, selectedSource) ? prev : undefined),
+    [projectKey, selectedSource],
+  );
 
   const latestQuery = useQuery({
-    queryKey: projectKeys.scores(selectedProject || "_none_", null, selectedSource),
+    queryKey: projectKeys.scores(projectKey, null, selectedSource),
     queryFn: () => fetchScores(selectedProject),
     enabled: !!selectedProject,
     staleTime: 60_000,
-    // Latest scores are project-wide (no per-run swap), so prev-data
-    // flashing isn't a concern — keep placeholder unconditionally.
-    placeholderData: (prev) => prev,
+    // Latest scores are project-wide (no per-run swap), so within one project
+    // there is nothing to flash — but a project/source switch must still drop
+    // to a real loading state rather than showing the old project's grades.
+    placeholderData: keepInScope,
   });
 
   // Overview is anchored on completed runs. If selectedRun points at an
@@ -59,7 +68,7 @@ export function useProjectScores({ selectedProject, selectedRun, selectedSource 
   }, [isLatestSelection, selectedRun, latestQuery.data]);
 
   const scoresQuery = useQuery({
-    queryKey: projectKeys.scores(selectedProject || "_none_", asOf, selectedSource),
+    queryKey: projectKeys.scores(projectKey, asOf, selectedSource),
     queryFn: () => fetchScores(selectedProject, asOf),
     // Wait for the latest run-status list before issuing a scoped fetch —
     // otherwise we'd briefly call with the raw selectedRun and only later
@@ -71,8 +80,9 @@ export function useProjectScores({ selectedProject, selectedRun, selectedSource 
     // the project subtree and force a refetch regardless of staleTime.
     // Freeze to skip the routine background refetch on re-entry.
     staleTime: asOf ? Infinity : 60_000,
-    // Keep prior scores visible while switching runs — see useDashboard for rationale.
-    placeholderData: keepPlaceholder ? (prev) => prev : undefined,
+    // Keep prior scores visible while switching runs — see useDashboard for
+    // rationale. Scoped to this project+source, so a project switch loads clean.
+    placeholderData: keepPlaceholder ? keepInScope : undefined,
   });
 
   const availableRuns = useMemo(() => {

--- a/src/quodeq/ui/src/hooks/useProjectScores.test.jsx
+++ b/src/quodeq/ui/src/hooks/useProjectScores.test.jsx
@@ -176,6 +176,115 @@ describe("useProjectScores", () => {
     expect(fakeApi.getProjectScores).not.toHaveBeenCalled();
   });
 
+  // placeholderData is observer-scoped, not key-scoped: without a guard it
+  // hands back whatever this observer last saw, so switching PROJECTS keeps
+  // the previous project's scores on screen (and suppresses `loading`) until
+  // the new fetch lands.
+  //
+  // NOTE: these tests must NOT use `wrap()` above. It calls withQueryClient()
+  // during the wrapper's render, minting a fresh component type every render —
+  // React then remounts the whole subtree, destroying the very observer that
+  // carries placeholderData across a key change. Build the wrapper ONCE.
+  describe("placeholder scope", () => {
+    function stableWrapper(api) {
+      const QC = withQueryClient();
+      return function Wrapper({ children }) {
+        return (
+          <QC>
+            <ApiProvider value={api}>{children}</ApiProvider>
+          </QC>
+        );
+      };
+    }
+
+    it("drops the previous project's scores while the new project loads", async () => {
+      let release;
+      const api = {
+        getProjectScores: vi.fn(async (project) => {
+          if (project === "p1") {
+            return { accumulated: { score: 90 }, trend: [], availableRuns: [{ runId: "r9", status: "complete" }] };
+          }
+          return new Promise((resolve) => {
+            release = () => resolve({ accumulated: { score: 40 }, trend: [], availableRuns: [] });
+          });
+        }),
+        sharedGetProjectScores: vi.fn(),
+      };
+      const { result, rerender } = renderHook(
+        ({ p }) => useProjectScores({ selectedProject: p, selectedRun: null }),
+        { wrapper: stableWrapper(api), initialProps: { p: "p1" } },
+      );
+      await waitFor(() => expect(result.current.latestScores?.accumulated?.score).toBe(90));
+
+      rerender({ p: "p2" });
+      expect(result.current.latestScores).toBeNull();
+      expect(result.current.scores).toBeNull();
+      expect(result.current.loading).toBe(true);
+
+      release();
+      await waitFor(() => expect(result.current.latestScores?.accumulated?.score).toBe(40));
+    });
+
+    it("keeps the previous run's scores while a new run in the SAME project loads", async () => {
+      let release;
+      const api = {
+        getProjectScores: vi.fn(async (project, asOf) => {
+          if (!asOf) {
+            return {
+              accumulated: { score: 90 },
+              trend: [],
+              availableRuns: [
+                { runId: "r9", status: "complete" },
+                { runId: "r1", status: "complete" },
+              ],
+            };
+          }
+          return new Promise((resolve) => {
+            release = () => resolve({ accumulated: { score: 80 }, trend: [] });
+          });
+        }),
+        sharedGetProjectScores: vi.fn(),
+      };
+      const { result, rerender } = renderHook(
+        ({ run }) => useProjectScores({ selectedProject: "p1", selectedRun: run }),
+        { wrapper: stableWrapper(api), initialProps: { run: null } },
+      );
+      await waitFor(() => expect(result.current.scores?.accumulated?.score).toBe(90));
+
+      rerender({ run: "r1" });
+      await waitFor(() => expect(api.getProjectScores).toHaveBeenCalledWith("p1", "r1"));
+      // Same project — the previous run's payload stays visible during the fetch.
+      expect(result.current.scores?.accumulated?.score).toBe(90);
+
+      release();
+      await waitFor(() => expect(result.current.scores?.accumulated?.score).toBe(80));
+    });
+
+    it("drops the placeholder when only the SOURCE changes", async () => {
+      let release;
+      const api = {
+        getProjectScores: vi.fn(async () => ({ accumulated: { score: 90 }, trend: [], availableRuns: [] })),
+        sharedGetProjectScores: vi.fn(
+          async () => new Promise((resolve) => {
+            release = () => resolve({ accumulated: { score: 55 }, trend: [], availableRuns: [] });
+          }),
+        ),
+      };
+      const { result, rerender } = renderHook(
+        ({ source }) => useProjectScores({ selectedProject: "p1", selectedRun: null, selectedSource: source }),
+        { wrapper: stableWrapper(api), initialProps: { source: "local" } },
+      );
+      await waitFor(() => expect(result.current.latestScores?.accumulated?.score).toBe(90));
+
+      rerender({ source: "shared" });
+      expect(result.current.latestScores).toBeNull();
+      expect(result.current.loading).toBe(true);
+
+      release();
+      await waitFor(() => expect(result.current.latestScores?.accumulated?.score).toBe(55));
+    });
+  });
+
   // Task 17: source-aware fetch selection. A shared-source selection must
   // read from the shared-repo mirror endpoints, never the local ones.
   describe("source-aware fetch selection", () => {

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1858,11 +1858,22 @@ textarea:focus {
   position: fixed;
   inset: 0;
   display: flex;
+  /* Column so an optional .loading-message stacks under the logo. With the
+     logo alone this is visually identical to the row layout. */
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: var(--space-3);
   z-index: 50;
   pointer-events: none;
   animation: loading-fadein 500ms ease;
+}
+
+.loading-message {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  text-align: center;
 }
 
 .loading-logo {


### PR DESCRIPTION
## Problem

React Query's `placeholderData: (prev) => prev` is **observer**-scoped, not key-scoped: it hands back whatever this observer last rendered, regardless of which key produced it.

That is what makes run-to-run Overview navigation feel instant. It also means switching *projects* leaves the previous project's dashboard and scores on screen, with `isLoading` false since status is `'success'` on placeholder data, until the new fetch lands. `DashboardPage` therefore never reached its `LoadingScreen` branch and rendered the stale payload under the subtle `dashboard-refreshing` dim instead. On a large project that is several seconds of the wrong project's grades, visually indistinguishable from the new project's real data.

## Fix

`samePlaceholderScope(prevQuery, projectId, source)` gates the reuse on the key's project + source segments, so a placeholder only survives a change *within* one project's subtree (the run swap it exists for). A project or source switch falls through to a real loading state.

Applied at all three placeholder sites: `useDashboard`'s dashboard query, and `useProjectScores`' latest + scoped score queries. The scores queries matter as much as the dashboard one: they feed `accumulated`, so the dimension cards were stale too.

The source segment is load-bearing, not just symmetry. A local project and its shared-repo mirror can share a projectId, and the mirror's payload must not stand in for the local one.

Since a project switch now actually shows a loading screen, `DashboardPage` names the project being loaded, otherwise the wait reads as a hang.

The guard relies on the `[scope, projectId, source, ...]` layout the `projectKeys` factories build; that coupling is documented on the function.

## Tests

5 new tests across `useDashboard.test.jsx` and `useProjectScores.test.jsx`: placeholder reuse is preserved within a project (run swap), and dropped on both project and source switches.

Full UI suite from a clean checkout: **1276 passed across 166 files.**

## Verification

Verified live against a real multi-project store (Vite dev server against the local backend). Switching to an uncached project shows `Loading selectives-ios…` with no stale overview behind it, then resolves to that project's own data (6.7/C, distinct from selectives-android's 7.8/1279).

Two method notes, both of which changed the outcome and are worth knowing before touching this area again:

1. **The first version of these tests passed against the bug.** `wrap()` in both test files calls `withQueryClient()` *during the wrapper's render*, minting a new component type on every render. React then remounts the whole subtree, destroying the very observer that carries `placeholderData` across a key change, so the regression is invisible to any test built on that helper. The new tests build the wrapper **once**, and each project-switch test was confirmed red without the fix. Both `describe` blocks carry a comment so this trap does not get re-entered.

2. **`staleTime: 60_000` masks this on revisits.** An already-visited project switches with no fetch at all, so the bug only manifests on a cold project. Reproducing it required throttling the API; a quick manual click-around between two warm projects will not show it.

## Notes

- `refreshScores` / `refreshDashboard` / `scheduleDashboardReconcile` invalidation semantics are untouched.
- The `react-query` hooks-order warning currently visible in the dev console under HMR is unrelated to this change; it reproduces with these changes stashed.

## Follow-up commit: centralize the rerender-safe test wrapper

Trap 1 above turned out to be a repeat, not a one-off. `usePublish.test.jsx` had already hit it and grown a local `makeStableWrapper` carrying the same explanation, and this PR added a third copy under a different name. Promoted to `test-utils/withQueryClient.jsx` as `withStableQueryApi`, with the reasoning documented once, and used at all three sites.

Re-verified after the refactor that the three project-switch tests still go **red** without the `samePlaceholderScope` guard, confirming the shared helper genuinely preserves observer continuity rather than just looking like it does.

Worth knowing: only tests that call `rerender()` are affected, since that is the only time the wrapper itself re-renders. A survey of the 9 test files using the `wrap()` idiom found `usePublish` was the sole pre-existing file at risk, and it was already handled.
