### PR TITLE
feat(ui): net suppressed findings out of the live scan counters

### DIFF
--- a/src/quodeq/analysis/subagents/_heartbeat.py
+++ b/src/quodeq/analysis/subagents/_heartbeat.py
@@ -5,6 +5,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable
 
 from quodeq.analysis.subagents.file_queue import FileQueue
 from quodeq.analysis.subagents.jsonl_utils import FindingTally, tally_unique_findings
@@ -14,7 +15,7 @@ _HEARTBEAT_INTERVAL = 10
 _SECONDS_PER_MINUTE = 60
 _HEARTBEAT_FMT = (
     "[{dimension}] {mins}m{secs:02d}s | "
-    "{violations} v · {compliance} c | "
+    "{violations} v · {compliance} c{suppressed} | "
     "files {taken}/{total_files} · {remaining} left | "
     "{active} agent{plural}"
 )
@@ -27,13 +28,20 @@ class HeartbeatContext:
     dimension_key: str
     jsonl_path: Path
     lock: threading.Lock
+    # Predicate over a raw evidence row: True when the dashboard already
+    # suppresses that finding. Injected (see quodeq.services.suppression)
+    # rather than imported, so this module stays free of a services import.
+    suppressed: Callable[[dict], bool] | None = None
 
 
-def _read_tally(jsonl_path: Path, lock: threading.Lock) -> FindingTally:
+def _read_tally(
+    jsonl_path: Path, lock: threading.Lock,
+    suppressed: Callable[[dict], bool] | None = None,
+) -> FindingTally:
     """Tally under the shared write lock to avoid TOCTOU with MCP writers."""
     try:
         with lock:
-            return tally_unique_findings(jsonl_path)
+            return tally_unique_findings(jsonl_path, suppressed=suppressed)
     except OSError:
         return FindingTally()
 
@@ -47,13 +55,17 @@ def heartbeat_loop(
     Each tick re-reads the dimension JSONL and deduplicates by
     ``(p, file, line, t)`` in memory, so the violation/compliance counts
     always match :mod:`quodeq.services.scan_progress` (which the UI consumes).
+    ``ctx.suppressed`` nets out findings the user already dismissed or deleted
+    — the scanner keeps re-finding them, and a raw count here would read as
+    several times the number the finished report shows. The excluded total is
+    appended as its own ``N supp`` segment so the drop is never silent.
     """
     start = time.monotonic()
     while not stop.wait(_HEARTBEAT_INTERVAL):
         try:
             elapsed = int(time.monotonic() - start)
             mins, secs = divmod(elapsed, _SECONDS_PER_MINUTE)
-            tally = _read_tally(ctx.jsonl_path, ctx.lock)
+            tally = _read_tally(ctx.jsonl_path, ctx.lock, ctx.suppressed)
             remaining, taken = FileQueue(ctx.queue_path).stats()
             active = sum(1 for v in finished.values() if not v)
             log_info(_HEARTBEAT_FMT.format(
@@ -67,6 +79,7 @@ def heartbeat_loop(
                 remaining=remaining,
                 violations=tally.violations,
                 compliance=tally.compliance,
+                suppressed=f" · {tally.suppressed} supp" if tally.suppressed else "",
             ))
         except (OSError, ValueError, RuntimeError) as exc:
             log_warning(f"Heartbeat error: {exc}")

--- a/src/quodeq/analysis/subagents/jsonl_utils.py
+++ b/src/quodeq/analysis/subagents/jsonl_utils.py
@@ -5,7 +5,7 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
+from typing import Callable, Iterable
 
 from quodeq.shared.logging import log_info
 from quodeq.shared.utils import open_text
@@ -15,17 +15,26 @@ _logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class FindingTally:
-    """Unique violation/compliance counts plus the duplicates folded out."""
+    """Unique violation/compliance counts plus the duplicates folded out.
+
+    ``violations`` is the *net* count the user will see in the report:
+    ``suppressed`` holds the unique violations a caller-supplied predicate
+    excluded (findings already dismissed or deleted in the dashboard), which
+    the scanner still re-finds on every run.
+    """
     violations: int = 0
     compliance: int = 0
     duplicates: int = 0
+    suppressed: int = 0
 
     @property
     def total(self) -> int:
         return self.violations + self.compliance
 
 
-def tally_unique_findings(jsonl_path: Path) -> FindingTally:
+def tally_unique_findings(
+    jsonl_path: Path, suppressed: "Callable[[dict], bool] | None" = None,
+) -> FindingTally:
     """Count unique findings (deduplicated by ``(p, file, line, t)``) and duplicates.
 
     Single source of truth for the heartbeat and the dashboard progress reader,
@@ -33,13 +42,18 @@ def tally_unique_findings(jsonl_path: Path) -> FindingTally:
     :func:`deduplicate_jsonl` pass runs at end of pool, the file holds raw
     appends from many parallel agents and contains overlapping findings.
 
+    *suppressed* is an optional predicate over a raw evidence row (see
+    ``quodeq.services.suppression``). It is applied AFTER dedup, so a row
+    excluded three times counts once — and it is injected rather than imported
+    to keep this analysis-layer module free of a services dependency.
+
     Tolerant: missing files, malformed lines, and OSError yield empty/partial
     tallies silently.
     """
     if not jsonl_path.is_file():
         return FindingTally()
     seen: set[tuple] = set()
-    violations = compliance = duplicates = 0
+    violations = compliance = duplicates = hidden = 0
     try:
         with open_text(jsonl_path) as f:
             for raw in f:
@@ -50,6 +64,8 @@ def tally_unique_findings(jsonl_path: Path) -> FindingTally:
                     obj = json.loads(stripped)
                 except json.JSONDecodeError:
                     continue
+                if not isinstance(obj, dict):
+                    continue  # valid JSON but not an object (a bare list/number)
                 t = obj.get("t")
                 key = (obj.get("p"), obj.get("file"), obj.get("line"), t)
                 if key in seen:
@@ -57,12 +73,18 @@ def tally_unique_findings(jsonl_path: Path) -> FindingTally:
                     continue
                 seen.add(key)
                 if t == "violation":
-                    violations += 1
+                    if suppressed is not None and suppressed(obj):
+                        hidden += 1
+                    else:
+                        violations += 1
                 elif t == "compliance":
                     compliance += 1
     except OSError:
         pass
-    return FindingTally(violations=violations, compliance=compliance, duplicates=duplicates)
+    return FindingTally(
+        violations=violations, compliance=compliance,
+        duplicates=duplicates, suppressed=hidden,
+    )
 
 
 def dedup_jsonl_lines(lines: Iterable[str]) -> list[str]:

--- a/src/quodeq/analysis/subagents/pool.py
+++ b/src/quodeq/analysis/subagents/pool.py
@@ -21,7 +21,7 @@ from quodeq.analysis.subagents.file_queue import WorkQueue
 from quodeq.analysis.subagents.jsonl_utils import deduplicate_jsonl, merge_jsonl
 from quodeq.analysis.subprocess import AnalysisConfig
 from quodeq.shared.constants import _DEFAULT_TIME_LIMIT
-from quodeq.shared.logging import log_info
+from quodeq.shared.logging import log_info, log_warning
 
 # Re-export public API so existing imports keep working.
 __all__ = ["SubagentPool", "SubagentResult", "PoolPaths", "PoolOptions"]
@@ -81,11 +81,36 @@ class SubagentPool:
         self._futures[executor.submit(self._run_single, self._next_idx)] = self._next_idx
         self._next_idx += 1
 
+    def _suppression_predicate(self):
+        """Predicate the heartbeat uses to net dismissed/deleted findings out.
+
+        Built once per pool, not per tick: the stores are read here and the
+        resulting matcher is immutable, so a heartbeat firing every 10s costs
+        no extra file reads. Suppression state is project-scoped and the
+        evidence dir is ``<project>/<run>/evidence``.
+
+        Returns None when the project has no suppressions, when the layout
+        isn't the expected one, or for consolidated runs — whose synthetic
+        dimension key would never match a real delete key anyway. The counts
+        then stay raw, which is the pre-existing behaviour.
+        """
+        if self._dimension_key == "consolidated":
+            return None
+        try:
+            from quodeq.services.suppression import matcher_for  # noqa: PLC0415
+            project_dir = self._evidence_dir.parent.parent
+            matcher = matcher_for(project_dir, self._dimension_key)
+        except (ImportError, OSError, ValueError) as exc:
+            log_warning(f"Suppression state unavailable, counts stay raw: {exc}")
+            return None
+        return matcher.is_suppressed if matcher.active else None
+
     def _start_heartbeat(self) -> tuple[threading.Event, threading.Thread]:
         stop = threading.Event()
         ctx = HeartbeatContext(
             queue_path=self._queue_path, dimension_key=self._dimension_key,
             jsonl_path=self._shared_jsonl_path(), lock=self._jsonl_lock,
+            suppressed=self._suppression_predicate(),
         )
         hb = threading.Thread(
             target=heartbeat_loop, args=(stop, self._finished, ctx), daemon=True,

--- a/src/quodeq/services/_violations_jsonl.py
+++ b/src/quodeq/services/_violations_jsonl.py
@@ -10,6 +10,7 @@ from quodeq.core.types import Finding, ViolationResponse
 from quodeq.core.evidence.parser import build_req_refs_lookup
 from quodeq.analysis.stream.counters import count_files_in_stream
 from quodeq.services.violation_context import ViolationContext
+from quodeq.services.suppression import SuppressionMatcher, load_req_to_principle
 from quodeq.services.violations_parsing import (
     _build_finding_entry,
     _build_violation_response,
@@ -18,9 +19,7 @@ from quodeq.services.violations_parsing import (
     _TYPE_COMPLIANCE,
     _TYPE_VIOLATION,
 )
-from quodeq.config.paths import default_paths
 from quodeq.shared.utils import open_text
-from quodeq.shared.validation import validate_path_segment
 
 _logger = logging.getLogger(__name__)
 
@@ -35,6 +34,14 @@ def _parse_jsonl_findings(
     violations: list[Finding] = []
     compliance: list[Finding] = []
     seen: set[tuple] = set()
+    # One seam for both suppression stores, shared with the live-progress
+    # tally -- see quodeq.services.suppression for the key shapes.
+    matcher = SuppressionMatcher(
+        dimension=dimension,
+        dismissed=frozenset(dismissed_keys or ()),
+        deleted=frozenset(deleted_keys or ()),
+        req_to_principle=req_to_principle or {},
+    )
     for raw_line in lines:
         raw = raw_line.strip()
         if not raw:
@@ -48,18 +55,9 @@ def _parse_jsonl_findings(
         principle = obj.get("p") or obj.get("req")
         if not principle or obj.get("t") not in _FINDING_TYPES:
             continue
-        # Skip dismissed findings -- match by req ID (e.g. "M-MOD-3"), not principle name
-        if dismissed_keys and obj.get("t") == _TYPE_VIOLATION:
-            req_id = obj.get("req") or principle
-            dismissed_key = (req_id, obj.get("file", ""), obj.get("line", 0))
-            if dismissed_key in dismissed_keys:
-                continue
-        obj["p"] = req_to_principle.get(principle, principle) if req_to_principle else principle
-        # Skip permanently-deleted findings -- match by (dimension, principle, file).
-        if deleted_keys and obj.get("t") == _TYPE_VIOLATION:
-            deleted_key = (dimension, obj["p"], obj.get("file", ""))
-            if deleted_key in deleted_keys:
-                continue
+        if matcher.is_suppressed(obj):
+            continue
+        obj["p"] = matcher.principle_for(principle)
         dedup_key = (principle, obj.get("t"), obj.get("file"), obj.get("line"))
         if dedup_key in seen:
             continue
@@ -72,36 +70,10 @@ def _parse_jsonl_findings(
     return violations, compliance
 
 
-def _load_req_to_principle(dimension: str, evaluators_dir: "Path | None" = None) -> dict[str, str]:
-    """Load req ID -> principle name mapping for custom evaluators.
-
-    Args:
-        dimension: The dimension ID to look up.
-        evaluators_dir: Directory containing evaluator JSON files.
-            Defaults to ``default_paths().evaluators_dir`` when not provided.
-    """
-    if evaluators_dir is None:
-        evaluators_dir = default_paths().evaluators_dir
-    if not evaluators_dir.is_dir():
-        return {}
-    validate_path_segment(dimension)
-    path = evaluators_dir / f"{dimension}.json"
-    if not path.is_file():
-        return {}
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-        if not isinstance(data, dict):
-            return {}  # valid JSON but not an object: degrade, don't crash
-        mapping: dict[str, str] = {}
-        for p in data.get("principles", []):
-            pname = p.get("name", "")
-            for req in p.get("requirements", []):
-                rid = req.get("id", "")
-                if rid and pname:
-                    mapping[rid] = pname
-        return mapping
-    except (OSError, ValueError):
-        return {}
+# Moved to quodeq.services.suppression, which owns the req -> principle map
+# because the delete key is built from it. Kept as an alias: several tests and
+# call sites still reach for the private name.
+_load_req_to_principle = load_req_to_principle
 
 
 def parse_violations_from_jsonl(
@@ -112,7 +84,7 @@ def parse_violations_from_jsonl(
 ) -> ViolationResponse | None:
     """Parse live JSONL findings written by the MCP server."""
     req_refs_lookup = build_req_refs_lookup(compiled_dir, ctx.dimension) if compiled_dir else None
-    req_to_principle = _load_req_to_principle(ctx.dimension)
+    req_to_principle = load_req_to_principle(ctx.dimension)
     try:
         with open_text(jsonl_path) as _f:
             violations, compliance = _parse_jsonl_findings(

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -331,18 +331,27 @@ def _attach_exit_reason_to_dim(
 
 def _attach_dismissed_count_to_dim(
     dim_dict: dict[str, Any], dismissed_counts: dict[str, int],
+    suppressed_counts: dict[str, int] | None = None,
 ) -> dict[str, Any]:
-    """Add ``dismissedCount`` to a serialized dimension dict when > 0.
+    """Add ``dismissedCount`` / ``suppressedCount`` to a dimension dict when > 0.
 
-    The count says how many of the scan's re-found violations were hidden by
-    the project-level dismissed filter, so the UI can explain the gap between
-    "what the scan found" and "what the view shows". Omitted when nothing was
-    filtered, mirroring the exitReason convention.
+    Both explain the gap between "what the scan found" and "what the view
+    shows". ``dismissedCount`` covers the dismissed filter alone;
+    ``suppressedCount`` covers dismissals *and* deletions, so it is the total
+    the UI reports. They differ sharply on projects with a triage history:
+    deletions suppress a whole principle across a file and accumulate over
+    many runs, so a scan can re-find several times what the report displays.
+    Omitted when nothing was filtered, mirroring the exitReason convention.
     """
-    count = dismissed_counts.get(dim_dict.get("dimension") or "", 0)
-    if count <= 0:
-        return dim_dict
-    return {**dim_dict, "dismissedCount": count}
+    key = dim_dict.get("dimension") or ""
+    out = dim_dict
+    count = dismissed_counts.get(key, 0)
+    if count > 0:
+        out = {**out, "dismissedCount": count}
+    total = (suppressed_counts or {}).get(key, 0)
+    if total > 0:
+        out = {**out, "suppressedCount": total}
+    return out
 
 
 def _slim_history_dim(dim: DimensionResult) -> dict[str, Any]:
@@ -368,12 +377,14 @@ def _build_dashboard_result(
     *,
     exit_reason: str | None = None,
     dismissed_counts: dict[str, int] | None = None,
+    suppressed_counts: dict[str, int] | None = None,
 ) -> dict[str, Any]:
     """Assemble the final dashboard response dict from pre-computed parts."""
     dim_dicts = [
         _attach_dismissed_count_to_dim(
             _attach_exit_reason_to_dim(to_camel_dict(d), exit_reason),
             dismissed_counts or {},
+            suppressed_counts or {},
         )
         for d in payload.dimensions_with_trend
     ]
@@ -598,6 +609,12 @@ def build_dashboard(
     }
     selected_dims = _rescore_run_dimensions(
         raw_dims, reports_root, project, selected_run.run_id, params)
+    # Measured against the SAME dimensions the response ships, so the number
+    # the UI shows always reconciles: shown + suppressed == what the scan found.
+    suppressed_counts = {
+        (d.dimension or ""): pre_filter_counts.get(d.dimension, 0) - len(d.violations)
+        for d in selected_dims
+    }
     ctx = _SelectedRunContext(
         run=selected_run,
         index=selected_index,
@@ -609,4 +626,5 @@ def build_dashboard(
     return _build_dashboard_result(
         project, runs, selected_run, payload,
         exit_reason=exit_reason, dismissed_counts=dismissed_counts,
+        suppressed_counts=suppressed_counts,
     )

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from quodeq.analysis.subagents.jsonl_utils import tally_unique_findings
+from quodeq.services.suppression import build_matcher, project_suppressions
 from quodeq.shared.dim_estimates_io import read_dim_estimates
 from quodeq.shared.dimensions_state import read_dimensions
 
@@ -35,6 +36,7 @@ class _DimProgress:
     violations: int = 0
     compliance: int = 0
     duplicates: int = 0
+    suppressed: int = 0  # re-found findings already dismissed/deleted in the dashboard
     elapsed_s: float | None = None
     budget_s: int | None = None
     active_agents: int = 0
@@ -218,6 +220,11 @@ def build_scan_progress(
             recovered.setdefault(key, None)
         dim_ids = list(recovered)
     evidence_dir = run_dir / "evidence"
+    # The scanner re-finds everything the user has dismissed or deleted, so a
+    # raw evidence tally can run several times the number the finished report
+    # shows. Read the suppression stores once per tick and net them out here,
+    # so the live counters and the run report never tell different stories.
+    dismissed, deleted = project_suppressions(run_dir.parent)
 
     dim_results: list[_DimProgress] = []
     for dim_id in dim_ids:
@@ -261,7 +268,11 @@ def build_scan_progress(
         files_project_total = estimate_meta["total"] if estimate_meta else None
         files_excluded = estimate_meta["excluded"] if estimate_meta else None
 
-        tally = tally_unique_findings(evidence_dir / f"{dim_id}_evidence.jsonl")
+        matcher = build_matcher(dim_id, dismissed, deleted)
+        tally = tally_unique_findings(
+            evidence_dir / f"{dim_id}_evidence.jsonl",
+            suppressed=matcher.is_suppressed if matcher.active else None,
+        )
         elapsed = _dim_elapsed_s(dim_id, run_dir, d_state)
         budget = time_limit_s if (d_state == "running" and time_limit_s and time_limit_s > 0) else None
         active = _active_agents(evidence_dir, dim_id) if d_state == "running" else 0
@@ -273,6 +284,7 @@ def build_scan_progress(
             violations=tally.violations,
             compliance=tally.compliance,
             duplicates=tally.duplicates,
+            suppressed=tally.suppressed,
             elapsed_s=elapsed,
             budget_s=budget,
             active_agents=active,

--- a/src/quodeq/services/suppression.py
+++ b/src/quodeq/services/suppression.py
@@ -1,0 +1,153 @@
+"""One place that decides whether a raw evidence row is suppressed.
+
+Dismiss and delete use different identity keys, and those keys have drifted
+from their consumers before (a dismiss filter matching on principle name
+while the finding dicts carried practiceId, so the filter sat inert). Every
+reader that has to answer "would the dashboard hide this finding?" should
+build its keys here rather than re-deriving them:
+
+- dismissed: ``(req, file, line)``           -- one finding, exact line
+- deleted:   ``(dimension, principle, file)`` -- whole principle in a file
+
+Evidence rows carry ``p`` (a req ID for custom evaluators, otherwise the
+principle name) and optionally ``req``. The delete store carries principle
+*names*, so ``p`` is mapped through the evaluator's req -> principle table
+before the delete key is built -- the same order ``_parse_jsonl_findings``
+applies when it builds the scored report.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping
+
+from quodeq.config.paths import default_paths
+from quodeq.shared.validation import validate_path_segment
+
+_TYPE_VIOLATION = "violation"
+
+
+def _coerce_line(line: object) -> int:
+    try:
+        return int(line)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+
+
+@dataclass(frozen=True)
+class SuppressionMatcher:
+    """Immutable view of one dimension's suppression state."""
+
+    dimension: str
+    dismissed: frozenset = frozenset()
+    deleted: frozenset = frozenset()
+    req_to_principle: Mapping[str, str] = field(default_factory=dict)
+
+    @property
+    def active(self) -> bool:
+        """False when nothing is suppressed -- callers can skip the scan."""
+        return bool(self.dismissed or self.deleted)
+
+    def principle_for(self, raw: str) -> str:
+        """Map an evidence ``p`` (req ID or principle name) to a principle name."""
+        return self.req_to_principle.get(raw, raw)
+
+    def is_suppressed(self, row: dict) -> bool:
+        """True when the dashboard would hide this raw evidence row.
+
+        Compliance rows are never suppressed: both stores only ever record
+        violations, and hiding a passing check would silently inflate the
+        compliance ratio.
+        """
+        if not self.active or row.get("t") != _TYPE_VIOLATION:
+            return False
+        raw = row.get("p") or row.get("req")
+        if not raw:
+            return False
+        file = row.get("file") or ""
+        if self.dismissed:
+            req = row.get("req") or raw
+            if (req, file, _coerce_line(row.get("line"))) in self.dismissed:
+                return True
+        if self.deleted:
+            return (self.dimension, self.principle_for(raw), file) in self.deleted
+        return False
+
+
+def load_req_to_principle(
+    dimension: str, evaluators_dir: Path | None = None,
+) -> dict[str, str]:
+    """Load the req ID -> principle name mapping for a custom evaluator.
+
+    Empty dict when the evaluator is absent or malformed: built-in dimensions
+    already emit principle names in ``p``, so an empty map is the identity.
+    """
+    if evaluators_dir is None:
+        evaluators_dir = default_paths().evaluators_dir
+    if not evaluators_dir.is_dir():
+        return {}
+    validate_path_segment(dimension)
+    path = evaluators_dir / f"{dimension}.json"
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return {}  # valid JSON but not an object: degrade, don't crash
+        mapping: dict[str, str] = {}
+        for p in data.get("principles", []):
+            pname = p.get("name", "")
+            for req in p.get("requirements", []):
+                rid = req.get("id", "")
+                if rid and pname:
+                    mapping[rid] = pname
+        return mapping
+    except (OSError, ValueError):
+        return {}
+
+
+def project_suppressions(project_dir: Path) -> tuple[frozenset, frozenset]:
+    """Read a project's ``(dismissed, deleted)`` key sets.
+
+    Read fresh on every call. The live-progress reader polls this once per
+    tick, and a dismiss landing mid-scan has to show up on the next one -- a
+    memo keyed on anything coarser than the file contents would freeze the
+    counts for the rest of the run.
+    """
+    from quodeq.services.deleted import deleted_keys  # noqa: PLC0415
+    from quodeq.services.dismissed import dismissed_keys  # noqa: PLC0415
+
+    return frozenset(dismissed_keys(project_dir)), frozenset(deleted_keys(project_dir))
+
+
+def build_matcher(
+    dimension: str,
+    dismissed: frozenset,
+    deleted: frozenset,
+    *,
+    evaluators_dir: Path | None = None,
+) -> SuppressionMatcher:
+    """Attach already-loaded key sets to one dimension.
+
+    Split from :func:`matcher_for` so a caller iterating every dimension of a
+    run (the progress reader) pays for the store reads once, not once per
+    dimension.
+    """
+    if not dismissed and not deleted:
+        # Nothing to map against, so skip the evaluator read entirely.
+        return SuppressionMatcher(dimension=dimension)
+    return SuppressionMatcher(
+        dimension=dimension,
+        dismissed=dismissed,
+        deleted=deleted,
+        req_to_principle=load_req_to_principle(dimension, evaluators_dir),
+    )
+
+
+def matcher_for(
+    project_dir: Path, dimension: str, *, evaluators_dir: Path | None = None,
+) -> SuppressionMatcher:
+    """Build the matcher for *dimension* from *project_dir*'s suppression stores."""
+    dismissed, deleted = project_suppressions(project_dir)
+    return build_matcher(dimension, dismissed, deleted, evaluators_dir=evaluators_dir)

--- a/src/quodeq/ui/src/features/dashboard/buildRunSummary.js
+++ b/src/quodeq/ui/src/features/dashboard/buildRunSummary.js
@@ -20,6 +20,7 @@ export default function buildRunSummary(dimensions, apiSummary) {
       dimensionCount: 0,
       severity: { critical: 0, major: 0, minor: 0 },
       dismissed: 0,
+      suppressed: 0,
     };
   }
 
@@ -30,7 +31,8 @@ export default function buildRunSummary(dimensions, apiSummary) {
       ? (scores.reduce((a, b) => a + b, 0) / scores.length).toFixed(1)
       : null;
 
-  let totalViolations = 0, totalCompliance = 0, critical = 0, major = 0, minor = 0, dismissed = 0;
+  let totalViolations = 0, totalCompliance = 0, critical = 0, major = 0, minor = 0;
+  let dismissed = 0, suppressed = 0;
   for (const d of dimensions) {
     totalViolations += d.totals?.violationCount || 0;
     totalCompliance += d.totals?.complianceCount || 0;
@@ -38,6 +40,10 @@ export default function buildRunSummary(dimensions, apiSummary) {
     major += d.totals?.severity?.major || 0;
     minor += d.totals?.severity?.minor || 0;
     dismissed += typeof d.dismissedCount === 'number' ? d.dismissedCount : 0;
+    // Dismissed AND deleted. On a project with a triage history this dwarfs
+    // `dismissed` — deletions suppress a whole principle across a file and
+    // accumulate across runs, while the scan re-finds them every time.
+    suppressed += typeof d.suppressedCount === 'number' ? d.suppressedCount : 0;
   }
 
   return {
@@ -48,5 +54,6 @@ export default function buildRunSummary(dimensions, apiSummary) {
     dimensionCount: dimensions.length,
     severity: { critical, major, minor },
     dismissed,
+    suppressed,
   };
 }

--- a/src/quodeq/ui/src/features/dashboard/buildRunSummary.test.js
+++ b/src/quodeq/ui/src/features/dashboard/buildRunSummary.test.js
@@ -42,6 +42,38 @@ test('dismissed: ignores non-numeric dismissedCount', () => {
 });
 
 // ---------------------------------------------------------------------------
+// suppressed aggregation (dismissed + deleted)
+// ---------------------------------------------------------------------------
+
+test('suppressed: sums suppressedCount across dimensions', () => {
+  const summary = buildRunSummary([
+    dim({ dimension: 'reliability', suppressedCount: 339 }),
+    dim({ dimension: 'security', suppressedCount: 52 }),
+  ]);
+  assert.equal(summary.suppressed, 391);
+});
+
+test('suppressed: counts deletions that dismissedCount misses', () => {
+  // A project whose triage history is all deletions: dismissed reads 0 while
+  // the scan still re-finds hundreds of suppressed findings every run.
+  const summary = buildRunSummary([dim({ suppressedCount: 339 })]);
+  assert.equal(summary.dismissed, 0);
+  assert.equal(summary.suppressed, 339);
+});
+
+test('suppressed: 0 when no dimension carries suppressedCount', () => {
+  assert.equal(buildRunSummary([dim()]).suppressed, 0);
+});
+
+test('suppressed: 0 for the empty-dimensions fallback', () => {
+  assert.equal(buildRunSummary([]).suppressed, 0);
+});
+
+test('suppressed: ignores a non-numeric suppressedCount', () => {
+  assert.equal(buildRunSummary([dim({ suppressedCount: 'nope' })]).suppressed, 0);
+});
+
+// ---------------------------------------------------------------------------
 // existing aggregation still intact
 // ---------------------------------------------------------------------------
 

--- a/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
@@ -60,7 +60,7 @@ export function RunHeroSection({ dashboard, selectedRunId, runSummary, onCardNav
   const grade = runSummary.overallGrade;
   const violations = runSummary.totalViolations || 0;
   const compliance = runSummary.totalCompliance || 0;
-  const dismissed = runSummary.dismissed || 0;
+  const suppressed = runSummary.suppressed || 0;
   const totalChecks = violations + compliance;
   const ratio = complianceRatio(violations, compliance);
 
@@ -85,8 +85,8 @@ export function RunHeroSection({ dashboard, selectedRunId, runSummary, onCardNav
           hint={
             <>
               <SeverityBadgeRow severity={runSummary.severity} onSeverityClick={handleSeverity} />
-              {dismissed > 0 && (
-                <span className="term-stat__dismissed-note">{dismissed} dismissed hidden</span>
+              {suppressed > 0 && (
+                <span className="term-stat__suppressed-note">{suppressed} suppressed</span>
               )}
             </>
           }

--- a/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.test.jsx
@@ -10,23 +10,24 @@ const baseSummary = {
   dimensionCount: 1,
   severity: { critical: 0, major: 11, minor: 120 },
   dismissed: 0,
+  suppressed: 0,
 };
 
 const dashboard = { selectedRun: { runId: 'r1', dateLabel: '4 Jul 2026' } };
 
-describe('RunHeroSection dismissed note', () => {
-  it('shows how many findings the dismissed filter hid', () => {
+describe('RunHeroSection suppressed note', () => {
+  it('shows how many findings the suppression filters hid', () => {
     render(
       <RunHeroSection
         dashboard={dashboard}
         selectedRunId="r1"
-        runSummary={{ ...baseSummary, dismissed: 404 }}
+        runSummary={{ ...baseSummary, suppressed: 404 }}
       />,
     );
-    expect(screen.getByText(/404 dismissed hidden/)).toBeTruthy();
+    expect(screen.getByText(/404 suppressed/)).toBeTruthy();
   });
 
-  it('renders no note when nothing was dismissed', () => {
+  it('renders no note when nothing was suppressed', () => {
     render(
       <RunHeroSection
         dashboard={dashboard}
@@ -34,10 +35,10 @@ describe('RunHeroSection dismissed note', () => {
         runSummary={baseSummary}
       />,
     );
-    expect(screen.queryByText(/dismissed hidden/)).toBeNull();
+    expect(screen.queryByText(/suppressed/)).toBeNull();
   });
 
-  it('shows the note even when every violation was dismissed', () => {
+  it('shows the note even when every violation was suppressed', () => {
     render(
       <RunHeroSection
         dashboard={dashboard}
@@ -46,10 +47,23 @@ describe('RunHeroSection dismissed note', () => {
           ...baseSummary,
           totalViolations: 0,
           severity: { critical: 0, major: 0, minor: 0 },
-          dismissed: 535,
+          suppressed: 535,
         }}
       />,
     );
-    expect(screen.getByText(/535 dismissed hidden/)).toBeTruthy();
+    expect(screen.getByText(/535 suppressed/)).toBeTruthy();
+  });
+
+  it('counts deletions, which the dismissed-only number misses', () => {
+    // The case that motivated this: a project whose triage history is all
+    // deletions reads dismissed: 0 while 391 findings are hidden from the view.
+    render(
+      <RunHeroSection
+        dashboard={dashboard}
+        selectedRunId="r1"
+        runSummary={{ ...baseSummary, dismissed: 0, suppressed: 391 }}
+      />,
+    );
+    expect(screen.getByText(/391 suppressed/)).toBeTruthy();
   });
 });

--- a/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
@@ -12,6 +12,13 @@ function sumLiveViolations(liveViolations) {
   return Object.values(liveViolations).reduce((n, vs) => n + (vs?.length || 0), 0);
 }
 
+// The live feed already excludes dismissed/deleted findings (it reads the same
+// filtered dimension evals the report does), so FOUND is a net number. The
+// progress payload carries what was netted out, so the strip can say so.
+function sumSuppressed(progress) {
+  return (progress?.dimensions || []).reduce((n, d) => n + (d?.suppressed || 0), 0);
+}
+
 // Live elapsed from wall-clock so the cell ticks every second between the 2s
 // progress polls. Falls back to the backend-reported elapsed only when the job
 // carries no usable startedAt.
@@ -75,7 +82,10 @@ export default function JobStatStrip({ job, liveViolations }) {
     // because the parallel start burst-completes cached files cheaply.
     const rate = isTerminal ? null : computeRate(getRateSamples(jobId));
     const etaHint = isTerminal ? null : buildEtaHint({ rate, takenFiles, totalFiles });
-    return buildJobStatCells(job.status, { overallPct, takenFiles, totalFiles, elapsedS, liveCount, etaHint });
+    const suppressedCount = sumSuppressed(progress);
+    return buildJobStatCells(job.status, {
+      overallPct, takenFiles, totalFiles, elapsedS, liveCount, etaHint, suppressedCount,
+    });
     // `tick` drives the per-second recompute; the sample store is read (not a dep).
   }, [jobId, job?.status, job?.startedAt, job?.endedAt, isTerminal, progress, liveViolations, tick]);
 

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
@@ -130,11 +130,22 @@ function elapsedCell(elapsedS, label = 'ELAPSED', hint = null) {
   };
 }
 
-function foundCell(liveCount, label = 'FOUND', hint = 'live violations') {
+/**
+ * The count of findings this run re-discovered but the user had already
+ * dismissed or deleted, as a hint suffix. Without it the counter silently
+ * drops a number that can dwarf what's shown — on a project with a triage
+ * history the scan re-finds hundreds of suppressed findings every run.
+ */
+export function suppressedSuffix(suppressedCount) {
+  if (!(suppressedCount > 0)) return '';
+  return ` · ${suppressedCount} suppressed`;
+}
+
+function foundCell(liveCount, label = 'FOUND', hint = 'live violations', suppressedCount = 0) {
   return {
     label,
     value: liveCount,
-    hint,
+    hint: `${hint}${suppressedSuffix(suppressedCount)}`,
     tone: liveCount > 0 ? 'critical' : 'default',
   };
 }
@@ -147,6 +158,7 @@ function foundCell(liveCount, label = 'FOUND', hint = 'live violations') {
  * @param {number} inputs.totalFiles
  * @param {number|null|undefined} inputs.elapsedS
  * @param {number} inputs.liveCount
+ * @param {number} [inputs.suppressedCount] — re-found findings already dismissed/deleted
  * @returns {Array<{label,value,hint,tone}>} exactly 4 cells.
  */
 export function buildJobStatCells(status, inputs) {
@@ -157,7 +169,7 @@ export function buildJobStatCells(status, inputs) {
     return [
       statusCell,
       { label: 'SCANNED', value: inputs.totalFiles > 0 ? inputs.totalFiles : '—', hint: 'files', tone: 'default' },
-      foundCell(inputs.liveCount, 'VIOLATIONS', severityHint(inputs.liveCount)),
+      foundCell(inputs.liveCount, 'VIOLATIONS', severityHint(inputs.liveCount), inputs.suppressedCount),
       elapsedCell(inputs.elapsedS, 'DURATION', 'total'),
     ];
   }
@@ -165,7 +177,7 @@ export function buildJobStatCells(status, inputs) {
   return [
     statusCell,
     progressCell(inputs),
-    foundCell(inputs.liveCount),
+    foundCell(inputs.liveCount, 'FOUND', 'live violations', inputs.suppressedCount),
     elapsedCell(inputs.elapsedS, 'ELAPSED', inputs.etaHint ?? null),
   ];
 }

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
@@ -9,6 +9,7 @@ import {
   formatEta,
   buildEtaHint,
   msUntilNextSecond,
+  suppressedSuffix,
 } from './buildJobStatCells.js';
 
 const baseInputs = {
@@ -224,4 +225,34 @@ test('msUntilNextSecond: normalizes negatives and defaults non-finite to 1000', 
   assert.equal(msUntilNextSecond(-300), 300);
   assert.equal(msUntilNextSecond(NaN), 1000);
   assert.equal(msUntilNextSecond(Infinity), 1000);
+});
+
+// ---------------------------------------------------------------------------
+// suppressed hint — the live counters are net, so say what was netted out
+// ---------------------------------------------------------------------------
+
+test('buildJobStatCells: FOUND hint reports the suppressed count while running', () => {
+  const cells = buildJobStatCells('running', { ...baseInputs, liveCount: 122, suppressedCount: 339 });
+  assert.equal(cells[2].label, 'FOUND');
+  assert.equal(cells[2].value, 122);
+  assert.equal(cells[2].hint, 'live violations · 339 suppressed');
+});
+
+test('buildJobStatCells: VIOLATIONS hint reports it on a finished job too', () => {
+  const cells = buildJobStatCells('done', { ...baseInputs, liveCount: 146, suppressedCount: 391 });
+  assert.equal(cells[2].label, 'VIOLATIONS');
+  assert.ok(cells[2].hint.endsWith('391 suppressed'), `got: ${cells[2].hint}`);
+});
+
+test('buildJobStatCells: no suppressed hint on a project with nothing suppressed', () => {
+  const running = buildJobStatCells('running', { ...baseInputs, suppressedCount: 0 });
+  const missing = buildJobStatCells('running', baseInputs);
+  assert.equal(running[2].hint, 'live violations');
+  assert.equal(missing[2].hint, 'live violations');
+});
+
+test('suppressedSuffix: ignores negative and non-numeric counts', () => {
+  assert.equal(suppressedSuffix(-5), '');
+  assert.equal(suppressedSuffix(undefined), '');
+  assert.equal(suppressedSuffix('lots'), '');
 });

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -494,16 +494,21 @@ button.term-sev-badge--clickable:focus-visible {
   align-items: center;
 }
 /* Quiet meta note beside the severity badges: how many re-found findings the
-   project-level dismissed filter hid from this run view. */
-.term-stat__dismissed-note {
+   project-level dismissed + deleted filters hid from this run view. */
+.term-stat__suppressed-note {
+  /* Own line, not trailing the severity badges: the count runs to four digits
+     on a triaged project, and inline it wrapped between the number and its
+     unit ("1337" / "suppressed"). */
+  display: block;
   font-family: var(--term-font-mono);
   font-size: 11px;
   color: var(--color-text-muted);
   letter-spacing: 0.04em;
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
-.acc-eval-sev-row + .term-stat__dismissed-note {
-  margin-left: var(--term-space-2);
+.acc-eval-sev-row + .term-stat__suppressed-note {
+  margin-top: var(--term-space-1);
 }
 
 /* ------------------------------------------------------------

--- a/tests/analysis/test_heartbeat_coverage.py
+++ b/tests/analysis/test_heartbeat_coverage.py
@@ -70,7 +70,7 @@ class TestHeartbeatFormat:
             dimension="security", mins=1, secs=2,
             active=2, plural="s",
             taken=10, total_files=30, remaining=20,
-            violations=2, compliance=5,
+            violations=2, compliance=5, suppressed="",
         )
         assert line.startswith("[security] 1m02s")
         assert "2 v · 5 c" in line
@@ -84,9 +84,29 @@ class TestHeartbeatFormat:
             dimension="security", mins=0, secs=5,
             active=1, plural="",
             taken=1, total_files=2, remaining=1,
-            violations=0, compliance=0,
+            violations=0, compliance=0, suppressed="",
         )
         assert line.endswith("1 agent")
+
+    def test_suppressed_segment_follows_the_compliance_count(self) -> None:
+        line = _HEARTBEAT_FMT.format(
+            dimension="reliability", mins=16, secs=1,
+            active=1, plural="",
+            taken=34, total_files=34, remaining=0,
+            violations=122, compliance=261, suppressed=" · 339 supp",
+        )
+        assert "122 v · 261 c · 339 supp |" in line
+
+    def test_no_suppressed_segment_when_nothing_is_hidden(self) -> None:
+        """A project with no dismissals must keep the pre-existing line shape."""
+        line = _HEARTBEAT_FMT.format(
+            dimension="reliability", mins=1, secs=0,
+            active=1, plural="",
+            taken=1, total_files=2, remaining=1,
+            violations=7, compliance=3, suppressed="",
+        )
+        assert "7 v · 3 c |" in line
+        assert "supp" not in line
 
 
 class TestHeartbeatLoop:

--- a/tests/services/test_suppression.py
+++ b/tests/services/test_suppression.py
@@ -1,0 +1,144 @@
+"""The single seam that decides whether an evidence row is suppressed.
+
+Dismiss/delete identity keys have diverged from their consumers more than
+once (dismiss matching (req, file, line) vs the dashboard's practiceId
+delete key). These tests pin the key shapes and, crucially, pin that the
+live-progress tally and the dashboard's parse path agree on them.
+"""
+import json
+
+import pytest
+
+from quodeq.services.suppression import SuppressionMatcher, matcher_for
+
+
+def _evidence(**over):
+    row = {"t": "violation", "p": "Fault Tolerance", "file": "a.py", "line": 10}
+    row.update(over)
+    return row
+
+
+class TestSuppressionMatcher:
+    def test_empty_matcher_is_inactive_and_suppresses_nothing(self):
+        m = SuppressionMatcher(dimension="reliability")
+        assert not m.active
+        assert not m.is_suppressed(_evidence())
+
+    def test_dismissed_matches_req_file_line(self):
+        m = SuppressionMatcher(
+            dimension="reliability",
+            dismissed=frozenset({("R-FT-1", "a.py", 10)}),
+        )
+        assert m.active
+        assert m.is_suppressed(_evidence(req="R-FT-1"))
+        assert not m.is_suppressed(_evidence(req="R-FT-1", line=11))
+        assert not m.is_suppressed(_evidence(req="R-FT-2"))
+
+    def test_dismissed_falls_back_to_p_when_row_has_no_req(self):
+        m = SuppressionMatcher(
+            dimension="reliability",
+            dismissed=frozenset({("R-FT-1", "a.py", 10)}),
+        )
+        assert m.is_suppressed(_evidence(p="R-FT-1"))
+
+    def test_dismissed_missing_line_coerces_to_zero(self):
+        m = SuppressionMatcher(
+            dimension="reliability",
+            dismissed=frozenset({("R-FT-1", "a.py", 0)}),
+        )
+        row = _evidence(req="R-FT-1")
+        del row["line"]
+        assert m.is_suppressed(row)
+
+    def test_deleted_matches_dimension_principle_file_ignoring_line(self):
+        m = SuppressionMatcher(
+            dimension="reliability",
+            deleted=frozenset({("reliability", "Fault Tolerance", "a.py")}),
+        )
+        assert m.is_suppressed(_evidence())
+        assert m.is_suppressed(_evidence(line=999))
+        assert not m.is_suppressed(_evidence(file="b.py"))
+
+    def test_deleted_key_uses_the_mapped_principle_not_the_req_id(self):
+        """Evidence rows carry req IDs; the delete store carries principle names."""
+        m = SuppressionMatcher(
+            dimension="reliability",
+            deleted=frozenset({("reliability", "Fault Tolerance", "a.py")}),
+            req_to_principle={"R-FT-1": "Fault Tolerance"},
+        )
+        assert m.is_suppressed(_evidence(p="R-FT-1"))
+
+    def test_deleted_does_not_match_a_different_dimension(self):
+        m = SuppressionMatcher(
+            dimension="security",
+            deleted=frozenset({("reliability", "Fault Tolerance", "a.py")}),
+        )
+        assert not m.is_suppressed(_evidence())
+
+    def test_compliance_rows_are_never_suppressed(self):
+        m = SuppressionMatcher(
+            dimension="reliability",
+            dismissed=frozenset({("R-FT-1", "a.py", 10)}),
+            deleted=frozenset({("reliability", "Fault Tolerance", "a.py")}),
+        )
+        assert not m.is_suppressed(_evidence(t="compliance", req="R-FT-1"))
+
+
+class TestMatcherFor:
+    def test_reads_dismissed_and_deleted_from_the_project_dir(self, tmp_path):
+        (tmp_path / "deleted.json").write_text(json.dumps([
+            {"dimension": "reliability", "principle": "Fault Tolerance", "file": "a.py"},
+        ]))
+        m = matcher_for(tmp_path, "reliability", evaluators_dir=tmp_path / "nope")
+        assert m.active
+        assert m.is_suppressed(_evidence())
+
+    def test_inactive_when_the_project_has_no_suppressions(self, tmp_path):
+        assert not matcher_for(tmp_path, "reliability", evaluators_dir=tmp_path / "nope").active
+
+    def test_picks_up_a_delete_written_after_the_first_call(self, tmp_path):
+        """Polled every second during a scan -- a stale memo would freeze counts."""
+        assert not matcher_for(tmp_path, "reliability", evaluators_dir=tmp_path / "nope").active
+        (tmp_path / "deleted.json").write_text(json.dumps([
+            {"dimension": "reliability", "principle": "Fault Tolerance", "file": "a.py"},
+        ]))
+        assert matcher_for(tmp_path, "reliability", evaluators_dir=tmp_path / "nope").active
+
+
+class TestParityWithTheDashboardParsePath:
+    """The live tally and the scored report must exclude the same rows."""
+
+    @pytest.fixture
+    def project(self, tmp_path):
+        (tmp_path / "deleted.json").write_text(json.dumps([
+            {"dimension": "reliability", "principle": "Fault Tolerance", "file": "a.py"},
+        ]))
+        return tmp_path
+
+    def test_tally_and_parse_agree_on_which_rows_survive(self, project, tmp_path):
+        from quodeq.analysis.subagents.jsonl_utils import tally_unique_findings
+        from quodeq.services._violations_jsonl import _parse_jsonl_findings
+        from quodeq.services.deleted import deleted_keys
+
+        rows = [
+            _evidence(file="a.py", line=1),          # deleted
+            _evidence(file="a.py", line=2),          # deleted
+            _evidence(file="b.py", line=3),          # kept
+            _evidence(file="b.py", line=3),          # duplicate of the above
+            _evidence(t="compliance", file="a.py", line=4),  # kept, compliance
+        ]
+        jsonl = tmp_path / "reliability_evidence.jsonl"
+        jsonl.write_text("\n".join(json.dumps(r) for r in rows))
+
+        m = matcher_for(project, "reliability", evaluators_dir=tmp_path / "nope")
+        tally = tally_unique_findings(jsonl, suppressed=m.is_suppressed)
+
+        parsed, compliance = _parse_jsonl_findings(
+            jsonl.read_text().splitlines(), "reliability",
+            deleted_keys=deleted_keys(project),
+        )
+
+        assert tally.violations == len(parsed) == 1
+        assert tally.compliance == len(compliance) == 1
+        assert tally.suppressed == 2
+        assert tally.duplicates == 1


### PR DESCRIPTION
## Why

The scanner re-finds every violation the user has dismissed or deleted, but only the finished report filtered them out. On a project with a triage history the gap is huge and completely unexplained:

| | live scan counter | run report |
|---|---|---|
| reliability | 461 violations | **122** |
| security | 76 violations | **24** |

Compliance matched exactly in both (261 / 39), which is the tell: suppression only ever touches violations. This project carries **2185 delete keys** from past FP triage batches, and 339 of them re-matched reliability in this run. Nothing in the UI or the log said so.

## What changed

- **New `services/suppression.py`** owns both identity keys — dismissed `(req, file, line)`, deleted `(dimension, principle, file)` — and the req→principle mapping the delete key depends on. `_parse_jsonl_findings` now routes through it instead of re-deriving the keys inline. These keys have drifted from their consumers before (#723 had a filter matching `principle` while the dicts carried `practiceId`), so they get one seam and a parity test.
- **`tally_unique_findings`** takes an optional suppression predicate, applied *after* dedup, and reports what it excluded. Injected rather than imported, so `analysis/` keeps its no-`services`-import boundary.
- **`scan_progress`** reads the stores once per tick (not per dimension) and reports net violations plus a per-dimension `suppressed`.
- **Heartbeat** gains a `N supp` segment beside the existing v/c ones:
  `[reliability] 16m01s | 122 v · 261 c · 339 supp | files 34/34 · 0 left | 1 agent`
- **Dashboard** emits `suppressedCount` per dimension. Note this is *not* the existing `dismissedCount`, which covers dismissals only and reads 0 on a delete-only project like this one. The run header shows a quiet `1337 suppressed` under the severity badges.

Also fixes a latent non-dict-JSON `.get()` crash in the tally loop (the recurring class from the nightly triages).

## Verification

Against real run `8fc08558`, every dimension's live count now equals what the report shows:

```
security         v=  24 supp=  52     report: 24
reliability      v= 122 supp= 339     report: 122
performance      v=  36 supp= 107     report: 36
flexibility      v=  58 supp= 116     report: 58
usability        v= 158 supp= 333     report: 158
maintainability  v= 181 supp= 390     report: 180  <- see below
```

Full suite: 5025 passed. UI: 339 node + 1285 vitest. Checked in the running app, light and dark, no console errors.

## Known residual (pre-existing, out of scope)

Maintainability is off by one. That is **not** suppression: `_group_judgments` quarantines findings whose principle isn't in the standard, and the live tally doesn't. The extra row is a `req: "N/A"` finding in `_llamacpp_log_routes.py`. The 571-vs-570 gap predates this PR — it was just invisible until the two numbers were supposed to agree. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)