### PR TITLE
refactor(log): shorten the scan progress line

### DIFF
--- a/src/quodeq/analysis/subagents/_heartbeat.py
+++ b/src/quodeq/analysis/subagents/_heartbeat.py
@@ -17,7 +17,7 @@ _SECONDS_PER_MINUTE = 60
 _HEARTBEAT_FMT = (
     "[{dimension}] {mins}m{secs:02d}s | "
     "{violations} v · {compliance} c{suppressed}{quarantined} | "
-    "files {taken}/{total_files} · {remaining} left | "
+    "files {taken}/{total_files} | "
     "{active} agent{plural}"
 )
 
@@ -65,8 +65,9 @@ def heartbeat_loop(
     — the scanner keeps re-finding them, and a raw count here would read as
     several times the number the finished report shows. ``ctx.resolver`` drops
     the ones the report path quarantines for naming a principle outside the
-    standard. Each excluded total is appended as its own segment (``N supp``,
-    ``N unmapped``) so neither drop is silent.
+    standard. Each excluded total is appended as its own segment (``N s``,
+    ``N u``) so neither drop is silent. The letters are spelled out in
+    ``quodeq evaluate --help``.
     """
     start = time.monotonic()
     while not stop.wait(_HEARTBEAT_INTERVAL):
@@ -84,15 +85,15 @@ def heartbeat_loop(
                 secs=secs,
                 # Only surfaces when a finding was actually quarantined, so the
                 # usual line keeps its shape.
-                quarantined=f" · {tally.quarantined} unmapped" if tally.quarantined else "",
+                quarantined=f" · {tally.quarantined} u" if tally.quarantined else "",
                 active=active,
                 plural="" if active == 1 else "s",
                 taken=taken,
+                # ``remaining`` is not printed: it is always total minus taken.
                 total_files=taken + remaining,
-                remaining=remaining,
                 violations=tally.violations,
                 compliance=tally.compliance,
-                suppressed=f" · {tally.suppressed} supp" if tally.suppressed else "",
+                suppressed=f" · {tally.suppressed} s" if tally.suppressed else "",
             ))
         except (OSError, ValueError, RuntimeError) as exc:
             log_warning(f"Heartbeat error: {exc}")

--- a/src/quodeq/cli_parser.py
+++ b/src/quodeq/cli_parser.py
@@ -9,6 +9,21 @@ _DEFAULT_N_SUBAGENTS = 5
 _MODE_NUMERICAL = "numerical"
 _MODE_GRADES = "grades"
 
+# Spells out the single-letter counters in the progress lines the scan emits.
+# They are abbreviated there to keep the line readable at a glance.
+_EVALUATE_EPILOG = """\
+progress lines:
+  [security] 1m30s | 13 v · 316 c · 4 s · 2 u | files 105/200 | 5 agents
+
+  v  violations found so far
+  c  compliance findings found so far
+  s  suppressed: findings you already dismissed or deleted, not counted in v
+  u  unmapped: findings quarantined for naming a principle outside the
+     standard, not counted in v either
+
+  s and u only appear when non-zero.
+"""
+
 
 def _add_output_args(parser: argparse.ArgumentParser) -> None:
     """Register output and scoring mode arguments."""
@@ -127,7 +142,9 @@ def build_parser() -> argparse.ArgumentParser:
     dashboard_parser.set_defaults(handler_command="dashboard")
 
     evaluate_parser = subparsers.add_parser(
-        "evaluate", help="Run evaluation (auto-detects language)"
+        "evaluate", help="Run evaluation (auto-detects language)",
+        epilog=_EVALUATE_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     _add_evaluate_args(evaluate_parser)
     evaluate_parser.set_defaults(handler_command="evaluate")

--- a/tests/analysis/test_heartbeat_coverage.py
+++ b/tests/analysis/test_heartbeat_coverage.py
@@ -75,7 +75,9 @@ class TestHeartbeatFormat:
         )
         assert line.startswith("[security] 1m02s")
         assert "2 v · 5 c" in line
-        assert "files 10/30 · 20 left" in line
+        # The remaining count is dropped: 30 minus 10 already says it.
+        assert "files 10/30 |" in line
+        assert "left" not in line
         assert line.endswith("2 agents")
         assert "findings" not in line
         assert "total" not in line
@@ -94,10 +96,10 @@ class TestHeartbeatFormat:
             dimension="reliability", mins=16, secs=1,
             active=1, plural="",
             taken=34, total_files=34, remaining=0,
-            violations=122, compliance=261, suppressed=" · 339 supp",
+            violations=122, compliance=261, suppressed=" · 339 s",
             quarantined="",
         )
-        assert "122 v · 261 c · 339 supp |" in line
+        assert "122 v · 261 c · 339 s |" in line
 
     def test_no_suppressed_segment_when_nothing_is_hidden(self) -> None:
         """A project with no dismissals must keep the pre-existing line shape."""
@@ -108,7 +110,6 @@ class TestHeartbeatFormat:
             violations=7, compliance=3, suppressed="", quarantined="",
         )
         assert "7 v · 3 c |" in line
-        assert "supp" not in line
 
     def test_unmapped_segment_only_appears_when_something_was_quarantined(self) -> None:
         """A clean run keeps the line's original shape."""
@@ -117,9 +118,9 @@ class TestHeartbeatFormat:
             taken=1, total_files=2, remaining=1, violations=3, compliance=0,
             suppressed="",
         )
-        assert "unmapped" not in _HEARTBEAT_FMT.format(quarantined="", **kwargs)
-        assert "3 v · 0 c · 1 unmapped" in _HEARTBEAT_FMT.format(
-            quarantined=" · 1 unmapped", **kwargs,
+        assert "3 v · 0 c |" in _HEARTBEAT_FMT.format(quarantined="", **kwargs)
+        assert "3 v · 0 c · 1 u |" in _HEARTBEAT_FMT.format(
+            quarantined=" · 1 u", **kwargs,
         )
 
     def test_both_exclusion_segments_render_together(self) -> None:
@@ -129,9 +130,9 @@ class TestHeartbeatFormat:
             active=1, plural="",
             taken=5, total_files=5, remaining=0,
             violations=570, compliance=168,
-            suppressed=" · 12 supp", quarantined=" · 1 unmapped",
+            suppressed=" · 12 s", quarantined=" · 1 u",
         )
-        assert "570 v · 168 c · 12 supp · 1 unmapped |" in line
+        assert "570 v · 168 c · 12 s · 1 u |" in line
 
 
 class TestHeartbeatLoop:


### PR DESCRIPTION
The heartbeat line was wide enough to wrap in a normal terminal, which made a running scan hard to read.

Before:
```
[security] 1m30s | 13 v · 316 c · 4 supp · 2 unmapped | files 105/200 · 95 left | 5 agents
```

After:
```
[security] 1m30s | 13 v · 316 c · 4 s · 2 u | files 105/200 | 5 agents
```

- `supp` -> `s`, `unmapped` -> `u`. Both segments still only render when non-zero.
- Dropped `· N left`: it is always total minus taken, so `105/200` already carries it. `remaining` is still read from the queue to compute the total.
- Added a legend to `quodeq evaluate --help` so the letters stay discoverable:

```
progress lines:
  [security] 1m30s | 13 v · 316 c · 4 s · 2 u | files 105/200 | 5 agents

  v  violations found so far
  c  compliance findings found so far
  s  suppressed: findings you already dismissed or deleted, not counted in v
  u  unmapped: findings quarantined for naming a principle outside the
     standard, not counted in v either

  s and u only appear when non-zero.
```

Display only. Grepped the UI and the Python side: nothing parses this line, only the format tests.

The two "segment absent" tests moved from substring checks (`"supp" not in line`) to pinning the segment boundary (`"7 v · 3 c |"`), since single letters occur elsewhere in the line ("files", "agents").