### PR TITLE
fix(ui): hide the evaluation countdown when the time limit is unlimited

### DIFF
--- a/src/quodeq/ui/src/constants.js
+++ b/src/quodeq/ui/src/constants.js
@@ -15,6 +15,12 @@ export const PER_DIMENSION_STORAGE_KEY = 'cc-per-dimension';
 
 export const ACTIVE_PROVIDER_KEY = 'cc-active-provider';
 
+// Providers that talk to a local model server. They default to no time limit
+// (Settings renders them as "Unlimited" and only writes the key once the user
+// edits it), so every reader of the stored limit must agree on the list or the
+// UI and the run disagree about whether the run is limited at all.
+export const LOCAL_API_PROVIDERS = new Set(['ollama', 'llamacpp', 'omlx']);
+
 export function providerKey(providerId, setting) {
   return `cc-${providerId}-${setting}`;
 }

--- a/src/quodeq/ui/src/features/evaluation/components/CountdownTimer.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/CountdownTimer.jsx
@@ -21,8 +21,12 @@ export default function CountdownTimer({ deadlineAt, budgetSeconds, phase }) {
   }, [deadlineAt]);
 
   if (TERMINAL_PHASES.has(phase)) return null;
+  // Unlimited means there is nothing to count. A run can still carry a
+  // deadline while the configured limit is Unlimited (it was started under a
+  // limit, or it is a CLI run the Evaluate tab adopted), and counting that
+  // stale deadline down reads as "my unlimited run is about to be cut off".
   const unlimited = !budgetSeconds || budgetSeconds <= 0;
-  if (unlimited && !deadlineAt) return null;
+  if (unlimited) return null;
 
   if (!deadlineAt) {
     return (

--- a/src/quodeq/ui/src/features/evaluation/components/CountdownTimer.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/CountdownTimer.test.jsx
@@ -11,6 +11,17 @@ describe('CountdownTimer', () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it('renders nothing when the limit is unlimited even if the run carries a deadline', () => {
+    // A run started under a limit (or a CLI run the tab adopted) keeps its
+    // deadline in status.json. Once the user has switched to Unlimited the
+    // header must stay empty rather than counting that stale deadline down.
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const deadline = new Date(now + 90_000).toISOString();
+    const { container } = render(<CountdownTimer deadlineAt={deadline} budgetSeconds={0} phase="analyzing" />);
+    expect(container.firstChild).toBeNull();
+  });
+
   it('shows greyed static budget during preparing', () => {
     render(<CountdownTimer deadlineAt={null} budgetSeconds={600} phase="preparing" />);
     const el = screen.getByTestId('eval-countdown');

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import EvaluationStatus from './EvaluationStatus.jsx';
 import ReEvaluateCard from './ReEvaluateCard.jsx';
 import CountdownTimer from './CountdownTimer.jsx';
-import { ACTIVE_PROVIDER_KEY, DEFAULT_TIME_LIMIT_S, providerKey } from '../../../constants.js';
+import { ACTIVE_PROVIDER_KEY, DEFAULT_TIME_LIMIT_S, LOCAL_API_PROVIDERS, providerKey } from '../../../constants.js';
 import { TermHeader } from '../../../components/terminal/index.js';
 
 const TOAST_DISMISS_TIMEOUT_MS = 5000;
@@ -33,13 +33,15 @@ function ActiveProviderBadge({ storage = localStorage, onClick }) {
   return <div className="eval-provider-badge">{content}</div>;
 }
 
-function readBudgetSeconds(storage = localStorage) {
+export function readBudgetSeconds(storage = localStorage) {
   const provider = storage.getItem(ACTIVE_PROVIDER_KEY) || '';
   if (!provider) return 0;
   // Read new key first; fall back to legacy 'pool-budget' for back-compat.
   const raw = storage.getItem(providerKey(provider, 'time-limit'))
     ?? storage.getItem(providerKey(provider, 'pool-budget'));
-  if (raw === null || raw === undefined) return (provider === 'ollama' || provider === 'llamacpp') ? 0 : DEFAULT_TIME_LIMIT_S;
+  // Same unset-key defaults the start payload uses (see preparePayload in
+  // useEvaluation.js) so the header can never claim a limit the run won't get.
+  if (raw === null || raw === undefined) return LOCAL_API_PROVIDERS.has(provider) ? 0 : DEFAULT_TIME_LIMIT_S;
   const parsed = parseInt(raw, 10);
   return Number.isFinite(parsed) ? parsed : 0;
 }

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.test.jsx
@@ -11,10 +11,11 @@ vi.mock('../../../components/terminal/index.js', () => ({
 vi.mock('../../../constants.js', () => ({
   ACTIVE_PROVIDER_KEY: 'active-provider',
   DEFAULT_TIME_LIMIT_S: 3600,
+  LOCAL_API_PROVIDERS: new Set(['ollama', 'llamacpp', 'omlx']),
   providerKey: (p, k) => `${p}-${k}`,
 }));
 
-import EvaluateScreen from './EvaluateScreen.jsx';
+import EvaluateScreen, { readBudgetSeconds } from './EvaluateScreen.jsx';
 
 const baseEvaluation = { job: null, jobError: null, liveViolations: [] };
 const baseContext = { selectedProject: null, projectInfo: null, jobProjectInfo: null };
@@ -53,5 +54,26 @@ describe('ErrorToast accessibility', () => {
     fireEvent.click(toast);
     // After click the toast should be gone from DOM
     expect(document.querySelector('.job-error-toast')).toBeNull();
+  });
+});
+
+describe('readBudgetSeconds', () => {
+  const storage = (entries) => ({ getItem: (key) => (key in entries ? entries[key] : null) });
+
+  it('treats every local-API provider as unlimited when no limit was ever stored', () => {
+    // Settings shows these providers as Unlimited by default and never writes
+    // the key until the user edits it, so the header must agree — otherwise it
+    // renders a phantom countdown for a run that has no limit at all.
+    for (const provider of ['ollama', 'llamacpp', 'omlx']) {
+      expect(readBudgetSeconds(storage({ 'active-provider': provider }))).toBe(0);
+    }
+  });
+
+  it('keeps the CLI default for providers that default to a limit', () => {
+    expect(readBudgetSeconds(storage({ 'active-provider': 'claude' }))).toBe(3600);
+  });
+
+  it('honours an explicitly stored unlimited value', () => {
+    expect(readBudgetSeconds(storage({ 'active-provider': 'claude', 'claude-time-limit': '0' }))).toBe(0);
   });
 });

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -32,6 +32,7 @@ import {
   providerKey,
   DEFAULT_MAX_SUBAGENTS,
   DEFAULT_TIME_LIMIT_S,
+  LOCAL_API_PROVIDERS,
 } from "../../../constants.js";
 
 const SSE_ENABLED = import.meta.env?.VITE_USE_SSE_EVENTS === "true";
@@ -41,7 +42,9 @@ const DEFAULT_OLLAMA_SUBAGENTS = "1";
 const DEFAULT_CLI_SUBAGENTS = String(DEFAULT_MAX_SUBAGENTS);
 const DEFAULT_OLLAMA_BUDGET = "0";
 const DEFAULT_CLI_BUDGET = String(DEFAULT_TIME_LIMIT_S);
-export const LOCAL_API_PROVIDERS = new Set(["ollama", "llamacpp", "omlx"]);
+// Re-exported for the existing importers; the set itself lives in constants.js
+// so the Evaluate header resolves unset limits exactly like the start payload.
+export { LOCAL_API_PROVIDERS };
 
 /**
  * Merge per-provider Settings (provider, model, subagents, budget, etc.)


### PR DESCRIPTION
## Problem

With the evaluation time limit set to **Unlimited**, a countdown still ticks in the Evaluate header.

`CountdownTimer` only bailed out when the configured limit was unlimited **and** the job had no `deadlineAt`. A run keeps `deadline_at` in `status.json` once it was started under a limit, and the Evaluate tab also adopts CLI-started runs (the nightly runs with `--time-limit 39600`), so an Unlimited setting still rendered a ticking timer that reads as "this unlimited run is about to be cut off".

A second, independent path produced a phantom *static* budget: `readBudgetSeconds` carried its own hardcoded `ollama`/`llamacpp` list for resolving an unset per-provider key. `omlx` was missing, so it fell back to the 600s CLI default and displayed `10:00` while Settings showed Unlimited and `preparePayload` (which uses `LOCAL_API_PROVIDERS`) sent `timeLimit: 0`.

The backend was never at fault: unlimited runs write no `deadline_at` (`_cli_evaluation.py:494`), the pool auto-scaler preserves `0` verbatim (`_pool_launcher.py:42`), and the progress route gates its budget on `raw > 0`.

## Fix

- `CountdownTimer` returns `null` as soon as the limit is unlimited, before the deadline branch.
- `LOCAL_API_PROVIDERS` moves to `constants.js` and is re-exported from `useEvaluation.js`; the header now resolves an unset limit exactly like the start payload does, so the UI can't claim a limit the run won't get.

## Verification

Reproduced through the real stack with a fixture run (`state=running`, `deadline_at` 42 min out, live pid, fresh heartbeat) served under `QUODEQ_EVALUATIONS_DIR`, with `cc-ollama-time-limit=0`:

- Released 1.7.1 bundle: header renders `41:24`, ticking.
- This branch: no countdown, provider badge only. The card's ELAPSED cell still counts up as before.

Tests: 3 new cases (unlimited + deadline renders nothing; local-API providers default to unlimited; CLI providers keep their default). Full UI suite green, 1288 tests.