### PR TITLE
fix(scan): stop the live counter over-counting quarantined findings

### DIFF
--- a/src/quodeq/analysis/subagents/_heartbeat.py
+++ b/src/quodeq/analysis/subagents/_heartbeat.py
@@ -8,13 +8,14 @@ from pathlib import Path
 
 from quodeq.analysis.subagents.file_queue import FileQueue
 from quodeq.analysis.subagents.jsonl_utils import FindingTally, tally_unique_findings
+from quodeq.core.evidence._req_mapping import PrincipleResolver
 from quodeq.shared.logging import log_info, log_warning
 
 _HEARTBEAT_INTERVAL = 10
 _SECONDS_PER_MINUTE = 60
 _HEARTBEAT_FMT = (
     "[{dimension}] {mins}m{secs:02d}s | "
-    "{violations} v · {compliance} c | "
+    "{violations} v · {compliance} c{quarantined} | "
     "files {taken}/{total_files} · {remaining} left | "
     "{active} agent{plural}"
 )
@@ -27,13 +28,17 @@ class HeartbeatContext:
     dimension_key: str
     jsonl_path: Path
     lock: threading.Lock
+    resolver: PrincipleResolver | None = None
 
 
-def _read_tally(jsonl_path: Path, lock: threading.Lock) -> FindingTally:
+def _read_tally(
+    jsonl_path: Path, lock: threading.Lock,
+    resolver: PrincipleResolver | None = None,
+) -> FindingTally:
     """Tally under the shared write lock to avoid TOCTOU with MCP writers."""
     try:
         with lock:
-            return tally_unique_findings(jsonl_path)
+            return tally_unique_findings(jsonl_path, resolver)
     except OSError:
         return FindingTally()
 
@@ -47,19 +52,26 @@ def heartbeat_loop(
     Each tick re-reads the dimension JSONL and deduplicates by
     ``(p, file, line, t)`` in memory, so the violation/compliance counts
     always match :mod:`quodeq.services.scan_progress` (which the UI consumes).
+
+    Findings the report path quarantines are excluded from the v/c counts and
+    reported separately, so the heartbeat matches the final run report rather
+    than over-counting by the number of unmappable findings.
     """
     start = time.monotonic()
     while not stop.wait(_HEARTBEAT_INTERVAL):
         try:
             elapsed = int(time.monotonic() - start)
             mins, secs = divmod(elapsed, _SECONDS_PER_MINUTE)
-            tally = _read_tally(ctx.jsonl_path, ctx.lock)
+            tally = _read_tally(ctx.jsonl_path, ctx.lock, ctx.resolver)
             remaining, taken = FileQueue(ctx.queue_path).stats()
             active = sum(1 for v in finished.values() if not v)
             log_info(_HEARTBEAT_FMT.format(
                 dimension=ctx.dimension_key,
                 mins=mins,
                 secs=secs,
+                # Only surfaces when a finding was actually quarantined, so the
+                # usual line keeps its shape.
+                quarantined=f" · {tally.quarantined} unmapped" if tally.quarantined else "",
                 active=active,
                 plural="" if active == 1 else "s",
                 taken=taken,

--- a/src/quodeq/analysis/subagents/jsonl_utils.py
+++ b/src/quodeq/analysis/subagents/jsonl_utils.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
+from quodeq.core.evidence._req_mapping import PrincipleResolver
 from quodeq.shared.logging import log_info
 from quodeq.shared.utils import open_text
 
@@ -19,13 +20,16 @@ class FindingTally:
     violations: int = 0
     compliance: int = 0
     duplicates: int = 0
+    quarantined: int = 0
 
     @property
     def total(self) -> int:
         return self.violations + self.compliance
 
 
-def tally_unique_findings(jsonl_path: Path) -> FindingTally:
+def tally_unique_findings(
+    jsonl_path: Path, resolver: PrincipleResolver | None = None,
+) -> FindingTally:
     """Count unique findings (deduplicated by ``(p, file, line, t)``) and duplicates.
 
     Single source of truth for the heartbeat and the dashboard progress reader,
@@ -33,13 +37,24 @@ def tally_unique_findings(jsonl_path: Path) -> FindingTally:
     :func:`deduplicate_jsonl` pass runs at end of pool, the file holds raw
     appends from many parallel agents and contains overlapping findings.
 
+    When *resolver* is supplied, findings whose principle is not in the
+    dimension's standard are counted under ``quarantined`` instead of
+    ``violations``/``compliance`` — matching what the report path drops in
+    :func:`~quodeq.core.evidence._req_mapping._group_judgments`, so the live
+    counter and the persisted evaluation agree. Without a resolver the tally
+    stays permissive and counts every finding, since there is no standard to
+    validate against.
+
+    Deduplication happens before the quarantine check, so a repeated unmappable
+    finding is one quarantined entry, not one per copy.
+
     Tolerant: missing files, malformed lines, and OSError yield empty/partial
     tallies silently.
     """
     if not jsonl_path.is_file():
         return FindingTally()
     seen: set[tuple] = set()
-    violations = compliance = duplicates = 0
+    violations = compliance = duplicates = quarantined = 0
     try:
         with open_text(jsonl_path) as f:
             for raw in f:
@@ -50,19 +65,32 @@ def tally_unique_findings(jsonl_path: Path) -> FindingTally:
                     obj = json.loads(stripped)
                 except json.JSONDecodeError:
                     continue
+                if not isinstance(obj, dict):
+                    continue
                 t = obj.get("t")
                 key = (obj.get("p"), obj.get("file"), obj.get("line"), t)
                 if key in seen:
                     duplicates += 1
                     continue
                 seen.add(key)
+                if t not in ("violation", "compliance"):
+                    # Non-finding rows (e.g. the file_done markers the pool
+                    # appends) still occupy a dedup key but classify as neither.
+                    continue
+                # Mirror parse_jsonl_line: `p` wins, `req` is the fallback.
+                if resolver is not None and resolver.resolve(obj.get("p") or obj.get("req")) is None:
+                    quarantined += 1
+                    continue
                 if t == "violation":
                     violations += 1
-                elif t == "compliance":
+                else:
                     compliance += 1
     except OSError:
         pass
-    return FindingTally(violations=violations, compliance=compliance, duplicates=duplicates)
+    return FindingTally(
+        violations=violations, compliance=compliance,
+        duplicates=duplicates, quarantined=quarantined,
+    )
 
 
 def dedup_jsonl_lines(lines: Iterable[str]) -> list[str]:

--- a/src/quodeq/analysis/subagents/pool.py
+++ b/src/quodeq/analysis/subagents/pool.py
@@ -20,6 +20,7 @@ from quodeq.analysis.subagents._pool_worker import WorkerContext, build_agent_co
 from quodeq.analysis.subagents.file_queue import WorkQueue
 from quodeq.analysis.subagents.jsonl_utils import deduplicate_jsonl, merge_jsonl
 from quodeq.analysis.subprocess import AnalysisConfig
+from quodeq.core.evidence._req_mapping import build_principle_resolver
 from quodeq.shared.constants import _DEFAULT_TIME_LIMIT
 from quodeq.shared.logging import log_info
 
@@ -83,9 +84,17 @@ class SubagentPool:
 
     def _start_heartbeat(self) -> tuple[threading.Event, threading.Thread]:
         stop = threading.Event()
+        run_config = getattr(self._base_config, "run_config", None)
         ctx = HeartbeatContext(
             queue_path=self._queue_path, dimension_key=self._dimension_key,
             jsonl_path=self._shared_jsonl_path(), lock=self._jsonl_lock,
+            # Same standard the evidence parser uses at end of run, so the
+            # heartbeat counts what the report will keep.
+            resolver=build_principle_resolver(
+                self._dimension_key,
+                getattr(run_config, "evaluators_dir", None),
+                self._base_config.compiled_dir,
+            ),
         )
         hb = threading.Thread(
             target=heartbeat_loop, args=(stop, self._finished, ctx), daemon=True,

--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -211,7 +211,10 @@ def register_evaluation_item_routes(app: Flask, provider: ActionProvider) -> Non
             )
             if isinstance(raw, int) and raw > 0:
                 time_limit_s = raw
-        progress = build_scan_progress(job_id, run_dir, time_limit_s=time_limit_s)
+        progress = build_scan_progress(
+            job_id, run_dir, time_limit_s=time_limit_s,
+            compiled_dir=Path(app.config["STANDARDS_COMPILED_DIR"]),
+        )
         if progress is None:
             body, status = error_response("Run not ready", HTTPStatus.NOT_FOUND, "NOT_FOUND")
             return jsonify(body), status

--- a/src/quodeq/core/evidence/_req_mapping.py
+++ b/src/quodeq/core/evidence/_req_mapping.py
@@ -73,6 +73,52 @@ def _resolve_req_to_principle_map(
     return mapping
 
 
+@dataclass(frozen=True)
+class PrincipleResolver:
+    """Resolves a finding's raw principle/requirement ID to a canonical principle.
+
+    The single source of truth for "does this finding belong to the dimension's
+    standard?". Both the report path (:func:`_group_judgments`) and the live
+    scan counters resolve through this, so the counters the UI shows mid-scan
+    and the persisted evaluation JSON can never disagree on which findings count.
+    """
+
+    req_to_principle: dict[str, str]
+    canonical: frozenset[str]
+
+    def resolve(self, practice_id: str | None) -> str | None:
+        """Canonical principle name, or None when the finding is unmappable.
+
+        None means quarantine: the dimension has a standard and this finding's
+        principle is not one it defines. With no standard (canonical empty) every
+        finding maps through unchanged, keeping callers permissive. A missing
+        practice_id never resolves — it has no principle to group under.
+        """
+        if not practice_id:
+            return None
+        principle = self.req_to_principle.get(practice_id, practice_id)
+        if self.canonical and principle not in self.canonical:
+            return None
+        return principle
+
+
+def build_principle_resolver(
+    dimension: str, evaluators_dir: Path | None = None,
+    compiled_dir: Path | None = None,
+) -> PrincipleResolver:
+    """Build the resolver for *dimension* from its standard.
+
+    A custom evaluator standard wins; otherwise the compiled built-in standard.
+    An unknown/blank dimension yields a permissive resolver. The directories must
+    be supplied by the caller; the core layer does not resolve paths itself.
+    """
+    mapping = (
+        _resolve_req_to_principle_map(dimension, evaluators_dir, compiled_dir)
+        if dimension else {}
+    )
+    return PrincipleResolver(mapping, frozenset(p for p in mapping.values() if p))
+
+
 def principle_names_for_dimension(
     dimension: str, evaluators_dir: Path | None = None,
     compiled_dir: Path | None = None,
@@ -94,28 +140,26 @@ def _group_judgments(
     evaluators_dir: Path | None = None,
     compiled_dir: Path | None = None,
 ) -> _GroupedJudgments:
-    req_to_principle = (
-        _resolve_req_to_principle_map(dimension, evaluators_dir, compiled_dir)
-        if dimension else {}
-    )
-    canonical = {p for p in req_to_principle.values() if p}
+    resolver = build_principle_resolver(dimension, evaluators_dir, compiled_dir)
     sc_violations: dict[str, list[Judgment]] = {}
     sc_compliance: dict[str, list[Judgment]] = {}
     sc_severity: dict[str, str] = {}
 
     for j in judgments:
-        principle = req_to_principle.get(j.practice_id, j.practice_id)
         # When the dimension has a standard, a finding whose principle is not
         # one the standard defines is unmappable: quarantine it (keep it out of
         # principle scoring) and log, so a misfiled finding -- a critical, in the
         # worst case -- is never silently turned into a phantom principle (e.g.
-        # an "N/A" card on the dashboard). Without a standard (canonical empty),
-        # stay permissive and group by the raw principle.
-        if canonical and principle not in canonical:
+        # an "N/A" card on the dashboard). The live scan counters resolve through
+        # the same PrincipleResolver, so they exclude exactly these findings too.
+        principle = resolver.resolve(j.practice_id)
+        if principle is None:
             _logger.warning(
                 "Quarantining unmapped %s finding in dimension %r: principle %r "
                 "not in standard (practice_id=%r, req=%r, file=%s)",
-                j.severity or "?", dimension, principle, j.practice_id, j.req, j.file,
+                j.severity or "?", dimension,
+                resolver.req_to_principle.get(j.practice_id, j.practice_id),
+                j.practice_id, j.req, j.file,
             )
             continue
         if j.verdict == "violation":

--- a/src/quodeq/services/_violations_jsonl.py
+++ b/src/quodeq/services/_violations_jsonl.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Iterable
 
 from quodeq.core.types import Finding, ViolationResponse
+from quodeq.core.evidence._req_mapping import PrincipleResolver, build_principle_resolver
 from quodeq.core.evidence.parser import build_req_refs_lookup
 from quodeq.analysis.stream.counters import count_files_in_stream
 from quodeq.services.violation_context import ViolationContext
@@ -27,11 +28,17 @@ _logger = logging.getLogger(__name__)
 
 def _parse_jsonl_findings(
     lines: Iterable[str], dimension: str, req_refs_lookup: dict[str, list[dict]] | None = None,
-    req_to_principle: dict[str, str] | None = None,
+    resolver: PrincipleResolver | None = None,
     dismissed_keys: "set[tuple] | None" = None,
     deleted_keys: "set[tuple] | None" = None,
 ) -> tuple[list[Finding], list[Finding]]:
-    """Parse raw JSONL lines into deduplicated violation and compliance lists."""
+    """Parse raw JSONL lines into deduplicated violation and compliance lists.
+
+    When *resolver* is supplied, findings whose principle is not in the
+    dimension's standard are skipped -- the same quarantine the report path
+    applies in ``_group_judgments``, so this live view cannot show more
+    findings than the persisted evaluation.
+    """
     violations: list[Finding] = []
     compliance: list[Finding] = []
     seen: set[tuple] = set()
@@ -54,7 +61,13 @@ def _parse_jsonl_findings(
             dismissed_key = (req_id, obj.get("file", ""), obj.get("line", 0))
             if dismissed_key in dismissed_keys:
                 continue
-        obj["p"] = req_to_principle.get(principle, principle) if req_to_principle else principle
+        if resolver is not None:
+            resolved = resolver.resolve(principle)
+            if resolved is None:
+                continue
+            obj["p"] = resolved
+        else:
+            obj["p"] = principle
         # Skip permanently-deleted findings -- match by (dimension, principle, file).
         if deleted_keys and obj.get("t") == _TYPE_VIOLATION:
             deleted_key = (dimension, obj["p"], obj.get("file", ""))
@@ -72,36 +85,19 @@ def _parse_jsonl_findings(
     return violations, compliance
 
 
-def _load_req_to_principle(dimension: str, evaluators_dir: "Path | None" = None) -> dict[str, str]:
-    """Load req ID -> principle name mapping for custom evaluators.
+def _build_resolver(dimension: str, compiled_dir: Path | None) -> PrincipleResolver:
+    """Resolve *dimension*'s principle set the same way the report path does.
 
-    Args:
-        dimension: The dimension ID to look up.
-        evaluators_dir: Directory containing evaluator JSON files.
-            Defaults to ``default_paths().evaluators_dir`` when not provided.
+    Routes through the shared builder in ``core.evidence._req_mapping`` rather
+    than reading evaluators here, so this path inherits the compiled-standard
+    fallback. Without it the map is empty on a stock install (the evaluators
+    dir exists but is empty for built-in dimensions) and every requirement ID
+    would look unmappable.
     """
-    if evaluators_dir is None:
-        evaluators_dir = default_paths().evaluators_dir
-    if not evaluators_dir.is_dir():
-        return {}
-    validate_path_segment(dimension)
-    path = evaluators_dir / f"{dimension}.json"
-    if not path.is_file():
-        return {}
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-        if not isinstance(data, dict):
-            return {}  # valid JSON but not an object: degrade, don't crash
-        mapping: dict[str, str] = {}
-        for p in data.get("principles", []):
-            pname = p.get("name", "")
-            for req in p.get("requirements", []):
-                rid = req.get("id", "")
-                if rid and pname:
-                    mapping[rid] = pname
-        return mapping
-    except (OSError, ValueError):
-        return {}
+    validate_path_segment(dimension)  # dimension reaches a path join downstream
+    return build_principle_resolver(
+        dimension, default_paths().evaluators_dir, compiled_dir,
+    )
 
 
 def parse_violations_from_jsonl(
@@ -112,11 +108,11 @@ def parse_violations_from_jsonl(
 ) -> ViolationResponse | None:
     """Parse live JSONL findings written by the MCP server."""
     req_refs_lookup = build_req_refs_lookup(compiled_dir, ctx.dimension) if compiled_dir else None
-    req_to_principle = _load_req_to_principle(ctx.dimension)
+    resolver = _build_resolver(ctx.dimension, compiled_dir)
     try:
         with open_text(jsonl_path) as _f:
             violations, compliance = _parse_jsonl_findings(
-                _f, ctx.dimension, req_refs_lookup, req_to_principle,
+                _f, ctx.dimension, req_refs_lookup, resolver,
                 dismissed_keys=dismissed_keys, deleted_keys=deleted_keys,
             )
     except OSError as exc:

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -21,6 +21,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from quodeq.analysis.subagents.jsonl_utils import tally_unique_findings
+from quodeq.config.paths import default_paths
+from quodeq.core.evidence._req_mapping import build_principle_resolver
 from quodeq.shared.dim_estimates_io import read_dim_estimates
 from quodeq.shared.dimensions_state import read_dimensions
 
@@ -35,6 +37,7 @@ class _DimProgress:
     violations: int = 0
     compliance: int = 0
     duplicates: int = 0
+    quarantined: int = 0  # findings whose principle is not in the dimension's standard
     elapsed_s: float | None = None
     budget_s: int | None = None
     active_agents: int = 0
@@ -170,11 +173,18 @@ def build_scan_progress(
     run_dir: Path,
     *,
     time_limit_s: int | None = None,
+    compiled_dir: Path | None = None,
 ) -> _ScanProgress | None:
     """Compute progress for a run.
 
     Reads only on-disk state — works for internal and external runs uniformly.
     Returns None if the run dir is missing or has no status.json.
+
+    *compiled_dir* supplies the built-in standards used to exclude findings the
+    report path quarantines, so the live counters match the persisted run report.
+    Without it only custom evaluators are consulted, which on a stock install is
+    an empty directory — the counters then stay permissive and can over-count by
+    the number of unmappable findings.
     """
     if not run_dir.is_dir():
         return None
@@ -218,6 +228,7 @@ def build_scan_progress(
             recovered.setdefault(key, None)
         dim_ids = list(recovered)
     evidence_dir = run_dir / "evidence"
+    evaluators_dir = default_paths().evaluators_dir
 
     dim_results: list[_DimProgress] = []
     for dim_id in dim_ids:
@@ -261,7 +272,8 @@ def build_scan_progress(
         files_project_total = estimate_meta["total"] if estimate_meta else None
         files_excluded = estimate_meta["excluded"] if estimate_meta else None
 
-        tally = tally_unique_findings(evidence_dir / f"{dim_id}_evidence.jsonl")
+        resolver = build_principle_resolver(dim_id, evaluators_dir, compiled_dir)
+        tally = tally_unique_findings(evidence_dir / f"{dim_id}_evidence.jsonl", resolver)
         elapsed = _dim_elapsed_s(dim_id, run_dir, d_state)
         budget = time_limit_s if (d_state == "running" and time_limit_s and time_limit_s > 0) else None
         active = _active_agents(evidence_dir, dim_id) if d_state == "running" else 0
@@ -273,6 +285,7 @@ def build_scan_progress(
             violations=tally.violations,
             compliance=tally.compliance,
             duplicates=tally.duplicates,
+            quarantined=tally.quarantined,
             elapsed_s=elapsed,
             budget_s=budget,
             active_agents=active,

--- a/tests/analysis/test_heartbeat_coverage.py
+++ b/tests/analysis/test_heartbeat_coverage.py
@@ -70,7 +70,7 @@ class TestHeartbeatFormat:
             dimension="security", mins=1, secs=2,
             active=2, plural="s",
             taken=10, total_files=30, remaining=20,
-            violations=2, compliance=5,
+            violations=2, compliance=5, quarantined="",
         )
         assert line.startswith("[security] 1m02s")
         assert "2 v · 5 c" in line
@@ -84,9 +84,20 @@ class TestHeartbeatFormat:
             dimension="security", mins=0, secs=5,
             active=1, plural="",
             taken=1, total_files=2, remaining=1,
-            violations=0, compliance=0,
+            violations=0, compliance=0, quarantined="",
         )
         assert line.endswith("1 agent")
+
+    def test_unmapped_segment_only_appears_when_something_was_quarantined(self) -> None:
+        """A clean run keeps the line's original shape."""
+        kwargs = dict(
+            dimension="security", mins=0, secs=5, active=1, plural="",
+            taken=1, total_files=2, remaining=1, violations=3, compliance=0,
+        )
+        assert "unmapped" not in _HEARTBEAT_FMT.format(quarantined="", **kwargs)
+        assert "3 v · 0 c · 1 unmapped" in _HEARTBEAT_FMT.format(
+            quarantined=" · 1 unmapped", **kwargs,
+        )
 
 
 class TestHeartbeatLoop:

--- a/tests/services/test_scan_counter_report_parity.py
+++ b/tests/services/test_scan_counter_report_parity.py
@@ -1,0 +1,124 @@
+"""Parity between the live scan counter and the persisted run report.
+
+The live counter (``tally_unique_findings``, read by the heartbeat and by
+``services.scan_progress``) and the report path (``_group_judgments``, which
+builds the per-dimension evaluation JSON) read the same evidence JSONL. Only
+the report path used to apply the standard-membership predicate, so a finding
+whose principle is not in the dimension's standard was counted live but
+quarantined out of the report — a visible off-by-N in the UI.
+
+Regression case: run 8fc08558 of project d33f1fd0 had 571 unique maintainability
+violations in the JSONL and 570 in evaluation/maintainability.json. The extra row
+carried no ``p`` and ``req: "N/A"``, so it resolved to the phantom principle
+"N/A", which the standard does not define.
+
+These tests pin the invariant by running BOTH paths over one input and comparing,
+rather than asserting hand-computed constants.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis.subagents.jsonl_utils import tally_unique_findings
+from quodeq.core.evidence._jsonl import parse_jsonl_line
+from quodeq.core.evidence._req_mapping import _group_judgments, build_principle_resolver
+
+_DIMENSION = "demo"
+
+
+@pytest.fixture
+def compiled_dir(tmp_path: Path) -> Path:
+    """A compiled standard defining one principle with two requirements."""
+    d = tmp_path / "compiled"
+    d.mkdir()
+    (d / f"{_DIMENSION}.json").write_text(json.dumps({
+        "id": _DIMENSION,
+        "name": "Demo",
+        "principles": [{
+            "name": "Analyzability",
+            "requirements": [{"id": "D-ANA-1"}, {"id": "D-ANA-2"}],
+        }],
+    }), encoding="utf-8")
+    return d
+
+
+def _rows() -> list[dict]:
+    """Four unique violations + one compliance; exactly one is unmappable."""
+    return [
+        # Mappable: `p` already carries the principle name (the common shape).
+        {"p": "Analyzability", "req": "D-ANA-1", "t": "violation",
+         "d": _DIMENSION, "file": "a.py", "line": 1},
+        {"p": "Analyzability", "req": "D-ANA-2", "t": "violation",
+         "d": _DIMENSION, "file": "b.py", "line": 2},
+        # Mappable via the req -> principle map: `p` carries a requirement ID.
+        {"p": "D-ANA-1", "t": "violation", "d": _DIMENSION, "file": "c.py", "line": 3},
+        # Unmappable: no `p`, and `req` is the phantom "N/A" principle. This is
+        # the row the report quarantines and the live counter used to count.
+        {"req": "N/A", "t": "violation", "d": _DIMENSION,
+         "file": "d.py", "line": 4, "severity": "critical"},
+        {"p": "Analyzability", "req": "D-ANA-1", "t": "compliance",
+         "d": _DIMENSION, "file": "e.py", "line": 5},
+    ]
+
+
+@pytest.fixture
+def evidence(tmp_path: Path) -> Path:
+    p = tmp_path / f"{_DIMENSION}_evidence.jsonl"
+    p.write_text("".join(json.dumps(r) + "\n" for r in _rows()), encoding="utf-8")
+    return p
+
+
+def _report_violation_count(evidence_path: Path, compiled: Path) -> int:
+    """Violations the report path keeps, via the real grouping code."""
+    judgments = []
+    for line in evidence_path.read_text(encoding="utf-8").splitlines():
+        parsed = parse_jsonl_line(line)
+        if parsed is not None:
+            judgments.append(parsed[0])
+    grouped = _group_judgments(judgments, dimension=_DIMENSION, compiled_dir=compiled)
+    return sum(len(v) for v in grouped.violations.values())
+
+
+def test_live_counter_matches_report_violation_count(evidence, compiled_dir):
+    """The invariant: both paths agree on how many violations exist."""
+    resolver = build_principle_resolver(_DIMENSION, compiled_dir=compiled_dir)
+    tally = tally_unique_findings(evidence, resolver=resolver)
+    assert tally.violations == _report_violation_count(evidence, compiled_dir)
+
+
+def test_unmappable_finding_is_counted_as_quarantined_not_dropped(evidence, compiled_dir):
+    """Excluded from the violation count, but carried so it is not lost."""
+    resolver = build_principle_resolver(_DIMENSION, compiled_dir=compiled_dir)
+    tally = tally_unique_findings(evidence, resolver=resolver)
+    assert tally.violations == 3
+    assert tally.quarantined == 1
+    assert tally.compliance == 1
+
+
+def test_without_resolver_the_tally_stays_permissive(evidence):
+    """No standard available means no predicate to apply: count everything."""
+    tally = tally_unique_findings(evidence)
+    assert tally.violations == 4
+    assert tally.quarantined == 0
+
+
+def test_duplicates_are_folded_before_the_quarantine_check(tmp_path, compiled_dir):
+    """A repeated unmappable row is one quarantined finding, not N."""
+    p = tmp_path / "ev.jsonl"
+    line = json.dumps({"req": "N/A", "t": "violation", "d": _DIMENSION,
+                       "file": "d.py", "line": 4})
+    p.write_text((line + "\n") * 3, encoding="utf-8")
+    resolver = build_principle_resolver(_DIMENSION, compiled_dir=compiled_dir)
+    tally = tally_unique_findings(p, resolver=resolver)
+    assert tally.quarantined == 1
+    assert tally.duplicates == 2
+    assert tally.violations == 0
+
+
+def test_resolver_without_a_standard_maps_everything_through(tmp_path):
+    """An empty canonical set stays permissive rather than quarantining all."""
+    resolver = build_principle_resolver(_DIMENSION, compiled_dir=tmp_path / "absent")
+    assert resolver.resolve("anything") == "anything"

--- a/tests/services/test_violations_jsonl_coverage.py
+++ b/tests/services/test_violations_jsonl_coverage.py
@@ -84,56 +84,58 @@ class TestParseJsonlFindings:
         assert len(v) == 0
 
     def test_req_to_principle_mapping(self):
+        from quodeq.core.evidence._req_mapping import PrincipleResolver
         from quodeq.services._violations_jsonl import _parse_jsonl_findings
         line = json.dumps({"p": "REQ-1", "t": "compliance", "file": "a.py", "line": 1})
-        mapping = {"REQ-1": "Authentication"}
-        v, c = _parse_jsonl_findings([line], "security", req_to_principle=mapping)
+        resolver = PrincipleResolver({"REQ-1": "Authentication"}, frozenset({"Authentication"}))
+        v, c = _parse_jsonl_findings([line], "security", resolver=resolver)
         assert len(c) == 1
+        assert c[0].practice_id == "Authentication"
+
+    def test_unmappable_finding_is_skipped(self):
+        """Matches the report path, which quarantines it out of the evaluation."""
+        from quodeq.core.evidence._req_mapping import PrincipleResolver
+        from quodeq.services._violations_jsonl import _parse_jsonl_findings
+        line = json.dumps({"req": "N/A", "t": "violation", "file": "a.py", "line": 1})
+        resolver = PrincipleResolver({"REQ-1": "Authentication"}, frozenset({"Authentication"}))
+        v, c = _parse_jsonl_findings([line], "security", resolver=resolver)
+        assert v == []
 
 
-class TestLoadReqToPrinciple:
-    def test_no_evaluators_dir(self, tmp_path):
-        from quodeq.services._violations_jsonl import _load_req_to_principle
-        result = _load_req_to_principle("security", tmp_path / "nonexistent")
-        assert result == {}
+class TestBuildResolver:
+    """The live view resolves principles through the shared builder.
 
-    def test_no_dimension_file(self, tmp_path):
-        from quodeq.services._violations_jsonl import _load_req_to_principle
-        tmp_path.mkdir(exist_ok=True)
-        result = _load_req_to_principle("security", tmp_path)
-        assert result == {}
+    It used to read the evaluators dir itself, with no fallback to the compiled
+    built-in standards. On a stock install that dir exists but is empty for
+    built-in dimensions, so the map came back empty and requirement IDs never
+    resolved to their principle. Malformed-evaluator degradation is covered by
+    tests/core/test_req_mapping_robustness.py, which the shared builder shares.
+    """
 
-    def test_valid_dimension_file(self, tmp_path):
-        from quodeq.services._violations_jsonl import _load_req_to_principle
-        data = {
+    def test_falls_back_to_compiled_standard(self, tmp_path):
+        from quodeq.services._violations_jsonl import _build_resolver
+        compiled = tmp_path / "compiled"
+        compiled.mkdir()
+        (compiled / "security.json").write_text(json.dumps({
             "principles": [
-                {
-                    "name": "Authentication",
-                    "requirements": [
-                        {"id": "REQ-1"},
-                        {"id": "REQ-2"},
-                    ]
-                }
+                {"name": "Authentication", "requirements": [{"id": "REQ-1"}]},
             ]
-        }
-        dim_file = tmp_path / "security.json"
-        dim_file.write_text(json.dumps(data))
-        result = _load_req_to_principle("security", tmp_path)
-        assert result == {"REQ-1": "Authentication", "REQ-2": "Authentication"}
+        }))
+        resolver = _build_resolver("security", compiled)
+        assert resolver.resolve("REQ-1") == "Authentication"
+        assert resolver.resolve("Authentication") == "Authentication"
+        assert resolver.resolve("N/A") is None
 
-    def test_corrupt_json(self, tmp_path):
-        from quodeq.services._violations_jsonl import _load_req_to_principle
-        (tmp_path / "security.json").write_text("not json")
-        result = _load_req_to_principle("security", tmp_path)
-        assert result == {}
+    def test_no_standard_stays_permissive(self, tmp_path):
+        from quodeq.services._violations_jsonl import _build_resolver
+        resolver = _build_resolver("security", tmp_path / "nonexistent")
+        assert resolver.resolve("anything") == "anything"
 
-    @pytest.mark.parametrize("payload", ['[{"name": "x"}]', "null", '"hello"', "42"])
-    def test_non_dict_top_level_returns_empty(self, tmp_path, payload):
-        """A valid-JSON-but-non-dict evaluator file must not crash with
-        AttributeError on data.get(); it degrades to an empty mapping."""
-        from quodeq.services._violations_jsonl import _load_req_to_principle
-        (tmp_path / "security.json").write_text(payload)
-        assert _load_req_to_principle("security", tmp_path) == {}
+    def test_rejects_a_traversing_dimension(self, tmp_path):
+        """The dimension reaches a path join, so the guard must survive."""
+        from quodeq.services._violations_jsonl import _build_resolver
+        with pytest.raises(ValueError):
+            _build_resolver("../../etc/passwd", tmp_path)
 
 
 class TestParseViolationsFromJsonl:
@@ -152,8 +154,7 @@ class TestParseViolationsFromJsonl:
         jsonl = tmp_path / "findings.jsonl"
         jsonl.write_text(json.dumps({"p": "P1", "t": "violation", "file": "a.py", "line": 1}) + "\n")
         ctx = ViolationContext(dimension="sec", run_id="r1", project="p1")
-        with patch("quodeq.services._violations_jsonl._load_req_to_principle", return_value={}), \
-             patch("quodeq.services._violations_jsonl.build_req_refs_lookup", return_value=None):
+        with patch("quodeq.services._violations_jsonl.build_req_refs_lookup", return_value=None):
             result = parse_violations_from_jsonl(jsonl, None, ctx)
             assert result is not None
             assert result.dimension == "sec"

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -16,7 +16,7 @@ src/quodeq/data/projection/grade_projector.py:20:services
 src/quodeq/data/sqlite/state_store.py:272:services
 src/quodeq/engine/scoring_pipeline.py:10:services
 src/quodeq/services/_external_jobs.py:22:analysis
-src/quodeq/services/_violations_jsonl.py:11:analysis
+src/quodeq/services/_violations_jsonl.py:12:analysis
 src/quodeq/services/_violations_stream.py:10:analysis
 src/quodeq/services/_violations_stream.py:11:analysis
 src/quodeq/services/evaluation_mixin.py:22:analysis


### PR DESCRIPTION
## The bug

The live scan counter and the persisted run report read the same evidence JSONL, but only the report path applied the standard-membership predicate. A finding whose principle is not in the dimension's standard was counted live and quarantined out of the report, so the two disagreed by the number of unmappable findings.

Repro: run `8fc08558` of project `d33f1fd0` has **571** unique maintainability violations in the JSONL and **570** in `evaluation/maintainability.json`. The extra row carries no `p` and `req: "N/A"`, so it resolves to a principle the standard does not define.

This was invisible until the live counters were made to match the report. It is now a visible off-by-N on any dimension with unmappable findings.

## Root cause

One missing predicate, not a counting bug. `_group_judgments` resolves `p or req` through the req->principle map and drops anything outside the standard. `tally_unique_findings` and `_parse_jsonl_findings` had no membership check at all.

Confirmed by replicating the predicate across all six dimensions of the repro run: the quarantined count equals the delta everywhere, which rules out any other contributor.

| dim | live (before) | report | delta |
|---|---|---|---|
| flexibility | 174 | 174 | 0 |
| maintainability | 571 | 570 | **1** |
| performance | 143 | 143 | 0 |
| reliability | 461 | 461 | 0 |
| security | 76 | 76 | 0 |
| usability | 491 | 491 | 0 |

## The fix

Extracted the predicate into `PrincipleResolver` in `core/evidence/_req_mapping.py` and routed **`_group_judgments` itself** through it, so the report path and the live counters share one object and cannot drift again. `tally_unique_findings`, the heartbeat, `scan_progress`, and `_parse_jsonl_findings` all resolve through it now.

Quarantined findings are counted under `FindingTally.quarantined` / `_DimProgress.quarantined` rather than silently discarded. The heartbeat appends an `N unmapped` segment only when something was actually quarantined, so a clean run's log keeps its shape. No dashboard change.

## Also in here

**`services/_violations_jsonl._load_req_to_principle` is deleted.** It read the evaluators dir with no fallback to the compiled built-in standards. On a stock install that dir exists but is empty for built-in dimensions, so the map came back empty (0 entries vs 51) and requirement IDs never resolved to their principle. Adding a canonical check on top of it would have wrongly quarantined every finding whose `p` is a req ID. It was also less robust than the shared builder, crashing on non-dict principle items. Its path-traversal guard on `dimension` is preserved at the service boundary, with a test.

**`tools/import_baseline.txt` regenerated.** The new import shifted a pre-existing grandfathered `analysis` import from line 11 to 12. Both import-layer tests failed for the same file and target, which is the tool's own documented signal for a pure line shift. The diff is one line and grandfathers nothing new.

## Verification

Fixed code against the real repro run, all six dimensions now match the report exactly, maintainability at 570 with `quarantined=1`.

- `pytest -m "not integration"`: 5013 passed, 1 skipped
- UI evaluation feature: 119 passed

New guard is `tests/services/test_scan_counter_report_parity.py`, which runs both paths over one input and compares, rather than asserting hand-computed constants.

## Notes for review

- Branched off `develop`, so it does **not** contain #878's `services/suppression.py`. Both add an exclusion to `scan_progress`; whichever merges second will need the two seams reconciled.
- Quarantined findings remain absent from the persisted report. Surfacing the *count* as run metadata alongside `coveragePct` / `exitReason` is a deliberate follow-up, stacked on this branch. They should not become a findings bucket, that would rebuild the phantom "N/A" card #659/#663/#721 removed.
- The one quarantined finding here is a security issue the maintainability scan produced. Routing misfiled findings to their correct dimension is the separate, already-tracked "remap findings to correct req IDs" work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)