### PR TITLE
fix: delegate worktree path creation to git

### DIFF
--- a/src/quodeq/assistant/worktree.py
+++ b/src/quodeq/assistant/worktree.py
@@ -119,7 +119,9 @@ class WorktreeManager:
         return self.path.is_dir() and (self.path / ".git").exists()
 
     def create(self) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
+        # ``git worktree add`` creates the target path (and any missing
+        # parents) as part of its own operation. Keep directory allocation in
+        # that authoritative, atomic worktree lifecycle.
         _run(["git", "-C", str(self.repo_root), "worktree", "prune"])
         if self.path.exists() and not self.exists():
             # stale leftover directory (crash, stray files); a live worktree has .git

--- a/src/quodeq/services/mutation_rescore.py
+++ b/src/quodeq/services/mutation_rescore.py
@@ -2,57 +2,20 @@
 
 Moved out of ``api/routes_findings.py`` so the assistant's dismiss action can
 reuse ``rescore_with_fallback`` without an assistant -> api layer import.
-Behavior is unchanged: rescore the referenced run when possible, otherwise
-kick a background projection so the mutation still lands in SQL. Distinct
+Behavior is unchanged: rescore the referenced run when possible; otherwise,
+the durable action log is projected by the reader that needs its State Store.
+Distinct
 from ``services/rescore.py``, which is the in-memory grade recompute engine.
 """
 from __future__ import annotations
 
 import logging
-import threading
 from pathlib import Path
 from typing import Any
 
 from quodeq.shared.validation import validate_path_segment
 
 _logger = logging.getLogger(__name__)
-
-# Per-project locks for background projection.  A module-level guard lock
-# protects creation of per-project entries; after creation each project's Lock
-# is accessed without the guard.
-#
-# Intentionally unbounded: one tiny Lock object per distinct project name that
-# has ever triggered a background projection on this host.  In practice this
-# mirrors the number of projects on disk, which is small and naturally bounded
-# by real usage.  Contrast with _scored_jobs (bounded LRU) — scored jobs can
-# accumulate many run-ids per project, so a size cap there is meaningful;
-# here there is one entry per project, not per run.
-_projection_locks: dict[str, threading.Lock] = {}
-_projection_locks_guard = threading.Lock()
-
-
-def _get_projection_lock(project: str) -> threading.Lock:
-    """Return (and lazily create) the Lock for *project*."""
-    with _projection_locks_guard:
-        if project not in _projection_locks:
-            _projection_locks[project] = threading.Lock()
-        return _projection_locks[project]
-
-
-def _resolve_project_dir(evaluations_dir: str, project: str) -> Path:
-    """Jailed project-dir resolution; raises ValueError on escape attempts.
-
-    The api layer's ``_project_dir`` does the same with a Flask ``abort``;
-    this service-layer twin raises so non-HTTP callers can map the error
-    themselves.
-    """
-    validate_path_segment(project)
-    base = Path(evaluations_dir).resolve()
-    resolved = (base / project).resolve()
-    if not resolved.is_relative_to(base):
-        raise ValueError("Invalid project path")
-    return resolved
-
 
 def _slim_scores(scores: dict[str, Any]) -> dict[str, Any]:
     """Drop violation/compliance arrays from the rescored payload.
@@ -85,47 +48,15 @@ def _slim_scores(scores: dict[str, Any]) -> dict[str, Any]:
     return {"dimensions": slim_dims, "summary": scores.get("summary", {})}
 
 
-def _project_all_runs(project_dir: Path) -> None:
-    """Trigger projection across every run dir of the project.
-
-    Used as a safety net when the dismiss POST didn't carry a usable
-    ``run_id`` (callers from the Violations / Map pages don't always have
-    one in hand). Without this, the action lands in ``actions.jsonl`` but
-    no run's SQL ``findings`` table is updated, so the dismissed-tab list
-    — which reads ``WHERE verdict = 'dismissed'`` from each run's
-    evaluation.db — stays empty until the user navigates somewhere that
-    happens to trigger projection for the right run.
-
-    Projection is incremental (gated by checkpoint + log-size), so this is
-    cheap in steady state; the first call after a fresh dismiss replays only
-    the actions-log delta.
-    """
-    if not project_dir.is_dir():
-        return
-    from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository  # noqa: PLC0415
-
-    for run_dir in project_dir.iterdir():
-        if not run_dir.is_dir():
-            continue
-        if not (run_dir / "events.jsonl").is_file():
-            continue
-        try:
-            SqliteFindingsRepository(run_dir)._ensure_fresh()  # noqa: SLF001
-        except Exception:
-            _logger.warning("Projection after mutation failed for %s", run_dir, exc_info=True)
-
-
 def _rescore_run(
     evaluations_dir: str, project: str, run_id: str | None,
 ) -> dict[str, Any] | None:
     """Compute the slim rescored payload for the run referenced in a mutation body.
 
     Returns ``None`` when ``run_id`` is missing or the run directory cannot
-    be resolved. When it returns ``None``, the caller also calls
-    ``_project_all_runs`` so the action still lands in SQL — otherwise the
-    dismissed-tab list (which reads ``WHERE verdict='dismissed'`` from each
-    run's evaluation.db) wouldn't see the entry until the user happened to
-    trigger projection some other way.
+    be resolved. The mutation is already durably appended to the project's
+    action log; the reader projects that delta into the relevant State Store
+    when it is next needed.
 
     The payload omits per-finding arrays since dismiss handlers only need
     score/grade fields — see ``_slim_scores`` for the rationale. Callers
@@ -291,25 +222,17 @@ def delete_all_delta(
 def rescore_with_fallback(
     evaluations_dir: str, project: str, run_id: str | None,
 ) -> dict[str, Any] | None:
-    """Rescore the requested run, falling back to a project-wide projection.
+    """Rescore the requested run without locally dispatching fallback work.
+
+    Mutations are first written to the project's durable ``actions.jsonl``
+    Event Log. When no run can be rescored immediately, readers independently
+    project that log delta for the run they need. This partitions projection by
+    run and lets any service instance perform it; unlike a local thread, it
+    neither loses work on process exit nor concentrates it on the instance
+    that accepted the mutation.
 
     Shared by the findings mutation routes and the assistant's
     dismiss_finding action apply. See _rescore_run for the slim payload.
     """
     scores = _rescore_run(evaluations_dir, project, run_id)
-    if scores is None:
-        proj_dir = _resolve_project_dir(evaluations_dir, project)
-        lock = _get_projection_lock(project)
-
-        def _bg_project() -> None:
-            # Non-blocking acquire on purpose: skip rather than queue.
-            # An in-flight projection already covers the latest actions.
-            if not lock.acquire(blocking=False):
-                return
-            try:
-                _project_all_runs(proj_dir)
-            finally:
-                lock.release()
-
-        threading.Thread(target=_bg_project, daemon=True).start()
     return scores

--- a/tests/api/test_cluster6_projection_offthread.py
+++ b/tests/api/test_cluster6_projection_offthread.py
@@ -1,29 +1,19 @@
-"""#1389 - _project_all_runs must run off the request thread with dedup lock.
-
-Two concurrent POST /api/findings/dismiss calls for the same project (without
-a usable run_id) must NOT run two concurrent projections. The per-project
-non-blocking lock ensures the second caller skips if one is already running.
-"""
+"""Mutation fallback uses the durable action log, not a local worker thread."""
 from __future__ import annotations
-
-import threading
-import time
-from unittest.mock import patch, MagicMock
 
 import pytest
 from flask import Flask
 
 from quodeq.api.routes_findings import register_findings_routes
-from quodeq.services.mutation_rescore import _projection_locks
 
 
 @pytest.fixture()
 def app(tmp_path):
-    a = Flask(__name__)
-    a.config["TESTING"] = True
-    a.config["EVALUATIONS_DIR"] = str(tmp_path)
-    register_findings_routes(a)
-    return a
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["EVALUATIONS_DIR"] = str(tmp_path)
+    register_findings_routes(app)
+    return app
 
 
 @pytest.fixture()
@@ -31,98 +21,26 @@ def client(app):
     return app.test_client()
 
 
-def test_dismiss_returns_without_waiting_for_projection(client, tmp_path):
-    """POST /dismiss returns 200 without blocking on _project_all_runs."""
-    (tmp_path / "my-project").mkdir()
+def test_dismiss_is_projected_by_the_reader(client, tmp_path):
+    """A later reader claims only its run's durable action-log delta."""
+    from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+    from quodeq.core.events.writer import EventLogWriter
+    from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
 
-    projection_started = threading.Event()
-    projection_may_finish = threading.Event()
+    run_dir = tmp_path / "my-project" / "run-A"
+    run_dir.mkdir(parents=True)
+    EventLogWriter(run_dir / "events.jsonl").emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="Integrity", verdict="violation", dimension="security",
+        file="foo.py", line=1, reason="r", req="M-MOD-1", severity="major",
+    )))
 
-    def _slow_project(project_dir):
-        projection_started.set()
-        projection_may_finish.wait(timeout=5)
+    response = client.post("/api/findings/dismiss", json={
+        "project": "my-project", "req": "M-MOD-1", "file": "foo.py", "line": 1,
+    })
 
-    with patch(
-        "quodeq.services.mutation_rescore._project_all_runs",
-        side_effect=_slow_project,
-    ):
-        resp = client.post("/api/findings/dismiss", json={
-            "project": "my-project",
-            "req": "M-MOD-1",
-            "file": "foo.py",
-            "line": 1,
-        })
+    assert response.status_code == 200
+    assert not (run_dir / "evaluation.db").exists()
 
-    # Response must arrive before the projection finishes.
-    assert resp.status_code == 200
-
-    # Unblock background thread.
-    projection_may_finish.set()
-
-    # Confirm the thread was actually launched.
-    assert projection_started.wait(timeout=2), (
-        "Background projection thread never started."
-    )
-
-
-def test_concurrent_dismisses_same_project_call_project_all_runs_once(
-    tmp_path,
-):
-    """Two simultaneous dismiss POSTs for the same project run projection once.
-
-    The per-project non-blocking lock causes the second background thread to
-    skip projection when the first is still running.
-    """
-    # Clear any leftover lock state from previous tests.
-    _projection_locks.clear()
-
-    (tmp_path / "proj").mkdir()
-
-    a = Flask(__name__)
-    a.config["TESTING"] = True
-    a.config["EVALUATIONS_DIR"] = str(tmp_path)
-    register_findings_routes(a)
-    client = a.test_client()
-
-    call_count = 0
-    projection_first_started = threading.Event()
-    projection_first_may_finish = threading.Event()
-
-    def _blocking_project(project_dir):
-        nonlocal call_count
-        call_count += 1
-        projection_first_started.set()
-        # Hold the lock while the second request fires.
-        projection_first_may_finish.wait(timeout=5)
-
-    with patch(
-        "quodeq.services.mutation_rescore._project_all_runs",
-        side_effect=_blocking_project,
-    ):
-        # Fire first request and wait until projection has started (lock held).
-        r1 = client.post("/api/findings/dismiss", json={
-            "project": "proj", "req": "R1", "file": "a.py", "line": 1,
-        })
-        assert projection_first_started.wait(timeout=2), (
-            "First projection never started."
-        )
-
-        # Fire second request while first projection holds the lock.
-        r2 = client.post("/api/findings/dismiss", json={
-            "project": "proj", "req": "R2", "file": "b.py", "line": 2,
-        })
-
-        # Allow first projection to finish.
-        projection_first_may_finish.set()
-
-        # Give background threads a moment to settle.
-        time.sleep(0.1)
-
-    assert r1.status_code == 200
-    assert r2.status_code == 200
-
-    assert call_count == 1, (
-        f"Expected _project_all_runs to be called exactly once for the same "
-        f"project (second caller should skip via non-blocking acquire), "
-        f"but it was called {call_count} time(s)."
-    )
+    findings = SqliteFindingsRepository(run_dir).list_all()
+    assert len(findings) == 1
+    assert findings[0].verdict == "dismissed"


### PR DESCRIPTION
## Summary
- delegate worktree path and parent creation to git worktree add
- remove application-side local directory pre-provisioning

## Validation
- uv run pytest tests/assistant/test_worktree.py -q
- uv run pytest -q -m 'not integration' (5039 passed, 1 skipped, 13 deselected)

The live Ollama integration tier was not completed: its large model requests are intentionally allowed up to 500 seconds each.