### PR TITLE
test: stop the Windows job losing timing races, and reap a leaked worker thread

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,14 @@ jobs:
         # across cores cuts wall time roughly linearly (~12 min -> a few).
         # Verbose + -ra so per-test names and the FAILED summary survive
         # GitHub's log truncation, keeping this blocking gate easy to triage.
+        #
+        # QUODEQ_TEST_TIMEOUT_SCALE (tests/_timeouts.py): -n auto puts four
+        # workers on a 4-vCPU runner, so the box is saturated and a thread can
+        # miss a 5s window purely by not being scheduled. Multiply every
+        # budget() wait here rather than hand-tuning ~45 call sites for the
+        # slowest runner and slowing local runs down with them.
+        env:
+          QUODEQ_TEST_TIMEOUT_SCALE: "4"
         run: uv run pytest tests/ -v -ra --tb=short -m "not integration" -n auto
 
   ui:

--- a/tests/_timeouts.py
+++ b/tests/_timeouts.py
@@ -1,0 +1,51 @@
+"""One knob for every wall-clock budget in the suite.
+
+CI's Windows runner has 4 vCPUs and the job runs pytest-xdist with ``-n auto``,
+so four workers saturate the box. A literal ``wait(timeout=5)`` that is
+generous on an idle laptop becomes a coin flip there: a worker thread can miss
+its window purely because it never got scheduled. That is not hypothetical —
+run 30148774491 on develop logged a daemon thread dying on
+``assert cancel.wait(timeout=5)`` in ``test_assistant_routes.py`` while the
+stop route it was waiting for had not been scheduled yet.
+
+Wrap positive waits in ``budget()`` and set ``QUODEQ_TEST_TIMEOUT_SCALE`` on
+the loaded runners instead of hand-tuning individual call sites. Local runs
+stay fast because the default scale is 1.
+
+Only wrap a wait that guards something that *should* happen. A wait that
+proves a thing does *not* happen (``assert not done.wait(timeout=0.01)``)
+already returns as late as it ever will; scaling it only burns wall time.
+"""
+from __future__ import annotations
+
+import os
+
+_ENV_VAR = "QUODEQ_TEST_TIMEOUT_SCALE"
+
+
+def scale() -> float:
+    """Return the configured budget multiplier, or 1.0 if unusable.
+
+    Read at call time, not at import, so a fixture can change it mid-session.
+    A missing, unparseable, or non-positive value falls back to 1.0 rather
+    than raising: a broken knob must never take the suite down with it, and a
+    zero multiplier would silently turn every wait into a no-op.
+    """
+    raw = os.environ.get(_ENV_VAR)
+    if raw is None:
+        return 1.0
+    try:
+        parsed = float(raw)
+    except ValueError:
+        return 1.0
+    return parsed if parsed > 0 else 1.0
+
+
+def budget(seconds: float) -> float:
+    """Scale ``seconds`` up by the configured multiplier.
+
+    Clamped so the result is never *below* the budget the caller asked for.
+    The knob exists to buy headroom on contended runners; letting it shrink a
+    timeout would make the suite flakier, which is the opposite of the point.
+    """
+    return max(float(seconds), float(seconds) * scale())

--- a/tests/analysis/mcp/test_findings_server_cache.py
+++ b/tests/analysis/mcp/test_findings_server_cache.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._timeouts import budget
+
 
 def _make_jsonrpc(method: str, params: dict, msg_id: int) -> bytes:
     """Frame a JSON-RPC 2.0 request for the findings_server stdio protocol."""
@@ -92,7 +94,7 @@ def test_findings_server_writes_cache_via_mcp(tmp_path):
     finally:
         proc.stdin.close()
         proc.terminate()
-        proc.wait(timeout=5)
+        proc.wait(timeout=budget(5))
 
 
 def test_findings_server_raises_when_dimension_set_without_cache_args(tmp_path):

--- a/tests/analysis/test_heartbeat_coverage.py
+++ b/tests/analysis/test_heartbeat_coverage.py
@@ -12,6 +12,7 @@ from quodeq.analysis.subagents._heartbeat import (
     heartbeat_loop,
 )
 from quodeq.analysis.subagents.jsonl_utils import FindingTally
+from tests._timeouts import budget
 
 
 def _violation(p: str, file: str, line: int) -> str:
@@ -160,9 +161,9 @@ class TestHeartbeatLoop:
         )
         thread.start()
         # Wait briefly for at least one tick, then stop.
-        thread.join(timeout=0.2)
+        thread.join(timeout=budget(0.2))
         stop.set()
-        thread.join(timeout=1.0)
+        thread.join(timeout=budget(1.0))
 
         assert emitted, "heartbeat should emit at least one log line"
         assert "[security]" in emitted[0]

--- a/tests/analysis/test_pool_respawn_deadline.py
+++ b/tests/analysis/test_pool_respawn_deadline.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from quodeq.analysis.subagents._pool_scaling import should_respawn
 from quodeq.analysis.subagents.file_queue import FileQueue
+from tests._timeouts import budget
 
 
 def _queue(tmp_path: Path, files: int = 5) -> FileQueue:
@@ -35,7 +36,7 @@ def test_respawn_allowed_before_run_deadline(tmp_path):
         queue, queue._path,
         pool_start=time.monotonic(),
         max_duration=600,
-        deadline_at=time.monotonic() + 60,
+        deadline_at=time.monotonic() + budget(60),
     ) == 5
 
 

--- a/tests/api/test_assistant_routes.py
+++ b/tests/api/test_assistant_routes.py
@@ -714,8 +714,19 @@ def test_stop_cancels_running_turn_and_frees_the_token(client, monkeypatch):
     else:
         pytest.fail("cancel token not cleaned up after the turn ended")
 
+    # The slot is reclaimable. Reap the turn this starts before returning:
+    # fake_run_turn parks the worker until something cancels it, so a thread
+    # left running here outlives the test, and once monkeypatch unwinds its
+    # assert fires inside whichever test happens to be running 5s later
+    # (it surfaced as a PytestUnhandledThreadExceptionWarning attributed to
+    # test_shared_session_resolves_clone_run_dir on an unrelated xdist worker).
+    started.clear()
+    finished.clear()
     assert client.post(f"/api/assistant/sessions/{sid}/messages",
                        json={"text": "again"}).status_code == 202
+    assert started.wait(timeout=budget(5))
+    assert client.post(f"/api/assistant/sessions/{sid}/stop").status_code == 202
+    assert finished.wait(timeout=budget(5))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_assistant_routes.py
+++ b/tests/api/test_assistant_routes.py
@@ -6,6 +6,7 @@ from flask import Flask
 
 from quodeq.api.assistant_routes import register_assistant_routes
 from quodeq.data.sqlite.assistant_repository import AssistantRepository
+from tests._timeouts import budget
 
 _VALID_STANDARD = {
     "id": "api-errors", "name": "API Error Contract", "description": "d",
@@ -451,7 +452,7 @@ def test_apply_unknown_action_404(client):
 
 
 def _wait_for(seen, key, timeout=2.0):
-    deadline = time.time() + timeout
+    deadline = time.time() + budget(timeout)
     while key not in seen and time.time() < deadline:
         time.sleep(0.01)
     return seen.get(key)
@@ -653,7 +654,7 @@ def test_message_passes_write_enabled(client, app, monkeypatch):
                       json={"provider": "ollama"}).get_json()["sessionId"]
     client.post(f"/api/assistant/sessions/{sid}/messages",
                 json={"text": "hi", "writeEnabled": True})
-    assert done.wait(timeout=2)  # run_turn runs on a daemon thread
+    assert done.wait(timeout=budget(2))  # run_turn runs on a daemon thread
     assert seen.get("write_enabled") is True
 
 
@@ -688,7 +689,7 @@ def test_stop_cancels_running_turn_and_frees_the_token(client, monkeypatch):
 
     def fake_run_turn(request, *, repository, tool_ctx, cancel, **kw):
         started.set()
-        assert cancel.wait(timeout=5)  # blocks until the stop route cancels
+        assert cancel.wait(timeout=budget(5))  # blocks until the stop route cancels
         finished.set()
 
     monkeypatch.setattr("quodeq.api.assistant_routes.run_turn", fake_run_turn)
@@ -696,22 +697,23 @@ def test_stop_cancels_running_turn_and_frees_the_token(client, monkeypatch):
                       json={"provider": "ollama", "model": "m"}).get_json()["sessionId"]
     assert client.post(f"/api/assistant/sessions/{sid}/messages",
                        json={"text": "hi"}).status_code == 202
-    assert started.wait(timeout=5)
+    assert started.wait(timeout=budget(5))
 
     resp = client.post(f"/api/assistant/sessions/{sid}/stop")
     assert resp.status_code == 202
     assert resp.get_json() == {"stopping": True}
-    assert finished.wait(timeout=5)
+    assert finished.wait(timeout=budget(5))
 
     # once the worker unwinds, the token is gone: a second stop has nothing to
     # cancel, and a new message can claim the turn slot again
-    deadline = time.time() + 5
+    deadline = time.time() + budget(5)
     while time.time() < deadline:
         if client.post(f"/api/assistant/sessions/{sid}/stop").status_code == 409:
             break
         time.sleep(0.01)
     else:
         pytest.fail("cancel token not cleaned up after the turn ended")
+
     assert client.post(f"/api/assistant/sessions/{sid}/messages",
                        json={"text": "again"}).status_code == 202
 

--- a/tests/api/test_cluster6_projection_offthread.py
+++ b/tests/api/test_cluster6_projection_offthread.py
@@ -15,6 +15,7 @@ from flask import Flask
 
 from quodeq.api.routes_findings import register_findings_routes
 from quodeq.services.mutation_rescore import _projection_locks
+from tests._timeouts import budget
 
 
 @pytest.fixture()
@@ -40,7 +41,7 @@ def test_dismiss_returns_without_waiting_for_projection(client, tmp_path):
 
     def _slow_project(project_dir):
         projection_started.set()
-        projection_may_finish.wait(timeout=5)
+        projection_may_finish.wait(timeout=budget(5))
 
     with patch(
         "quodeq.services.mutation_rescore._project_all_runs",
@@ -60,7 +61,7 @@ def test_dismiss_returns_without_waiting_for_projection(client, tmp_path):
     projection_may_finish.set()
 
     # Confirm the thread was actually launched.
-    assert projection_started.wait(timeout=2), (
+    assert projection_started.wait(timeout=budget(2)), (
         "Background projection thread never started."
     )
 
@@ -93,7 +94,7 @@ def test_concurrent_dismisses_same_project_call_project_all_runs_once(
         call_count += 1
         projection_first_started.set()
         # Hold the lock while the second request fires.
-        projection_first_may_finish.wait(timeout=5)
+        projection_first_may_finish.wait(timeout=budget(5))
 
     with patch(
         "quodeq.services.mutation_rescore._project_all_runs",
@@ -103,7 +104,7 @@ def test_concurrent_dismisses_same_project_call_project_all_runs_once(
         r1 = client.post("/api/findings/dismiss", json={
             "project": "proj", "req": "R1", "file": "a.py", "line": 1,
         })
-        assert projection_first_started.wait(timeout=2), (
+        assert projection_first_started.wait(timeout=budget(2)), (
             "First projection never started."
         )
 

--- a/tests/api/test_cluster6_score_offthread.py
+++ b/tests/api/test_cluster6_score_offthread.py
@@ -21,6 +21,7 @@ from quodeq.api._evaluation_routes import (
 )
 from quodeq.services.base import ActionProvider, EvaluationOptions
 from quodeq.services._job_model import JobSnapshot
+from tests._timeouts import budget
 
 
 @pytest.fixture(autouse=True)
@@ -105,7 +106,7 @@ def test_get_evaluation_returns_before_scoring_completes(client):
         scoring_started.set()
         # Block until the test releases it — if the handler waited for this
         # the test would deadlock.
-        scoring_may_finish.wait(timeout=5)
+        scoring_may_finish.wait(timeout=budget(5))
 
     with patch(
         "quodeq.api._evaluation_routes._score_completed_evidence",
@@ -120,7 +121,7 @@ def test_get_evaluation_returns_before_scoring_completes(client):
     scoring_may_finish.set()
 
     # Wait briefly for the thread to actually start, confirming it was launched.
-    assert scoring_started.wait(timeout=2), (
+    assert scoring_started.wait(timeout=budget(2)), (
         "Background scoring thread never started — check that the thread is "
         "actually launched in the handler."
     )
@@ -186,7 +187,7 @@ def test_claim_scoring_exactly_once_under_concurrency():
     for t in threads:
         t.start()
     for t in threads:
-        t.join(timeout=5)
+        t.join(timeout=budget(5))
 
     assert len(results) == n_threads, "Not all threads reported a result"
     true_count = sum(1 for r in results if r)

--- a/tests/api/test_cwe_cache_lock.py
+++ b/tests/api/test_cwe_cache_lock.py
@@ -7,6 +7,7 @@ import time as _time
 import pytest
 
 import quodeq.api.standards_read_routes as _mod
+from tests._timeouts import budget
 
 
 @pytest.fixture(autouse=True)
@@ -36,7 +37,7 @@ def test_concurrent_expiry_reloads_exactly_once():
     def _loader():
         nonlocal call_count
         load_started.set()        # signal that loading has begun
-        slow_start.wait(timeout=5)  # wait for test harness to let it proceed
+        slow_start.wait(timeout=budget(5))  # wait for test harness to let it proceed
         call_count += 1
         return [{"id": "CWE-79", "name": "XSS"}]
 
@@ -51,7 +52,7 @@ def test_concurrent_expiry_reloads_exactly_once():
 
     def _thread():
         try:
-            start_gate.wait(timeout=5)  # all three release together
+            start_gate.wait(timeout=budget(5))  # all three release together
             result = _mod._reload_cwe_if_needed(_loader)
             results.append(result)
         except Exception as exc:
@@ -63,12 +64,12 @@ def test_concurrent_expiry_reloads_exactly_once():
     t2.start()
 
     # Release all three (main + 2 workers) simultaneously.
-    start_gate.wait(timeout=5)
+    start_gate.wait(timeout=budget(5))
     # Let the loader proceed after threads are racing.
     slow_start.set()
 
-    t1.join(timeout=10)
-    t2.join(timeout=10)
+    t1.join(timeout=budget(10))
+    t2.join(timeout=budget(10))
 
     assert not errors, f"Thread errors: {errors}"
     assert call_count == 1, f"Expected exactly 1 reload, got {call_count}"

--- a/tests/api/test_routes_shared.py
+++ b/tests/api/test_routes_shared.py
@@ -21,6 +21,7 @@ from quodeq.services.shared_repo import (
     shared_cache_dir,
     shared_repo_path,
 )
+from tests._timeouts import budget
 
 _ORIGIN = {"Origin": "http://localhost"}
 
@@ -356,11 +357,11 @@ def test_delete_config_waits_for_clone_lock(client, monkeypatch, tmp_path):
     def _hold_lock():
         with lock:
             lock_acquired.set()
-            release_lock.wait(timeout=5)
+            release_lock.wait(timeout=budget(5))
 
     holder = threading.Thread(target=_hold_lock, name="holder")
     holder.start()
-    assert lock_acquired.wait(timeout=5), "lock holder thread never acquired the lock"
+    assert lock_acquired.wait(timeout=budget(5)), "lock holder thread never acquired the lock"
 
     results: list = []
     # A fresh, un-entered client (rather than the fixture's own `client`,
@@ -381,8 +382,8 @@ def test_delete_config_waits_for_clone_lock(client, monkeypatch, tmp_path):
     assert cache_dir.exists(), "cache dir was removed while the clone lock was still held"
 
     release_lock.set()
-    delete_thread.join(timeout=5)
-    holder.join(timeout=5)
+    delete_thread.join(timeout=budget(5))
+    holder.join(timeout=budget(5))
 
     assert not delete_thread.is_alive(), "DELETE deadlocked waiting for the clone lock"
     assert not holder.is_alive()

--- a/tests/api/test_terminal_routes.py
+++ b/tests/api/test_terminal_routes.py
@@ -6,6 +6,7 @@ import pytest
 from flask import Flask
 
 from quodeq.api.terminal_routes import _apply_control, register_terminal_routes
+from tests._timeouts import budget
 
 try:
     import simple_websocket
@@ -160,7 +161,7 @@ def _serve(manager):
         yield srv.server_port
     finally:
         srv.shutdown()
-        t.join(timeout=2)
+        t.join(timeout=budget(2))
 
 
 @contextlib.contextmanager
@@ -208,11 +209,11 @@ if _WS_OK:
 def test_ws_single_active_connection_refuses_second():
     with _serve(_LiveManager()) as port:
         with _connect(port) as a:
-            assert a.receive(timeout=_RECV_TIMEOUT) == "0ready\n"   # A acquired the conn lock
+            assert a.receive(timeout=budget(_RECV_TIMEOUT)) == "0ready\n"   # A acquired the conn lock
             with _connect(port) as b:
                 msg = None
                 with contextlib.suppress(simple_websocket.ConnectionClosed):
-                    msg = b.receive(timeout=_RECV_TIMEOUT)
+                    msg = b.receive(timeout=budget(_RECV_TIMEOUT))
                 assert msg is not None and "already open" in msg
 
 
@@ -222,11 +223,11 @@ def test_ws_busy_close_uses_dedicated_code():
     # and spam the other window), so the refusal carries close code 4002.
     with _serve(_LiveManager()) as port:
         with _connect(port) as a:
-            assert a.receive(timeout=2) == "0ready\n"
+            assert a.receive(timeout=budget(2)) == "0ready\n"
             with _connect(port) as b:
                 with pytest.raises(simple_websocket.ConnectionClosed) as exc:
-                    b.receive(timeout=2)   # banner frame...
-                    b.receive(timeout=2)   # ...then the close
+                    b.receive(timeout=budget(2))   # banner frame...
+                    b.receive(timeout=budget(2))   # ...then the close
                 assert exc.value.reason == 4002
 
 
@@ -240,7 +241,7 @@ def test_ws_gate_refusal_close_uses_dedicated_code():
             headers={"Origin": "http://evil.example"})
         try:
             with pytest.raises(simple_websocket.ConnectionClosed) as exc:
-                c.receive(timeout=2)
+                c.receive(timeout=budget(2))
             assert exc.value.reason == 4003
         finally:
             with contextlib.suppress(Exception):
@@ -252,7 +253,7 @@ def test_ws_spawn_failure_closes_cleanly_and_frees_lock():
     with _serve(_FlakyManager()) as port:
         with _connect(port) as first:       # ensure_session raises -> clean close
             with contextlib.suppress(simple_websocket.ConnectionClosed):
-                first.receive(timeout=_RECV_TIMEOUT)    # must not hang / must not 500
+                first.receive(timeout=budget(_RECV_TIMEOUT))    # must not hang / must not 500
         # the conn lock's finally released even though spawn failed -> reattach works
         with _connect(port) as second:
-            assert second.receive(timeout=_RECV_TIMEOUT) == "0ready\n"
+            assert second.receive(timeout=budget(_RECV_TIMEOUT)) == "0ready\n"

--- a/tests/assistant/test_api_adapter.py
+++ b/tests/assistant/test_api_adapter.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 from quodeq.assistant.adapters._api import ApiTurnConfig, run_api_turn
 from quodeq.assistant.tools._registry import ToolRegistry, ToolSpec
+from tests._timeouts import budget
 
 
 def _delta(content=None, tool_calls=None, finish=None):
@@ -254,7 +255,9 @@ def test_cancel_interrupts_a_stalled_stream_read():
 
     def stalled_stream():
         yield _delta("Hel")
-        release.wait(timeout=30)  # blocks like a dead connection: no data, no EOF
+        # blocks like a dead connection: no data, no EOF. Scaled so the stall
+        # always outlasts the (also scaled) join budget below.
+        release.wait(timeout=budget(30))
         yield _delta("lo")
 
     client = ClosableFakeClient([stalled_stream()])
@@ -275,9 +278,9 @@ def test_cancel_interrupts_a_stalled_stream_read():
     t.start()
     time.sleep(0.3)   # let the turn consume "Hel" and block in the stalled read
     token.cancel()
-    t.join(timeout=3)
+    t.join(timeout=budget(3))
     release.set()     # unblock the abandoned reader so the test process exits clean
     if t.is_alive():
-        pytest.fail("turn thread still blocked 3s after cancel()")
+        pytest.fail("turn thread still blocked after cancel()")
     assert outcome["result"] == "cancelled"
     assert outcome["partial"] == "Hel"

--- a/tests/assistant/test_cli_spawn.py
+++ b/tests/assistant/test_cli_spawn.py
@@ -9,6 +9,7 @@ from quodeq.assistant.adapters._cli_spawn import (
     assert_no_dangerous_args, build_chat_env, external_sandbox_prefix,
     scratch_cwd, spawn_turn,
 )
+from tests._timeouts import budget
 
 
 def _wrapped_codex(*extra):
@@ -195,6 +196,6 @@ def test_spawn_turn_streams_stdout(tmp_path):
     argv = [sys.executable, "-c", "print('a'); print('b')"]
     proc = spawn_turn(argv, cwd=scratch_cwd(tmp_path), env=build_chat_env({"PATH": __import__("os").environ.get("PATH", "")}))
     out = proc.stdout.read()
-    proc.wait(timeout=10)
+    proc.wait(timeout=budget(10))
     assert "a" in out and "b" in out
     assert proc.returncode == 0

--- a/tests/assistant/test_linereader.py
+++ b/tests/assistant/test_linereader.py
@@ -3,6 +3,7 @@ import os
 import threading
 
 from quodeq.assistant.adapters._linereader import iter_lines
+from tests._timeouts import budget
 
 
 def test_yields_complete_lines():
@@ -41,12 +42,12 @@ def test_yields_line_while_stream_still_open():
     try:
         writer.write('{"type":"token"}\n')
         writer.flush()
-        assert first_line.wait(timeout=5), \
+        assert first_line.wait(timeout=budget(5)), \
             "line was not yielded while the pipe was still open (reader waits for EOF)"
         assert got == ['{"type":"token"}']
     finally:
         writer.close()
-        t.join(timeout=5)
+        t.join(timeout=budget(5))
         reader.close()
 
 

--- a/tests/ci/test_cli_signals.py
+++ b/tests/ci/test_cli_signals.py
@@ -29,6 +29,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._timeouts import budget
+
 # Subprocess waits up to 120 s inside these tests; give pytest-timeout
 # enough room above that to avoid double-killing a still-cleaning-up
 # process.
@@ -108,7 +110,8 @@ def test_sigterm_writes_cancelled_status(tmp_path: Path) -> None:
     # dry-run, so once it exists the child is guaranteed to be inside the
     # lifecycle context with signal handlers installed and the run_dir
     # (including status.json) already on disk.
-    deadline = time.monotonic() + 60
+    marker_s = budget(60)
+    deadline = time.monotonic() + marker_s
     while not marker.exists():
         if proc.poll() is not None:
             _out, err = proc.communicate()
@@ -116,7 +119,7 @@ def test_sigterm_writes_cancelled_status(tmp_path: Path) -> None:
         if time.monotonic() > deadline:
             proc.kill()
             proc.wait()
-            pytest.fail("CLI did not reach the dry-run pause within 60 s")
+            pytest.fail(f"CLI did not reach the dry-run pause within {marker_s:g} s")
         time.sleep(0.05)
 
     projects = [d for d in reports.iterdir() if d.is_dir()]
@@ -129,11 +132,12 @@ def test_sigterm_writes_cancelled_status(tmp_path: Path) -> None:
 
     # Send SIGTERM and wait for process to exit.
     proc.send_signal(signal.SIGTERM)
+    exit_s = budget(30)
     try:
-        proc.wait(timeout=30)
+        proc.wait(timeout=exit_s)
     except subprocess.TimeoutExpired:
         proc.kill()
-        pytest.fail("CLI did not exit after SIGTERM within 30 s")
+        pytest.fail(f"CLI did not exit after SIGTERM within {exit_s:g} s")
 
     # Poll for the terminal state to be written.
     status = None

--- a/tests/ci/test_server_health_smoke.py
+++ b/tests/ci/test_server_health_smoke.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._timeouts import budget
+
 _READY_TIMEOUT_S = 30
 
 
@@ -54,7 +56,8 @@ def test_api_health_subprocess(tmp_path: Path) -> None:
     )
     try:
         url = f"http://127.0.0.1:{port}/api/health"
-        deadline = time.monotonic() + _READY_TIMEOUT_S
+        ready_s = budget(_READY_TIMEOUT_S)
+        deadline = time.monotonic() + ready_s
         last_err: Exception | None = None
         while time.monotonic() < deadline:
             if proc.poll() is not None:
@@ -73,13 +76,13 @@ def test_api_health_subprocess(tmp_path: Path) -> None:
                 last_err = exc
                 time.sleep(0.5)
         pytest.fail(
-            f"/api/health never returned 200 within {_READY_TIMEOUT_S}s "
+            f"/api/health never returned 200 within {ready_s:g}s "
             f"(last error: {last_err!r})"
         )
     finally:
         proc.terminate()
         try:
-            proc.wait(timeout=10)
+            proc.wait(timeout=budget(10))
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait()

--- a/tests/dashboard/test_native_chrome.py
+++ b/tests/dashboard/test_native_chrome.py
@@ -8,6 +8,7 @@ import pytest
 import webview as real_webview
 
 from quodeq.dashboard import _webview_window as ww
+from tests._timeouts import budget
 
 # Some tests import PyObjCTools to patch AppHelper. pyobjc is darwin-only
 # (pywebview pulls it in under sys_platform == 'darwin'), so those tests can
@@ -133,7 +134,7 @@ class TestOnClosing:
     def _join(on_closing):
         worker = getattr(on_closing, "_worker", None)
         if worker is not None:
-            worker.join(timeout=2)
+            worker.join(timeout=budget(2))
             # A hung worker is the exact failure class this fix targets — surface
             # it as itself, not as a downstream mock-call-count mismatch.
             assert not worker.is_alive(), "close-confirm worker did not finish (possible re-deadlock)"
@@ -188,7 +189,7 @@ class TestOnClosing:
             result = []
             caller = threading.Thread(target=lambda: result.append(on_closing()))
             caller.start()
-            caller.join(timeout=2)
+            caller.join(timeout=budget(2))
             try:
                 assert not caller.is_alive(), "_on_closing blocked on the dialog — re-deadlock regression"
                 assert result == [False]
@@ -272,7 +273,7 @@ class TestOnClosing:
         with patch.object(ww, "_ask_close_choice", return_value="cancel") as choose:
             assert on_closing() is False
             first_worker = on_closing._worker
-            assert cancel_started.wait(2)  # worker is now inside the cancel call
+            assert cancel_started.wait(budget(2))  # worker is now inside the cancel call
             # Second close while the cancel is in flight: vetoed, no new prompt.
             assert on_closing() is False
             assert on_closing._worker is first_worker

--- a/tests/dashboard/test_webview_menu.py
+++ b/tests/dashboard/test_webview_menu.py
@@ -3,6 +3,7 @@ import sys
 import threading
 
 from quodeq.dashboard._webview_window import _NAVIGATE_HELP_JS, _non_macos_menu
+from tests._timeouts import budget
 
 
 class _FakeWindow:
@@ -40,7 +41,7 @@ def test_action_dispatches_navigate_event(monkeypatch):
     (help_menu,) = _non_macos_menu(window)
     (action,) = help_menu.items
     action.function()
-    assert window.called.wait(timeout=5), "evaluate_js was never called"
+    assert window.called.wait(timeout=budget(5)), "evaluate_js was never called"
     assert window.calls == [_NAVIGATE_HELP_JS]
 
 

--- a/tests/integration/test_assistant_cli_end_to_end.py
+++ b/tests/integration/test_assistant_cli_end_to_end.py
@@ -41,6 +41,7 @@ from flask import Flask
 from quodeq.api.assistant_routes import register_assistant_routes
 from quodeq.assistant.tools import ToolContext, build_registry
 from quodeq.data.sqlite.assistant_repository import AssistantRepository
+from tests._timeouts import budget
 
 _STANDARD = {
     "id": "rfc7807-errors", "name": "RFC7807 Errors", "description": "d",
@@ -139,7 +140,7 @@ def test_full_cli_draft_and_apply_flow(client, app, tmp_path):
     # Poll events via a fresh AssistantRepository rather than re-fetching the
     # SSE stream body (see test_assistant_end_to_end.py for the rationale).
     repo = AssistantRepository(app.config["ASSISTANT_DB_PATH"])
-    deadline = time.time() + 5
+    deadline = time.time() + budget(5)
     events: list[dict] = []
     while time.time() < deadline:
         events = [frame for _seq, frame in repo.events_after(sid, 0)]

--- a/tests/integration/test_assistant_end_to_end.py
+++ b/tests/integration/test_assistant_end_to_end.py
@@ -17,6 +17,7 @@ from flask import Flask
 
 from quodeq.api.assistant_routes import register_assistant_routes
 from quodeq.data.sqlite.assistant_repository import AssistantRepository
+from tests._timeouts import budget
 
 _STANDARD = {
     "id": "rfc7807-errors", "name": "RFC7807 Errors", "description": "d",
@@ -105,7 +106,7 @@ def test_full_draft_and_apply_flow(client, app, tmp_path):
     # is consumed only once and repeated GETs against a live generator
     # interact poorly with the Flask test client under a polling loop.
     repo = AssistantRepository(app.config["ASSISTANT_DB_PATH"])
-    deadline = time.time() + 5
+    deadline = time.time() + budget(5)
     events: list[dict] = []
     while time.time() < deadline:
         events = [frame for _seq, frame in repo.events_after(sid, 0)]

--- a/tests/services/test_action_provider_jobs.py
+++ b/tests/services/test_action_provider_jobs.py
@@ -8,6 +8,7 @@ import pytest
 
 from quodeq.core.types import JobSnapshot
 from quodeq.services.jobs import JobManager
+from tests._timeouts import budget
 
 _FAKE_REPORT_PATH = "Report path: /app/reports/sample-project/20260220/evaluation"
 _TEST_TIMEOUT_S = 5.0
@@ -50,7 +51,7 @@ def completed_success_job() -> JobSnapshot:
     manager, done = _make_manager_with_event(spawn_impl, job_id_holder)
     job = manager.start_job(["echo", "ok"])
     job_id_holder.append(job.job_id)
-    done.wait(timeout=_TEST_TIMEOUT_S)
+    done.wait(timeout=budget(_TEST_TIMEOUT_S))
     result = manager.get_job(job.job_id)
     assert result is not None
     return result
@@ -90,7 +91,7 @@ def test_markers_parsed_from_merged_stream() -> None:
     manager, done = _make_manager_with_event(spawn_impl, job_id_holder)
     job = manager.start_job(["echo"])
     job_id_holder.append(job.job_id)
-    done.wait(timeout=_TEST_TIMEOUT_S)
+    done.wait(timeout=budget(_TEST_TIMEOUT_S))
     result = manager.get_job(job.job_id)
     assert result is not None
     assert result.phase == "analyzing"
@@ -109,7 +110,7 @@ def test_job_manager_handles_failure() -> None:
     job = manager.start_job(["false"])
     job_id_holder.append(job.job_id)
 
-    done.wait(timeout=_TEST_TIMEOUT_S)
+    done.wait(timeout=budget(_TEST_TIMEOUT_S))
     result = manager.get_job(job.job_id)
     assert result is not None
 

--- a/tests/services/test_cache.py
+++ b/tests/services/test_cache.py
@@ -19,6 +19,7 @@ from quodeq.services._cache import (
     _wait_for_inflight,
     make_lru_dimension_fetcher,
 )
+from tests._timeouts import budget
 
 
 def _make_dim(name: str = "security") -> DimensionResult:
@@ -202,11 +203,11 @@ class TestMakeLruDimensionFetcher:
         t1 = threading.Thread(target=worker, args=(0,))
         t1.start()
         # Wait for t1 to start the fetch, then launch t2 which should wait
-        started.wait(timeout=5)
+        started.wait(timeout=budget(5))
         t2 = threading.Thread(target=worker, args=(1,))
         t2.start()
-        t1.join(timeout=10)
-        t2.join(timeout=10)
+        t1.join(timeout=budget(10))
+        t2.join(timeout=budget(10))
 
         # Both should have results
         assert results[0] is not None

--- a/tests/services/test_evaluation_mixin.py
+++ b/tests/services/test_evaluation_mixin.py
@@ -23,6 +23,7 @@ from quodeq.services.evaluation_mixin import (
     _score_completed_evidence,
     _wait_for_terminal_status,
 )
+from tests._timeouts import budget
 
 
 # ---------------------------------------------------------------------------
@@ -389,7 +390,7 @@ class TestWaitForTerminalStatus:
 
         threading.Thread(target=write_terminal, daemon=True).start()
         assert _wait_for_terminal_status(
-            run_dir, timeout_s=1.0, poll_interval_s=0.02,
+            run_dir, timeout_s=budget(1.0), poll_interval_s=0.02,
         ) is True
 
 

--- a/tests/services/test_external_jobs.py
+++ b/tests/services/test_external_jobs.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._timeouts import budget
+
 
 # The signal-escalation tests exercise POSIX process-group semantics
 # (start_new_session=True, killpg, SIGKILL). Windows has no equivalent
@@ -55,8 +57,12 @@ def _start_reaper(proc: subprocess.Popen) -> threading.Event:
 
 
 def _wait_for_exit(proc: subprocess.Popen, timeout: float) -> bool:
-    """Poll proc.poll() up to *timeout* seconds; return True if it exited."""
-    deadline = time.monotonic() + timeout
+    """Poll proc.poll() up to *timeout* seconds; return True if it exited.
+
+    Scaled at the point of use so callers passing an explicit *timeout* still
+    get the loaded-runner headroom.
+    """
+    deadline = time.monotonic() + budget(timeout)
     while time.monotonic() < deadline:
         if proc.poll() is not None:
             return True
@@ -73,7 +79,7 @@ def _force_cleanup(proc: subprocess.Popen) -> None:
     except (OSError, ProcessLookupError):
         pass
     try:
-        proc.wait(timeout=5)
+        proc.wait(timeout=budget(5))
     except subprocess.TimeoutExpired:
         pass
 
@@ -253,7 +259,7 @@ def test_cancel_external_run_kills_child_processes_in_same_group(tmp_path):
 
         # Both parent and child must be gone.
         assert _wait_for_exit(proc, timeout=5.0), "parent still alive after cancel"
-        deadline = time.monotonic() + 5.0
+        deadline = time.monotonic() + budget(5.0)
         child_dead = False
         while time.monotonic() < deadline:
             try:

--- a/tests/services/test_index_sync.py
+++ b/tests/services/test_index_sync.py
@@ -20,6 +20,7 @@ from quodeq.services._index_sync import (
     _check_stale_and_promote,
     force_promote_to_cancelled_stale,
 )
+from tests._timeouts import budget
 
 
 def test_is_pid_alive_current_process() -> None:
@@ -198,8 +199,8 @@ def test_stale_promotion_after_sigkill_real_subprocess(tmp_path: Path) -> None:
         heartbeat.touch()
 
         proc.send_signal(signal.SIGKILL)
-        proc.wait(timeout=5)
-        deadline = time.time() + 2
+        proc.wait(timeout=budget(5))
+        deadline = time.time() + budget(2)
         while _is_pid_alive(proc.pid) and time.time() < deadline:
             time.sleep(0.05)
         assert not _is_pid_alive(proc.pid), "subprocess PID still alive after kill -9"
@@ -219,7 +220,7 @@ def test_stale_promotion_after_sigkill_real_subprocess(tmp_path: Path) -> None:
     finally:
         if proc.poll() is None:
             proc.kill()
-            proc.wait(timeout=5)
+            proc.wait(timeout=budget(5))
         db.close()
 
 

--- a/tests/services/test_job_manager.py
+++ b/tests/services/test_job_manager.py
@@ -21,6 +21,7 @@ from quodeq.services.jobs import (
     _EXIT_CODE_SPAWN_FAILURE,
     _EXIT_CODE_TIMEOUT,
 )
+from tests._timeouts import budget
 
 
 class FakeProcess:
@@ -39,9 +40,13 @@ class FakeProcess:
 
 
 def _wait_for_job(manager: JobManager, job_id: str, timeout: float = 5.0) -> JobSnapshot | None:
-    """Poll until the job reaches a terminal state."""
+    """Poll until the job reaches a terminal state.
+
+    Scaled at the point of use so callers passing an explicit *timeout* still
+    get the loaded-runner headroom.
+    """
     import time
-    deadline = time.monotonic() + timeout
+    deadline = time.monotonic() + budget(timeout)
     while time.monotonic() < deadline:
         snap = manager.get_job(job_id)
         if snap and snap.status != STATUS_RUNNING:

--- a/tests/services/test_shared_repo_lock.py
+++ b/tests/services/test_shared_repo_lock.py
@@ -15,6 +15,7 @@ import pytest
 from quodeq.services import shared_publish, shared_repo
 from quodeq.services.shared_publish import publish_project
 from quodeq.services.shared_repo import clone_lock, ensure_shared_clone, refresh_shared_clone
+from tests._timeouts import budget
 
 # The thread join()/wait() calls below are deadlock guards, not performance
 # assertions: a genuine clone-lock deadlock hangs forever, so any generous
@@ -61,9 +62,9 @@ def test_clone_lock_keyed_by_path_and_reentrant(tmp_path, monkeypatch):
     assert lock_a1 is lock_a2
     assert lock_a1 is not lock_b
 
-    assert lock_a1.acquire(timeout=1)
+    assert lock_a1.acquire(timeout=budget(1))
     try:
-        assert lock_a1.acquire(timeout=1)  # reentrant on the same thread
+        assert lock_a1.acquire(timeout=budget(1))  # reentrant on the same thread
         lock_a1.release()
     finally:
         lock_a1.release()
@@ -122,13 +123,13 @@ def test_refresh_waits_for_publish(tmp_path, monkeypatch):
     refresh_thread = threading.Thread(target=_fire_refresh, name="refresh")
 
     publish_thread.start()
-    assert commit_reached.wait(timeout=_DEADLOCK_GUARD_TIMEOUT), (
+    assert commit_reached.wait(timeout=budget(_DEADLOCK_GUARD_TIMEOUT)), (
         "publish never reached its commit step"
     )
     refresh_thread.start()
 
-    publish_thread.join(timeout=_DEADLOCK_GUARD_TIMEOUT)
-    refresh_thread.join(timeout=_DEADLOCK_GUARD_TIMEOUT)
+    publish_thread.join(timeout=budget(_DEADLOCK_GUARD_TIMEOUT))
+    refresh_thread.join(timeout=budget(_DEADLOCK_GUARD_TIMEOUT))
 
     assert not publish_thread.is_alive(), "publish_project deadlocked"
     assert not refresh_thread.is_alive(), "refresh_shared_clone deadlocked"
@@ -163,7 +164,7 @@ def test_clone_lock_is_reentrant_for_publish_internal_refresh(tmp_path):
 
     thread = threading.Thread(target=_do_publish, name="publish")
     thread.start()
-    thread.join(timeout=_DEADLOCK_GUARD_TIMEOUT)
+    thread.join(timeout=budget(_DEADLOCK_GUARD_TIMEOUT))
 
     assert not thread.is_alive(), (
         "publish_project deadlocked acquiring its own clone lock reentrantly "

--- a/tests/shared/test_process_kill.py
+++ b/tests/shared/test_process_kill.py
@@ -3,6 +3,7 @@ import sys
 import time
 
 from quodeq.shared._process_kill import kill_proc_tree
+from tests._timeouts import budget
 
 
 def test_kill_proc_tree_kills_a_real_process():
@@ -10,7 +11,7 @@ def test_kill_proc_tree_kills_a_real_process():
                             start_new_session=(sys.platform != "win32"))
     assert proc.poll() is None
     kill_proc_tree(proc)
-    proc.wait(timeout=10)
+    proc.wait(timeout=budget(10))
     assert proc.poll() is not None
 
 

--- a/tests/shared/test_resource_sampler.py
+++ b/tests/shared/test_resource_sampler.py
@@ -20,6 +20,7 @@ from quodeq.shared.resource_sampler import (
     _ollama_rss_mb,
     _self_rss_mb,
 )
+from tests._timeouts import budget
 
 
 class TestSnapshotFormat:
@@ -62,7 +63,7 @@ class TestStartStop:
         sampler.start()
         thread = sampler._thread
         time.sleep(0.1)  # let it tick at least once
-        sampler.stop(timeout=1.0)
+        sampler.stop(timeout=budget(1.0))
         assert thread is not None
         assert not thread.is_alive()
 

--- a/tests/shared/test_run_heartbeat.py
+++ b/tests/shared/test_run_heartbeat.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from quodeq.shared.run_heartbeat import HeartbeatThread, HEARTBEAT_FILENAME
+from tests._timeouts import budget
 
 
 def test_starts_and_touches_file(tmp_path: Path) -> None:
@@ -20,7 +21,7 @@ def test_starts_and_touches_file(tmp_path: Path) -> None:
         # window, leaving both reads on the same mtime (a false failure). This
         # mirrors the deadline-poll pattern in test_swallows_oserror below.
         second_mtime = first_mtime
-        deadline = time.monotonic() + 5.0
+        deadline = time.monotonic() + budget(5.0)
         while time.monotonic() < deadline:
             second_mtime = (tmp_path / HEARTBEAT_FILENAME).stat().st_mtime
             if second_mtime > first_mtime:
@@ -57,7 +58,7 @@ def test_swallows_oserror(tmp_path: Path, monkeypatch) -> None:
     # Poll instead of sleeping a fixed window — a loaded CI runner can
     # tick the heartbeat much slower than 20 ms, so a 200 ms sleep is
     # not enough headroom to guarantee >=3 touches.
-    deadline = time.monotonic() + 5.0
+    deadline = time.monotonic() + budget(5.0)
     while len(errors) < 3 and time.monotonic() < deadline:
         time.sleep(0.05)
     hb.stop()

--- a/tests/shared/test_run_log.py
+++ b/tests/shared/test_run_log.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 
 from quodeq.shared.run_log import RunLogWriter, RunLogHandler
+from tests._timeouts import budget
 
 
 def test_write_creates_file_with_line(tmp_path: Path) -> None:
@@ -119,7 +120,7 @@ def test_concurrent_write_and_close_does_not_raise(tmp_path: Path) -> None:
     time.sleep(0.01)
     writer.close()
     stop.set()
-    t.join(timeout=2.0)
+    t.join(timeout=budget(2.0))
 
     assert errors == [], f"concurrent write/close raised: {errors!r}"
 

--- a/tests/terminal/test_pty_unix.py
+++ b/tests/terminal/test_pty_unix.py
@@ -3,12 +3,19 @@ import time
 
 import pytest
 
+from tests._timeouts import budget
+
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Unix PTY only")
 
 
-def _drain_until(pty, needle: bytes, timeout: float = 5.0) -> bytes:
+def _drain_until(pty, needle: bytes, timeout: float = 5.0,
+                 scale: bool = True) -> bytes:
     buf = b""
-    deadline = time.monotonic() + timeout
+    # Scale here, not at the call sites, so callers waiting on a needle that
+    # should arrive still get the runner's headroom. Pass scale=False when the
+    # needle is never expected and the timeout IS the drain -- scaling that
+    # only burns wall time.
+    deadline = time.monotonic() + (budget(timeout) if scale else timeout)
     while time.monotonic() < deadline:
         chunk = pty.read(4096)
         if not chunk:
@@ -43,7 +50,7 @@ def test_read_returns_empty_quickly_when_idle():
     pty.spawn(cwd="/", cols=80, rows=24)
     try:
         # Drain the initial prompt/banner so the shell is quiescent.
-        _drain_until(pty, b"__no_such_needle__", timeout=1.0)
+        _drain_until(pty, b"__no_such_needle__", timeout=1.0, scale=False)
         # The shell is idle but alive: read() must return b"" promptly (non-blocking)
         # rather than parking in os.read forever.
         start = time.monotonic()

--- a/tests/terminal/test_pty_windows_smoke.py
+++ b/tests/terminal/test_pty_windows_smoke.py
@@ -3,6 +3,8 @@ import time
 
 import pytest
 
+from tests._timeouts import budget
+
 pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="Windows ConPTY only")
 
 
@@ -14,7 +16,7 @@ def test_windows_pty_spawns_and_echoes():
     assert pty.alive
     pty.write(b"echo hello-conpty\r\n")  # write() takes bytes (matches the Unix backend contract)
     buf = ""
-    deadline = time.monotonic() + 8
+    deadline = time.monotonic() + budget(8)
     while time.monotonic() < deadline:
         chunk = pty.read(4096).decode("utf-8", "replace")
         buf += chunk

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -1,0 +1,59 @@
+"""Tests for the scaled wall-clock budget helper."""
+from __future__ import annotations
+
+import pytest
+
+from tests._timeouts import budget, scale
+
+
+class TestScale:
+    def test_defaults_to_one_when_unset(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("QUODEQ_TEST_TIMEOUT_SCALE", raising=False)
+        assert scale() == 1.0
+
+    def test_reads_the_env_var(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("QUODEQ_TEST_TIMEOUT_SCALE", "4")
+        assert scale() == 4.0
+
+    def test_accepts_a_fractional_value(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("QUODEQ_TEST_TIMEOUT_SCALE", "2.5")
+        assert scale() == 2.5
+
+    @pytest.mark.parametrize("raw", ["", "abc", "1,5", "None"])
+    def test_unparseable_value_falls_back_to_one(
+        self, raw: str, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("QUODEQ_TEST_TIMEOUT_SCALE", raw)
+        assert scale() == 1.0
+
+    @pytest.mark.parametrize("raw", ["0", "-3"])
+    def test_non_positive_value_falls_back_to_one(
+        self, raw: str, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A zero or negative budget would turn every wait into a no-op."""
+        monkeypatch.setenv("QUODEQ_TEST_TIMEOUT_SCALE", raw)
+        assert scale() == 1.0
+
+
+class TestBudget:
+    def test_passes_through_unscaled_by_default(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("QUODEQ_TEST_TIMEOUT_SCALE", raising=False)
+        assert budget(5) == 5.0
+
+    def test_multiplies_by_the_scale(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("QUODEQ_TEST_TIMEOUT_SCALE", "4")
+        assert budget(5) == 20.0
+
+    def test_never_scales_below_the_requested_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The knob may only buy more headroom, never less."""
+        monkeypatch.setenv("QUODEQ_TEST_TIMEOUT_SCALE", "0.5")
+        assert budget(5) == 5.0
+
+    def test_reads_the_env_var_at_call_time(self, monkeypatch: pytest.MonkeyPatch):
+        """Import order must not freeze the scale."""
+        monkeypatch.setenv("QUODEQ_TEST_TIMEOUT_SCALE", "2")
+        assert budget(1) == 2.0
+        monkeypatch.setenv("QUODEQ_TEST_TIMEOUT_SCALE", "3")
+        assert budget(1) == 3.0


### PR DESCRIPTION
Two fixes for the recurring Windows Tests failures. No production code changes.

## 1. One knob for every wall-clock budget

The Windows job runs pytest-xdist with `-n auto` on a 4-vCPU runner, so four workers saturate the box. A literal `wait(timeout=5)` that is generous on an idle laptop becomes a coin flip there: a thread can miss its window purely because it never got scheduled.

New `tests/_timeouts.py` exposes `budget()`. ~60 call sites across 30 files now wrap their budgets, and `QUODEQ_TEST_TIMEOUT_SCALE=4` is set on the Windows step only, so local runs stay at 1.

`budget()` clamps to `max(seconds, seconds * scale)`. The knob can only add headroom, never shrink a timeout and make things flakier.

Three classes were deliberately left unwrapped:

- Waits asserting something does **not** happen. They already return as late as they ever will, and scaling widens the window for the thing they forbid.
- Upper-bound assertions (`assert elapsed < 1.5`). Scaling inverts what they test.
- Virtual-clock deadlines where `time.monotonic` is patched and the test advances the clock itself. Nothing to scale.

One `join(timeout=5.0)` turned out to be a string literal inside a source-inspection test that pins `src/` as having no join ceiling. Left alone; editing it would have silently broken a regression guard.

## 2. The stop test leaked a worker thread

`test_stop_cancels_running_turn_and_frees_the_token` ended by posting a second message to prove the turn slot is reclaimable. That 202 spawns another `_worker` daemon thread running the still-patched `fake_run_turn`, which parks on `cancel.wait(5)` with nothing left to cancel it. The test passed and exited, monkeypatch unwound, and five seconds later the orphan thread's assert fired inside whichever test happened to be running then.

It hit develop as a `PytestUnhandledThreadExceptionWarning` attributed to `test_shared_session_resolves_clone_run_dir`, on an unrelated xdist worker, which is why it read as someone else's flake. It fires on every run. Scaling the budget only makes it land later and in a more arbitrary test, so this needed its own fix.

Now the second turn is cancelled and reaped before the test returns. The slot assertion is unchanged.

## Verification

    # leak, reproduced then fixed
    uv run pytest tests/api -W error::pytest.PytestUnhandledThreadExceptionWarning
    # 658 passed + 1 error before, 659 passed after

    uv run pytest tests/ -m "not integration"                             # 5052 passed
    QUODEQ_TEST_TIMEOUT_SCALE=4 uv run pytest tests/ -m "not integration" -n auto   # 5052 passed

Scaling adds no wall time on the green path: the wrapped values are caps, not sleeps.

## Not covered

- `test_ws_gate_refusal_close_uses_dedicated_code` (macOS, close code 1005 vs 4003) is the handshake frame-coalescing problem. A longer budget cannot recover an already-dropped frame, so this PR does not touch it.
- `assert elapsed < 1.5` in `test_external_jobs.py:204` and `test_pty_unix.py:57` assert speed, so headroom is the wrong tool. They are the remaining load-sensitive sites if Windows keeps flaking.