### PR TITLE
test(ui): centralize the rerender-safe query wrapper

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
@@ -3,7 +3,7 @@ import { renderHook, waitFor, act } from "@testing-library/react";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useDashboard } from "./useDashboard";
-import { withQueryClient } from "../../../test-utils/withQueryClient.jsx";
+import { withQueryClient, withStableQueryApi } from "../../../test-utils/withQueryClient.jsx";
 import { ApiProvider } from "../../../api/ApiContext.jsx";
 import { projectKeys } from "../../../api/queryKeys.js";
 
@@ -475,21 +475,11 @@ describe("useDashboard frozen historical runs", () => {
   // loading false, so no loading state either) until the new project's fetch
   // lands. See samePlaceholderScope in api/queryKeys.js.
   //
-  // NOTE: build the wrapper ONCE. `wrap()` above calls withQueryClient()
-  // during the wrapper's render, minting a new component type every render;
-  // React remounts the subtree and destroys the observer that carries the
-  // placeholder, so the bug becomes invisible to the test.
+  // NOTE: these tests must NOT use `wrap()` above — it remounts the subtree on
+  // every render and destroys the observer that carries the placeholder, so
+  // they would pass against the bug. See withStableQueryApi's doc comment.
   describe("placeholder scope", () => {
-    function stableWrapper(api) {
-      const QC = withQueryClient();
-      return function Wrapper({ children }) {
-        return (
-          <QC>
-            <ApiProvider value={api}>{children}</ApiProvider>
-          </QC>
-        );
-      };
-    }
+    const stableWrapper = withStableQueryApi;
 
     it("drops the previous project's dashboard while the new project loads", async () => {
       let release;

--- a/src/quodeq/ui/src/features/dashboard/hooks/usePublish.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/usePublish.test.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { usePublish } from './usePublish.js';
 import { useSharedProjects } from './useSharedProjects.js';
-import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+import { withQueryClient, withStableQueryApi } from '../../../test-utils/withQueryClient.jsx';
 import { ApiProvider } from '../../../api/ApiContext.jsx';
 import { sharedKeys } from '../../../api/queryKeys.js';
 
@@ -40,21 +40,10 @@ function wrap(fakeApi, children) {
   );
 }
 
-// Rerender-safe wrapper: builds the QueryClient wrapper component ONCE.
-// The inline `({ children }) => wrap(fakeApi, children)` idiom above calls
-// withQueryClient() on every render, producing a NEW component type each
-// time -- a rerender() would remount the whole tree and silently reset all
-// hook state. Tests that rerender (the enabled-toggle repros) must use this.
-function makeStableWrapper(fakeApi) {
-  const QC = withQueryClient();
-  return function StableWrapper({ children }) {
-    return (
-      <QC>
-        <ApiProvider value={fakeApi}>{children}</ApiProvider>
-      </QC>
-    );
-  };
-}
+// Rerender-safe wrapper. See withStableQueryApi's doc comment for why the
+// inline `({ children }) => wrap(fakeApi, children)` idiom above must not be
+// used by any test that rerenders.
+const makeStableWrapper = withStableQueryApi;
 
 describe('usePublish', () => {
   it('publish(id) ignores a second call while the first is still in flight (double-click guard)', async () => {

--- a/src/quodeq/ui/src/hooks/useProjectScores.test.jsx
+++ b/src/quodeq/ui/src/hooks/useProjectScores.test.jsx
@@ -3,7 +3,7 @@ import { renderHook, waitFor } from "@testing-library/react";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useProjectScores } from "./useProjectScores";
-import { withQueryClient } from "../test-utils/withQueryClient.jsx";
+import { withQueryClient, withStableQueryApi } from "../test-utils/withQueryClient.jsx";
 import { ApiProvider } from "../api/ApiContext.jsx";
 import { projectKeys } from "../api/queryKeys.js";
 
@@ -181,21 +181,11 @@ describe("useProjectScores", () => {
   // the previous project's scores on screen (and suppresses `loading`) until
   // the new fetch lands.
   //
-  // NOTE: these tests must NOT use `wrap()` above. It calls withQueryClient()
-  // during the wrapper's render, minting a fresh component type every render —
-  // React then remounts the whole subtree, destroying the very observer that
-  // carries placeholderData across a key change. Build the wrapper ONCE.
+  // NOTE: these tests must NOT use `wrap()` above — it remounts the subtree on
+  // every render and destroys the observer that carries placeholderData, so
+  // they would pass against the bug. See withStableQueryApi's doc comment.
   describe("placeholder scope", () => {
-    function stableWrapper(api) {
-      const QC = withQueryClient();
-      return function Wrapper({ children }) {
-        return (
-          <QC>
-            <ApiProvider value={api}>{children}</ApiProvider>
-          </QC>
-        );
-      };
-    }
+    const stableWrapper = withStableQueryApi;
 
     it("drops the previous project's scores while the new project loads", async () => {
       let release;

--- a/src/quodeq/ui/src/test-utils/withQueryClient.jsx
+++ b/src/quodeq/ui/src/test-utils/withQueryClient.jsx
@@ -10,6 +10,7 @@
  */
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ApiProvider } from "../api/ApiContext.jsx";
 
 export function withQueryClient() {
   const client = new QueryClient({
@@ -20,5 +21,43 @@ export function withQueryClient() {
   });
   return function Wrapper({ children }) {
     return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+/**
+ * Rerender-safe query + api wrapper. Use this for ANY test that calls
+ * rerender().
+ *
+ *   const { result, rerender } = renderHook(({ p }) => useFoo(p), {
+ *     wrapper: withStableQueryApi(fakeApi), initialProps: { p: 'p1' },
+ *   });
+ *
+ * The tempting idiom is a local `wrap()` helper called from inside the
+ * wrapper:
+ *
+ *   function wrap(api, children) { const QC = withQueryClient(); ... }
+ *   { wrapper: ({ children }) => wrap(fakeApi, children) }   // <-- BROKEN
+ *
+ * That calls withQueryClient() on every render, so `QC` is a NEW component
+ * type each time. React unmounts and remounts the whole subtree, discarding
+ * the QueryClient, the cache, and every query observer. On the initial render
+ * that is harmless, which is why such tests pass — but the moment a test
+ * rerenders, anything that depends on continuity across a render is silently
+ * destroyed: placeholderData, isPlaceholderData, isFetching-with-data, and
+ * any hook state. Tests asserting those behaviours then pass against broken
+ * code (this is exactly how the project-switch placeholder bug initially
+ * evaded its own regression tests).
+ *
+ * Building the wrapper ONCE, here, keeps the component type stable across
+ * rerenders.
+ */
+export function withStableQueryApi(api) {
+  const QC = withQueryClient();
+  return function StableWrapper({ children }) {
+    return (
+      <QC>
+        <ApiProvider value={api}>{children}</ApiProvider>
+      </QC>
+    );
   };
 }


### PR DESCRIPTION
Follow-up to #876. That PR's own regression tests initially **passed against the unfixed code**, and the reason generalizes, so it is worth removing the trap rather than just working around it locally.

## The trap

The `wrap()` idiom in these test files calls `withQueryClient()` from *inside* the wrapper's render:

```js
function wrap(api, children) { const QC = withQueryClient(); ... }
{ wrapper: ({ children }) => wrap(fakeApi, children) }   // BROKEN for rerender()
```

`QC` is therefore a new component type on every render. React unmounts and remounts the whole subtree, discarding the QueryClient, the cache, and every query observer.

On the initial render that is harmless, which is exactly why tests built this way pass and nobody notices. But the moment a test calls `rerender()`, everything that depends on continuity across a render is silently destroyed: `placeholderData`, `isPlaceholderData`, `isFetching`-with-data, and any hook state. Tests asserting those behaviours then pass against broken code.

## Why now

This was not a one-off. `usePublish.test.jsx` had already hit it and grown a local `makeStableWrapper` carrying essentially the same explanation, and #876 added a third copy under a different name. Three sites, two names, one lesson learned twice.

## Change

Promote it to `test-utils/withQueryClient.jsx` as `withStableQueryApi`, with the reasoning documented in one place, and use it at all three sites. Net effect is a small reduction in test-file boilerplate plus one shared doc comment.

## Verification

- Full UI suite: **1284 passed across 166 files.**
- Re-ran the adversarial check after the refactor: with the `samePlaceholderScope` guard from #876 reverted, the three project-switch tests still go **red** through the shared helper. That is the property that matters here, since a helper that quietly restored the remount behaviour would look identical on a green run.

## Scope

Only tests that call `rerender()` are affected, since that is the only time the wrapper itself re-renders. A survey of the 9 test files using the `wrap()` idiom found `usePublish` was the sole pre-existing file at risk, and it was already handled locally. No production code is touched.