### PR TITLE
fix: make dismiss/delete affect scores the same way on every surface

### DIFF
--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -25,7 +25,7 @@ from quodeq.core.types import ScoringResult
 from quodeq.engine.scoring_pipeline import run_full
 from quodeq.services.deleted import deleted_keys
 from quodeq.services.dismissed import dismissed_keys
-from quodeq.services.evidence_rescore import score_dimension_from_evidence
+from quodeq.services.evidence_rescore import score_dimension_from_evidence, standard_dirs
 from quodeq.services.grade_formula import load_params
 from quodeq.shared.project_resolver import ProjectIdentity, resolve_project_uuid
 from quodeq.shared.logging import log_error, log_info, log_warning
@@ -203,11 +203,14 @@ def _count_excluded_findings(
     jsonl = run_dir / "evidence" / f"{dim_id}_evidence.jsonl"
     if not jsonl.is_file() or jsonl.stat().st_size == 0:
         return 0
+    # Same standard dirs as the rescore: a quarantined finding never entered
+    # the grade, so a dismissal targeting it must not count as an exclusion.
+    compiled_dir, evaluators_dir = standard_dirs()
     try:
         evidence = parse_jsonl_to_evidence(jsonl, EvidenceContext(
             language="", repository="", date_str="",
             source_file_count=0, files_read=0,
-        ))
+        ), compiled_dir=compiled_dir, evaluators_dir=evaluators_dir)
     except (OSError, ValueError, KeyError):
         return 0
     if evidence is None:

--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -26,6 +26,7 @@ from quodeq.engine.scoring_pipeline import run_full
 from quodeq.services.deleted import deleted_keys
 from quodeq.services.dismissed import dismissed_keys
 from quodeq.services.evidence_rescore import score_dimension_from_evidence, standard_dirs
+from quodeq.services.suppression import is_deleted, is_dismissed
 from quodeq.services.grade_formula import load_params
 from quodeq.shared.project_resolver import ProjectIdentity, resolve_project_uuid
 from quodeq.shared.logging import log_error, log_info, log_warning
@@ -219,13 +220,10 @@ def _count_excluded_findings(
     count = 0
     for pe in evidence.principles.values():
         for v in pe.violations:
-            file = v.get("file") or ""
-            try:
-                line = int(v.get("line") or 0)
-            except (TypeError, ValueError):
-                line = 0
-            req = v.get("req") or ""
-            if (req, file, line) in dismissed or (dim_id, pe.practice_id, file) in deleted:
+            if is_dismissed(dismissed, req=v.get("req"), principle=pe.practice_id,
+                            file=v.get("file"), line=v.get("line")) \
+                    or is_deleted(deleted, dimension=dim_id,
+                                  principle=pe.practice_id, file=v.get("file")):
                 count += 1
     return count
 

--- a/src/quodeq/ci/_evidence_reader.py
+++ b/src/quodeq/ci/_evidence_reader.py
@@ -41,10 +41,10 @@ def _judgment_to_violation(obj: dict) -> dict | None:
     req = obj.get("req")
     if req:
         out["req"] = req
-    # Carry the principle forward as "practiceId" -- the same key name scored
-    # report JSON uses (Finding.practice_id -> camelCase via to_camel_dict) --
-    # so filter_suppressed_violations can match deleted-finding keys, which
-    # are (dimension, principle, file), without needing a second field name.
+    # Carry the principle forward as "practiceId". Scored report JSON names
+    # this field "principle" (analysis/_report_findings), so
+    # filter_suppressed_violations matches deleted-finding keys against
+    # either name.
     principle = obj.get("p")
     if principle:
         out["practiceId"] = principle

--- a/src/quodeq/ci/_suppressions.py
+++ b/src/quodeq/ci/_suppressions.py
@@ -40,6 +40,8 @@ def filter_suppressed_violations(report: dict, project_dir: Path) -> dict:
     kept = [
         v for v in report.get("violations") or []
         if (v.get("req") or "", v.get("file") or "", _coerce_line(v.get("line"))) not in dismissed
-        and (v.get("dimension") or report_dim, v.get("practiceId") or "", v.get("file") or "") not in deleted
+        and (v.get("dimension") or report_dim,
+             v.get("principle") or v.get("practiceId") or "",
+             v.get("file") or "") not in deleted
     ]
     return {**report, "violations": kept}

--- a/src/quodeq/ci/_suppressions.py
+++ b/src/quodeq/ci/_suppressions.py
@@ -5,13 +5,7 @@ from pathlib import Path
 
 from quodeq.services.deleted import deleted_keys
 from quodeq.services.dismissed import dismissed_keys
-
-
-def _coerce_line(line: object) -> int:
-    try:
-        return int(line)  # type: ignore[arg-type]
-    except (TypeError, ValueError):
-        return 0
+from quodeq.services.suppression import is_deleted, is_dismissed
 
 
 def filter_suppressed_violations(report: dict, project_dir: Path) -> dict:
@@ -37,11 +31,14 @@ def filter_suppressed_violations(report: dict, project_dir: Path) -> dict:
     if not dismissed and not deleted:
         return report
     report_dim = report.get("dimension") or ""
-    kept = [
-        v for v in report.get("violations") or []
-        if (v.get("req") or "", v.get("file") or "", _coerce_line(v.get("line"))) not in dismissed
-        and (v.get("dimension") or report_dim,
-             v.get("principle") or v.get("practiceId") or "",
-             v.get("file") or "") not in deleted
-    ]
-    return {**report, "violations": kept}
+
+    def _keep(v: dict) -> bool:
+        # Scored report JSON names the field "principle"; evidence-derived
+        # reports (--from-evidence, quodeq review) carry "practiceId".
+        principle = v.get("principle") or v.get("practiceId")
+        return not is_dismissed(dismissed, req=v.get("req"), principle=principle,
+                                file=v.get("file"), line=v.get("line")) \
+            and not is_deleted(deleted, dimension=v.get("dimension") or report_dim,
+                               principle=principle, file=v.get("file"))
+
+    return {**report, "violations": [v for v in report.get("violations") or [] if _keep(v)]}

--- a/src/quodeq/services/deleted.py
+++ b/src/quodeq/services/deleted.py
@@ -204,9 +204,9 @@ def is_finding_deleted(
     file: str,
 ) -> bool:
     """Return True if ``(dimension, principle, file)`` is in *deleted*."""
-    if not deleted:
-        return False
-    return (dimension or "", principle or "", file or "") in deleted
+    from quodeq.services.suppression import is_deleted  # noqa: PLC0415
+
+    return is_deleted(deleted, dimension=dimension, principle=principle, file=file)
 
 
 def filter_deleted_from_dimensions(
@@ -225,7 +225,8 @@ def filter_deleted_from_dimensions(
         dim_id = (getattr(dim, "dimension", "") or "")
         filtered = [
             v for v in dim.violations
-            if (dim_id, _principle_of(v), v.file or "") not in keys
+            if not is_finding_deleted(keys, dimension=dim_id,
+                                      principle=_principle_of(v), file=v.file or "")
         ]
         if len(filtered) == len(dim.violations):
             result.append(dim)

--- a/src/quodeq/services/dismissed.py
+++ b/src/quodeq/services/dismissed.py
@@ -241,17 +241,6 @@ def restore_all_findings(project_dir: Path) -> int:
     return count
 
 
-def _finding_key(f: Finding) -> tuple:
-    # line is coerced to int to match the stored dismiss key (dismissed_keys
-    # stores int(line)); Finding.line is typed int|str|None, so a string line
-    # would otherwise never match its own dismissal.
-    try:
-        line = int(f.line)
-    except (TypeError, ValueError):
-        line = 0
-    return (f.req or "", f.file or "", line)
-
-
 def recount_totals(
     violations: list[Finding],
     compliance_count: int | None = None,
@@ -285,12 +274,18 @@ def filter_dismissed_from_dimensions(
     Recalculates totals for any dimension whose violations were filtered.
     Leaves compliance, principles, overall_score, overall_grade unchanged.
     """
+    from quodeq.services.suppression import is_dismissed  # noqa: PLC0415
+
     keys = dismissed_keys(project_dir)
     if not keys:
         return dimensions
     result = []
     for dim in dimensions:
-        filtered = [v for v in dim.violations if _finding_key(v) not in keys]
+        filtered = [
+            v for v in dim.violations
+            if not is_dismissed(keys, req=v.req, principle=v.practice_id,
+                                file=v.file, line=v.line)
+        ]
         if len(filtered) == len(dim.violations):
             result.append(dim)
         else:

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -641,6 +641,10 @@ def _score_completed_evidence(reports_dir: str, job: dict) -> None:
     evaluation_dir.mkdir(parents=True, exist_ok=True)
     source_file_count = _read_project_source_file_count(reports_dir, project)
     params = load_params()
+    # Same standard dirs as a completed run's scoring, so off-standard
+    # findings are quarantined here too instead of entering the grade.
+    from quodeq.services.evidence_rescore import standard_dirs  # noqa: PLC0415
+    compiled_dir, evaluators_dir = standard_dirs()
 
     from quodeq.shared.dimensions_state import read_dimensions
     dim_states = read_dimensions(Path(reports_dir) / project / run_id).get("dimensions", {})
@@ -665,7 +669,7 @@ def _score_completed_evidence(reports_dir: str, job: dict) -> None:
             evidence = parse_jsonl_to_evidence(jsonl_path, EvidenceContext(
                 language="", repository="", date_str="",
                 source_file_count=source_file_count, files_read=files_read,
-            ))
+            ), compiled_dir=compiled_dir, evaluators_dir=evaluators_dir)
             if evidence is None:
                 continue
             scores = score_evidence(evidence, mode="numerical", params=params)

--- a/src/quodeq/services/evidence_rescore.py
+++ b/src/quodeq/services/evidence_rescore.py
@@ -18,6 +18,7 @@ from quodeq.core.evidence.parser import EvidenceContext, parse_jsonl_to_evidence
 from quodeq.core.scoring.engine import score_evidence
 from quodeq.core.scoring.params import ScoringParams
 from quodeq.core.types import ScoringResult
+from quodeq.services.suppression import is_deleted, is_dismissed
 from quodeq.shared.validation import validate_path_segment
 
 _logger = logging.getLogger(__name__)
@@ -35,21 +36,6 @@ def standard_dirs() -> tuple[Path | None, Path | None]:
     standards = paths.standards_dir
     compiled = (standards / "compiled") if standards and standards.exists() else None
     return compiled, paths.evaluators_dir
-
-
-def _coerce_line(line: object) -> int:
-    try:
-        return int(line)  # type: ignore[arg-type]
-    except (TypeError, ValueError):
-        return 0
-
-
-def _is_dismissed(v: dict, dismissed: set[tuple]) -> bool:
-    return (v.get("req") or "", v.get("file") or "", _coerce_line(v.get("line"))) in dismissed
-
-
-def _is_deleted(v: dict, dim_id: str, practice_id: str, deleted: set[tuple]) -> bool:
-    return (dim_id, practice_id, v.get("file") or "") in deleted
 
 
 def score_dimension_from_evidence(
@@ -97,8 +83,10 @@ def score_dimension_from_evidence(
     for pe in evidence.principles.values():
         pe.violations = [
             v for v in pe.violations
-            if not _is_dismissed(v, dismissed)
-            and not _is_deleted(v, dim_id, pe.practice_id, deleted)
+            if not is_dismissed(dismissed, req=v.get("req"), principle=pe.practice_id,
+                                file=v.get("file"), line=v.get("line"))
+            and not is_deleted(deleted, dimension=dim_id, principle=pe.practice_id,
+                               file=v.get("file"))
         ]
         # Same call shape as core/evidence/parser._build_principles so the
         # recomputed metrics (confidence, compliance %) match scan time.

--- a/src/quodeq/services/evidence_rescore.py
+++ b/src/quodeq/services/evidence_rescore.py
@@ -13,6 +13,7 @@ import logging
 import os
 from pathlib import Path
 
+from quodeq.config.paths import default_paths
 from quodeq.core.evidence.parser import EvidenceContext, parse_jsonl_to_evidence
 from quodeq.core.scoring.engine import score_evidence
 from quodeq.core.scoring.params import ScoringParams
@@ -20,6 +21,20 @@ from quodeq.core.types import ScoringResult
 from quodeq.shared.validation import validate_path_segment
 
 _logger = logging.getLogger(__name__)
+
+
+def standard_dirs() -> tuple[Path | None, Path | None]:
+    """(compiled_dir, evaluators_dir) resolved exactly as scan time does.
+
+    Scan runs build RunConfig from default_paths() (see _cli_evaluation), so
+    resolving here keeps the rescore's PrincipleResolver identical to the one
+    that quarantined findings at scan time. Without these dirs the resolver is
+    permissive and quarantined findings would re-enter the grade on rescore.
+    """
+    paths = default_paths()
+    standards = paths.standards_dir
+    compiled = (standards / "compiled") if standards and standards.exists() else None
+    return compiled, paths.evaluators_dir
 
 
 def _coerce_line(line: object) -> int:
@@ -67,11 +82,12 @@ def score_dimension_from_evidence(
     jsonl = Path(candidate)
     if not jsonl.is_file() or jsonl.stat().st_size == 0:
         return None
+    compiled_dir, evaluators_dir = standard_dirs()
     try:
         evidence = parse_jsonl_to_evidence(jsonl, EvidenceContext(
             language="", repository="", date_str="",
             source_file_count=source_file_count, files_read=files_read,
-        ))
+        ), compiled_dir=compiled_dir, evaluators_dir=evaluators_dir)
     except (OSError, ValueError, KeyError) as exc:
         _logger.debug("Evidence rescore parse failed for %s/%s: %s", run_dir.name, dim_id, exc)
         return None

--- a/src/quodeq/services/evidence_rescore.py
+++ b/src/quodeq/services/evidence_rescore.py
@@ -104,4 +104,12 @@ def score_dimension_from_evidence(
         # recomputed metrics (confidence, compliance %) match scan time.
         pe.compute_metrics(source_file_count=source_file_count)
 
-    return score_evidence(evidence, mode="numerical", params=params)
+    # Broad catch on purpose (mirrors mutation_rescore and the CLI print
+    # guard): the engine can throw on edge-case evidence, and every consumer
+    # (dashboard build, /api/rescore, trend fetcher) treats None as "fall back
+    # to the stored score" — one bad dimension must not fail the whole run.
+    try:
+        return score_evidence(evidence, mode="numerical", params=params)
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning("Evidence rescore failed for %s/%s: %s", run_dir.name, dim_id, exc)
+        return None

--- a/src/quodeq/services/rescore.py
+++ b/src/quodeq/services/rescore.py
@@ -21,6 +21,7 @@ from quodeq.core.scoring.params import DEFAULT_PARAMS, ScoringParams
 from quodeq.core.types.scoring import PrincipleScore
 from quodeq.data.fs.report_parser.grades import summarize_dimensions
 from quodeq.services.dismissed import recount_totals
+from quodeq.services.suppression import is_deleted, is_dismissed
 
 
 def _finding_to_dict(f: Finding) -> dict[str, Any]:
@@ -123,20 +124,6 @@ def _score_all_principles(
     return principle_scores, principle_grades
 
 
-def _coerce_line(line) -> int:
-    """Coerce a Finding.line (typed int|str|None) to the int used in dismiss keys.
-
-    Dismiss keys store line as ``int`` (see services/dismissed.dismissed_keys),
-    but a Finding's line may be a string, so a straight ``line or 0`` compare
-    would miss a string-lined finding. Coercing here keeps the suppression key
-    identical to the stored dismiss key.
-    """
-    try:
-        return int(line)
-    except (TypeError, ValueError):
-        return 0
-
-
 def _rescore_dimension(
     dim: DimensionResult,
     dismissed: set[tuple],
@@ -156,8 +143,10 @@ def _rescore_dimension(
     dim_id = dim.dimension or ""
     filtered_violations = [
         v for v in dim.violations
-        if (v.req or "", v.file or "", _coerce_line(v.line)) not in dismissed
-        and (dim_id, v.practice_id or "", v.file or "") not in deleted
+        if not is_dismissed(dismissed, req=v.req, principle=v.practice_id,
+                            file=v.file, line=v.line)
+        and not is_deleted(deleted, dimension=dim_id, principle=v.practice_id,
+                           file=v.file)
     ]
     if len(filtered_violations) == len(dim.violations):
         return dim

--- a/src/quodeq/services/suppression.py
+++ b/src/quodeq/services/suppression.py
@@ -35,6 +35,41 @@ def _coerce_line(line: object) -> int:
         return 0
 
 
+def is_dismissed(
+    dismissed: frozenset | set, *, req: str | None, principle: str | None = "",
+    file: str | None = "", line: object = 0,
+) -> bool:
+    """True when the dismiss store hides this finding.
+
+    A finding's dismiss identity is its ``req``, falling back to its principle
+    when it has none -- the same ``req || principle`` the UI stores
+    (buildDismissPayload). Every read side must apply the same fallback, or a
+    no-req finding disappears from the counters while its grade never moves.
+
+    For a no-req finding the assistant's draft/apply path records the key with
+    an empty req (``("", file, line)``, see tests/assistant/
+    test_dismiss_apply_e2e.py), and older stores may hold either form -- so
+    both are accepted.
+    """
+    if not dismissed:
+        return False
+    file_key = file or ""
+    line_key = _coerce_line(line)
+    if (req or principle or "", file_key, line_key) in dismissed:
+        return True
+    return not req and ("", file_key, line_key) in dismissed
+
+
+def is_deleted(
+    deleted: frozenset | set, *, dimension: str | None,
+    principle: str | None, file: str | None,
+) -> bool:
+    """True when the delete store hides this finding's whole principle+file."""
+    if not deleted:
+        return False
+    return (dimension or "", principle or "", file or "") in deleted
+
+
 @dataclass(frozen=True)
 class SuppressionMatcher:
     """Immutable view of one dimension's suppression state."""
@@ -66,13 +101,11 @@ class SuppressionMatcher:
         if not raw:
             return False
         file = row.get("file") or ""
-        if self.dismissed:
-            req = row.get("req") or raw
-            if (req, file, _coerce_line(row.get("line"))) in self.dismissed:
-                return True
-        if self.deleted:
-            return (self.dimension, self.principle_for(raw), file) in self.deleted
-        return False
+        if is_dismissed(self.dismissed, req=row.get("req"), principle=raw,
+                        file=file, line=row.get("line")):
+            return True
+        return is_deleted(self.deleted, dimension=self.dimension,
+                          principle=self.principle_for(raw), file=file)
 
 
 def load_req_to_principle(

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -447,7 +447,10 @@ function renderEvalPrincipleDetail(params, props) {
         const payload = { ...buildDismissPayload(v, evalPrincipal.dimension), run_id: evalPrincipal.runId };
         const result = await props.dismissFinding(selectedProject, payload);
         props.applyDelta?.(selectedProject, result?.scores, result?.delta);
-        props.refreshDashboard?.();
+        // One call per suppression mutation: the reconcile marks the project
+        // queries stale synchronously AND schedules the debounced active
+        // refetch (see scheduleDashboardReconcile in useDashboard.js), so a
+        // separate refreshDashboard call here would be redundant.
         props.scheduleDashboardReconcile?.();
         props.bumpDismissRefresh?.();
         return result;
@@ -619,7 +622,11 @@ export const ROUTE_RENDERERS = {
           onDimensionClick: (dim) => props.navigation.handleNavigate('explorer', { dimension: dim.dimension, runId: dim.fromRunId, dateLabel: dim.fromDateLabel, fromProject: dim.fromProject }),
           onNavigate: props.navigation.handleNavigate,
           onRunChange: props.navigation.setHistorySelectedRun,
-          onRunDeleted: () => props.refreshDashboard?.(),
+          // Run deletion changes the accumulated rollup the Overview grade is
+          // built from — same mutation class as dismiss/restore, so it gets
+          // the same debounced ACTIVE reconcile (mark-stale alone never
+          // reaches the always-mounted Overview observer).
+          onRunDeleted: () => props.scheduleDashboardReconcile?.(),
         }}
         projects={props.navigation.projects}
         projectsLoaded={props.navigation.projectsLoaded}
@@ -670,7 +677,10 @@ export const ROUTE_RENDERERS = {
         const payload = { ...buildDismissPayload(v), run_id: params.runId };
         const result = await props.dismissFinding(props.navigation.selectedProject, payload);
         props.applyDelta?.(props.navigation.selectedProject, result?.scores, result?.delta);
-        props.refreshDashboard?.();
+        // One call per suppression mutation: the reconcile marks the project
+        // queries stale synchronously AND schedules the debounced active
+        // refetch (see scheduleDashboardReconcile in useDashboard.js), so a
+        // separate refreshDashboard call here would be redundant.
         props.scheduleDashboardReconcile?.();
         props.bumpDismissRefresh?.();
         return result;
@@ -688,7 +698,10 @@ export const ROUTE_RENDERERS = {
         const payload = { ...buildDismissPayload(v, params.dimension), run_id: params.runId };
         const result = await props.dismissFinding(props.navigation.selectedProject, payload);
         props.applyDelta?.(props.navigation.selectedProject, result?.scores, result?.delta);
-        props.refreshDashboard?.();
+        // One call per suppression mutation: the reconcile marks the project
+        // queries stale synchronously AND schedules the debounced active
+        // refetch (see scheduleDashboardReconcile in useDashboard.js), so a
+        // separate refreshDashboard call here would be redundant.
         props.scheduleDashboardReconcile?.();
         props.bumpDismissRefresh?.();
         return result;
@@ -745,7 +758,6 @@ export function buildAssistantSessionPayload({ provider, model, projectId, runId
  * @param {{
  *   applyDelta: (project: string, scores: Object, delta: Object) => void,
  *   bumpDismissRefresh: () => void,
- *   refreshDashboard?: () => void,
  *   scheduleDashboardReconcile?: () => void,
  *   selectedProject: string,
  * }} deps
@@ -754,7 +766,6 @@ export function buildAssistantSessionPayload({ provider, model, projectId, runId
 export function buildAssistantActionAppliedHandler({
   applyDelta,
   bumpDismissRefresh,
-  refreshDashboard,
   scheduleDashboardReconcile,
   selectedProject,
 }) {
@@ -779,11 +790,10 @@ export function buildAssistantActionAppliedHandler({
       }
     }
     bumpDismissRefresh();
-    // Invalidate the project queries so frozen run views (staleTime Infinity)
-    // refetch on their next mount instead of showing the pre-dismiss counts
-    // forever. Mark-stale only (refetchType:'none'), so this is cheap.
-    refreshDashboard?.();
-    // ...and actively reconcile, exactly as the manual dismiss handlers do
+    // Reconcile exactly as the manual dismiss handlers do: the call below
+    // marks the project queries stale synchronously (so frozen run views
+    // refetch on their next mount) and then actively refetches after the
+    // debounce window
     // (see useDismissedFindings.js). Mark-stale alone never reaches the
     // Overview: its useDashboard observer is mounted at the app root and
     // never remounts, and the pywebview window never fires the focus-refetch
@@ -794,7 +804,7 @@ export function buildAssistantActionAppliedHandler({
     // coalesces into one refetch of the 10-20 MB payload.
     //
     // Unlike applyDelta this keys on the LIVE selectedProject rather than the
-    // delta's frozen project, matching refreshDashboard. That is safe here
+    // delta's frozen project. That is safe here
     // where it wouldn't be above: reconciling is a refetch, so aiming it at
     // the wrong project after a mid-flight switch merely re-pulls fresh data;
     // it never writes one project's rollup into another's cache.
@@ -868,7 +878,6 @@ export default function App() {
   const [dismissRefreshKey, setDismissRefreshKey] = useState(0);
   const bumpDismissRefresh = () => setDismissRefreshKey((k) => k + 1);
   const {
-    refreshDashboard: refreshDashboardForApply,
     scheduleDashboardReconcile: scheduleReconcileForApply,
     selectedProject,
   } = state;
@@ -881,13 +890,12 @@ export default function App() {
     const handler = buildAssistantActionAppliedHandler({
       applyDelta,
       bumpDismissRefresh,
-      refreshDashboard: refreshDashboardForApply,
       scheduleDashboardReconcile: scheduleReconcileForApply,
       selectedProject,
     });
     window.addEventListener('quodeq:assistant-action-applied', handler);
     return () => window.removeEventListener('quodeq:assistant-action-applied', handler);
-  }, [refreshDashboardForApply, scheduleReconcileForApply, selectedProject]);
+  }, [scheduleReconcileForApply, selectedProject]);
   // Auto-open is a once-per-session decision. Without this guard, closing the
   // wizard sets wizardEntry → null, which re-fires this effect and re-opens
   // the wizard immediately because projects.length is still 0. The user's

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -160,34 +160,34 @@ describe('ROUTE_RENDERERS onDismiss source gating', () => {
 
   // The dashboard must eventually reflect a dismiss even though the delta
   // patch is only best-effort (e.g. it doesn't cover every view). Each
-  // onDismiss success path calls BOTH the existing lazy refreshDashboard
-  // (mark-stale, cheap) AND the new debounced scheduleDashboardReconcile
-  // (active refetch of the always-mounted Overview observer) — see
-  // useDashboard.js. Neither call replaces the other.
-  it('file route onDismiss calls refreshDashboard, scheduleDashboardReconcile, and bumpDismissRefresh on success', async () => {
+  // onDismiss success path makes ONE reconcile call: scheduleDashboardReconcile
+  // marks the project queries stale synchronously AND actively refetches the
+  // always-mounted Overview observer after the debounce (see useDashboard.js),
+  // so a separate refreshDashboard call would be redundant.
+  it('file route onDismiss calls scheduleDashboardReconcile and bumpDismissRefresh on success', async () => {
     const props = baseProps('local');
     const el = ROUTE_RENDERERS.file({ file: { path: 'a.py' }, runId: 'r1' }, props);
     await el.props.onDismiss({ reason: 'test' });
-    expect(props.refreshDashboard).toHaveBeenCalledTimes(1);
     expect(props.scheduleDashboardReconcile).toHaveBeenCalledTimes(1);
+    expect(props.refreshDashboard).not.toHaveBeenCalled();
     expect(props.bumpDismissRefresh).toHaveBeenCalledTimes(1);
   });
 
-  it('finding route onDismiss calls refreshDashboard, scheduleDashboardReconcile, and bumpDismissRefresh on success', async () => {
+  it('finding route onDismiss calls scheduleDashboardReconcile and bumpDismissRefresh on success', async () => {
     const props = baseProps('local');
     const el = ROUTE_RENDERERS.finding({ finding: {}, principle: 'P', dimension: 'Security' }, props);
     await el.props.onDismiss({ reason: 'test' });
-    expect(props.refreshDashboard).toHaveBeenCalledTimes(1);
     expect(props.scheduleDashboardReconcile).toHaveBeenCalledTimes(1);
+    expect(props.refreshDashboard).not.toHaveBeenCalled();
     expect(props.bumpDismissRefresh).toHaveBeenCalledTimes(1);
   });
 
-  it('evalprinciple route onDismiss calls refreshDashboard, scheduleDashboardReconcile, and bumpDismissRefresh on success', async () => {
+  it('evalprinciple route onDismiss calls scheduleDashboardReconcile and bumpDismissRefresh on success', async () => {
     const props = baseProps('local');
     const el = ROUTE_RENDERERS.evalprinciple({ evalPrincipal: { principle: 'P', dimension: 'Security' } }, props);
     await el.props.onDismiss({ reason: 'test' });
-    expect(props.refreshDashboard).toHaveBeenCalledTimes(1);
     expect(props.scheduleDashboardReconcile).toHaveBeenCalledTimes(1);
+    expect(props.refreshDashboard).not.toHaveBeenCalled();
     expect(props.bumpDismissRefresh).toHaveBeenCalledTimes(1);
   });
 });
@@ -248,7 +248,6 @@ describe('buildAssistantActionAppliedHandler', () => {
     return {
       applyDelta: vi.fn(),
       bumpDismissRefresh: vi.fn(),
-      refreshDashboard: vi.fn(),
       scheduleDashboardReconcile: vi.fn(),
       selectedProject: 'proj1',
       ...overrides,
@@ -263,10 +262,9 @@ describe('buildAssistantActionAppliedHandler', () => {
     expect(d.scheduleDashboardReconcile).toHaveBeenCalledTimes(1);
   });
 
-  it('calls the lazy refresh as well, never one in place of the other', () => {
+  it('bumps the dismissed list alongside the reconcile', () => {
     const d = deps();
     buildAssistantActionAppliedHandler(d)(dismissEvent({ delta: { project: 'proj1' }, scores: {} }));
-    expect(d.refreshDashboard).toHaveBeenCalledTimes(1);
     expect(d.bumpDismissRefresh).toHaveBeenCalledTimes(1);
   });
 
@@ -277,7 +275,6 @@ describe('buildAssistantActionAppliedHandler', () => {
     const d = deps();
     buildAssistantActionAppliedHandler(d)(dismissEvent({}));
     expect(d.applyDelta).not.toHaveBeenCalled();
-    expect(d.refreshDashboard).toHaveBeenCalledTimes(1);
     expect(d.scheduleDashboardReconcile).toHaveBeenCalledTimes(1);
   });
 
@@ -299,10 +296,9 @@ describe('buildAssistantActionAppliedHandler', () => {
 
   // The patch is best-effort; a throw must not swallow the follow-ups that
   // are the actual convergence guarantee.
-  it('still refreshes and reconciles when the delta patch throws', () => {
+  it('still reconciles when the delta patch throws', () => {
     const d = deps({ applyDelta: vi.fn(() => { throw new Error('bad delta'); }) });
     buildAssistantActionAppliedHandler(d)(dismissEvent({ delta: { project: 'proj1' }, scores: {} }));
-    expect(d.refreshDashboard).toHaveBeenCalledTimes(1);
     expect(d.scheduleDashboardReconcile).toHaveBeenCalledTimes(1);
   });
 
@@ -311,7 +307,6 @@ describe('buildAssistantActionAppliedHandler', () => {
     buildAssistantActionAppliedHandler(d)({ detail: { actionType: 'verify_finding', delta: {} } });
     expect(d.applyDelta).not.toHaveBeenCalled();
     expect(d.bumpDismissRefresh).not.toHaveBeenCalled();
-    expect(d.refreshDashboard).not.toHaveBeenCalled();
     expect(d.scheduleDashboardReconcile).not.toHaveBeenCalled();
   });
 
@@ -766,5 +761,31 @@ describe('buildDashboardDataBundle', () => {
     ];
     const missing = consumed.filter((k) => !(k in bundle));
     expect(missing).toEqual([]);
+  });
+});
+
+// Deleting a run changes the accumulated rollup the Overview grade is built
+// from -- the same class of mutation as dismiss/restore/delete-finding, which
+// all get the debounced ACTIVE reconcile. mark-stale alone leaves the
+// always-mounted Overview observer on pre-deletion numbers indefinitely
+// (pywebview never fires a focus refetch).
+describe('history route onRunDeleted wiring', () => {
+  it('wires onRunDeleted to the debounced active reconcile, not mark-stale only', () => {
+    const props = {
+      dashboardData: {
+        dashboard: { trend: [] }, availableRuns: [], overviewRunIndex: 0,
+        accumulated: null, loading: false, isFetching: false,
+      },
+      navigation: {
+        selectedProject: 'proj1', selectedSource: 'local', projects: [],
+        projectsLoaded: true, handleNavigate: vi.fn(), historySelectedRun: null,
+        setHistorySelectedRun: vi.fn(),
+      },
+      refreshDashboard: vi.fn(),
+      scheduleDashboardReconcile: vi.fn(),
+    };
+    const el = ROUTE_RENDERERS.history({}, props);
+    el.props.callbacks.onRunDeleted();
+    expect(props.scheduleDashboardReconcile).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -154,12 +154,14 @@ export function useDashboard({ selectedProject, selectedRun, selectedSource = "l
   const scheduleDashboardReconcile = useCallback(() => {
     if (!selectedProject) return;
     // Mark-stale NOW, synchronously, before the timer is (re)armed. The
-    // timer is a single shared ref: a rapid project switch clears it before
-    // the 1200ms elapses, dropping the ACTIVE refetch below. Without this,
-    // a dropped reconcile would leave the cache silently fresh-and-wrong
-    // (no invalidation happened at all); with it, a dropped reconcile
-    // degrades to exactly refreshDashboard's mark-stale-only semantics, so
-    // a remount or Overview-return still self-heals.
+    // timer is a single shared ref, cleared on unmount and re-armed by the
+    // next schedule call; if the ACTIVE refetch below ever gets dropped
+    // (unmount) or fires against a stale closure (the project switched
+    // before the 1200ms elapsed, so it invalidates the old project's now
+    // inactive queries -- a harmless no-op), this mark-stale has already
+    // happened, so the mutation degrades to refreshDashboard's
+    // mark-stale-only semantics and a remount or Overview-return still
+    // self-heals.
     queryClient.invalidateQueries({
       queryKey: projectKeys.project(selectedProject, selectedSource),
       refetchType: 'none',
@@ -167,7 +169,6 @@ export function useDashboard({ selectedProject, selectedRun, selectedSource = "l
     if (reconcileTimer.current) clearTimeout(reconcileTimer.current);
     reconcileTimer.current = setTimeout(() => {
       reconcileTimer.current = null;
-      if (!selectedProject) return;
       queryClient.invalidateQueries({
         queryKey: projectKeys.project(selectedProject, selectedSource),
       });

--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
@@ -13,10 +13,9 @@ import { confirmDialog } from '../../../utils/confirmDialog.js';
 
 /**
  * @param {string} selectedProject
- * @param {Function} [onRefresh] - Called by every mutation handler below on
- *   success. This is the lazy refreshDashboard (mark-stale, refetchType:
- *   'none') threaded from App.jsx via ViolationsPage -- NOT the ACTIVE
- *   reconcile; see `onReconcile` for that.
+ * @param {Function} [onRefresh] - Unused by the mutation handlers (the
+ *   reconcile below marks stale itself); kept in the signature for the
+ *   navigation-time mount refresh ViolationsPage wires separately.
  * @param {Function} [setRestoreError]
  * @param {number} [refreshKey=0]
  * @param {'local'|'shared'} [selectedSource='local'] - Shared projects have no
@@ -28,13 +27,12 @@ import { confirmDialog } from '../../../utils/confirmDialog.js';
  *   handler slipping through some other path and corrupting the local cache
  *   with shared-derived deltas (the local id can collide with a shared id).
  * @param {Function} [onReconcile] - The debounced ACTIVE
- *   scheduleDashboardReconcile (see useDashboard.js). Called IN ADDITION to
- *   onRefresh by every mutation handler below, never in place of it.
- *   restore-all/delete-all return a payload applyMutationDelta's gates can't
- *   patch (scores:null, delta.isLatest:false), so onRefresh's lazy mark-stale
- *   alone would leave the always-mounted Overview observer showing stale
- *   data indefinitely; onReconcile actively refetches it after a short
- *   debounce window.
+ *   scheduleDashboardReconcile (see useDashboard.js): the ONE call every
+ *   mutation handler below makes on success. It marks the project queries
+ *   stale synchronously and then actively refetches after the debounce
+ *   window -- restore-all/delete-all return a payload applyMutationDelta's
+ *   gates can't patch (scores:null, delta.isLatest:false), and mark-stale
+ *   alone never reaches the always-mounted Overview observer.
  */
 export function useDismissedFindings(selectedProject, onRefresh, setRestoreError, refreshKey = 0, selectedSource = 'local', onReconcile) {
   const [dismissed, setDismissed] = useState([]);
@@ -44,7 +42,7 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
   // Fold the mutation-delta from a restore/delete response into the React Query
   // caches so dimension scores/grades update instantly and the run-detail
   // violation lists get invalidated for a lazy refetch. Additive — the local
-  // setDismissed splices and the onRefresh/onReconcile calls below still run.
+  // setDismissed splices and the onReconcile calls below still run.
   const applyDelta = useCallback((result) => {
     const delta = result?.delta;
     if (!delta) return;
@@ -70,13 +68,12 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
       const result = await restoreFinding(selectedProject, { req: d.req, file: d.file, line: d.line });
       applyDelta(result);
       setDismissed((prev) => prev.filter((item) => !(item.req === d.req && item.file === d.file && item.line === d.line)));
-      onRefresh?.();
       onReconcile?.();
     } catch (err) {
       console.error('Failed to restore finding:', err);
       setRestoreError?.('Failed to restore finding. Please try again.');
     }
-  }, [selectedProject, onRefresh, onReconcile, setRestoreError, applyDelta, isShared]);
+  }, [selectedProject, onReconcile, setRestoreError, applyDelta, isShared]);
 
   const handleRestoreAll = useCallback(async () => {
     if (isShared) return;
@@ -84,13 +81,12 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
       const result = await restoreAllFindings(selectedProject);
       applyDelta(result);
       setDismissed([]);
-      onRefresh?.();
       onReconcile?.();
     } catch (err) {
       console.error('Failed to restore all findings:', err);
       setRestoreError?.('Failed to restore all findings. Please try again.');
     }
-  }, [selectedProject, onRefresh, onReconcile, setRestoreError, applyDelta, isShared]);
+  }, [selectedProject, onReconcile, setRestoreError, applyDelta, isShared]);
 
   const handleDelete = useCallback(async (d) => {
     if (isShared) return;
@@ -108,13 +104,12 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
         && item.principle === d.principle
         && item.file === d.file
       )));
-      onRefresh?.();
       onReconcile?.();
     } catch (err) {
       console.error('Failed to delete finding:', err);
       setRestoreError?.('Failed to delete finding. Please try again.');
     }
-  }, [selectedProject, onRefresh, onReconcile, setRestoreError, applyDelta, isShared]);
+  }, [selectedProject, onReconcile, setRestoreError, applyDelta, isShared]);
 
   const handleDeleteAll = useCallback(async () => {
     if (isShared) return;
@@ -131,13 +126,12 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
       const result = await deleteAllFindings(selectedProject);
       applyDelta(result);
       setDismissed([]);
-      onRefresh?.();
       onReconcile?.();
     } catch (err) {
       console.error('Failed to delete all findings:', err);
       setRestoreError?.('Failed to delete all findings. Please try again.');
     }
-  }, [selectedProject, onRefresh, onReconcile, setRestoreError, dismissed.length, applyDelta, isShared]);
+  }, [selectedProject, onReconcile, setRestoreError, dismissed.length, applyDelta, isShared]);
 
   return { dismissed, handleRestore, handleRestoreAll, handleDelete, handleDeleteAll };
 }

--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
@@ -54,19 +54,19 @@ beforeEach(() => {
 });
 
 describe('useDismissedFindings — restore handlers', () => {
-  it('handleRestore removes the matching entry on success and calls onRefresh', async () => {
+  it('handleRestore removes the matching entry on success and calls onReconcile', async () => {
     listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
     restoreFinding.mockResolvedValueOnce({ ok: true });
-    const onRefresh = vi.fn();
+    const onReconcile = vi.fn();
     const setRestoreError = vi.fn();
-    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError), withQueryClient());
+    const { result } = renderHook(() => useDismissedFindings('proj', vi.fn(), setRestoreError, 0, 'local', onReconcile), withQueryClient());
     await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
 
     await act(async () => { await result.current.handleRestore(sampleA); });
 
     expect(restoreFinding).toHaveBeenCalledWith('proj', { req: 'A1', file: 'a.py', line: 10 });
     expect(result.current.dismissed).toEqual([sampleB]);
-    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(onReconcile).toHaveBeenCalledTimes(1);
     expect(setRestoreError).not.toHaveBeenCalled();
   });
 
@@ -74,8 +74,9 @@ describe('useDismissedFindings — restore handlers', () => {
     listDismissedFindings.mockResolvedValueOnce([sampleA]);
     restoreFinding.mockRejectedValueOnce(new Error('boom'));
     const onRefresh = vi.fn();
+    const onReconcile = vi.fn();
     const setRestoreError = vi.fn();
-    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError), withQueryClient());
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError, 0, 'local', onReconcile), withQueryClient());
     await waitFor(() => expect(result.current.dismissed).toHaveLength(1));
 
     await act(async () => { await result.current.handleRestore(sampleA); });
@@ -83,21 +84,22 @@ describe('useDismissedFindings — restore handlers', () => {
     expect(setRestoreError).toHaveBeenCalledWith('Failed to restore finding. Please try again.');
     expect(result.current.dismissed).toEqual([sampleA]);
     expect(onRefresh).not.toHaveBeenCalled();
+    expect(onReconcile).not.toHaveBeenCalled();
   });
 
-  it('handleRestoreAll clears state on success and calls onRefresh', async () => {
+  it('handleRestoreAll clears state on success and calls onReconcile', async () => {
     listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
     restoreAllFindings.mockResolvedValueOnce({ ok: true, restored: 2 });
-    const onRefresh = vi.fn();
+    const onReconcile = vi.fn();
     const setRestoreError = vi.fn();
-    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError), withQueryClient());
+    const { result } = renderHook(() => useDismissedFindings('proj', vi.fn(), setRestoreError, 0, 'local', onReconcile), withQueryClient());
     await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
 
     await act(async () => { await result.current.handleRestoreAll(); });
 
     expect(restoreAllFindings).toHaveBeenCalledWith('proj');
     expect(result.current.dismissed).toEqual([]);
-    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(onReconcile).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -105,9 +107,9 @@ describe('useDismissedFindings — handleDelete', () => {
   it('permanently deletes by (dimension, principle, file) and removes the entry locally', async () => {
     listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
     deleteFinding.mockResolvedValueOnce({ ok: true, swept: 1 });
-    const onRefresh = vi.fn();
+    const onReconcile = vi.fn();
     const setRestoreError = vi.fn();
-    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError), withQueryClient());
+    const { result } = renderHook(() => useDismissedFindings('proj', vi.fn(), setRestoreError, 0, 'local', onReconcile), withQueryClient());
     await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
 
     await act(async () => { await result.current.handleDelete(sampleA); });
@@ -119,7 +121,7 @@ describe('useDismissedFindings — handleDelete', () => {
     });
     expect(restoreFinding).not.toHaveBeenCalled();
     expect(result.current.dismissed).toEqual([sampleB]);
-    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(onReconcile).toHaveBeenCalledTimes(1);
     expect(setRestoreError).not.toHaveBeenCalled();
   });
 
@@ -139,15 +141,16 @@ describe('useDismissedFindings — handleDelete', () => {
     listDismissedFindings.mockResolvedValueOnce([sampleA]);
     deleteFinding.mockRejectedValueOnce(new Error('boom'));
     const onRefresh = vi.fn();
+    const onReconcile = vi.fn();
     const setRestoreError = vi.fn();
-    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError), withQueryClient());
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError, 0, 'local', onReconcile), withQueryClient());
     await waitFor(() => expect(result.current.dismissed).toHaveLength(1));
 
     await act(async () => { await result.current.handleDelete(sampleA); });
 
     expect(setRestoreError).toHaveBeenCalledWith('Failed to delete finding. Please try again.');
     expect(result.current.dismissed).toEqual([sampleA]);
-    expect(onRefresh).not.toHaveBeenCalled();
+    expect(onReconcile).not.toHaveBeenCalled();
   });
 });
 
@@ -156,9 +159,9 @@ describe('useDismissedFindings — handleDeleteAll', () => {
     listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
     confirmDialog.mockResolvedValueOnce(true);
     deleteAllFindings.mockResolvedValueOnce({ ok: true, deleted: 2 });
-    const onRefresh = vi.fn();
+    const onReconcile = vi.fn();
     const setRestoreError = vi.fn();
-    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError), withQueryClient());
+    const { result } = renderHook(() => useDismissedFindings('proj', vi.fn(), setRestoreError, 0, 'local', onReconcile), withQueryClient());
     await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
 
     await act(async () => { await result.current.handleDeleteAll(); });
@@ -172,7 +175,7 @@ describe('useDismissedFindings — handleDeleteAll', () => {
     expect(deleteAllFindings).toHaveBeenCalledWith('proj');
     expect(restoreAllFindings).not.toHaveBeenCalled();
     expect(result.current.dismissed).toEqual([]);
-    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(onReconcile).toHaveBeenCalledTimes(1);
   });
 
   it('does nothing when the user cancels the confirmation dialog', async () => {
@@ -208,15 +211,13 @@ describe('useDismissedFindings — handleDeleteAll', () => {
   });
 });
 
-// Item 1 fix: onRefresh is now the lazy refreshDashboard (mark-stale only) --
-// wiring it to the ACTIVE scheduleDashboardReconcile forced a full refetch of
-// the 10-20 MB dashboard payload on every plain navigation remount (see
-// ViolationsPage's tabKey mount effect). The four mutation handlers below
-// must therefore call a SEPARATE onReconcile callback in addition to
-// onRefresh, so restore/delete still gets the debounced ACTIVE reconcile
-// without plain navigation triggering it.
-describe('useDismissedFindings — onReconcile (called alongside onRefresh, not instead of it)', () => {
-  it('handleRestore calls both onRefresh and onReconcile on success', async () => {
+// The mutation handlers make exactly ONE freshness call: onReconcile (the
+// debounced ACTIVE scheduleDashboardReconcile, which marks stale synchronously
+// itself). onRefresh stays reserved for ViolationsPage's plain-navigation
+// mount effect and must NOT be called by mutations -- wiring mutations to it
+// as well was a redundant two-call ritual that call sites kept forgetting.
+describe('useDismissedFindings — onReconcile (the single mutation freshness call)', () => {
+  it('handleRestore calls onReconcile and leaves onRefresh untouched on success', async () => {
     listDismissedFindings.mockResolvedValueOnce([sampleA]);
     restoreFinding.mockResolvedValueOnce({ ok: true });
     const onRefresh = vi.fn();
@@ -229,8 +230,8 @@ describe('useDismissedFindings — onReconcile (called alongside onRefresh, not 
 
     await act(async () => { await result.current.handleRestore(sampleA); });
 
-    expect(onRefresh).toHaveBeenCalledTimes(1);
     expect(onReconcile).toHaveBeenCalledTimes(1);
+    expect(onRefresh).not.toHaveBeenCalled();
   });
 
   it('handleRestore does not call onReconcile on failure', async () => {
@@ -248,7 +249,7 @@ describe('useDismissedFindings — onReconcile (called alongside onRefresh, not 
     expect(onReconcile).not.toHaveBeenCalled();
   });
 
-  it('handleRestoreAll calls both onRefresh and onReconcile on success', async () => {
+  it('handleRestoreAll calls onReconcile and leaves onRefresh untouched on success', async () => {
     listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
     restoreAllFindings.mockResolvedValueOnce({ ok: true, restored: 2 });
     const onRefresh = vi.fn();
@@ -261,11 +262,11 @@ describe('useDismissedFindings — onReconcile (called alongside onRefresh, not 
 
     await act(async () => { await result.current.handleRestoreAll(); });
 
-    expect(onRefresh).toHaveBeenCalledTimes(1);
     expect(onReconcile).toHaveBeenCalledTimes(1);
+    expect(onRefresh).not.toHaveBeenCalled();
   });
 
-  it('handleDelete calls both onRefresh and onReconcile on success', async () => {
+  it('handleDelete calls onReconcile and leaves onRefresh untouched on success', async () => {
     listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
     deleteFinding.mockResolvedValueOnce({ ok: true, swept: 1 });
     const onRefresh = vi.fn();
@@ -278,11 +279,11 @@ describe('useDismissedFindings — onReconcile (called alongside onRefresh, not 
 
     await act(async () => { await result.current.handleDelete(sampleA); });
 
-    expect(onRefresh).toHaveBeenCalledTimes(1);
     expect(onReconcile).toHaveBeenCalledTimes(1);
+    expect(onRefresh).not.toHaveBeenCalled();
   });
 
-  it('handleDeleteAll calls both onRefresh and onReconcile on success', async () => {
+  it('handleDeleteAll calls onReconcile and leaves onRefresh untouched on success', async () => {
     listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
     confirmDialog.mockResolvedValueOnce(true);
     deleteAllFindings.mockResolvedValueOnce({ ok: true, deleted: 2 });
@@ -296,8 +297,8 @@ describe('useDismissedFindings — onReconcile (called alongside onRefresh, not 
 
     await act(async () => { await result.current.handleDeleteAll(); });
 
-    expect(onRefresh).toHaveBeenCalledTimes(1);
     expect(onReconcile).toHaveBeenCalledTimes(1);
+    expect(onRefresh).not.toHaveBeenCalled();
   });
 
   it('handleDeleteAll does not call onReconcile when the user cancels', async () => {
@@ -316,18 +317,17 @@ describe('useDismissedFindings — onReconcile (called alongside onRefresh, not 
   });
 
   it('works fine when onReconcile is omitted (optional param, back-compat)', async () => {
-    listDismissedFindings.mockResolvedValueOnce([sampleA]);
+    listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
     restoreFinding.mockResolvedValueOnce({ ok: true });
-    const onRefresh = vi.fn();
     const { result } = renderHook(
-      () => useDismissedFindings('proj', onRefresh, vi.fn()),
+      () => useDismissedFindings('proj', vi.fn(), vi.fn()),
       withQueryClient(),
     );
-    await waitFor(() => expect(result.current.dismissed).toHaveLength(1));
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
 
     await act(async () => { await result.current.handleRestore(sampleA); });
 
-    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(result.current.dismissed).toEqual([sampleB]);
   });
 });
 

--- a/tests/assistant/test_dismiss_apply_e2e.py
+++ b/tests/assistant/test_dismiss_apply_e2e.py
@@ -14,7 +14,14 @@ from quodeq.assistant.tools import ToolContext, build_registry
 from quodeq.assistant.tools._actions import ACTIONS
 from quodeq.core.types.finding import Finding
 from quodeq.data.sqlite.assistant_repository import AssistantRepository
-from quodeq.services.dismissed import _finding_key, dismissed_keys
+from quodeq.services.dismissed import dismissed_keys
+from quodeq.services.suppression import is_dismissed
+
+
+def _suppresses(keys, finding) -> bool:
+    """The read-side predicate hides *finding* given the recorded keys."""
+    return is_dismissed(keys, req=finding.req, principle=finding.practice_id,
+                        file=finding.file, line=finding.line)
 
 
 def _ctx(tmp_path, violations):
@@ -71,7 +78,7 @@ def test_dismiss_roundtrip_suppresses_the_finding(tmp_path):
     keys = dismissed_keys(eval_root / "proj")
     assert keys == {("R1", "a.py", 10)}
     finding = Finding(req="R1", file="a.py", line=10, practice_id="P1", severity="critical")
-    assert _finding_key(finding) in keys
+    assert _suppresses(keys, finding)
 
 
 def test_dismiss_roundtrip_for_req_none_finding(tmp_path):
@@ -96,4 +103,4 @@ def test_dismiss_roundtrip_for_req_none_finding(tmp_path):
     keys = dismissed_keys(eval_root / "proj")
     assert keys == {("", "b.py", 7)}
     finding = Finding(file="b.py", line=7, practice_id="P1", severity="major")  # req=None
-    assert _finding_key(finding) in keys
+    assert _suppresses(keys, finding)

--- a/tests/ci/test_suppressions.py
+++ b/tests/ci/test_suppressions.py
@@ -36,3 +36,20 @@ def test_no_suppressions_is_identity(tmp_path):
               "violations": [{"req": "R-1", "file": "a.kt", "line": 10,
                               "practiceId": "Modularity"}]}
     assert filter_suppressed_violations(report, tmp_path) == report
+
+
+def test_deleted_drops_scored_report_violation_with_principle_key(tmp_path):
+    # Scored report JSON (analysis/_report_findings) names the field
+    # "principle"; only evidence-derived reports carry "practiceId". The
+    # delete filter must match both, otherwise deletes are inert in
+    # `ci report` / `export sarif` over scored reports.
+    (tmp_path / "deleted.json").write_text(json.dumps([
+        {"dimension": "maintainability", "principle": "Modularity",
+         "file": "a.kt", "deleted_at": "2026-07-24T10:00:00Z"},
+    ]))
+    report = {"dimension": "maintainability", "violations": [
+        {"req": "R-1", "file": "a.kt", "line": 10, "principle": "Modularity"},
+        {"req": "R-2", "file": "b.kt", "line": 2, "principle": "Modularity"},
+    ]}
+    out = filter_suppressed_violations(report, tmp_path)
+    assert [v["req"] for v in out["violations"]] == ["R-2"]

--- a/tests/services/test_evidence_rescore.py
+++ b/tests/services/test_evidence_rescore.py
@@ -180,3 +180,17 @@ def test_traversal_dim_id_does_not_read_evidence_planted_outside_run_dir(tmp_pat
             run_dir, traversal_dim_id, dismissed=set(), deleted=set(),
             source_file_count=1000, files_read=50, params=DEFAULT_PARAMS,
         )
+
+
+def test_scoring_engine_exception_returns_none_for_fallback(run_dir, monkeypatch):
+    """The engine can throw on edge-case evidence (see da04c1a2). The rescore
+    must degrade to None (callers fall back to the stored/legacy score) rather
+    than propagate and 500 the dashboard or /api/rescore for the whole run.
+    """
+    def _boom(*args, **kwargs):
+        raise RuntimeError("scoring engine exploded")
+    monkeypatch.setattr("quodeq.services.evidence_rescore.score_evidence", _boom)
+    out = score_dimension_from_evidence(
+        run_dir, DIM, dismissed=set(), deleted=set(),
+        source_file_count=10, files_read=5, params=DEFAULT_PARAMS)
+    assert out is None

--- a/tests/services/test_evidence_rescore.py
+++ b/tests/services/test_evidence_rescore.py
@@ -194,3 +194,25 @@ def test_scoring_engine_exception_returns_none_for_fallback(run_dir, monkeypatch
         run_dir, DIM, dismissed=set(), deleted=set(),
         source_file_count=10, files_read=5, params=DEFAULT_PARAMS)
     assert out is None
+
+
+def test_dismiss_by_principle_key_matches_no_req_finding(run_dir):
+    """The UI stores a dismiss key as `req || principle`. For a finding whose
+    evidence row carries no req, the stored key is (principle, file, line);
+    the rescore must fall back to the principle group like the live counter
+    matcher does, or the counter hides the finding while the grade never moves.
+    """
+    lines = [
+        _line("M-MOD-1", "a.kt", 10),
+        {k: v for k, v in _line(None, "b.kt", 7, sev="critical").items() if k != "req"},
+        _line("C-1", "a.kt", 1, t="compliance"),
+    ]
+    _write_evidence(run_dir, lines)
+    base = score_dimension_from_evidence(
+        run_dir, DIM, dismissed=set(), deleted=set(),
+        source_file_count=10, files_read=5, params=DEFAULT_PARAMS)
+    out = score_dimension_from_evidence(
+        run_dir, DIM, dismissed={("Modularity", "b.kt", 7)}, deleted=set(),
+        source_file_count=10, files_read=5, params=DEFAULT_PARAMS)
+    assert out.principles["Modularity"].deductions.critical_type_count \
+        == base.principles["Modularity"].deductions.critical_type_count - 1

--- a/tests/services/test_evidence_rescore.py
+++ b/tests/services/test_evidence_rescore.py
@@ -94,6 +94,43 @@ def test_deleted_key_removes_principle_file_matches(run_dir):
     assert out.principles["Reusability"].deductions.major_type_count == 0
 
 
+def test_quarantined_findings_stay_excluded_from_rescore(tmp_path, monkeypatch):
+    """Scan time quarantines findings whose principle is not in the dimension's
+    standard. The rescore must resolve the same standard and quarantine them
+    too, otherwise a dismiss makes previously excluded findings re-enter the
+    grade and phantom principles appear in the payload.
+    """
+    monkeypatch.setenv("QUODEQ_EVALUATORS_DIR", str(tmp_path / "no-evals"))
+    lines = [
+        _line("M-MOD-1", "a.kt", 10, p="Modularity"),
+        _line("M-MOD-2", "a.kt", 1, t="compliance", p="Modularity"),
+        # Off-standard principle: quarantined at scan time.
+        _line("X-1", "z.kt", 3, sev="critical", p="NotInStandard"),
+    ]
+    _write_evidence(tmp_path, lines)
+
+    from quodeq.config.paths import default_paths
+    scan = score_evidence(
+        parse_jsonl_to_evidence(
+            tmp_path / "evidence" / f"{DIM}_evidence.jsonl",
+            EvidenceContext(language="", repository="", date_str="",
+                            source_file_count=10, files_read=5),
+            compiled_dir=default_paths().standards_dir / "compiled",
+            evaluators_dir=default_paths().evaluators_dir,
+        ),
+        mode="numerical", params=DEFAULT_PARAMS,
+    )
+    assert "NotInStandard" not in scan.principles  # fixture sanity
+
+    rescored = score_dimension_from_evidence(
+        tmp_path, DIM, dismissed=set(), deleted=set(),
+        source_file_count=10, files_read=5, params=DEFAULT_PARAMS,
+    )
+    assert rescored is not None
+    assert "NotInStandard" not in rescored.principles
+    assert rescored.overall.weighted_score == scan.overall.weighted_score
+
+
 @pytest.mark.parametrize("bad", ["../secret", "a/b", "..\\x", "x\0y"])
 def test_traversal_dim_id_rejected_before_filesystem_access(tmp_path, bad):
     # dim_id builds a filesystem path; separators/traversal must be refused

--- a/tests/services/test_fs_metadata.py
+++ b/tests/services/test_fs_metadata.py
@@ -545,7 +545,7 @@ class TestCardUsesDefaultViewRuns:
 # ---------------------------------------------------------------------------
 
 
-def _fsm_evidence_line(dim, req, file, line, sev="major", t="violation", p="Modularity", vt="VT-COUPLING"):
+def _fsm_evidence_line(dim, req, file, line, sev="major", t="violation", p="Confidentiality", vt="VT-COUPLING"):
     """One evidence-jsonl judgment (same shape as test_evidence_rescore.py)."""
     return {"schema_version": 1, "req": req, "t": t, "file": file, "line": line,
             "severity": sev, "w": "title", "reason": f"reason {req} {file} {line}",
@@ -593,8 +593,8 @@ class TestPerDimensionRunDirRescore:
                 _fsm_evidence_line(dim_a, "R-5", "b.kt", 7, sev="major", vt="VT-COUPLING"),
                 _fsm_evidence_line(dim_a, "C-1", "a.kt", 1, t="compliance"),
                 _fsm_evidence_line(dim_a, "C-3", "b.kt", 3, t="compliance"),
-                _fsm_evidence_line(dim_a, "R-4", "c.kt", 9, sev="major", vt="VT-DUPLICATION", p="Reusability"),
-                _fsm_evidence_line(dim_a, "C-2", "c.kt", 2, t="compliance", p="Reusability"),
+                _fsm_evidence_line(dim_a, "R-4", "c.kt", 9, sev="major", vt="VT-DUPLICATION", p="Integrity"),
+                _fsm_evidence_line(dim_a, "C-2", "c.kt", 2, t="compliance", p="Integrity"),
             ]) + "\n", encoding="utf-8",
         )
 
@@ -603,8 +603,8 @@ class TestPerDimensionRunDirRescore:
         ev_dir_new.mkdir(parents=True)
         (ev_dir_new / f"{dim_b}_evidence.jsonl").write_text(
             "\n".join(json.dumps(l) for l in [
-                _fsm_evidence_line(dim_b, "R-10", "x.kt", 3, sev="major", vt="VT-COUPLING"),
-                _fsm_evidence_line(dim_b, "C-10", "x.kt", 1, t="compliance"),
+                _fsm_evidence_line(dim_b, "R-10", "x.kt", 3, sev="major", vt="VT-COUPLING", p="Availability"),
+                _fsm_evidence_line(dim_b, "C-10", "x.kt", 1, t="compliance", p="Availability"),
             ]) + "\n", encoding="utf-8",
         )
 
@@ -627,31 +627,31 @@ class TestPerDimensionRunDirRescore:
                 dimension=dim_b, overall_score="7.0/10", overall_grade="B",
                 files_read=files_read, source_file_count=sfc,
                 violations=[Finding(req="R-10", file="x.kt", line=3,
-                                     practice_id="Modularity", severity="major",
+                                     practice_id="Availability", severity="major",
                                      dimension=dim_b)],
                 compliance=[Finding(req="C-10", file="x.kt", line=1,
-                                    practice_id="Modularity", dimension=dim_b)],
+                                    practice_id="Availability", dimension=dim_b)],
             )],
             run_old_id: [DimensionResult(
                 dimension=dim_a, overall_score="6.0/10", overall_grade="C",
                 files_read=files_read, source_file_count=sfc,
                 violations=[
                     Finding(req="R-1", file="a.kt", line=10,
-                            practice_id="Modularity", severity="major", dimension=dim_a),
+                            practice_id="Confidentiality", severity="major", dimension=dim_a),
                     Finding(req="R-2", file="a.kt", line=20,
-                            practice_id="Modularity", severity="critical", dimension=dim_a),
+                            practice_id="Confidentiality", severity="critical", dimension=dim_a),
                     Finding(req="R-5", file="b.kt", line=7,
-                            practice_id="Modularity", severity="major", dimension=dim_a),
+                            practice_id="Confidentiality", severity="major", dimension=dim_a),
                     Finding(req="R-4", file="c.kt", line=9,
-                            practice_id="Reusability", severity="major", dimension=dim_a),
+                            practice_id="Integrity", severity="major", dimension=dim_a),
                 ],
                 compliance=[
                     Finding(req="C-1", file="a.kt", line=1,
-                            practice_id="Modularity", dimension=dim_a),
+                            practice_id="Confidentiality", dimension=dim_a),
                     Finding(req="C-3", file="b.kt", line=3,
-                            practice_id="Modularity", dimension=dim_a),
+                            practice_id="Confidentiality", dimension=dim_a),
                     Finding(req="C-2", file="c.kt", line=2,
-                            practice_id="Reusability", dimension=dim_a),
+                            practice_id="Integrity", dimension=dim_a),
                 ],
             )],
         }

--- a/tests/services/test_rescore.py
+++ b/tests/services/test_rescore.py
@@ -213,3 +213,17 @@ def test_untouched_dimension_passthrough_even_with_run_dir(tmp_path):
     dim = _make_dimension(violations=[_make_violation(req="R-9", file="z.kt", line=1)])
     out = _rescore_dimension(dim, {("OTHER", "x.kt", 5)}, set(), run_dir=tmp_path)
     assert out is dim  # early return preserved: no filtering -> no rescoring
+
+
+def test_rescore_dismiss_by_principle_key_matches_no_req_finding():
+    """A dismissal stored with the principle as its key (the UI's `req ||
+    principle` fallback for findings without a req) must filter the matching
+    no-req violation, or the early "nothing filtered" return keeps the score
+    frozen while the live counters hide the finding.
+    """
+    dim = _make_dimension(violations=[
+        _make_violation(req=None, practice_id="P1", file="a.py", line=3),
+        _make_violation(req="R2", practice_id="P1", file="b.py", line=9),
+    ])
+    rescored = _rescore_dimension(dim, {("P1", "a.py", 3)})
+    assert [v.req for v in rescored.violations] == ["R2"]

--- a/tests/services/test_score_skips_incomplete_dims.py
+++ b/tests/services/test_score_skips_incomplete_dims.py
@@ -84,3 +84,41 @@ def test_idempotent_does_not_rescore(tmp_path: Path):
     })
     second_mtime = (run / "evaluation" / "d1.json").stat().st_mtime_ns
     assert first_mtime == second_mtime
+
+
+def test_cancelled_run_scoring_quarantines_off_standard_findings(tmp_path: Path, monkeypatch):
+    """Scoring after cancellation must resolve the dimension's standard like a
+    completed run does, so off-standard findings stay quarantined instead of
+    re-entering the grade as phantom principles.
+    """
+    from quodeq.services.evaluation_mixin import _score_completed_evidence
+    from quodeq.shared.dimensions_state import DimState, write_dim_state
+
+    monkeypatch.setenv("QUODEQ_EVALUATORS_DIR", str(tmp_path / "no-evals"))
+    reports, run = _seed_run(tmp_path)
+    _write_scan_json(reports, "proj")
+    dim = "maintainability"
+    p = run / "evidence" / f"{dim}_evidence.jsonl"
+    lines = [
+        {"file": "a.py", "req": "M-MOD-1", "t": "violation", "line": 1,
+         "severity": "minor", "w": "w", "reason": "r",
+         "p": "Modularity", "d": dim},
+        {"file": "z.py", "req": "X-1", "t": "violation", "line": 3,
+         "severity": "critical", "w": "w", "reason": "r",
+         "p": "NotInStandard", "d": dim},
+        {"_marker": "file_done", "file": "a.py", "status": "ok"},
+    ]
+    p.write_text("".join(json.dumps(line) + "\n" for line in lines))
+    _write_queue(run, dim)
+    write_dim_state(run, dim, DimState.PENDING)
+    write_dim_state(run, dim, DimState.RUNNING)
+    write_dim_state(run, dim, DimState.DONE)
+
+    _score_completed_evidence(str(reports), {
+        "outputProject": "proj", "outputRunId": "run-1",
+    })
+
+    report = json.loads((run / "evaluation" / f"{dim}.json").read_text())
+    assert report["quarantinedCount"] == 1
+    principles = {v.get("principle") for v in report["violations"]}
+    assert "NotInStandard" not in principles

--- a/tests/services/test_suppression_coherence.py
+++ b/tests/services/test_suppression_coherence.py
@@ -1,0 +1,93 @@
+"""One dismiss, one answer: every suppression surface agrees.
+
+Golden test for the unified exclusion predicate. A single dismissed finding
+(here the hard case: a finding without a req, dismissed under the UI's
+`req || principle` fallback key) must be excluded by:
+
+- the live-counter matcher (services/suppression),
+- the evidence-based rescore (services/evidence_rescore),
+- the report-level filter (services/rescore),
+- the CLI excluded-findings count (_cli_evaluation),
+- the CI report/SARIF filter (ci/_suppressions).
+
+If any surface answers differently, counters, grades, CLI output, and CI
+exports drift apart for the same project state.
+"""
+import json
+from pathlib import Path
+
+from quodeq.analysis._report_io import write_dimension_report
+from quodeq.core.evidence.parser import EvidenceContext, parse_jsonl_to_evidence
+from quodeq.core.scoring.engine import score_evidence
+from quodeq.core.scoring.params import DEFAULT_PARAMS
+from quodeq._cli_evaluation import _count_excluded_findings
+from quodeq.ci._suppressions import filter_suppressed_violations
+from quodeq.services.dismissed import dismiss_finding, dismissed_keys
+from quodeq.services.evidence_rescore import score_dimension_from_evidence, standard_dirs
+from quodeq.services.suppression import matcher_for
+
+DIM = "maintainability"
+SFC, FILES_READ = 10, 5
+
+
+def _build_run(run_dir: Path) -> dict:
+    """Real evidence + real scored report through the actual scan pipeline."""
+    lines = [
+        {"schema_version": 1, "req": "M-MOD-1", "t": "violation", "file": "a.kt",
+         "line": 10, "severity": "major", "w": "t", "reason": "r",
+         "p": "Modularity", "d": DIM},
+        # The hard case: no req. The UI dismisses this under its principle.
+        {"schema_version": 1, "t": "violation", "file": "b.kt", "line": 7,
+         "severity": "critical", "w": "t", "reason": "r",
+         "p": "Modularity", "d": DIM},
+        {"schema_version": 1, "req": "M-MOD-2", "t": "compliance", "file": "a.kt",
+         "line": 1, "w": "t", "reason": "r", "p": "Modularity", "d": DIM},
+    ]
+    ev_dir = run_dir / "evidence"
+    ev_dir.mkdir(parents=True)
+    jsonl = ev_dir / f"{DIM}_evidence.jsonl"
+    jsonl.write_text("\n".join(json.dumps(l) for l in lines) + "\n")
+    compiled_dir, evaluators_dir = standard_dirs()
+    evidence = parse_jsonl_to_evidence(jsonl, EvidenceContext(
+        language="", repository="", date_str="",
+        source_file_count=SFC, files_read=FILES_READ,
+    ), compiled_dir=compiled_dir, evaluators_dir=evaluators_dir)
+    scores = score_evidence(evidence, mode="numerical", params=DEFAULT_PARAMS)
+    write_dimension_report(evidence, scores, DIM, run_dir / "evaluation")
+    return json.loads((run_dir / "evaluation" / f"{DIM}.json").read_text())
+
+
+def test_one_dismiss_every_surface_agrees(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_EVALUATORS_DIR", str(tmp_path / "no-evals"))
+    project_dir = tmp_path / "proj"
+    run_dir = project_dir / "run-1"
+    report = _build_run(run_dir)
+
+    # Dismiss the no-req critical the way the UI does: key = req || principle.
+    dismiss_finding(project_dir, {"req": "Modularity", "file": "b.kt", "line": 7})
+    dismissed = dismissed_keys(project_dir)
+    assert dismissed, "dismiss did not register"
+
+    # 1. Live-counter matcher hides the raw evidence row.
+    matcher = matcher_for(project_dir, DIM)
+    row = {"t": "violation", "p": "Modularity", "file": "b.kt", "line": 7}
+    assert matcher.is_suppressed(row)
+
+    # 2. CLI counts exactly this one finding as excluded.
+    assert _count_excluded_findings(run_dir, DIM, dismissed, set()) == 1
+
+    # 3. The evidence rescore drops it from the grade.
+    base = score_dimension_from_evidence(
+        run_dir, DIM, dismissed=set(), deleted=set(),
+        source_file_count=SFC, files_read=FILES_READ, params=DEFAULT_PARAMS)
+    out = score_dimension_from_evidence(
+        run_dir, DIM, dismissed=dismissed, deleted=set(),
+        source_file_count=SFC, files_read=FILES_READ, params=DEFAULT_PARAMS)
+    assert out.principles["Modularity"].deductions.critical_type_count \
+        == base.principles["Modularity"].deductions.critical_type_count - 1
+
+    # 4. The CI report/SARIF filter drops it from the scored report dict.
+    filtered = filter_suppressed_violations(report, project_dir)
+    kept_files = [(v.get("file"), v.get("line")) for v in filtered["violations"]]
+    assert ("b.kt", 7) not in kept_files
+    assert ("a.kt", 10) in kept_files

--- a/tests/test_cli_evaluation_print.py
+++ b/tests/test_cli_evaluation_print.py
@@ -151,3 +151,27 @@ def test_rescore_exception_falls_back_to_original_line(tmp_path, capsys, monkeyp
 
     out = capsys.readouterr().out
     assert out == f"  {DIM}: {original_score}\n"
+
+
+def test_excluded_count_ignores_quarantined_findings(tmp_path, monkeypatch):
+    """A dismissed finding that scan time quarantined (principle not in the
+    dimension's standard) never entered the grade, so it must not count as
+    an exclusion: the printed suffix would otherwise promise a score change
+    the rescore does not deliver.
+    """
+    from quodeq._cli_evaluation import _count_excluded_findings
+
+    monkeypatch.setenv("QUODEQ_EVALUATORS_DIR", str(tmp_path / "no-evals"))
+    run_dir = tmp_path / "run"
+    ev_dir = run_dir / "evidence"
+    ev_dir.mkdir(parents=True)
+    lines = [
+        _ev_line("M-MOD-1", "a.kt", 10),
+        _ev_line("X-1", "z.kt", 3, sev="critical", p="NotInStandard"),
+    ]
+    (ev_dir / f"{DIM}_evidence.jsonl").write_text(
+        "\n".join(json.dumps(l) for l in lines) + "\n", encoding="utf-8")
+
+    count = _count_excluded_findings(
+        run_dir, DIM, dismissed={("X-1", "z.kt", 3)}, deleted=set())
+    assert count == 0


### PR DESCRIPTION
Audit of the dismiss/grades pipeline since v1.7.1 found the exclusion logic duplicated across six read sites, with three real bugs. This lands the fixes.

## Bugs fixed

**Rescore resurrected quarantined findings.** `score_dimension_from_evidence` parsed evidence without the standard dirs, so the `PrincipleResolver` went permissive and findings quarantined at scan time re-entered the grade after any dismiss (with phantom principle rows). A dismissed minor finding could drop a grade sharply for unrelated reasons. Same defect in the CLI excluded-count and the cancelled-run scorer. All three now resolve the dirs the way scan-time `RunConfig` does.

**Deletes were inert in `ci report` and SARIF export.** The filter matched deletes on `practiceId`, a key only evidence-derived reports carry. Scored report JSON names the field `principle`, so deleted findings kept appearing in CI output. The filter matches either name; the test now feeds a real scored-report shape.

**One bad dimension failed the whole dashboard.** `score_evidence` exceptions propagated out of the rescore, so an engine edge case 500'd `/api/rescore` and the dashboard build. The engine call is guarded at the seam; every consumer already treats None as "fall back to the stored score".

## Coherency refactor

`is_dismissed`/`is_deleted` in `services/suppression.py` are now the only exclusion predicate. The six former copies (matcher, evidence rescore, report rescore, CLI count, ci filter, dimension filters) all route through them. This also fixes the req-fallback drift: the UI stores dismiss keys as `req || principle`, but three read sites matched on `req` only, so dismissing a no-req finding hid it from the live counters while the grade never moved. The predicate accepts the assistant's empty-req key form too, since `actions.jsonl` holds historical keys in both shapes.

A golden test pins the contract: one dismiss, and the matcher, CLI count, evidence rescore, and CI filter all agree.

On the UI side, suppression mutations now make one reconcile call instead of the refresh+reconcile pair (the reconcile already marks stale synchronously). Run deletion, which had slipped through with mark-stale only, gets the active reconcile too.

## Testing

- New tests: quarantine-aware rescore, principle-key delete match, engine-exception fallback, no-req dismiss at both rescore sites, cross-surface golden test, run-deleted reconcile wiring.
- Full suites green: 5045 pytest, 1299 vitest, 339 node.
