### PR TITLE
feat(report): record how many findings were quarantined

### DIFF
--- a/src/quodeq/analysis/_report_assembly.py
+++ b/src/quodeq/analysis/_report_assembly.py
@@ -48,6 +48,9 @@ def _assemble_report_dict(data: _ReportData) -> dict:
         "sourceFileCount": data.evidence.get("source_file_count"),
         "filesRead": data.evidence.get("files_read", 0),
         "coveragePct": data.evidence.get("coverage_pct", 0.0),
+        # Trust metadata, not a findings bucket: how many findings never reached
+        # scoring because they named a principle outside the standard.
+        "quarantinedCount": data.evidence.get("quarantined_count", 0),
         "exitReason": data.evidence.get("exit_reason"),
         "meta": {
             "analysis_prompt_version": raw_meta.get("analysis_prompt_version"),

--- a/src/quodeq/core/evidence/_req_mapping.py
+++ b/src/quodeq/core/evidence/_req_mapping.py
@@ -22,6 +22,10 @@ class _GroupedJudgments:
     violations: dict[str, list[Judgment]]
     compliance: dict[str, list[Judgment]]
     severity: dict[str, str]
+    # Findings dropped for naming a principle the standard does not define.
+    # Reported as run metadata so a run that discarded most of its evidence is
+    # distinguishable from a clean one; never re-joined to the findings lists.
+    quarantined: int = 0
 
 
 def _build_req_to_principle_map(dimension: str, evaluators_dir: Path | None = None) -> dict[str, str]:
@@ -144,6 +148,7 @@ def _group_judgments(
     sc_violations: dict[str, list[Judgment]] = {}
     sc_compliance: dict[str, list[Judgment]] = {}
     sc_severity: dict[str, str] = {}
+    quarantined = 0
 
     for j in judgments:
         # When the dimension has a standard, a finding whose principle is not
@@ -161,6 +166,7 @@ def _group_judgments(
                 resolver.req_to_principle.get(j.practice_id, j.practice_id),
                 j.practice_id, j.req, j.file,
             )
+            quarantined += 1
             continue
         if j.verdict == "violation":
             sc_violations.setdefault(principle, []).append(j)
@@ -170,4 +176,4 @@ def _group_judgments(
         if principle not in sc_severity or _sev_rank(sev) > _sev_rank(sc_severity[principle]):
             sc_severity[principle] = sev
 
-    return _GroupedJudgments(sc_violations, sc_compliance, sc_severity)
+    return _GroupedJudgments(sc_violations, sc_compliance, sc_severity, quarantined)

--- a/src/quodeq/core/evidence/model.py
+++ b/src/quodeq/core/evidence/model.py
@@ -148,6 +148,10 @@ class Evidence:
     coverage_pct: float
     principles: dict[str, PrincipleEvidence] = field(default_factory=dict)
     dismissed_count: int = 0
+    # Findings excluded for naming a principle outside the dimension's standard.
+    # Trust metadata alongside coverage_pct: it does not affect the score, it
+    # says how much of the evidence reached scoring at all.
+    quarantined_count: int = 0
     meta: dict = field(default_factory=dict)
     module: str = ""
     exit_reason: str | None = None
@@ -201,6 +205,7 @@ def evidence_to_scoring_dict(evidence: Evidence) -> dict:
         "source_file_count": evidence.source_file_count,
         "files_read": evidence.files_read,
         "coverage_pct": evidence.coverage_pct,
+        "quarantined_count": evidence.quarantined_count,
         "exit_reason": evidence.exit_reason,
         "meta": evidence.meta,
         "principles": principles,

--- a/src/quodeq/core/evidence/parser.py
+++ b/src/quodeq/core/evidence/parser.py
@@ -49,14 +49,17 @@ def _build_principles(
     return principles
 
 
-def _build_evidence(context: EvidenceContext, principles: dict[str, PrincipleEvidence]) -> Evidence:
+def _build_evidence(
+    context: EvidenceContext, principles: dict[str, PrincipleEvidence],
+    quarantined: int = 0,
+) -> Evidence:
     """Create an Evidence object from context and principles."""
     return Evidence(
         repository=context.repository, language=context.language, date=context.date_str,
         source_file_count=context.source_file_count, files_read=context.files_read,
         coverage_pct=compute_coverage_pct(context.files_read, context.source_file_count),
-        principles=principles, dismissed_count=0, module=context.module,
-        exit_reason=context.exit_reason,
+        principles=principles, dismissed_count=0, quarantined_count=quarantined,
+        module=context.module, exit_reason=context.exit_reason,
     )
 
 
@@ -83,13 +86,15 @@ def parse_jsonl_to_evidence_by_dimension(
                 by_dim.setdefault(j.dimension or "unknown", []).append(j)
     if not by_dim:
         return {}
-    return {
-        dim: _build_evidence(context, _build_principles(
-            _group_judgments(dj, dimension=dim, evaluators_dir=evaluators_dir,
-                             compiled_dir=compiled_dir),
-            dim, context.source_file_count))
-        for dim, dj in by_dim.items()
-    }
+    result: dict[str, Evidence] = {}
+    for dim, dj in by_dim.items():
+        grouped = _group_judgments(dj, dimension=dim, evaluators_dir=evaluators_dir,
+                                   compiled_dir=compiled_dir)
+        result[dim] = _build_evidence(
+            context, _build_principles(grouped, dim, context.source_file_count),
+            grouped.quarantined,
+        )
+    return result
 
 
 def parse_jsonl_to_evidence(
@@ -105,4 +110,7 @@ def parse_jsonl_to_evidence(
     dim = judgments[0].dimension if judgments else ""
     grouped = _group_judgments(judgments, dimension=dim, evaluators_dir=evaluators_dir,
                                compiled_dir=compiled_dir)
-    return _build_evidence(context, _build_principles(grouped, dim, context.source_file_count))
+    return _build_evidence(
+        context, _build_principles(grouped, dim, context.source_file_count),
+        grouped.quarantined,
+    )

--- a/src/quodeq/core/types/_mapper_dimensions.py
+++ b/src/quodeq/core/types/_mapper_dimensions.py
@@ -43,6 +43,7 @@ def parse_dimension_result(raw: dict[str, object]) -> DimensionResult:
         totals=totals,
         source_file_count=_opt_int(raw.get("sourceFileCount")),
         files_read=_opt_int(raw.get("filesRead")),
+        quarantined_count=_opt_int(raw.get("quarantinedCount")) or 0,
         exit_reason=_opt_str(raw.get("exitReason")),
         evidence_date=_opt_str(raw.get("evidenceDate")),
         discipline=_opt_str(raw.get("discipline")),

--- a/src/quodeq/core/types/dimension.py
+++ b/src/quodeq/core/types/dimension.py
@@ -37,6 +37,10 @@ class DimensionResult:
     totals: Totals | None = None
     source_file_count: int | None = None
     files_read: int | None = None
+    # Findings excluded from scoring for naming a principle outside the
+    # dimension's standard. Trust metadata beside the coverage counts, not a
+    # findings bucket. 0 on reports written before the field existed.
+    quarantined_count: int = 0
     exit_reason: str | None = None
     evidence_date: str | None = None
     discipline: str | None = None

--- a/src/quodeq/data/fs/report_parser/_report_parsing.py
+++ b/src/quodeq/data/fs/report_parser/_report_parsing.py
@@ -67,6 +67,10 @@ def parse_report_json(json_path: Path) -> dict[str, Any] | None:
         # missing values as "no coverage signal" and skips the badge.
         "filesRead": data.get("filesRead"),
         "sourceFileCount": data.get("sourceFileCount"),
+        # Findings that never reached scoring because they named a principle
+        # outside the standard. Same trust-signal tier as the coverage numbers;
+        # reports written before this field default to 0 (nothing known dropped).
+        "quarantinedCount": data.get("quarantinedCount", 0),
         "exitReason": data.get("exitReason"),
         "principles": [
             {"name": p.get("name"), "score": p.get("score"), "grade": p.get("grade")}

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.jsx
@@ -54,20 +54,37 @@ function buildPartialTooltip({ filesRead, sourceFileCount, exitReason }) {
   return parts.join(' · ');
 }
 
-function CoverageLine({ dateText, coveragePct, isPartial, tooltip }) {
+/**
+ * Findings the scan produced but scoring never saw, because the principle they
+ * named is not in this dimension's standard. Not a findings bucket: they have no
+ * principle, so no card and no score. The count sits next to coverage because it
+ * answers the same question, how much of the evidence actually reached the grade.
+ *
+ * Renders nothing at 0, which is every healthy run and every report written
+ * before the field existed.
+ */
+function UnmappedSegment({ count }) {
+  if (!count) return null;
+  const noun = count === 1 ? 'finding' : 'findings';
+  return (
+    <> · <span
+      className="dim-gauge-card__unmapped"
+      title={`${count.toLocaleString()} ${noun} excluded from scoring: the principle named is not in this dimension's standard`}
+    >{count.toLocaleString()} unmapped</span></>
+  );
+}
+
+function CoverageLine({ dateText, coveragePct, isPartial, tooltip, quarantinedCount }) {
   if (!dateText) return null;
-  if (coveragePct === null) {
-    return (
-      <div className="dim-gauge-card__coverage-line" title={isPartial ? tooltip : undefined}>
-        {dateText}
-      </div>
-    );
-  }
   return (
     <div className="dim-gauge-card__coverage-line" title={isPartial ? tooltip : undefined}>
-      {dateText} · <span
-        className={`dim-gauge-card__coverage-pct${isPartial ? ' dim-gauge-card__coverage-pct--partial' : ''}`}
-      >{coveragePct}%</span>
+      {dateText}
+      {coveragePct !== null && (
+        <> · <span
+          className={`dim-gauge-card__coverage-pct${isPartial ? ' dim-gauge-card__coverage-pct--partial' : ''}`}
+        >{coveragePct}%</span></>
+      )}
+      <UnmappedSegment count={quarantinedCount} />
     </div>
   );
 }
@@ -201,6 +218,7 @@ export default function DimensionGaugeCard({
         coveragePct={coverage.coveragePct}
         isPartial={coverage.isPartial}
         tooltip={partialTooltip}
+        quarantinedCount={item.quarantinedCount}
       />
     </article>
   );

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.test.jsx
@@ -163,6 +163,71 @@ describe('DimensionGaugeCard', () => {
 
   });
 
+  describe('unmapped findings', () => {
+    const dateLabel = '13 May 2026';
+    const coverageLineMatcher = (expectedText) => (_, el) =>
+      el?.classList?.contains('dim-gauge-card__coverage-line') &&
+      el.textContent.replace(/\s+/g, ' ').trim() === expectedText;
+
+    const renderWith = (extra) =>
+      render(
+        <DimensionGaugeCard
+          item={{ ...baseItem, filesRead: 100, sourceFileCount: 100, ...extra }}
+          dateLabel={dateLabel}
+          onDimensionClick={() => {}}
+        />,
+      );
+
+    it('appends "· N unmapped" after the coverage percentage', () => {
+      renderWith({ quarantinedCount: 1 });
+      expect(
+        screen.getByText(coverageLineMatcher(`${dateLabel} · 100% · 1 unmapped`)),
+      ).toBeInTheDocument();
+    });
+
+    it('explains the exclusion in a tooltip on the segment itself', () => {
+      renderWith({ quarantinedCount: 12 });
+      const seg = screen.getByText('12 unmapped');
+      expect(seg.getAttribute('title')).toBe(
+        '12 findings excluded from scoring: the principle named is not in this dimension\'s standard',
+      );
+    });
+
+    it('uses the singular noun for one finding', () => {
+      renderWith({ quarantinedCount: 1 });
+      expect(screen.getByText('1 unmapped').getAttribute('title')).toContain('1 finding excluded');
+    });
+
+    it('renders nothing at zero, keeping the pre-existing line shape', () => {
+      renderWith({ quarantinedCount: 0 });
+      expect(
+        screen.getByText(coverageLineMatcher(`${dateLabel} · 100%`)),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/unmapped/)).toBeNull();
+    });
+
+    it('renders nothing when the field is absent, as on reports written before it existed', () => {
+      renderWith({});
+      expect(
+        screen.getByText(coverageLineMatcher(`${dateLabel} · 100%`)),
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/unmapped/)).toBeNull();
+    });
+
+    it('still shows on a legacy run that has no file counts', () => {
+      render(
+        <DimensionGaugeCard
+          item={{ ...baseItem, quarantinedCount: 3 }}
+          dateLabel={dateLabel}
+          onDimensionClick={() => {}}
+        />,
+      );
+      expect(
+        screen.getByText(coverageLineMatcher(`${dateLabel} · 3 unmapped`)),
+      ).toBeInTheDocument();
+    });
+  });
+
   describe('partial coverage colouring', () => {
     it('applies the partial CSS class to the coverage % span when exitReason != "done"', () => {
       const item = {

--- a/src/quodeq/ui/src/styles/dim-gauge-card.css
+++ b/src/quodeq/ui/src/styles/dim-gauge-card.css
@@ -128,6 +128,12 @@
 .dim-gauge-card__coverage-pct--partial {
   color: #f0b95f;
 }
+/* Findings the scan produced but scoring never saw. Muted rather than warning-
+   coloured: it is a trust signal about the run, not a problem in the code. */
+.dim-gauge-card__unmapped {
+  color: var(--color-text-subtle);
+  cursor: help;
+}
 
 .dim-gauge-card__gauge--insuf .dim-gauge-card__score {
   fill: var(--color-text-subtle);

--- a/tests/analysis/test_report_quarantined_metadata.py
+++ b/tests/analysis/test_report_quarantined_metadata.py
@@ -1,0 +1,127 @@
+"""The run report records how many findings were quarantined.
+
+Quarantined findings are correctly kept out of scoring: they carry no principle
+the standard defines, so they have no card, no radial vertex and no dimension
+score. But dropping them without a trace makes the grade unexplainable from what
+a reader can see -- a run that discarded 200 of 571 findings looks identical to a
+clean one, and its grade was computed from a fraction of the evidence.
+
+So the COUNT is run metadata, in the same tier as ``coveragePct``, ``filesRead``
+and ``exitReason``: it does not change the grade, it tells you how much to trust
+it. Deliberately not a findings bucket -- that would rebuild the phantom "N/A"
+principle card removed in #659/#663/#721.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis._report_assembly import build_dashboard_report
+from quodeq.core.evidence.parser import EvidenceContext, parse_jsonl_to_evidence
+
+_DIMENSION = "demo"
+
+
+@pytest.fixture
+def compiled_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "compiled"
+    d.mkdir()
+    (d / f"{_DIMENSION}.json").write_text(json.dumps({
+        "id": _DIMENSION,
+        "principles": [
+            {"name": "Analyzability", "requirements": [{"id": "D-ANA-1"}]},
+        ],
+    }), encoding="utf-8")
+    return d
+
+
+@pytest.fixture
+def evidence_file(tmp_path: Path) -> Path:
+    rows = [
+        {"p": "Analyzability", "req": "D-ANA-1", "t": "violation",
+         "d": _DIMENSION, "file": "a.py", "line": 1},
+        # Unmappable: resolves to the phantom "N/A" principle.
+        {"req": "N/A", "t": "violation", "d": _DIMENSION,
+         "file": "b.py", "line": 2, "severity": "critical"},
+    ]
+    p = tmp_path / "evidence.jsonl"
+    p.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+    return p
+
+
+def _context() -> EvidenceContext:
+    return EvidenceContext(
+        language=_DIMENSION, repository="demo-repo", date_str="2026-07-25",
+        source_file_count=2, files_read=2,
+    )
+
+
+def test_evidence_carries_the_quarantined_count(evidence_file, compiled_dir):
+    evidence = parse_jsonl_to_evidence(evidence_file, _context(), compiled_dir=compiled_dir)
+    assert evidence.quarantined_count == 1
+    # Still excluded from scoring: no phantom principle was created.
+    assert set(evidence.principles) == {"Analyzability"}
+
+
+def test_report_json_records_the_quarantined_count(evidence_file, compiled_dir):
+    evidence = parse_jsonl_to_evidence(evidence_file, _context(), compiled_dir=compiled_dir)
+    report = build_dashboard_report(evidence, {})
+    assert report["quarantinedCount"] == 1
+    # The quarantined finding is metadata only -- it never joins the findings list.
+    assert report["totals"]["violationCount"] == 1
+    assert len(report["violations"]) == 1
+
+
+def test_clean_run_records_zero(tmp_path, compiled_dir):
+    p = tmp_path / "evidence.jsonl"
+    p.write_text(json.dumps({
+        "p": "Analyzability", "t": "violation", "d": _DIMENSION,
+        "file": "a.py", "line": 1,
+    }) + "\n", encoding="utf-8")
+    evidence = parse_jsonl_to_evidence(p, _context(), compiled_dir=compiled_dir)
+    assert build_dashboard_report(evidence, {})["quarantinedCount"] == 0
+
+
+def test_no_standard_quarantines_nothing(evidence_file):
+    """Without a standard there is no membership to fail, so nothing is dropped."""
+    evidence = parse_jsonl_to_evidence(evidence_file, _context())
+    assert evidence.quarantined_count == 0
+    assert build_dashboard_report(evidence, {})["quarantinedCount"] == 0
+
+
+def _write_report(run_dir: Path, dimension: str, extra: dict) -> None:
+    d = run_dir / "evaluation"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{dimension}.json").write_text(json.dumps({
+        "schema_version": 1, "dimension": dimension,
+        "overallScore": "7.0/10", "overallGrade": "good",
+        "filesRead": 10, "sourceFileCount": 10, "exitReason": "done",
+        "principles": [], "violations": [], "compliance": [],
+        **extra,
+    }), encoding="utf-8")
+
+
+def test_count_survives_the_run_read_into_the_dashboard_payload(tmp_path):
+    """DimensionResult is a strict whitelist: a field it does not name is dropped.
+
+    Writing the count into the report JSON is not enough on its own -- the run
+    read maps every dimension through that dataclass, so a new key silently
+    vanishes before the UI ever sees it and the feature is inert. Pin the whole
+    path: report JSON -> DimensionResult -> camelCase payload.
+    """
+    from quodeq.core.types import to_camel_dict
+    from quodeq.data.fs.report_parser.runs import read_run_data
+
+    _write_report(tmp_path / "proj" / "run1", "demo", {"quarantinedCount": 3})
+    result = read_run_data(tmp_path, "proj", "run1")[0]
+    assert result.quarantined_count == 3
+    assert to_camel_dict(result)["quarantinedCount"] == 3
+
+
+def test_reports_written_before_the_field_read_as_zero(tmp_path):
+    from quodeq.data.fs.report_parser.runs import read_run_data
+
+    _write_report(tmp_path / "proj" / "run1", "legacy", {})
+    assert read_run_data(tmp_path, "proj", "run1")[0].quarantined_count == 0


### PR DESCRIPTION
> Was stacked on #880, now merged. Rebased onto `develop`; this PR is a single self-contained commit.

## Why

Quarantined findings are correctly kept out of scoring: they name no principle the dimension's standard defines, so they have no card, no radial vertex and no dimension score. That part is right and does not change here.

But dropping them without a trace makes the grade unexplainable from what a reader can see. One unmappable finding in 571 is a healthy run. Two hundred in 571 would mean the prompt or the standard is broken, the grade was computed from a fraction of the evidence, and nothing anywhere would say so.

So this records the **count**, in the same tier as `coveragePct` / `filesRead` / `exitReason`: it does not change the grade, it says how much to trust it.

**Deliberately not a findings bucket.** Surfacing quarantined findings as findings would rebuild the phantom "N/A" principle card that #659/#663/#721 removed. They have no principle to group under.

## What changed

- `_group_judgments` counts what it quarantines. `Evidence.quarantined_count` carries it into the report as `quarantinedCount`.
- `DimensionResult` gains the field. **It is a strict whitelist**, so without this the key was silently dropped on the run read and the UI change would have been inert. Pinned by a test over the whole path: report JSON → `DimensionResult` → camelCase payload.
- The dimension gauge card appends `· N unmapped` after the coverage percentage, with a tooltip explaining the exclusion. Muted rather than warning-coloured: it is a signal about the run, not a problem in the code.

Renders nothing at 0, so clean runs and reports written before the field keep their exact shape. Schema version is unchanged; the field is additive and every reader defaults it to 0.

## Verification

- `pytest -m "not integration"`: 5034 passed, 1 skipped
- UI: 1295 passed across 166 files, including 6 new gauge-card cases (segment, tooltip, singular/plural, zero, field absent, legacy run with no file counts)

## Follow-up not in here

The quarantined finding in the repro run is a security issue the maintainability scan produced. Routing misfiled findings to their correct dimension is the separate, already-tracked "remap findings to correct req IDs" work. This PR makes the rate visible; it does not fix the misfiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
