### PR TITLE
perf(overview): reuse the run walk across as-of score selections

### DIFF
--- a/src/quodeq/services/_accumulated_data.py
+++ b/src/quodeq/services/_accumulated_data.py
@@ -1,12 +1,23 @@
 """Data loading helpers for the accumulated (cross-run) view."""
 from __future__ import annotations
 
+import hashlib
+import threading
+from collections import OrderedDict
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Callable
 
 from quodeq.services.ports import RunInfo, read_run_data
 from quodeq.core.types import DimensionResult
+
+# Files whose contents feed read_run_data for a single run. A completed run is
+# not immutable: dismissing a finding or applying a grade formula rewrites the
+# SQL grade tables that overlay_sql_grades reads back, so the fingerprint has
+# to cover the database (and its write-ahead log, which absorbs writes long
+# before a checkpoint touches the main file) alongside the JSON.
+_FINGERPRINT_DIRS = ("evaluation", "evidence")
+_FINGERPRINT_FILES = ("evaluation.db", "evaluation.db-wal", "events.jsonl")
 
 
 @dataclass
@@ -56,19 +67,143 @@ def _classify_dimension(
         buckets.prev_run_latest_map[dim_name] = dim
 
 
+def run_fingerprint(run_dir: Path) -> str:
+    """Cheap content fingerprint for the inputs ``read_run_data`` reads.
+
+    Stat-based rather than hash-based: the point is to be far cheaper than the
+    read it guards, while still changing whenever a run's data is rewritten in
+    place (see :data:`_FINGERPRINT_FILES`).
+    """
+    parts: list[str] = []
+    for sub in _FINGERPRINT_DIRS:
+        try:
+            entries = sorted((run_dir / sub).iterdir())
+        except OSError:
+            continue
+        for path in entries:
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            parts.append(f"{sub}/{path.name}:{stat.st_mtime_ns}:{stat.st_size}")
+    for name in _FINGERPRINT_FILES:
+        try:
+            stat = (run_dir / name).stat()
+        except OSError:
+            continue
+        parts.append(f"{name}:{stat.st_mtime_ns}:{stat.st_size}")
+    return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+
+
+def _strip_findings(dimensions: list[DimensionResult]) -> list[DimensionResult]:
+    """Drop the violation/compliance bodies, keeping every scalar field.
+
+    Everything the accumulated walk consults -- ``overall_score``,
+    ``files_read``, ``totals``, ``principles`` -- survives, so classification is
+    bit-identical to classifying the full read.
+    """
+    return [replace(d, violations=[], compliance=[]) for d in dimensions]
+
+
+def make_slim_run_fetcher(
+    reports_root: Path, project: str,
+    cache: OrderedDict, lock: threading.Lock, max_size: int,
+) -> Callable[[str], list[DimensionResult]]:
+    """Return a fetcher of findings-free per-run dimensions, LRU-cached.
+
+    The full read costs megabytes per run because it hydrates every finding
+    body; the walk over run history needs only the scores. Caching the stripped
+    projection instead lets the cache outlive a single request at kilobyte cost,
+    which is what makes consecutive as-of selections cheap.
+
+    *max_size* <= 0 disables caching entirely (every call reads through).
+    """
+    def get_slim(run_id: str) -> list[DimensionResult]:
+        if max_size <= 0:
+            return _strip_findings(_read_run_data_safely(reports_root, project, run_id))
+        key = (str(reports_root), project, run_id,
+               run_fingerprint(reports_root / project / run_id))
+        with lock:
+            hit = cache.get(key)
+            if hit is not None:
+                cache.move_to_end(key)
+                return hit
+        slim = _strip_findings(_read_run_data_safely(reports_root, project, run_id))
+        with lock:
+            cache[key] = slim
+            cache.move_to_end(key)
+            while len(cache) > max_size:
+                cache.popitem(last=False)
+        return slim
+
+    return get_slim
+
+
+def _read_run_data_safely(
+    reports_root: Path, project: str, run_id: str,
+) -> list[DimensionResult]:
+    """``read_run_data`` with the same error tolerance the LRU fetcher applies."""
+    try:
+        return read_run_data(reports_root, project, run_id)
+    except (OSError, ValueError, KeyError):
+        return []
+
+
+def _hydrate_latest_dimensions(
+    buckets: _DimensionBuckets, fetch_full: Callable[[str], list[DimensionResult]],
+) -> None:
+    """Swap the winning slim dimensions for their full findings bodies.
+
+    Only dimensions that survive as *latest* are rendered with violations and
+    compliance, and they come from a handful of runs -- so the expensive read is
+    paid for those runs alone rather than for the whole history.
+    """
+    names_by_run: dict[str, list[str]] = {}
+    for name, dim in buckets.latest_by_dimension.items():
+        if dim.from_run_id:
+            names_by_run.setdefault(dim.from_run_id, []).append(name)
+
+    for run_id, names in names_by_run.items():
+        full_by_name: dict[str, DimensionResult] = {}
+        for dim in fetch_full(run_id):
+            # First occurrence wins, matching the classification loop.
+            full_by_name.setdefault(dim.dimension, dim)
+        for name in names:
+            full = full_by_name.get(name)
+            if full is None:
+                continue
+            slim = buckets.latest_by_dimension[name]
+            buckets.latest_by_dimension[name] = replace(
+                full,
+                from_run_id=slim.from_run_id,
+                from_date_iso=slim.from_date_iso,
+                from_date_label=slim.from_date_label,
+            )
+
+
 def _read_all_run_data(
     reports_root: Path, project: str, all_run_infos: list[RunInfo], runs: list[str],
     get_run_data: Callable[[str], list[DimensionResult]] | None = None,
+    get_run_slim: Callable[[str], list[DimensionResult]] | None = None,
 ) -> tuple[dict[str, DimensionResult], dict[str, DimensionResult], list[DimensionResult]]:
-    """Build accumulated data structures in a single sequential pass."""
+    """Build accumulated data structures from a walk over *runs*.
+
+    With *get_run_slim* the walk runs on findings-free dimensions and only the
+    winning dimensions are re-read in full; without it the walk reads every run
+    in full, as it always did.
+    """
     run_lookup = {r.run_id: r for r in all_run_infos}
     buckets = _DimensionBuckets()
-    _fetch = get_run_data or (lambda rid: read_run_data(reports_root, project, rid))
+    _fetch_full = get_run_data or (lambda rid: read_run_data(reports_root, project, rid))
+    _fetch = get_run_slim or _fetch_full
 
     for run_idx_i, run_id in enumerate(runs):
         run_info = run_lookup.get(run_id)
         for dim in _fetch(run_id):
             _classify_dimension(dim, run_id, run_info, run_idx_i == 0, buckets)
+
+    if get_run_slim is not None:
+        _hydrate_latest_dimensions(buckets, _fetch_full)
 
     return (
         buckets.latest_by_dimension,

--- a/src/quodeq/services/accumulated.py
+++ b/src/quodeq/services/accumulated.py
@@ -20,8 +20,33 @@ from quodeq.shared.utils import _env_int
 
 # Re-export so existing external imports keep working.
 from quodeq.services._accumulated_data import _read_all_run_data  # noqa: F401
+from quodeq.services._accumulated_data import make_slim_run_fetcher
 
 _DEFAULT_ACC_CACHE_MAX = 256
+
+# Entries in the walk cache are findings-free (kilobytes), not full run reads
+# (megabytes), so this bound covers several projects' entire run history and
+# still costs a few MB. Set QUODEQ_ACC_WALK_CACHE_MAX=0 to disable.
+_DEFAULT_WALK_CACHE_MAX = 2048
+
+# Process-lived so consecutive as-of selections on the Overview score-history
+# chart reuse the walk. Their run sets overlap in all but a run or two; a
+# per-call cache made every newly-selected day re-read the whole history.
+_WALK_CACHE: OrderedDict[tuple, list[DimensionResult]] = OrderedDict()
+_WALK_CACHE_LOCK = threading.Lock()
+
+
+def clear_accumulated_process_cache() -> None:
+    """Drop the process-lived walk cache. For tests and cache kill switches."""
+    with _WALK_CACHE_LOCK:
+        _WALK_CACHE.clear()
+
+
+def _walk_cache_max(override: int | None = None, env: dict[str, str] | None = None) -> int:
+    """Return the walk-cache size limit (entries)."""
+    if override is not None:
+        return override
+    return _env_int("QUODEQ_ACC_WALK_CACHE_MAX", _DEFAULT_WALK_CACHE_MAX, env=env)
 
 
 def numeric_average(
@@ -192,8 +217,17 @@ def _build_accumulated_for_runs(
     runs = [r.run_id for r in run_infos]
     _cache, _lock, _max = _resolve_cache(cache_config)
     get_run_data = make_lru_dimension_fetcher(reports_root, project, _cache, _lock, _max)
+    # A caller-supplied cache_config asks for per-call isolation, so it backs the
+    # walk too; otherwise the walk runs off the shared process cache.
+    if cache_config is not None:
+        walk_cache, walk_lock, walk_max = _cache, _lock, _max
+    else:
+        walk_cache, walk_lock, walk_max = _WALK_CACHE, _WALK_CACHE_LOCK, _walk_cache_max()
+    get_run_slim = make_slim_run_fetcher(
+        reports_root, project, walk_cache, walk_lock, walk_max,
+    )
     latest_by_dim, prev_occurrence, prev_run_latest = _read_all_run_data(
-        reports_root, project, run_infos, runs, get_run_data,
+        reports_root, project, run_infos, runs, get_run_data, get_run_slim=get_run_slim,
     )
     project_dir = reports_root / project
     all_dims = filter_dismissed_from_dimensions(list(latest_by_dim.values()), project_dir)

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -256,6 +256,30 @@ export function shouldShowProjectTabs({ selectedSource, hasCurrentProjectRuns, s
  * consumed but never forwarded). Exported so producer and consumer can be
  * pinned together in tests without mounting the whole App.
  */
+/**
+ * The dashboard data bundle handed to every DashboardPage route.
+ *
+ * Same hazard as buildNavigationBundle, quieter failure: this is an explicit
+ * key whitelist, so a field added to useAppState and read by DashboardPage
+ * silently arrives as undefined unless it is forwarded here. Nothing throws --
+ * the feature just never activates (that is how scoresPending, and the
+ * dimension-panel pending state that depends on it, was inert at first).
+ * Exported so producer and consumer can be pinned together in tests.
+ */
+export function buildDashboardDataBundle({ state, sharedHasContent = false }) {
+  return {
+    selectedProject: state.selectedProject, selectedSource: state.selectedSource, selectedRun: state.selectedRun, projects: state.projects,
+    projectsLoaded: state.projectsLoaded,
+    dashboard: state.dashboard, accumulated: state.accumulated, latestAccumulated: state.latestAccumulated, loading: state.loading, isFetching: state.isFetching, error: state.error,
+    scoresPending: state.scoresPending,
+    sharedProjectInfo: state.sharedProjectInfo,
+    availableRuns: state.availableRuns, dailyRuns: state.dailyRuns, overviewRunIndex: state.overviewRunIndex,
+    selectedDisplayName: state.selectedDisplayName,
+    granularity: state.granularity, onGranularityChange: state.onGranularityChange,
+    sharedHasContent,
+  };
+}
+
 export function buildNavigationBundle({ state, navTab, navStackLength, isEvaluating, showToast, setWizardEntry, sharedHasContent = false }) {
   return {
     selectedProject: state.selectedProject, selectedSource: state.selectedSource, selectedRun: state.selectedRun, projects: state.projects,
@@ -1048,16 +1072,7 @@ export default function App() {
   );
 
   const contentProps = {
-    dashboardData: {
-      selectedProject: state.selectedProject, selectedSource: state.selectedSource, selectedRun: state.selectedRun, projects: state.projects,
-      projectsLoaded: state.projectsLoaded,
-      dashboard: state.dashboard, accumulated: state.accumulated, latestAccumulated: state.latestAccumulated, loading: state.loading, isFetching: state.isFetching, error: state.error,
-      sharedProjectInfo: state.sharedProjectInfo,
-      availableRuns: state.availableRuns, dailyRuns: state.dailyRuns, overviewRunIndex: state.overviewRunIndex,
-      selectedDisplayName: state.selectedDisplayName,
-      granularity: state.granularity, onGranularityChange: state.onGranularityChange,
-      sharedHasContent: sharedSignal.hasContent,
-    },
+    dashboardData: buildDashboardDataBundle({ state, sharedHasContent: sharedSignal.hasContent }),
     navigation: buildNavigationBundle({
       state, navTab, navStackLength: navStack.length,
       isEvaluating, showToast, setWizardEntry,

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom/vitest';
 import {
   buildEvalPrincipal, ROUTE_RENDERERS, isSharedSource, shouldBounceToEvaluate, shouldShowEvaluateButton,
   resolveSelectionAfterSharedDisconnect, shouldAutoOpenOnboardingWizard, shouldRedirectToRemoteRepositories, shouldShowProjectTabs,
-  buildNavigationBundle, shouldWallEmptyProjects, buildWizardHandlers, buildAssistantSessionPayload,
+  buildNavigationBundle, buildDashboardDataBundle, shouldWallEmptyProjects, buildWizardHandlers, buildAssistantSessionPayload,
   buildAssistantActionAppliedHandler, resolveProjectDisplayName,
 } from './App.jsx';
 import Sidebar from './components/Sidebar.jsx';
@@ -730,5 +730,41 @@ describe('resolveSelectionAfterSharedDisconnect', () => {
   it('clears the selection to the app\'s no-project state when there are no local projects', () => {
     expect(resolveSelectionAfterSharedDisconnect({ selectedSource: 'shared', projects: [] }))
       .toEqual({ id: '', source: 'local' });
+  });
+});
+
+// Same producer x consumer hazard as buildNavigationBundle, but silent: the
+// dashboard bundle is an explicit key whitelist, so a field DashboardPage
+// reads arrives as undefined unless it is forwarded. Nothing throws — the
+// feature is simply inert, which is exactly how the dimension-panel pending
+// state shipped dead the first time.
+describe('buildDashboardDataBundle', () => {
+  const stubState = () => ({
+    selectedProject: 'p1', selectedSource: 'local', selectedRun: 'latest',
+    projects: [], projectsLoaded: true,
+    dashboard: {}, accumulated: {}, latestAccumulated: {},
+    loading: false, isFetching: false, scoresPending: true, error: null,
+    sharedProjectInfo: null,
+    availableRuns: [], dailyRuns: [], overviewRunIndex: 0,
+    selectedDisplayName: 'p1',
+    granularity: 'day', onGranularityChange: () => {},
+  });
+
+  it('forwards scoresPending (the dimension cards look settled while stale without it)', () => {
+    const bundle = buildDashboardDataBundle({ state: stubState(), sharedHasContent: false });
+    expect(bundle.scoresPending).toBe(true);
+  });
+
+  it('forwards every key DashboardPage destructures off its data prop', () => {
+    const bundle = buildDashboardDataBundle({ state: stubState(), sharedHasContent: true });
+    // Mirrors the destructure at the top of DashboardPage.
+    const consumed = [
+      'selectedProject', 'selectedSource', 'selectedRun', 'projects', 'sharedProjectInfo',
+      'dashboard', 'accumulated', 'loading', 'isFetching', 'scoresPending', 'error',
+      'availableRuns', 'dailyRuns', 'overviewRunIndex', 'granularity',
+      'onGranularityChange', 'sharedHasContent',
+    ];
+    const missing = consumed.filter((k) => !(k in bundle));
+    expect(missing).toEqual([]);
   });
 });

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -137,11 +137,16 @@ export function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, accu
   );
 }
 
-function AccumulatedDimensionsSection({ sortedDimensions, onDimensionClick, selectedDayDimNames, dimTrends }) {
+function AccumulatedDimensionsSection({ sortedDimensions, onDimensionClick, selectedDayDimNames, dimTrends, pending }) {
   return (
-    <section className="quality-dimensions" aria-label="Quality dimensions">
+    <section
+      className={`quality-dimensions${pending ? ' quality-dimensions--pending' : ''}`}
+      aria-label="Quality dimensions"
+      aria-busy={pending || undefined}
+    >
       <div className="quality-dimensions__head">
         <SectionLabel>quality_dimensions · {sortedDimensions.length}</SectionLabel>
+        {pending && <span className="quality-dimensions__pending">updating…</span>}
       </div>
       <div className="dimensions-panel">
         <DimensionCardsGrid
@@ -303,6 +308,7 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
         onDimensionClick={onDimensionClick}
         selectedDayDimNames={selectedDayDimNames}
         dimTrends={dimTrends}
+        pending={data.scoresPending}
       />
 
       {topFiles.length > 0 && (

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -45,7 +45,7 @@ function NoCompletedEvalPanel({ availableRuns = [], onNavigate, selectedSource }
 }
 
 function DashboardContent({ runMode, data, focus, callbacks }) {
-  const { dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo, granularity, selectedSource } = data;
+  const { dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo, granularity, selectedSource, scoresPending } = data;
   const { dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData } = focus;
   const { onRunSelect, onDimensionCardClick, onAccumulatedDimensionClick, onFileClick, onNavigate, onGranularityChange } = callbacks;
   if (runMode) {
@@ -91,6 +91,7 @@ function DashboardContent({ runMode, data, focus, callbacks }) {
         accumulated: accumulated ? { ...accumulated, dimensions: accumulatedDimensions } : accumulated,
         accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex,
         trend: dashboard?.trend || [], selectedRunId, selectedProject, projectInfo, granularity, selectedSource,
+        scoresPending,
       }}
       callbacks={{
         onRunClick: onRunSelect, onDimensionClick: onAccumulatedDimensionClick, onNavigate, onGranularityChange,
@@ -133,7 +134,7 @@ export function selectDashboardProjectInfo({ selectedSource, projects, selectedP
 }
 
 export default function DashboardPage({ data = {}, callbacks = {}, runMode = false }) {
-  const { selectedProject, selectedSource, selectedRun, projects = [], sharedProjectInfo = null, dashboard, accumulated, loading, isFetching, error, availableRuns = [], dailyRuns, overviewRunIndex = 0, granularity = 'day', onGranularityChange, sharedHasContent = false } = data;
+  const { selectedProject, selectedSource, selectedRun, projects = [], sharedProjectInfo = null, dashboard, accumulated, loading, isFetching, scoresPending = false, error, availableRuns = [], dailyRuns, overviewRunIndex = 0, granularity = 'day', onGranularityChange, sharedHasContent = false } = data;
   const projectInfo = selectDashboardProjectInfo({ selectedSource, projects, selectedProject, sharedProjectInfo });
   const { onNavigate, onRunSelect, onProjectsReload } = callbacks;
   // After a successful clone-on-add migration the project's repository_info.json
@@ -253,7 +254,7 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
       {dashboard && (
         <DashboardContent
           runMode={runMode}
-          data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo, granularity, selectedSource }}
+          data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo, granularity, selectedSource, scoresPending }}
           focus={{ dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData }}
           callbacks={{ onRunSelect, onDimensionCardClick: handlers.handleDimensionCardClick, onAccumulatedDimensionClick: handlers.handleAccumulatedDimensionClick, onFileClick: handlers.handleFileClick, onNavigate, onGranularityChange }}
         />

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -55,6 +55,7 @@ export function useDashboard({ selectedProject, selectedRun, selectedSource = "l
     latestScores,
     loading: scoresLoading,
     error: scoresError,
+    scoresPending,
     availableRuns,
   } = useProjectScores({ selectedProject, selectedRun, selectedSource, keepPlaceholder });
 
@@ -184,6 +185,9 @@ export function useDashboard({ selectedProject, selectedRun, selectedSource = "l
     // (e.g. user switched to a different run). Page shows a subtle
     // shimmer/dim instead of the full loading screen.
     isFetching: dashboardQuery.isFetching,
+    // Scores for the newly-picked run are still loading; the panels below are
+    // showing the previous selection's numbers until they land.
+    scoresPending,
     error: dashboardQuery.isError
       ? "Failed to load dashboard data. Check your connection and try refreshing."
       : (scoresError || null),

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -157,7 +157,7 @@ export function useAppState() {
   // usually nearly identical. The dashboard-refreshing class dims the
   // page during the background refetch so the user sees that something
   // is happening without the jarring full-screen LoadingScreen.
-  const { dashboard, accumulated, latestAccumulated, rescoreLookup, loading, isFetching, error, availableRuns, refreshDashboard, refreshDashboardActive, scheduleDashboardReconcile, sharedProjectInfo } = useDashboard({
+  const { dashboard, accumulated, latestAccumulated, rescoreLookup, loading, isFetching, scoresPending, error, availableRuns, refreshDashboard, refreshDashboardActive, scheduleDashboardReconcile, sharedProjectInfo } = useDashboard({
     selectedProject,
     selectedRun: effectiveRun,
     selectedSource,
@@ -202,7 +202,7 @@ export function useAppState() {
     serverConnected, setServerConnected, serverVersion, navStack, activePage, navPop, navGoTo, navTab,
     projects, projectsLoaded, selectedProject, selectedSource, selectedRun, loadProjects, handleProjectChange, handleNavigate, handleNavigateReplace,
     handleDeleteProject, handleExportProject, handleRelocateProject, handleImportProject,
-    dashboard, accumulated, latestAccumulated, rescoreLookup, loading, isFetching, error, availableRuns, dailyRuns: visibleDailyRuns, overviewRunIndex, sharedProjectInfo,
+    dashboard, accumulated, latestAccumulated, rescoreLookup, loading, isFetching, scoresPending, error, availableRuns, dailyRuns: visibleDailyRuns, overviewRunIndex, sharedProjectInfo,
     currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect, prefetchHandlers,
     headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId,
     historySelectedRun, setHistorySelectedRun,

--- a/src/quodeq/ui/src/hooks/useProjectScores.js
+++ b/src/quodeq/ui/src/hooks/useProjectScores.js
@@ -106,6 +106,11 @@ export function useProjectScores({ selectedProject, selectedRun, selectedSource 
     scores: scoresQuery.data ?? null,
     latestScores: latestQuery.data ?? null,
     loading: scoresQuery.isLoading || latestQuery.isLoading,
+    // True while the panel is rendering the PREVIOUS selection's scores because
+    // the newly-picked run is still in flight. placeholderData keeps those old
+    // numbers on screen, so without this the dimension cards look settled while
+    // showing another day's grades.
+    scoresPending: scoresQuery.isPlaceholderData,
     error:
       (scoresQuery.isError || latestQuery.isError)
         ? "Failed to load score data. Check your connection and try refreshing."

--- a/src/quodeq/ui/src/hooks/useProjectScores.test.jsx
+++ b/src/quodeq/ui/src/hooks/useProjectScores.test.jsx
@@ -298,4 +298,49 @@ describe("useProjectScores", () => {
       expect(fakeApi.getProjectScores).not.toHaveBeenCalled();
     });
   });
+
+  // Selecting a day on the score-history chart refetches as-of scores, and
+  // placeholderData keeps the PREVIOUS day's numbers on screen meanwhile.
+  // scoresPending is what lets the dimension cards say so instead of
+  // presenting stale grades as settled.
+  describe("scoresPending", () => {
+    // Must use withStableQueryApi: a wrapper rebuilt per render remounts the
+    // subtree and destroys isPlaceholderData, so this would pass either way.
+    it("is true while a newly-selected run is in flight, false once it lands", async () => {
+      let release;
+      const gate = new Promise((r) => { release = r; });
+      let call = 0;
+      const api = {
+        getProjectScores: vi.fn(async (project, asOf) => {
+          call += 1;
+          if (call > 1 && asOf) await gate;
+          return {
+            accumulated: { score: asOf ? 80 : 90 },
+            trend: [],
+            availableRuns: [
+              { runId: "r9", status: "complete" },
+              { runId: "r1", status: "complete" },
+            ],
+          };
+        }),
+        sharedGetProjectScores: vi.fn(),
+      };
+
+      const { result, rerender } = renderHook(
+        ({ run }) => useProjectScores({ selectedProject: "p1", selectedRun: run }),
+        { wrapper: withStableQueryApi(api), initialProps: { run: null } },
+      );
+      await waitFor(() => expect(result.current.scores?.accumulated?.score).toBe(90));
+      expect(result.current.scoresPending).toBe(false);
+
+      rerender({ run: "r1" });
+      await waitFor(() => expect(result.current.scoresPending).toBe(true));
+      // The old day's scores are still what's rendered — that is the point.
+      expect(result.current.scores?.accumulated?.score).toBe(90);
+
+      release();
+      await waitFor(() => expect(result.current.scores?.accumulated?.score).toBe(80));
+      expect(result.current.scoresPending).toBe(false);
+    });
+  });
 });

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -388,6 +388,21 @@
   margin-bottom: 0;
 }
 
+/* Scores for a newly-picked day are still in flight, so the cards below are
+   still showing the previous selection's grades. Fade them and label the
+   panel rather than letting stale numbers read as the answer. */
+.quality-dimensions--pending .dimensions-panel {
+  opacity: 0.55;
+  transition: opacity 120ms ease;
+}
+
+.quality-dimensions__pending {
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 /* ── Dimension cards ──────────────────────────────────── */
 
 .dimension-grid {

--- a/tests/services/test_accumulated_process_cache.py
+++ b/tests/services/test_accumulated_process_cache.py
@@ -1,0 +1,211 @@
+"""Cross-request reuse of per-run data in the accumulated (as-of) view.
+
+Selecting a day on the Overview score-history chart issues
+``get_project_scores(..., as_of=<run>)``, which walks every run from the
+selected one backwards. Those run sets overlap almost entirely between two
+neighbouring selections, so the per-run reads must survive across calls --
+otherwise every newly-selected day re-hydrates the whole findings corpus and
+the dimension cards visibly lag behind the click.
+
+Only the runs that actually *win* a dimension slot need their full findings
+bodies; the rest are needed only for their scores. These tests pin both
+halves: the walk is served from a slim process-lived cache, and the answer is
+byte-identical to the uncached computation.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.services import accumulated as acc_mod
+from quodeq.services.accumulated import (
+    AccumulatedCacheConfig,
+    compute_accumulated,
+    create_accumulated_cache,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_run(reports_root: Path, project: str, run_id: str, dims: dict[str, str]) -> None:
+    """Write one run with *dims* mapping dimension name -> overall score.
+
+    Each dimension carries a violation body so a full read is measurably
+    heavier than the slim projection the walk needs.
+    """
+    run_dir = reports_root / project / run_id
+    eval_dir = run_dir / "evaluation"
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    evidence_dir = run_dir / "evidence"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    for dim_name, score in dims.items():
+        (eval_dir / f"{dim_name}.json").write_text(json.dumps({
+            "dimension": dim_name,
+            "overallScore": score,
+            "overallGrade": "B",
+            "filesRead": 12,
+            "principles": [],
+            "violations": [{
+                "principleId": "P1",
+                "severity": "major",
+                "file": f"src/{dim_name}.py",
+                "line": 4,
+                "description": f"body for {run_id}/{dim_name}",
+            }],
+            "compliance": [],
+        }))
+        (evidence_dir / f"{dim_name}_evidence.json").write_text(
+            json.dumps({"dimension": dim_name, "discipline": "python"}))
+    (evidence_dir / "manifest.json").write_text("{}")
+    (run_dir / "scan.json").write_text("{}")
+
+
+def _project_with_runs(tmp_path: Path, project: str, n: int) -> tuple[Path, list[str]]:
+    """Build *n* runs, newest last in creation order. Returns (root, run_ids desc)."""
+    reports_root = tmp_path / "evaluations"
+    run_ids = [f"2026070{i}" if i < 10 else f"202607{i}" for i in range(10, 10 + n)]
+    for i, run_id in enumerate(run_ids):
+        _write_run(reports_root, project, run_id, {"security": f"{5 + (i % 4)}.0"})
+    return reports_root, sorted(run_ids, reverse=True)
+
+
+@pytest.fixture
+def counting_reader(monkeypatch):
+    """Count full ``read_run_data`` calls per run id, wrapping the real reader."""
+    from quodeq.data.fs.report_parser import runs as runs_mod
+
+    calls: list[str] = []
+    real = runs_mod.read_run_data
+
+    def _counted(reports_root, project, run_id):
+        calls.append(run_id)
+        return real(reports_root, project, run_id)
+
+    monkeypatch.setattr("quodeq.services._cache.read_run_data", _counted)
+    monkeypatch.setattr("quodeq.services._accumulated_data.read_run_data", _counted)
+    return calls
+
+
+@pytest.fixture(autouse=True)
+def _clear_process_cache():
+    """Isolate each test from the module-level cache."""
+    acc_mod.clear_accumulated_process_cache()
+    yield
+    acc_mod.clear_accumulated_process_cache()
+
+
+# ---------------------------------------------------------------------------
+# Cross-call reuse
+# ---------------------------------------------------------------------------
+
+def test_neighbouring_as_of_selections_reuse_the_run_walk(tmp_path, counting_reader):
+    """The second day selected must not re-read every run's findings again.
+
+    This is the regression under test: ``_resolve_cache(None)`` used to build a
+    fresh empty LRU per call, so each as-of selection re-hydrated the entire
+    run history from disk.
+    """
+    root, runs_desc = _project_with_runs(tmp_path, "proj", 12)
+
+    compute_accumulated(str(root), "proj", runs_desc[1])
+    first_call_reads = len(counting_reader)
+    counting_reader.clear()
+
+    compute_accumulated(str(root), "proj", runs_desc[2])
+    second_call_reads = len(counting_reader)
+
+    # The two walks overlap in all but one run, so the second selection should
+    # only pay for the dimension bodies it actually renders -- a small constant,
+    # not another full sweep.
+    assert first_call_reads >= 10, "fixture too small to be meaningful"
+    assert second_call_reads <= 2, (
+        f"second as-of selection re-read {second_call_reads} runs in full; "
+        f"expected the walk to be served from the process cache"
+    )
+
+
+def test_repeat_selection_reads_only_the_winning_runs(tmp_path, counting_reader):
+    """A repeat selection still hydrates the rendered dimensions.
+
+    Those bodies are never cached in the process cache -- they are the megabyte
+    half of a run read. What must not repeat is the walk over the other seven
+    runs.
+    """
+    root, runs_desc = _project_with_runs(tmp_path, "proj", 8)
+
+    compute_accumulated(str(root), "proj", runs_desc[1])
+    counting_reader.clear()
+    compute_accumulated(str(root), "proj", runs_desc[1])
+
+    # One dimension in this fixture, so exactly one run owns a latest slot.
+    assert len(set(counting_reader)) <= 1, (
+        f"expected only the winning run to be re-read, got {sorted(set(counting_reader))}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Correctness: the cache must not change the answer, and must not go stale
+# ---------------------------------------------------------------------------
+
+def test_cached_result_matches_uncached_computation(tmp_path):
+    """Parity: a warm process cache yields the same payload as a cold one."""
+    root, runs_desc = _project_with_runs(tmp_path, "proj", 10)
+
+    # Cold: isolated per-call cache, nothing shared.
+    cold = []
+    for run_id in runs_desc[:5]:
+        cache, lock = create_accumulated_cache()
+        cold.append(compute_accumulated(
+            str(root), "proj", run_id,
+            cache_config=AccumulatedCacheConfig(cache=cache, cache_lock=lock, cache_max=256),
+        ))
+
+    acc_mod.clear_accumulated_process_cache()
+
+    # Warm: the module-level cache carries over between selections.
+    warm = [compute_accumulated(str(root), "proj", run_id) for run_id in runs_desc[:5]]
+
+    assert warm == cold
+
+
+def test_rewritten_run_invalidates_the_cached_entry(tmp_path):
+    """A run's scores can change in place (dismiss, grade-formula apply).
+
+    The process cache keys on a per-run fingerprint, so a rewritten run must be
+    re-read rather than served from the previous computation.
+    """
+    root, runs_desc = _project_with_runs(tmp_path, "proj", 4)
+    newest = runs_desc[0]
+
+    before = compute_accumulated(str(root), "proj", newest)
+    assert before["summary"]["numericAverage"] == pytest.approx(8.0)
+
+    eval_file = root / "proj" / newest / "evaluation" / "security.json"
+    data = json.loads(eval_file.read_text())
+    data["overallScore"] = "2.0"
+    eval_file.write_text(json.dumps(data))
+
+    after = compute_accumulated(str(root), "proj", newest)
+    assert after["summary"]["numericAverage"] == pytest.approx(2.0), (
+        "cached entry survived a rewrite of the run's evaluation data"
+    )
+
+
+def test_explicit_cache_config_still_isolates(tmp_path, counting_reader):
+    """Callers passing their own cache_config keep per-call isolation."""
+    root, runs_desc = _project_with_runs(tmp_path, "proj", 6)
+
+    for _ in range(2):
+        cache, lock = create_accumulated_cache()
+        compute_accumulated(
+            str(root), "proj", runs_desc[1],
+            cache_config=AccumulatedCacheConfig(cache=cache, cache_lock=lock, cache_max=256),
+        )
+
+    # Both calls did their own reads -- an explicitly supplied cache is not
+    # silently promoted to the shared process cache.
+    assert len(counting_reader) >= 8


### PR DESCRIPTION
## Why

Picking a different day/week on the Overview score-history chart left the quality-dimensions panel showing the *previous* day's grades for seconds. It felt cached-after-the-fact because it was: only the second visit to a given day was fast.

## Root cause

`/scores?asOf=<run>` walks every run from the selected one backwards to resolve the latest finding per dimension. Two consecutive selections overlap in all but a run or two, so that walk should be reusable — and `make_lru_dimension_fetcher` documents its cache as surviving *"within and across requests"*.

It never did. `_resolve_cache(None)` calls `create_accumulated_cache()`, which returns a **brand-new empty `OrderedDict`**, and no caller anywhere passes a `cache_config`. The LRU was allocated, filled with ~74 runs, and thrown away inside a single request. `_DEFAULT_ACC_CACHE_MAX = 256` was dead code.

cProfile of one selection on a 100-run project: 74 run reads, 160k finding rows hydrated out of SQLite + JSON, 4.5s of 4.7s inside `_read_all_run_data`.

## Why not just make that cache process-lived

Measured: 73 cached run reads = ~440 MB RSS (~6 MB/run). A 256-entry process cache would be ~1.5 GB in a desktop app.

The walk only needs scores, and only the dimensions that *win* a slot are rendered with their findings bodies. So:

- the walk runs on a **findings-free projection** (`replace(d, violations=[], compliance=[])`), cached in a module-level LRU — kilobytes per run;
- the winning dimensions alone are re-read in full (a handful of runs).

Classification is bit-identical because the projection keeps every scalar the walk consults (`overall_score`, `files_read`, `totals`, `principles`).

### Invalidation

A completed run is **not** immutable — dismissing a finding or applying a grade formula rewrites the SQL grade tables `overlay_sql_grades` reads back. Entries are keyed on a stat fingerprint over `evaluation/*.json`, `evidence/*`, `evaluation.db`, `evaluation.db-wal` (writes land in the WAL long before a checkpoint touches the main file) and `events.jsonl`.

`select_default_view_runs` already excludes `in_progress` from this view, so the "only cache terminal runs" rule holds here by construction.

## Results

Real 100-run project, 52 as-of payloads, old vs new:

| | old | new |
|---|---|---|
| 52 as-of computations | 66.28s | **7.33s** |
| mean per selection | 1.275s | **0.141s** |
| payload equality | — | **52/52 byte-identical** |

Through the endpoint on a warm process, a never-before-selected day: **1.4–2.9s → 0.50–0.61s**. The remainder is serializing a ~1.6 MB payload.

## Also: the panel no longer lies while loading

`placeholderData` keeps the previous selection's grades on screen, and the scores query had no pending signal wired to the cards (`isFetching` in `DashboardPage` comes from the *dashboard* query). So the panel looked settled while showing another day's numbers.

`scoresPending` (`isPlaceholderData`) now fades the cards and labels the panel `updating…`, with `aria-busy`.

That field was inert on first attempt: `dashboardData` in `App.jsx` is an explicit key whitelist and swallowed it silently — no throw, the feature just never activated. Extracted as `buildDashboardDataBundle` and pinned by tests, mirroring what `buildNavigationBundle` already does for navigation keys.

## Verification

- `tests/services/test_accumulated_process_cache.py` — cross-call reuse, parity warm vs cold, invalidation on rewrite, explicit-`cache_config` isolation
- Python suite: 5016 passed
- UI suite: 1287 passed; the new bundle guards confirmed failing when `scoresPending` is dropped
- Driven live in the app against the real 100-run project: pending state observed (`aria-busy=true`, `updating…`, cards faded), then clearing


🤖 Generated with [Claude Code](https://claude.com/claude-code)
