### PR TITLE
fix(assistant): answer general questions using only the visible standards

### DIFF
--- a/src/quodeq/api/_assistant_helpers.py
+++ b/src/quodeq/api/_assistant_helpers.py
@@ -11,6 +11,7 @@ from flask import Flask, current_app
 from quodeq.assistant import AssistantRepository
 from quodeq.assistant.tools import ToolContext
 from quodeq.assistant import LOCAL_PROVIDERS as _LOCAL_PROVIDERS
+from quodeq.core.standards.visibility import load_visible_standard_ids
 from quodeq.services._fs_projects import get_project_info
 from quodeq.services.shared_repo import (
     read_state,
@@ -201,11 +202,21 @@ def build_tool_context(app: Flask, session: dict) -> ToolContext:
             raise SharedSourceUnavailable(f"shared repository unavailable: {state}")
         reports_dir = shared_evaluations_root(settings.url)
         score_cache_path = shared_score_cache_path(settings.url)
+    repo_root = (
+        Path(session["project_uuid"]) if session.get("project_uuid") else None)
+    # Shared sessions never attach a local repo root (the clone has no
+    # working copy -- see repo_root's "no_project"/"online_project" handling
+    # in assistant_routes.create_session): guard the project_id fallback to
+    # local sessions only, so it can't resolve a coincidental local project
+    # of the same id into a shared, read-only session's context.
+    if repo_root is None and source != "shared" and session.get("project_id"):
+        resolved = resolve_repo_root(session["project_id"])
+        repo_root = Path(resolved) if resolved else None
     return ToolContext(
         repository=get_repository(app),
         session_id=session["id"],
         run_dir=Path(run_dir) if run_dir else None,
-        repo_root=Path(session["project_uuid"]) if session.get("project_uuid") else None,
+        repo_root=repo_root,
         evaluators_dir=Path(app.config["STANDARDS_EVALUATORS_DIR"]),
         compiled_dir=Path(app.config["STANDARDS_COMPILED_DIR"]),
         dimensions_file=Path(app.config["STANDARDS_DIMENSIONS_FILE"]),
@@ -213,6 +224,8 @@ def build_tool_context(app: Flask, session: dict) -> ToolContext:
         reports_dir=reports_dir,
         read_only=(source == "shared"),
         score_cache_path=score_cache_path,
+        visible_standard_ids=(
+            load_visible_standard_ids(repo_root) if repo_root is not None else None),
     )
 
 

--- a/src/quodeq/api/_assistant_helpers.py
+++ b/src/quodeq/api/_assistant_helpers.py
@@ -208,7 +208,11 @@ def build_tool_context(app: Flask, session: dict) -> ToolContext:
     # working copy -- see repo_root's "no_project"/"online_project" handling
     # in assistant_routes.create_session): guard the project_id fallback to
     # local sessions only, so it can't resolve a coincidental local project
-    # of the same id into a shared, read-only session's context.
+    # of the same id into a shared, read-only session's context. The fallback
+    # can flip a local session from no-repo-access to repo-access; it fires
+    # only when session-creation-time resolution failed, and it recomputes the
+    # identical repo_attach_info check rather than a looser one, so it is a
+    # self-healing retry rather than a widening of trust.
     if repo_root is None and source != "shared" and session.get("project_id"):
         resolved = resolve_repo_root(session["project_id"])
         repo_root = Path(resolved) if resolved else None

--- a/src/quodeq/api/_assistant_helpers.py
+++ b/src/quodeq/api/_assistant_helpers.py
@@ -228,8 +228,7 @@ def build_tool_context(app: Flask, session: dict) -> ToolContext:
         reports_dir=reports_dir,
         read_only=(source == "shared"),
         score_cache_path=score_cache_path,
-        visible_standard_ids=(
-            load_visible_standard_ids(repo_root) if repo_root is not None else None),
+        visible_standard_ids=load_visible_standard_ids(repo_root),
     )
 
 

--- a/src/quodeq/api/standards_routes.py
+++ b/src/quodeq/api/standards_routes.py
@@ -15,6 +15,7 @@ from quodeq.api.standards_crud_routes import register_crud_routes
 from quodeq.api.standards_import_routes import register_import_routes
 from quodeq.api.standards_overrides_routes import register_overrides_routes
 from quodeq.api.standards_read_routes import register_read_routes
+from quodeq.api.standards_visibility_routes import register_visibility_routes
 from quodeq.services.standards import StandardsService
 from quodeq.services.standards_library import StandardsLibraryClient, UrllibJsonClient
 
@@ -49,3 +50,4 @@ def register_standards_routes(app: Flask) -> None:
     register_import_routes(app, _get_service, _get_library_client)
     register_crud_routes(app, _get_service)
     register_overrides_routes(app)
+    register_visibility_routes(app)

--- a/src/quodeq/api/standards_visibility_routes.py
+++ b/src/quodeq/api/standards_visibility_routes.py
@@ -1,8 +1,9 @@
 """GET/PUT the per-project visible-standards selection.
 
 The file lives inside the analyzed repository
-(``<repo>/.quodeq/standards-visibility.json``) so the dashboard, the CLI and
-the assistant all read one selection. See core.standards.visibility.
+(``<repo>/.quodeq/standards-visibility.json``) so the dashboard and the
+assistant both read one selection (there is no CLI consumer). See
+core.standards.visibility.
 """
 from __future__ import annotations
 

--- a/src/quodeq/api/standards_visibility_routes.py
+++ b/src/quodeq/api/standards_visibility_routes.py
@@ -1,0 +1,79 @@
+"""GET/PUT the per-project visible-standards selection.
+
+The file lives inside the analyzed repository
+(``<repo>/.quodeq/standards-visibility.json``) so the dashboard, the CLI and
+the assistant all read one selection. See core.standards.visibility.
+"""
+from __future__ import annotations
+
+import logging
+from http import HTTPStatus
+from pathlib import Path
+
+from flask import Flask, Response, jsonify, request
+
+from quodeq.api._assistant_helpers import resolve_repo_root
+from quodeq.api.helpers import error_response
+from quodeq.core.standards.visibility import (
+    VISIBILITY_RELPATH,
+    load_visible_standard_ids,
+    save_visible_standard_ids,
+    validate_visible_ids,
+)
+from quodeq.services.standards import StandardsService
+
+logger = logging.getLogger(__name__)
+
+
+def register_visibility_routes(app: Flask) -> None:
+    """Register GET/PUT endpoints for the per-project standards selection."""
+
+    def _repo_root(project_id: str) -> Path | None:
+        root = resolve_repo_root(project_id)
+        return Path(root) if root else None
+
+    def _known_ids() -> set[str]:
+        service = StandardsService(
+            Path(app.config["STANDARDS_EVALUATORS_DIR"]),
+            Path(app.config["STANDARDS_COMPILED_DIR"]),
+            Path(app.config["STANDARDS_DIMENSIONS_FILE"]),
+        )
+        return {m.id.strip().lower() for m in service.list_standards()}
+
+    def _payload(root: Path) -> dict:
+        ids = load_visible_standard_ids(root)
+        return {
+            "visibleStandardIds": list(ids),
+            "isDefault": not (root / VISIBILITY_RELPATH).is_file(),
+            "knownStandardIds": sorted(_known_ids()),
+        }
+
+    @app.get("/api/projects/<project_id>/standards-visibility")
+    def get_standards_visibility(project_id: str) -> Response:
+        root = _repo_root(project_id)
+        if root is None:
+            return error_response("Project has no local repository",
+                                  HTTPStatus.NOT_FOUND, "not_found")
+        return jsonify(_payload(root))
+
+    @app.put("/api/projects/<project_id>/standards-visibility")
+    def put_standards_visibility(project_id: str) -> Response:
+        root = _repo_root(project_id)
+        if root is None:
+            return error_response("Project has no local repository",
+                                  HTTPStatus.NOT_FOUND, "not_found")
+        body = request.get_json(force=True, silent=True)
+        raw = body.get("visibleStandardIds") if isinstance(body, dict) else None
+        if raw is None:
+            return error_response('Body must be {"visibleStandardIds": [...]}',
+                                  HTTPStatus.BAD_REQUEST, "bad_request")
+        clean, errors = validate_visible_ids(raw, _known_ids())
+        if errors:
+            resp = jsonify({"error": "Invalid visibility selection",
+                            "code": "invalid_visibility", "details": errors})
+            resp.status_code = HTTPStatus.BAD_REQUEST
+            return resp
+        save_visible_standard_ids(root, clean)
+        logger.info("standards.visibility saved project=%s visible=%d",
+                    project_id, len(clean))
+        return jsonify(_payload(root))

--- a/src/quodeq/assistant/_context.py
+++ b/src/quodeq/assistant/_context.py
@@ -49,6 +49,11 @@ contents from the scratch directory. Call get_context first when project, run, o
 repository scope is unclear. Use Quodeq tools for data:
 - get_overview, get_scores, get_report, and get_violations for dashboard/run data.
 - search_findings for run-scoped finding details and snippets.
+- Read tools cover only the standards visible on this project's dashboard. When a
+  payload carries a non-empty hiddenStandardIds, say so once ("you also have
+  <ids> hidden") rather than omitting them silently, and fetch them only if the
+  user asks: get_standard(standard_id), get_report(dimension),
+  get_violations(dimension), or list_standards(include_hidden=true).
 - read_repo_file and list_repo_dir for source files when get_context says the
   repository is attached.
 If a Quodeq tool call is cancelled, unavailable, or too broad, retry once with a

--- a/src/quodeq/assistant/mcp/server.py
+++ b/src/quodeq/assistant/mcp/server.py
@@ -89,8 +89,7 @@ def _build_registry_from_args(ns: argparse.Namespace) -> ToolRegistry:
         reports_dir=reports_dir,
         worktree_dir=Path(ns.worktree_dir) if getattr(ns, "worktree_dir", "") else None,
         read_only=bool(getattr(ns, "read_only", False)),
-        visible_standard_ids=(
-            load_visible_standard_ids(repo_root) if repo_root is not None else None),
+        visible_standard_ids=load_visible_standard_ids(repo_root),
     )
     registry = build_registry(ctx)
     if (getattr(ns, "enable_write", False) and ctx.worktree_dir is not None

--- a/src/quodeq/assistant/mcp/server.py
+++ b/src/quodeq/assistant/mcp/server.py
@@ -13,6 +13,7 @@ from quodeq.assistant.tools import ToolContext, build_registry
 from quodeq.assistant.tools._registry import ToolRegistry
 from quodeq.assistant.tools._write_tools import register_write_tools
 from quodeq.assistant import AssistantRepository
+from quodeq.core.standards.visibility import load_visible_standard_ids
 
 _PROTOCOL = "2024-11-05"
 _SERVER_NAME = "quodeq-assistant"
@@ -75,11 +76,12 @@ def _build_registry_from_args(ns: argparse.Namespace) -> ToolRegistry:
     else:
         from quodeq.shared._env import get_evaluations_dir  # noqa: PLC0415
         reports_dir = Path(get_evaluations_dir())
+    repo_root = Path(ns.repo_root) if ns.repo_root else None
     ctx = ToolContext(
         repository=AssistantRepository(Path(ns.db_path)),
         session_id=ns.session_id,
         run_dir=Path(ns.run_dir) if ns.run_dir else None,
-        repo_root=Path(ns.repo_root) if ns.repo_root else None,
+        repo_root=repo_root,
         evaluators_dir=Path(ns.evaluators_dir),
         compiled_dir=Path(ns.compiled_dir),
         dimensions_file=Path(ns.dimensions_file),
@@ -87,6 +89,8 @@ def _build_registry_from_args(ns: argparse.Namespace) -> ToolRegistry:
         reports_dir=reports_dir,
         worktree_dir=Path(ns.worktree_dir) if getattr(ns, "worktree_dir", "") else None,
         read_only=bool(getattr(ns, "read_only", False)),
+        visible_standard_ids=(
+            load_visible_standard_ids(repo_root) if repo_root is not None else None),
     )
     registry = build_registry(ctx)
     if (getattr(ns, "enable_write", False) and ctx.worktree_dir is not None

--- a/src/quodeq/assistant/tools/_context.py
+++ b/src/quodeq/assistant/tools/_context.py
@@ -36,7 +36,9 @@ class ToolContext:
     # Per-project visible-standards selection
     # (<repo>/.quodeq/standards-visibility.json, see
     # core.standards.visibility). General-purpose read tools filter to this set
-    # so the assistant never quotes dimensions the dashboard hides. None means
-    # no filtering: reserved for sessions with no resolvable repo root, which
-    # keeps CLI/MCP callers on today's behaviour.
+    # so the assistant never quotes dimensions the dashboard hides. Production
+    # always resolves a concrete selection (load_visible_standard_ids falls
+    # back to DEFAULT_VISIBLE_STANDARDS even with no repo root); None is the
+    # explicit "no filtering" opt-out, kept for any future caller that wants
+    # it, not something production code paths produce.
     visible_standard_ids: tuple[str, ...] | None = None

--- a/src/quodeq/assistant/tools/_context.py
+++ b/src/quodeq/assistant/tools/_context.py
@@ -33,3 +33,10 @@ class ToolContext:
     # _with_shared_root mechanism). Wrapped in the messages-route worker and
     # the MCP server main.
     score_cache_path: Path | None = None
+    # Per-project visible-standards selection
+    # (<repo>/.quodeq/standards-visibility.json, see
+    # core.standards.visibility). General-purpose read tools filter to this set
+    # so the assistant never quotes dimensions the dashboard hides. None means
+    # no filtering: reserved for sessions with no resolvable repo root, which
+    # keeps CLI/MCP callers on today's behaviour.
+    visible_standard_ids: tuple[str, ...] | None = None

--- a/src/quodeq/assistant/tools/_overview.py
+++ b/src/quodeq/assistant/tools/_overview.py
@@ -10,8 +10,13 @@ from __future__ import annotations
 
 from quodeq.assistant.tools._context import ToolContext
 from quodeq.assistant.tools._registry import ToolError, ToolRegistry, ToolSpec
+from quodeq.core.standards.visibility import partition_entries_visible
 from quodeq.services import _fs_reports
 from quodeq.services.scoring import rescore_accumulated
+
+# Severity buckets recomputed for the filtered summary. Unknown/missing
+# severities are ignored rather than added as a fourth bucket.
+_SEVERITY_BUCKETS = ("critical", "major", "minor")
 
 
 def _get_overview(ctx: ToolContext, as_of: str | None = None) -> dict:
@@ -29,6 +34,10 @@ def _get_overview(ctx: ToolContext, as_of: str | None = None) -> dict:
     # scores than the Overview shows for the same project (no-op when the
     # project has no active dismissals/deletions).
     payload = rescore_accumulated(payload, ctx.reports_dir, ctx.project_id)
+    raw_dims = payload.get("dimensions", []) or []
+    # Shared with _read_tools._visible_only: one implementation of "what
+    # counts as hidden" for every read surface.
+    kept, hidden = partition_entries_visible(raw_dims, ctx.visible_standard_ids)
     dimensions = [
         {
             "dimension": d.get("dimension"),
@@ -36,19 +45,46 @@ def _get_overview(ctx: ToolContext, as_of: str | None = None) -> dict:
             "grade": d.get("overallGrade"),
             "trend": d.get("trend"),
         }
-        for d in payload.get("dimensions", [])
+        for d in kept
     ]
     summary = payload.get("summary", {}) or {}
-    return {
-        "project": payload.get("project"),
-        "dimensions": dimensions,
-        "summary": {
+    if not hidden:
+        out_summary = {
             "overallGrade": summary.get("overallGrade"),
             "numericAverage": summary.get("numericAverage"),
             "totalViolations": summary.get("totalViolations"),
             "dimensionCount": summary.get("dimensionCount"),
             "severity": summary.get("severity"),
-        },
+        }
+    else:
+        # overallGrade/numericAverage are deliberately absent. The Overview
+        # derives them from the filtered TREND in the browser
+        # (ui/src/utils/scoreFiltering.js), not from these dimensions, so any
+        # value computed here could contradict the number on screen -- the
+        # divergence this filtering exists to prevent. Counts are exact, so
+        # they are recomputed rather than dropped.
+        severity = {bucket: 0 for bucket in _SEVERITY_BUCKETS}
+        total = 0
+        for d in kept:
+            for v in (d.get("violations") or []):
+                total += 1
+                level = (v.get("severity") or "").lower()
+                if level in severity:
+                    severity[level] += 1
+        out_summary = {
+            "totalViolations": total,
+            "dimensionCount": len(kept),
+            "severity": severity,
+            "note": ("overall grade and average omitted: they cover all "
+                     "standards, including the ones hidden from this project's "
+                     "dashboard. Quote the per-dimension scores instead, or "
+                     "point the user at the Overview."),
+        }
+    return {
+        "project": payload.get("project"),
+        "dimensions": dimensions,
+        "summary": out_summary,
+        "hiddenStandardIds": hidden,
     }
 
 
@@ -59,7 +95,11 @@ def register_overview_tools(registry: ToolRegistry, ctx: ToolContext) -> None:
         "project's recent runs (the overview/dashboard view). Use this when no "
         "specific run is selected. Call get_context first if unsure whether "
         "overviewAvailable is true. Optional 'as_of' is a run id: accumulate "
-        "only that run and older ones.",
+        "only that run and older ones. Covers only the standards visible on "
+        "this project's dashboard; any others are named in hiddenStandardIds. "
+        "When standards are hidden the summary omits the overall grade and "
+        "average on purpose -- do not compute your own from the dimension "
+        "scores.",
         {"type": "object", "properties": {
             "as_of": {"type": "string"},
         }},

--- a/src/quodeq/assistant/tools/_read_tools.py
+++ b/src/quodeq/assistant/tools/_read_tools.py
@@ -5,6 +5,7 @@ import dataclasses
 import json
 import logging
 import re
+from pathlib import Path
 
 from quodeq.assistant.tools._context import ToolContext
 from quodeq.assistant.tools._registry import ToolError, ToolRegistry, ToolSpec
@@ -99,7 +100,7 @@ def _no_scope_error() -> ToolError:
         "scope, then ask the user to open a project overview or select a run.")
 
 
-def _raw_run_dims(eval_dir) -> list[dict]:
+def _raw_run_dims(eval_dir: Path) -> list[dict]:
     """A run's evaluation reports as dicts, each guaranteed a ``dimension``.
 
     Mirrors the pre-filtering fallback ``data.get("dimension", path.stem)``: a
@@ -123,22 +124,34 @@ def _available_names(ctx: ToolContext, dims: list[dict]) -> str:
     return ", ".join(sorted(shown))
 
 
+def _hidden_ids(ctx: ToolContext, names: list[str]) -> list[str]:
+    """Which of *names* the user has hidden, de-duplicated and sorted.
+
+    A blank/missing name is always treated as visible -- there is no
+    dimension to hide -- and must never itself surface as a hidden id.
+    """
+    non_blank = [n for n in names if (n or "").strip()]
+    _, hidden = partition_visible(non_blank, ctx.visible_standard_ids)
+    return sorted({h.strip().lower() for h in hidden})
+
+
 def _visible_only(ctx: ToolContext, entries: list[dict],
                   key: str = "dimension") -> tuple[list[dict], list[str]]:
     """Drop entries whose dimension the user has hidden.
 
     Returns ``(kept, hidden_ids)``. ``hidden_ids`` is de-duplicated and sorted
     so the payload is stable, and is what lets the assistant offer the withheld
-    data instead of silently omitting it.
+    data instead of silently omitting it. An entry with a blank/missing
+    dimension is always kept -- there is nothing to hide it as.
     """
     names = [str(e.get(key) or "") for e in entries]
-    _, hidden = partition_visible(names, ctx.visible_standard_ids)
+    hidden = _hidden_ids(ctx, names)
     if not hidden:
         return entries, []
-    hidden_set = {h.strip().lower() for h in hidden}
+    hidden_set = set(hidden)
     kept = [e for e, n in zip(entries, names, strict=True)
-            if n.strip().lower() not in hidden_set]
-    return kept, sorted(hidden_set)
+            if not n.strip() or n.strip().lower() not in hidden_set]
+    return kept, hidden
 
 
 # Trimmed violation shape shared by get_report and get_violations. We keep only
@@ -264,7 +277,19 @@ def _severity_key(v: dict):
 
 def _search_findings(ctx: ToolContext, query: str, limit: int = 20) -> dict:
     run_dir = _require_run(ctx)
-    hits = SqliteFindingsRepository(run_dir).search(query, limit=max(1, min(int(limit), 50)))
+    repo = SqliteFindingsRepository(run_dir)
+    # Hidden dims must be known BEFORE the query runs, so the exclusion can be
+    # pushed into SQL ahead of LIMIT (see SqliteFindingsRepository.search).
+    # Filtering the returned rows afterward is not equivalent: rows are
+    # ordered by insertion order, evaluators insert per dimension in batches,
+    # and enough hidden-dimension rows ahead of the visible ones can exhaust
+    # the whole limit window, returning zero results even though visible ones
+    # exist. Sourced from every dimension in the run's DB (not from the
+    # query's hits) so a dimension whose rows never come back from SQL is
+    # still reported as withheld.
+    hidden = _hidden_ids(ctx, list(repo.count_by_dimension()))
+    hits = repo.search(query, limit=max(1, min(int(limit), 50)),
+                        exclude_dimensions=hidden or None)
     # Model-facing key is "requirement"; the Finding attribute is `req`
     # (see data/sqlite/_row_mappers.py row_to_finding).
     rows = [
@@ -272,8 +297,7 @@ def _search_findings(ctx: ToolContext, query: str, limit: int = 20) -> dict:
          "file": f.file, "line": f.line, "reason": f.reason, "snippet": f.snippet}
         for f in hits
     ]
-    kept, hidden = _visible_only(ctx, rows)
-    return {"findings": kept, "hiddenStandardIds": hidden}
+    return {"findings": rows, "hiddenStandardIds": hidden}
 
 
 def _get_scores(ctx: ToolContext) -> dict:

--- a/src/quodeq/assistant/tools/_read_tools.py
+++ b/src/quodeq/assistant/tools/_read_tools.py
@@ -9,7 +9,11 @@ from pathlib import Path
 
 from quodeq.assistant.tools._context import ToolContext
 from quodeq.assistant.tools._registry import ToolError, ToolRegistry, ToolSpec
-from quodeq.core.standards.visibility import partition_visible
+from quodeq.core.standards.visibility import (
+    hidden_ids_for_names,
+    partition_entries_visible,
+    partition_visible,
+)
 from quodeq.core.types import to_camel_dict
 from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
 from quodeq.services import _fs_reports
@@ -125,33 +129,20 @@ def _available_names(ctx: ToolContext, dims: list[dict]) -> str:
 
 
 def _hidden_ids(ctx: ToolContext, names: list[str]) -> list[str]:
-    """Which of *names* the user has hidden, de-duplicated and sorted.
-
-    A blank/missing name is always treated as visible -- there is no
-    dimension to hide -- and must never itself surface as a hidden id.
-    """
-    non_blank = [n for n in names if (n or "").strip()]
-    _, hidden = partition_visible(non_blank, ctx.visible_standard_ids)
-    return sorted({h.strip().lower() for h in hidden})
+    """Which of *names* the user has hidden. See ``hidden_ids_for_names``."""
+    return hidden_ids_for_names(names, ctx.visible_standard_ids)
 
 
 def _visible_only(ctx: ToolContext, entries: list[dict],
                   key: str = "dimension") -> tuple[list[dict], list[str]]:
     """Drop entries whose dimension the user has hidden.
 
-    Returns ``(kept, hidden_ids)``. ``hidden_ids`` is de-duplicated and sorted
-    so the payload is stable, and is what lets the assistant offer the withheld
-    data instead of silently omitting it. An entry with a blank/missing
-    dimension is always kept -- there is nothing to hide it as.
+    Thin per-context wrapper around ``partition_entries_visible`` -- the one
+    shared implementation used by every read surface, including
+    ``_overview.get_overview``, so "what counts as hidden" cannot drift
+    between them.
     """
-    names = [str(e.get(key) or "") for e in entries]
-    hidden = _hidden_ids(ctx, names)
-    if not hidden:
-        return entries, []
-    hidden_set = set(hidden)
-    kept = [e for e, n in zip(entries, names, strict=True)
-            if not n.strip() or n.strip().lower() not in hidden_set]
-    return kept, hidden
+    return partition_entries_visible(entries, ctx.visible_standard_ids, key=key)
 
 
 # Trimmed violation shape shared by get_report and get_violations. We keep only

--- a/src/quodeq/assistant/tools/_read_tools.py
+++ b/src/quodeq/assistant/tools/_read_tools.py
@@ -99,6 +99,38 @@ def _no_scope_error() -> ToolError:
         "scope, then ask the user to open a project overview or select a run.")
 
 
+def _raw_run_dims(eval_dir) -> list[dict]:
+    """A run's evaluation reports as dicts, each guaranteed a ``dimension``.
+
+    Mirrors the pre-filtering fallback ``data.get("dimension", path.stem)``: a
+    report that omits the field is named after its file rather than dropped.
+    """
+    out: list[dict] = []
+    for path in sorted(eval_dir.glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data.setdefault("dimension", path.stem)
+        out.append(data)
+    return out
+
+
+def _visible_only(ctx: ToolContext, entries: list[dict],
+                  key: str = "dimension") -> tuple[list[dict], list[str]]:
+    """Drop entries whose dimension the user has hidden.
+
+    Returns ``(kept, hidden_ids)``. ``hidden_ids`` is de-duplicated and sorted
+    so the payload is stable, and is what lets the assistant offer the withheld
+    data instead of silently omitting it.
+    """
+    names = [str(e.get(key) or "") for e in entries]
+    _, hidden = partition_visible(names, ctx.visible_standard_ids)
+    if not hidden:
+        return entries, []
+    hidden_set = {h.strip().lower() for h in hidden}
+    kept = [e for e, n in zip(entries, names, strict=True)
+            if n.strip().lower() not in hidden_set]
+    return kept, sorted(hidden_set)
+
+
 # Trimmed violation shape shared by get_report and get_violations. We keep only
 # the fields that let the model locate and explain an issue and DROP the large
 # `snippet`/`context` blobs so a report full of violations stays within a sane
@@ -225,11 +257,13 @@ def _search_findings(ctx: ToolContext, query: str, limit: int = 20) -> dict:
     hits = SqliteFindingsRepository(run_dir).search(query, limit=max(1, min(int(limit), 50)))
     # Model-facing key is "requirement"; the Finding attribute is `req`
     # (see data/sqlite/_row_mappers.py row_to_finding).
-    return {"findings": [
+    rows = [
         {"dimension": f.dimension, "requirement": f.req, "severity": f.severity,
          "file": f.file, "line": f.line, "reason": f.reason, "snippet": f.snippet}
         for f in hits
-    ]}
+    ]
+    kept, hidden = _visible_only(ctx, rows)
+    return {"findings": kept, "hiddenStandardIds": hidden}
 
 
 def _get_scores(ctx: ToolContext) -> dict:
@@ -240,24 +274,26 @@ def _get_scores(ctx: ToolContext) -> dict:
         if not eval_dir.is_dir():
             raise ToolError("no evaluation reports in this run")
         scored = _scored_run_dims(ctx)
-        if scored is not None:
-            return {d["dimension"]: {
+        if scored is None:
+            scored = _raw_run_dims(eval_dir)
+        kept, hidden = _visible_only(ctx, scored)
+        return {
+            "scores": {d["dimension"]: {
                 "score": d.get("overallScore"), "grade": d.get("overallGrade"),
-            } for d in scored if d.get("dimension")}
-        out = {}
-        for path in sorted(eval_dir.glob("*.json")):
-            data = json.loads(path.read_text(encoding="utf-8"))
-            out[data.get("dimension", path.stem)] = {
-                "score": data.get("overallScore"), "grade": data.get("overallGrade"),
-            }
-        return out
+            } for d in kept if d.get("dimension")},
+            "hiddenStandardIds": hidden,
+        }
     dims = _accumulated_dims(ctx)
     if dims is None:
         raise _no_scope_error()
-    return {d.get("dimension"): {
-        "score": d.get("overallScore"), "grade": d.get("overallGrade"),
-        "fromRun": d.get("fromRunId"),
-    } for d in dims if d.get("dimension")}
+    kept, hidden = _visible_only(ctx, dims)
+    return {
+        "scores": {d.get("dimension"): {
+            "score": d.get("overallScore"), "grade": d.get("overallGrade"),
+            "fromRun": d.get("fromRunId"),
+        } for d in kept if d.get("dimension")},
+        "hiddenStandardIds": hidden,
+    }
 
 
 def _get_report(ctx: ToolContext, dimension: str) -> dict:
@@ -320,9 +356,9 @@ def _get_violations(ctx: ToolContext, dimension: str | None = None,
                     limit: int = _VIOLATIONS_DEFAULT_LIMIT) -> dict:
     limit = max(1, min(int(limit), _VIOLATIONS_MAX_LIMIT))
     if _has_run(ctx):
-        raw, dim_out = _violations_from_run(ctx, dimension)
+        raw, dim_out, hidden = _violations_from_run(ctx, dimension)
     else:
-        raw, dim_out = _violations_from_accumulated(ctx, dimension)
+        raw, dim_out, hidden = _violations_from_accumulated(ctx, dimension)
 
     # by_principle counts reflect ALL violations so "worst principle" stays
     # accurate even when the returned list is capped by `limit`.
@@ -333,8 +369,8 @@ def _get_violations(ctx: ToolContext, dimension: str | None = None,
 
     ordered = sorted(raw, key=_severity_key)
     trimmed = [_trim_violation(v) for v in ordered[:limit]]
-    return {"dimension": dim_out, "count": len(raw),
-            "violations": trimmed, "by_principle": by_principle}
+    return {"dimension": dim_out, "count": len(raw), "violations": trimmed,
+            "by_principle": by_principle, "hiddenStandardIds": hidden}
 
 
 def _violations_from_run(ctx: ToolContext, dimension: str | None):
@@ -351,19 +387,18 @@ def _violations_from_run(ctx: ToolContext, dimension: str | None):
         if scored is not None:
             entry = next((d for d in scored if d.get("dimension") == dimension), None)
             if entry is not None:
-                return entry.get("violations") or [], dimension
-        return json.loads(path.read_text(encoding="utf-8")).get("violations") or [], dimension
+                return entry.get("violations") or [], dimension, []
+        viols = json.loads(path.read_text(encoding="utf-8")).get("violations") or []
+        return viols, dimension, []
     if not eval_dir.is_dir():
         raise ToolError(
             "no evaluation reports in this run. Try get_overview for "
             "accumulated scores across runs.")
     scored = _scored_run_dims(ctx)
-    if scored is not None:
-        return [v for d in scored for v in (d.get("violations") or [])], None
-    raw: list = []
-    for p in sorted(eval_dir.glob("*.json")):
-        raw.extend(json.loads(p.read_text(encoding="utf-8")).get("violations") or [])
-    return raw, None
+    if scored is None:
+        scored = _raw_run_dims(eval_dir)
+    kept, hidden = _visible_only(ctx, scored)
+    return [v for d in kept for v in (d.get("violations") or [])], None, hidden
 
 
 def _violations_from_accumulated(ctx: ToolContext, dimension: str | None):
@@ -377,11 +412,12 @@ def _violations_from_accumulated(ctx: ToolContext, dimension: str | None):
             raise ToolError(
                 f"no report for dimension: {dimension}. Available: "
                 f"{avail or '(none)'}. Or try get_overview for accumulated scores.")
-        return entry.get("violations") or [], dimension
+        return entry.get("violations") or [], dimension, []
+    kept, hidden = _visible_only(ctx, dims)
     raw: list = []
-    for d in dims:
+    for d in kept:
         raw.extend(d.get("violations") or [])
-    return raw, None
+    return raw, None, hidden
 
 
 def _service(ctx: ToolContext) -> StandardsService:
@@ -419,9 +455,12 @@ def register_read_tools(registry: ToolRegistry, ctx: ToolContext) -> None:
         lambda **kw: _search_findings(ctx, **kw)))
     registry.register(ToolSpec(
         "get_scores",
-        "Get all dimension scores and grades. Uses the selected run if one is "
-        "selected, otherwise the accumulated view (each dimension's latest "
-        "run, aggregated — the default dashboard data).",
+        "Get all dimension scores and grades, as {scores: {dimension: "
+        "{score, grade}}, hiddenStandardIds: [...]}. Uses the selected run if "
+        "one is selected, otherwise the accumulated view (each dimension's "
+        "latest run, aggregated — the default dashboard data). scores omits "
+        "any dimension the user has hidden; those ids are named in "
+        "hiddenStandardIds.",
         {"type": "object", "properties": {}},
         lambda **kw: _get_scores(ctx, **kw)))
     registry.register(ToolSpec(

--- a/src/quodeq/assistant/tools/_read_tools.py
+++ b/src/quodeq/assistant/tools/_read_tools.py
@@ -8,6 +8,7 @@ import re
 
 from quodeq.assistant.tools._context import ToolContext
 from quodeq.assistant.tools._registry import ToolError, ToolRegistry, ToolSpec
+from quodeq.core.standards.visibility import partition_visible
 from quodeq.core.types import to_camel_dict
 from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
 from quodeq.services import _fs_reports
@@ -387,9 +388,14 @@ def _service(ctx: ToolContext) -> StandardsService:
     return StandardsService(ctx.evaluators_dir, ctx.compiled_dir, ctx.dimensions_file)
 
 
-def _list_standards(ctx: ToolContext) -> dict:
+def _list_standards(ctx: ToolContext, include_hidden: bool = False) -> dict:
     metas = _service(ctx).list_standards()
-    return {"standards": [dataclasses.asdict(m) for m in metas]}
+    shown, hidden = partition_visible([m.id for m in metas], ctx.visible_standard_ids)
+    keep = set(shown) if not include_hidden else {m.id for m in metas}
+    return {
+        "standards": [dataclasses.asdict(m) for m in metas if m.id in keep],
+        "hiddenStandardIds": hidden,
+    }
 
 
 def _get_standard(ctx: ToolContext, standard_id: str) -> dict:
@@ -437,8 +443,15 @@ def register_read_tools(registry: ToolRegistry, ctx: ToolContext) -> None:
         }},
         lambda **kw: _get_violations(ctx, **kw)))
     registry.register(ToolSpec(
-        "list_standards", "List all built-in and custom standards.",
-        {"type": "object", "properties": {}},
+        "list_standards",
+        "List the standards this project evaluates. Returns only the standards "
+        "the user has selected as visible; any others are named in "
+        "hiddenStandardIds. Pass include_hidden=true, or call "
+        "get_standard(standard_id), when the user explicitly asks about a "
+        "hidden standard.",
+        {"type": "object", "properties": {
+            "include_hidden": {"type": "boolean"},
+        }},
         lambda **kw: _list_standards(ctx, **kw)))
     registry.register(ToolSpec(
         "get_standard", "Get one standard's full principles and requirements.",

--- a/src/quodeq/assistant/tools/_read_tools.py
+++ b/src/quodeq/assistant/tools/_read_tools.py
@@ -113,6 +113,16 @@ def _raw_run_dims(eval_dir) -> list[dict]:
     return out
 
 
+def _available_names(ctx: ToolContext, dims: list[dict]) -> str:
+    """Comma-joined visible dimension names for a not-found error message.
+
+    Filtered so an error never discloses a dimension the user has hidden.
+    """
+    names = [d.get("dimension") for d in dims if d.get("dimension")]
+    shown, _ = partition_visible(names, ctx.visible_standard_ids)
+    return ", ".join(sorted(shown))
+
+
 def _visible_only(ctx: ToolContext, entries: list[dict],
                   key: str = "dimension") -> tuple[list[dict], list[str]]:
     """Drop entries whose dimension the user has hidden.
@@ -327,7 +337,7 @@ def _get_report(ctx: ToolContext, dimension: str) -> dict:
         raise _no_scope_error()
     entry = next((d for d in dims if d.get("dimension") == dimension), None)
     if entry is None:
-        avail = ", ".join(sorted(d.get("dimension") for d in dims if d.get("dimension")))
+        avail = _available_names(ctx, dims)
         raise ToolError(
             f"no report for dimension: {dimension}. Available: {avail or '(none)'}")
     viols = entry.get("violations") or []
@@ -408,7 +418,7 @@ def _violations_from_accumulated(ctx: ToolContext, dimension: str | None):
     if dimension:
         entry = next((d for d in dims if d.get("dimension") == dimension), None)
         if entry is None:
-            avail = ", ".join(sorted(d.get("dimension") for d in dims if d.get("dimension")))
+            avail = _available_names(ctx, dims)
             raise ToolError(
                 f"no report for dimension: {dimension}. Available: "
                 f"{avail or '(none)'}. Or try get_overview for accumulated scores.")

--- a/src/quodeq/core/standards/visibility.py
+++ b/src/quodeq/core/standards/visibility.py
@@ -1,0 +1,117 @@
+"""Per-project selection of which standards are shown.
+
+Hiding a standard is project configuration, not a per-browser view preference:
+the dashboard, the CLI and the assistant must all agree on which standards are
+in play. The selection lives in the analyzed repository at
+``<project root>/.quodeq/standards-visibility.json``, alongside
+``standards-overrides.json``, so the whole team shares it:
+
+    {"version": 1, "visibleStandardIds": ["security", "reliability"]}
+
+An absent file means the six ISO defaults, NOT "everything". Quodeq ships more
+built-in standards than the default selection shows, so treating absence as
+"no filtering" would leave a fresh install disagreeing with its own dashboard.
+
+A malformed file never fails a read; it degrades to the defaults with a warning.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+VISIBILITY_RELPATH = Path(".quodeq") / "standards-visibility.json"
+
+# Must stay in lockstep with DEFAULT_VISIBLE_STANDARDS in
+# src/quodeq/ui/src/constants.js -- pinned by
+# tests/core/test_visible_standards_defaults_match_ui.py.
+DEFAULT_VISIBLE_STANDARDS: tuple[str, ...] = (
+    "security", "reliability", "maintainability",
+    "performance", "usability", "flexibility",
+)
+
+
+def _normalize(ids: Iterable[object]) -> tuple[str, ...]:
+    """Lowercase, de-duplicate and drop non-strings, preserving first order."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in ids:
+        if not isinstance(raw, str):
+            continue
+        key = raw.strip().lower()
+        if key and key not in seen:
+            seen.add(key)
+            out.append(key)
+    return tuple(out)
+
+
+def load_visible_standard_ids(project_root: str | Path | None) -> tuple[str, ...]:
+    """Visible standard ids for a project; defaults when absent or malformed."""
+    if not project_root:
+        return DEFAULT_VISIBLE_STANDARDS
+    path = Path(project_root) / VISIBILITY_RELPATH
+    if not path.is_file():
+        return DEFAULT_VISIBLE_STANDARDS
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, UnicodeDecodeError) as exc:
+        _logger.warning("Ignoring malformed standards visibility %s: %s", path, exc)
+        return DEFAULT_VISIBLE_STANDARDS
+    ids = data.get("visibleStandardIds") if isinstance(data, dict) else None
+    if not isinstance(ids, list):
+        _logger.warning(
+            "Ignoring standards visibility %s: no 'visibleStandardIds' array", path)
+        return DEFAULT_VISIBLE_STANDARDS
+    # An explicitly empty list is a real selection ("hide everything") and is
+    # returned as-is; only a missing/!list value falls back to the defaults.
+    return _normalize(ids)
+
+
+def save_visible_standard_ids(project_root: str | Path, ids: list[str]) -> None:
+    """Write the selection, creating ``.quodeq/`` when needed."""
+    path = Path(project_root) / VISIBILITY_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"version": 1, "visibleStandardIds": list(_normalize(ids))}
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def validate_visible_ids(raw: object, known_ids: set[str]) -> tuple[list[str], list[str]]:
+    """Validate a proposed selection; returns ``(clean, errors)``.
+
+    ``clean`` is empty whenever ``errors`` is non-empty: API writes are
+    all-or-nothing, unlike load-time parsing which skips bad entries.
+    """
+    if not isinstance(raw, list):
+        return [], ["visibleStandardIds must be an array"]
+    errors: list[str] = []
+    for entry in raw:
+        if not isinstance(entry, str):
+            errors.append(f"{entry!r}: must be a string")
+        elif entry.strip().lower() not in known_ids:
+            errors.append(f"{entry}: unknown standard")
+    if errors:
+        return [], errors
+    return list(_normalize(raw)), []
+
+
+def partition_visible(
+    ids: Iterable[str], visible: tuple[str, ...] | None,
+) -> tuple[list[str], list[str]]:
+    """Split ``ids`` into ``(visible, hidden)`` against a selection.
+
+    ``visible=None`` means no filtering is configured for this session, so
+    everything is visible and nothing is reported hidden. Comparison is on the
+    lowercase id, matching the UI's ``visibleSet.has(d.dimension.toLowerCase())``;
+    the returned strings keep their original casing.
+    """
+    if visible is None:
+        return list(ids), []
+    allowed = set(visible)
+    shown: list[str] = []
+    hidden: list[str] = []
+    for value in ids:
+        (shown if (value or "").strip().lower() in allowed else hidden).append(value)
+    return shown, hidden

--- a/src/quodeq/core/standards/visibility.py
+++ b/src/quodeq/core/standards/visibility.py
@@ -115,3 +115,38 @@ def partition_visible(
     for value in ids:
         (shown if (value or "").strip().lower() in allowed else hidden).append(value)
     return shown, hidden
+
+
+def hidden_ids_for_names(
+    names: Iterable[str], visible: tuple[str, ...] | None,
+) -> list[str]:
+    """Which of *names* are hidden, de-duplicated and sorted.
+
+    A blank/missing name is always treated as visible -- there is no
+    dimension to hide -- and must never itself surface as a hidden id.
+    Shared by every read surface (assistant tools and the overview) so
+    "what counts as hidden" cannot drift between them.
+    """
+    non_blank = [n for n in names if (n or "").strip()]
+    _, hidden = partition_visible(non_blank, visible)
+    return sorted({h.strip().lower() for h in hidden})
+
+
+def partition_entries_visible(
+    entries: list[dict], visible: tuple[str, ...] | None, key: str = "dimension",
+) -> tuple[list[dict], list[str]]:
+    """Drop entries whose ``entry[key]`` the selection hides.
+
+    Returns ``(kept, hidden_ids)``. ``hidden_ids`` is de-duplicated and sorted
+    so the payload is stable, and is what lets a caller offer the withheld
+    data instead of silently omitting it. An entry with a blank/missing key is
+    always kept -- there is nothing to hide it as.
+    """
+    names = [str(e.get(key) or "") for e in entries]
+    hidden = hidden_ids_for_names(names, visible)
+    if not hidden:
+        return entries, []
+    hidden_set = set(hidden)
+    kept = [e for e, n in zip(entries, names, strict=True)
+            if not n.strip() or n.strip().lower() not in hidden_set]
+    return kept, hidden

--- a/src/quodeq/core/standards/visibility.py
+++ b/src/quodeq/core/standards/visibility.py
@@ -1,8 +1,9 @@
 """Per-project selection of which standards are shown.
 
 Hiding a standard is project configuration, not a per-browser view preference:
-the dashboard, the CLI and the assistant must all agree on which standards are
-in play. The selection lives in the analyzed repository at
+the dashboard and the assistant must both agree on which standards are in
+play (there is no CLI consumer). The selection lives in the analyzed
+repository at
 ``<project root>/.quodeq/standards-visibility.json``, alongside
 ``standards-overrides.json``, so the whole team shares it:
 

--- a/src/quodeq/data/sqlite/findings_repository.py
+++ b/src/quodeq/data/sqlite/findings_repository.py
@@ -122,10 +122,13 @@ class SqliteFindingsRepository:
         """Full-text search, optionally excluding whole dimensions.
 
         ``exclude_dimensions``, when given, adds a ``dimension NOT IN (...)``
-        clause BEFORE ``LIMIT`` is applied (case-insensitively, since stored
-        ``dimension`` values are not guaranteed to be lowercase). This lets a
-        caller exclude hidden-standard rows inside the query itself, rather
-        than over-fetching and filtering after the fact -- rows are ordered by
+        clause BEFORE ``LIMIT`` is applied, matching case-insensitively via
+        SQLite's ``LOWER()`` (stored ``dimension`` values are not guaranteed
+        to be lowercase, and a custom standard's id has no charset
+        constraint). Note ``LOWER()`` is ASCII-only, so a non-ASCII uppercase
+        stored dimension would not match. This lets a caller exclude
+        hidden-standard rows inside the query itself, rather than
+        over-fetching and filtering after the fact -- rows are ordered by
         insertion order (``id``), and evaluators insert per dimension in
         batches, so a fixed over-fetch factor can still be exhausted entirely
         by excluded rows that happen to precede the ones the caller wants.

--- a/src/quodeq/data/sqlite/findings_repository.py
+++ b/src/quodeq/data/sqlite/findings_repository.py
@@ -1,6 +1,7 @@
 """SQLite implementation of FindingsRepository (per-run evaluation.db)."""
 from __future__ import annotations
 
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -111,16 +112,42 @@ class SqliteFindingsRepository:
             ).fetchall()
         return {dim: n for dim, n in rows}
 
-    def search(self, query: str, limit: int = 100) -> list[Finding]:
+    def search(
+        self,
+        query: str,
+        limit: int = 100,
+        *,
+        exclude_dimensions: Iterable[str] | None = None,
+    ) -> list[Finding]:
+        """Full-text search, optionally excluding whole dimensions.
+
+        ``exclude_dimensions``, when given, adds a ``dimension NOT IN (...)``
+        clause BEFORE ``LIMIT`` is applied (case-insensitively, since stored
+        ``dimension`` values are not guaranteed to be lowercase). This lets a
+        caller exclude hidden-standard rows inside the query itself, rather
+        than over-fetching and filtering after the fact -- rows are ordered by
+        insertion order (``id``), and evaluators insert per dimension in
+        batches, so a fixed over-fetch factor can still be exhausted entirely
+        by excluded rows that happen to precede the ones the caller wants.
+        Default ``None`` leaves every existing caller unaffected.
+        """
         self._ensure_fresh()
         fts_query = _quote_fts_query(query)
+        where = ["id IN (SELECT rowid FROM findings_fts WHERE findings_fts MATCH ?)"]
+        params: list[Any] = [fts_query]
+        excluded = [d.strip().lower() for d in (exclude_dimensions or []) if d and d.strip()]
+        if excluded:
+            placeholders = ", ".join("?" for _ in excluded)
+            where.append(f"LOWER(dimension) NOT IN ({placeholders})")
+            params.extend(excluded)
+        params.append(limit)
         with open_evaluation_db(self._run_dir) as conn:
             conn.row_factory = _dict_row
             rows = conn.execute(
                 f"SELECT {_SELECT_COLUMNS} FROM findings "
-                "WHERE id IN (SELECT rowid FROM findings_fts WHERE findings_fts MATCH ?) "
+                f"WHERE {' AND '.join(where)} "
                 "ORDER BY id LIMIT ?",
-                (fts_query, limit),
+                params,
             ).fetchall()
         return [row_to_finding(r) for r in rows]
 

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -33,7 +33,7 @@ import { ACTIVE_PROVIDER_KEY, providerKey } from './constants.js';
 import ProjectHeader from './components/ProjectHeader.jsx';
 import { useAppState, formatDayLabel } from './hooks/useAppState.js';
 import { useNativeNavBridge } from './hooks/useNativeNavBridge.js';
-import { readVisibleStandardIds } from './utils/visibleStandards.js';
+import { readVisibleStandardIds, hydrateVisibleStandardIds } from './utils/visibleStandards.js';
 import { buildProjectRootFile } from './utils/explorerUtils.js';
 import { filterTrendByVisibleStandards, filterAccumulatedByVisibleStandards } from './utils/scoreFiltering.js';
 import { syncNativeTitlebar } from './utils/nativeTitlebar.js';
@@ -1051,6 +1051,21 @@ export default function App() {
   useEffect(() => {
     const main = document.querySelector('.app-shell__main-column > .dashboard');
     if (main) main.scrollTop = 0;
+  }, [state.selectedProject]);
+
+  // Sync the visible-standards cache (localStorage) with the server's
+  // per-project file whenever the selected project settles. This is the
+  // earliest point at which "the current project" is known, so it runs
+  // before any newly-mounted page reads readVisibleStandardIds() for that
+  // project. It migrates a pre-existing local selection up to the server on
+  // first run and never throws (see hydrateVisibleStandardIds). Note: pages
+  // already mounted with a memoized visible-standards Set (e.g. the sidebar
+  // trend/accumulated filters below, keyed with empty deps) do not
+  // recompute from this — that is a pre-existing limitation of those read
+  // sites, not something this hydration fixes.
+  useEffect(() => {
+    if (!state.selectedProject) return;
+    hydrateVisibleStandardIds(state.selectedProject);
   }, [state.selectedProject]);
 
   const currentDayLabel = useMemo(

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -1063,9 +1063,18 @@ export default function App() {
   // trend/accumulated filters below, keyed with empty deps) do not
   // recompute from this — that is a pre-existing limitation of those read
   // sites, not something this hydration fixes.
+  //
+  // isStale guards a real race: switching A -> B before A's request resolves
+  // must not let A's (now-stale) response overwrite B's selection in the
+  // single, per-browser cache. hydrateVisibleStandardIds checks isStale()
+  // right before every write it makes (including the migration PUT), so
+  // flipping `cancelled` in the cleanup is enough to make a stale response a
+  // no-op.
   useEffect(() => {
     if (!state.selectedProject) return;
-    hydrateVisibleStandardIds(state.selectedProject);
+    let cancelled = false;
+    hydrateVisibleStandardIds(state.selectedProject, { isStale: () => cancelled });
+    return () => { cancelled = true; };
   }, [state.selectedProject]);
 
   const currentDayLabel = useMemo(

--- a/src/quodeq/ui/src/api/standards.js
+++ b/src/quodeq/ui/src/api/standards.js
@@ -128,3 +128,25 @@ export async function putStandardsOverrides(projectId, overrides, { dryRun = fal
     body: JSON.stringify({ overrides }),
   });
 }
+
+/**
+ * Fetch the project's visible-standards selection.
+ * @param {string} projectId
+ * @returns {Promise<{ visibleStandardIds: string[], isDefault: boolean, knownStandardIds: string[] }>}
+ */
+export async function getStandardsVisibility(projectId) {
+  return request(`/projects/${encodeURIComponent(projectId)}/standards-visibility`);
+}
+
+/**
+ * Persist the project's visible-standards selection.
+ * @param {string} projectId
+ * @param {string[]} visibleStandardIds
+ * @returns {Promise<{ visibleStandardIds: string[], isDefault: boolean, knownStandardIds: string[] }>}
+ */
+export async function putStandardsVisibility(projectId, visibleStandardIds) {
+  return request(`/projects/${encodeURIComponent(projectId)}/standards-visibility`, {
+    method: 'PUT',
+    body: JSON.stringify({ visibleStandardIds }),
+  });
+}

--- a/src/quodeq/ui/src/features/evaluation/hooks/usePluginDimensions.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/usePluginDimensions.js
@@ -55,8 +55,13 @@ export function invalidateDimensionCache() {
 }
 
 function _filterVisible(dims) {
-  const visibleSet = new Set(readVisibleStandardIds());
-  return dims.filter((d) => visibleSet.has(d.id));
+  // Lowercase both sides: the server normalizes stored ids to lowercase,
+  // but custom/imported standard ids aren't charset-constrained (e.g.
+  // "OWASP-Top10"), so a raw comparison would drop a visible standard from
+  // the scan dimension picker while the assistant and dashboard correctly
+  // keep it.
+  const visibleSet = new Set(readVisibleStandardIds().map((id) => id.toLowerCase()));
+  return dims.filter((d) => visibleSet.has((d.id || '').toLowerCase()));
 }
 
 /**

--- a/src/quodeq/ui/src/features/evaluation/hooks/usePluginDimensions.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/usePluginDimensions.test.jsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { ApiProvider } from '../../../api/ApiContext.jsx';
+
+vi.mock('../../../utils/visibleStandards.js', () => ({
+  readVisibleStandardIds: vi.fn(),
+}));
+
+const { readVisibleStandardIds } = await import('../../../utils/visibleStandards.js');
+const { usePluginDimensions, invalidateDimensionCache } =
+  await import('./usePluginDimensions.js');
+
+function makeWrapper(fakeApi) {
+  return function Wrapper({ children }) {
+    return <ApiProvider value={fakeApi}>{children}</ApiProvider>;
+  };
+}
+
+describe('usePluginDimensions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateDimensionCache();
+  });
+
+  it('matches a visible-standards id case-insensitively', async () => {
+    // The server normalizes stored ids to lowercase, but a custom/imported
+    // standard's own id isn't charset-constrained (e.g. "OWASP-Top10"). The
+    // stored selection carries the lowercase form; the dimension itself
+    // keeps its original casing. Both sides must be compared lowercase or
+    // the dimension wrongly disappears from the scan picker.
+    readVisibleStandardIds.mockReturnValue(['owasp-top10']);
+    const fakeApi = {
+      listPlugins: vi.fn().mockResolvedValue([
+        { dimensions: [{ id: 'OWASP-Top10', label: 'OWASP Top 10' }] },
+      ]),
+      listStandards: vi.fn().mockResolvedValue([]),
+    };
+    const { result } = renderHook(() => usePluginDimensions(), {
+      wrapper: makeWrapper(fakeApi),
+    });
+    await waitFor(() => expect(result.current.allDimensions).toHaveLength(1));
+    expect(result.current.allDimensions[0].id).toBe('OWASP-Top10');
+  });
+
+  it('filters out a dimension whose id is not in the visible set', async () => {
+    readVisibleStandardIds.mockReturnValue(['security']);
+    const fakeApi = {
+      listPlugins: vi.fn().mockResolvedValue([
+        { dimensions: [{ id: 'OWASP-Top10', label: 'OWASP Top 10' }] },
+      ]),
+      listStandards: vi.fn().mockResolvedValue([]),
+    };
+    const { result } = renderHook(() => usePluginDimensions(), {
+      wrapper: makeWrapper(fakeApi),
+    });
+    await waitFor(() => expect(fakeApi.listPlugins).toHaveBeenCalled());
+    expect(result.current.allDimensions).toHaveLength(0);
+  });
+});

--- a/src/quodeq/ui/src/features/standards/StandardsPage.jsx
+++ b/src/quodeq/ui/src/features/standards/StandardsPage.jsx
@@ -41,8 +41,8 @@ function StandardsListView({ grouped, loading, error, actions, customizedCounts 
 
 export default function StandardsPage({ onRescan }) {
   const { grouped, loading, error, refresh, handleDelete, handleDuplicate } = useStandards();
-  const { isVisible, toggle, add: addVisible, remove: removeVisible } = useVisibleStandards();
   const { selectedProject } = useAppState();
+  const { isVisible, toggle, add: addVisible, remove: removeVisible } = useVisibleStandards({ projectId: selectedProject });
   const { counts: customizedCounts } = useStandardsOverrides(selectedProject);
   const {
     view,

--- a/src/quodeq/ui/src/features/standards/hooks/useVisibleStandards.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useVisibleStandards.js
@@ -3,7 +3,7 @@ import { readVisibleStandardIds, writeVisibleStandardIds } from '../../../utils/
 import { putStandardsVisibility } from '../../../api/standards.js';
 
 export function useVisibleStandards({ storage = localStorage, projectId = null } = {}) {
-  const [visibleIds, setVisibleIds] = useState(readVisibleStandardIds);
+  const [visibleIds, setVisibleIds] = useState(() => readVisibleStandardIds(storage));
 
   const persist = useCallback((next) => {
     writeVisibleStandardIds(next, storage);

--- a/src/quodeq/ui/src/features/standards/hooks/useVisibleStandards.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useVisibleStandards.js
@@ -20,8 +20,14 @@ export function useVisibleStandards({ storage = localStorage, projectId = null }
     });
   }, [persist]);
 
-  const visibleSet = useMemo(() => new Set(visibleIds), [visibleIds]);
-  const isVisible = useCallback((id) => visibleSet.has(id), [visibleSet]);
+  // Lowercase both sides: the server normalizes stored ids to lowercase,
+  // but custom/imported standard ids aren't charset-constrained (e.g.
+  // "OWASP-Top10"), so a raw comparison would read a visible standard as
+  // hidden here while the assistant and dashboard correctly show it.
+  const visibleSet = useMemo(
+    () => new Set(visibleIds.map((id) => id.toLowerCase())), [visibleIds]);
+  const isVisible = useCallback(
+    (id) => visibleSet.has((id || '').toLowerCase()), [visibleSet]);
 
   const add = useCallback((id) => {
     setVisibleIds((prev) => {

--- a/src/quodeq/ui/src/features/standards/hooks/useVisibleStandards.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useVisibleStandards.js
@@ -1,21 +1,24 @@
 import { useState, useCallback, useMemo } from 'react';
-import { VISIBLE_STANDARDS_STORAGE_KEY } from '../../../constants.js';
-import { readVisibleStandardIds } from '../../../utils/visibleStandards.js';
+import { readVisibleStandardIds, writeVisibleStandardIds } from '../../../utils/visibleStandards.js';
+import { putStandardsVisibility } from '../../../api/standards.js';
 
-function writeToStorage(ids, storage = localStorage) {
-  storage.setItem(VISIBLE_STANDARDS_STORAGE_KEY, JSON.stringify(ids));
-}
-
-export function useVisibleStandards({ storage = localStorage } = {}) {
+export function useVisibleStandards({ storage = localStorage, projectId = null } = {}) {
   const [visibleIds, setVisibleIds] = useState(readVisibleStandardIds);
+
+  const persist = useCallback((next) => {
+    writeVisibleStandardIds(next, storage);
+    // Fire-and-forget: the cache is already updated, so a failed write leaves
+    // the UI correct for this session and re-syncs on the next hydrate.
+    if (projectId) putStandardsVisibility(projectId, next).catch(() => {});
+  }, [storage, projectId]);
 
   const toggle = useCallback((id) => {
     setVisibleIds((prev) => {
       const next = prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id];
-      writeToStorage(next, storage);
+      persist(next);
       return next;
     });
-  }, [storage]);
+  }, [persist]);
 
   const visibleSet = useMemo(() => new Set(visibleIds), [visibleIds]);
   const isVisible = useCallback((id) => visibleSet.has(id), [visibleSet]);
@@ -24,19 +27,19 @@ export function useVisibleStandards({ storage = localStorage } = {}) {
     setVisibleIds((prev) => {
       if (prev.includes(id)) return prev;
       const next = [...prev, id];
-      writeToStorage(next, storage);
+      persist(next);
       return next;
     });
-  }, [storage]);
+  }, [persist]);
 
   const remove = useCallback((id) => {
     setVisibleIds((prev) => {
       if (!prev.includes(id)) return prev;
       const next = prev.filter((x) => x !== id);
-      writeToStorage(next, storage);
+      persist(next);
       return next;
     });
-  }, [storage]);
+  }, [persist]);
 
   return { visibleIds, toggle, isVisible, add, remove };
 }

--- a/src/quodeq/ui/src/features/standards/hooks/useVisibleStandards.test.jsx
+++ b/src/quodeq/ui/src/features/standards/hooks/useVisibleStandards.test.jsx
@@ -71,6 +71,17 @@ describe('useVisibleStandards', () => {
     expect(result.current.isVisible('custom-standard')).toBe(true);
   });
 
+  it('isVisible compares mixed-case ids case-insensitively', () => {
+    // The server normalizes stored ids to lowercase, but custom/imported
+    // standard ids aren't charset-constrained (e.g. "OWASP-Top10"). A raw
+    // comparison would read a visible standard as hidden here.
+    const storage = fakeStorage({
+      [VISIBLE_STANDARDS_STORAGE_KEY]: JSON.stringify(['owasp-top10']),
+    });
+    const { result } = renderHook(() => useVisibleStandards({ storage }));
+    expect(result.current.isVisible('OWASP-Top10')).toBe(true);
+  });
+
   it('write-throughs a toggle to the server', async () => {
     const put = vi.spyOn(api, 'putStandardsVisibility').mockResolvedValue({});
     const storage = fakeStorage();

--- a/src/quodeq/ui/src/features/standards/hooks/useVisibleStandards.test.jsx
+++ b/src/quodeq/ui/src/features/standards/hooks/useVisibleStandards.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
+import { VISIBLE_STANDARDS_STORAGE_KEY } from '../../../constants.js';
 
 vi.mock('../../../api/standards.js', () => ({
   putStandardsVisibility: vi.fn(),
@@ -37,6 +38,18 @@ describe('useVisibleStandards', () => {
     expect(JSON.parse(storage._map[Object.keys(storage._map)[0]])).toContain('custom-standard');
     act(() => result.current.toggle('custom-standard'));
     expect(result.current.visibleIds).not.toContain('custom-standard');
+  });
+
+  it('initialises from the injected storage, not the real localStorage', () => {
+    // readVisibleStandardIds(storage) is honored on writes; the initial
+    // useState read must use the same injected storage rather than falling
+    // through to the real, unrelated localStorage.
+    window.localStorage.clear();
+    const storage = fakeStorage({
+      [VISIBLE_STANDARDS_STORAGE_KEY]: JSON.stringify(['custom-only']),
+    });
+    const { result } = renderHook(() => useVisibleStandards({ storage }));
+    expect(result.current.visibleIds).toEqual(['custom-only']);
   });
 
   it('add is idempotent and remove is a no-op when absent', () => {

--- a/src/quodeq/ui/src/features/standards/hooks/useVisibleStandards.test.jsx
+++ b/src/quodeq/ui/src/features/standards/hooks/useVisibleStandards.test.jsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+vi.mock('../../../api/standards.js', () => ({
+  putStandardsVisibility: vi.fn(),
+}));
+
+// Imported AFTER vi.mock so the mocked binding is the one under test —
+// vi.spyOn on the module object does not intercept a direct named import
+// under ESM (visibleStandards.js/useVisibleStandards.js bind
+// putStandardsVisibility at import time).
+const api = await import('../../../api/standards.js');
+const { useVisibleStandards } = await import('./useVisibleStandards.js');
+
+function fakeStorage(initial = {}) {
+  const map = { ...initial };
+  return {
+    getItem: (k) => (k in map ? map[k] : null),
+    setItem: (k, v) => { map[k] = v; },
+    _map: map,
+  };
+}
+
+describe('useVisibleStandards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // 'security' is one of DEFAULT_VISIBLE_STANDARDS (constants.js), so the
+  // hook's initial state already contains it. Use a non-default id here to
+  // exercise add/remove/toggle without fighting that default.
+  it('toggle adds and removes ids, persisting to storage', () => {
+    const storage = fakeStorage();
+    const { result } = renderHook(() => useVisibleStandards({ storage }));
+    act(() => result.current.toggle('custom-standard'));
+    expect(result.current.visibleIds).toContain('custom-standard');
+    expect(JSON.parse(storage._map[Object.keys(storage._map)[0]])).toContain('custom-standard');
+    act(() => result.current.toggle('custom-standard'));
+    expect(result.current.visibleIds).not.toContain('custom-standard');
+  });
+
+  it('add is idempotent and remove is a no-op when absent', () => {
+    const storage = fakeStorage();
+    const { result } = renderHook(() => useVisibleStandards({ storage }));
+    act(() => result.current.add('custom-standard'));
+    const afterFirstAdd = result.current.visibleIds;
+    act(() => result.current.add('custom-standard'));
+    expect(result.current.visibleIds).toBe(afterFirstAdd);
+    act(() => result.current.remove('does-not-exist'));
+    expect(result.current.visibleIds).toBe(afterFirstAdd);
+  });
+
+  it('isVisible reflects the current set', () => {
+    const storage = fakeStorage();
+    const { result } = renderHook(() => useVisibleStandards({ storage }));
+    expect(result.current.isVisible('custom-standard')).toBe(false);
+    act(() => result.current.add('custom-standard'));
+    expect(result.current.isVisible('custom-standard')).toBe(true);
+  });
+
+  it('write-throughs a toggle to the server', async () => {
+    const put = vi.spyOn(api, 'putStandardsVisibility').mockResolvedValue({});
+    const storage = fakeStorage();
+    const { result } = renderHook(() => useVisibleStandards({ storage, projectId: 'p1' }));
+    act(() => result.current.toggle('security'));
+    await waitFor(() => expect(put).toHaveBeenCalledWith('p1', expect.any(Array)));
+  });
+
+  it('does not call the server when no project is selected', () => {
+    const put = vi.spyOn(api, 'putStandardsVisibility');
+    const storage = fakeStorage();
+    const { result } = renderHook(() => useVisibleStandards({ storage, projectId: null }));
+    act(() => result.current.toggle('security'));
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it('does not break the session when the server write fails', async () => {
+    const put = vi.spyOn(api, 'putStandardsVisibility').mockRejectedValue(new Error('offline'));
+    const storage = fakeStorage();
+    const { result } = renderHook(() => useVisibleStandards({ storage, projectId: 'p1' }));
+    act(() => result.current.toggle('custom-standard'));
+    await waitFor(() => expect(put).toHaveBeenCalled());
+    expect(result.current.visibleIds).toContain('custom-standard');
+  });
+});

--- a/src/quodeq/ui/src/utils/visibleStandards.js
+++ b/src/quodeq/ui/src/utils/visibleStandards.js
@@ -21,10 +21,15 @@ export function readVisibleStandardIds(storage = localStorage) {
 // before issuing its GET; if the counter has moved by the time a write would
 // happen, some other write (a toggle's persist(), or another hydrate call)
 // already landed a newer value, and this response is discarded instead of
-// clobbering it. This is a fresh sample per call, not shared mutable state a
-// test could leave dirty for the next one, so no test-only reset is needed:
-// every assertion only cares whether the counter moved *during* a given
-// call, never its absolute value.
+// clobbering it.
+//
+// The counter is module state, so it is only safe across tests because each
+// call compares against its own sample rather than an absolute value, AND
+// every caller awaits its in-flight hydrate before the next one starts. A
+// promise left dangling across a test boundary WOULD trip a later call's
+// check. That invariant is not enforced structurally; if a second caller of
+// hydrateVisibleStandardIds ever appears, or a test stops awaiting, export a
+// test-only reset rather than relying on it.
 let writeGeneration = 0;
 
 /** Write the selection to the local cache. The server is the source of truth. */

--- a/src/quodeq/ui/src/utils/visibleStandards.js
+++ b/src/quodeq/ui/src/utils/visibleStandards.js
@@ -1,6 +1,29 @@
 import { VISIBLE_STANDARDS_STORAGE_KEY, DEFAULT_VISIBLE_STANDARDS } from '../constants.js';
 import { getStandardsVisibility, putStandardsVisibility } from '../api/standards.js';
 
+// Marks that the (per-browser, not per-project) cache has been reconciled
+// with SOME project's own real file -- either because that project already
+// had one (isDefault: false) or because the one-time legacy migration below
+// just created one. Once set, the migration below never fires again: a
+// later project with no file of its own must read as "give me the ISO
+// defaults", not "adopt whatever the previous project's cache happens to
+// hold". Stored in `storage` (not module state) so it rides along with
+// whichever cache it governs, including in tests that inject their own
+// fake storage per test.
+const VISIBLE_STANDARDS_MIGRATED_KEY = 'quodeq-visible-standards-migrated';
+
+function sameIdSet(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b)) return false;
+  if (a.length === 0 && b.length === 0) return true;
+  const setA = new Set(a);
+  const setB = new Set(b);
+  if (setA.size !== setB.size) return false;
+  for (const id of setA) {
+    if (!setB.has(id)) return false;
+  }
+  return true;
+}
+
 /**
  * Read the visible standard IDs from localStorage.
  * Returns the default ISO dimensions if nothing is stored.
@@ -44,7 +67,16 @@ export function writeVisibleStandardIds(ids, storage = localStorage) {
  * localStorage is a cache so the 8 synchronous read sites keep working; the
  * file in the repo is authoritative. On the first run after upgrading, the
  * server has no file yet (isDefault) while the browser may hold a real
- * selection — that one gets pushed up rather than silently lost.
+ * selection — that one gets pushed up rather than silently lost. This
+ * migration is one-shot and per-BROWSER, not per-project: it only fires
+ * while the cache (a) actually differs from the ISO defaults (nothing to
+ * migrate otherwise) and (b) has never been reconciled with any project's
+ * own real file yet (`VISIBLE_STANDARDS_MIGRATED_KEY`). Once either has
+ * happened once, a later project with no file of its own gets the plain ISO
+ * defaults, never another project's ids -- without guard (b), switching
+ * from a project with a real selection to one with none would otherwise
+ * "migrate" the first project's ids into the second project's brand-new
+ * file every time.
  *
  * Never throws: an offline/failed fetch leaves the cached value in place.
  *
@@ -69,16 +101,30 @@ export async function hydrateVisibleStandardIds(projectId, { storage = localStor
   try {
     const { visibleStandardIds, isDefault } = await getStandardsVisibility(projectId);
     if (supersededByNewerWrite()) return readVisibleStandardIds(storage);
-    const cachedRaw = storage.getItem(VISIBLE_STANDARDS_STORAGE_KEY);
-    if (isDefault && cachedRaw) {
-      const cached = JSON.parse(cachedRaw);
-      if (Array.isArray(cached)) {
+    if (isDefault && !storage.getItem(VISIBLE_STANDARDS_MIGRATED_KEY)) {
+      const cachedRaw = storage.getItem(VISIBLE_STANDARDS_STORAGE_KEY);
+      const cached = cachedRaw ? JSON.parse(cachedRaw) : null;
+      // Only a cache that actually differs from the ISO defaults carries
+      // real user intent worth migrating -- a cache that already equals the
+      // defaults (the common case: every project opened so far had no file
+      // of its own either) is nothing but the trailing residue of an
+      // earlier hydrate and must not spawn a file with nothing but the
+      // defaults in it.
+      if (Array.isArray(cached) && !sameIdSet(cached, DEFAULT_VISIBLE_STANDARDS)) {
         const saved = await putStandardsVisibility(projectId, cached);
         if (supersededByNewerWrite()) return readVisibleStandardIds(storage);
         const ids = saved?.visibleStandardIds ?? cached;
+        storage.setItem(VISIBLE_STANDARDS_MIGRATED_KEY, '1');
         writeVisibleStandardIds(ids, storage);
         return ids;
       }
+    }
+    if (!isDefault) {
+      // This project already has its own real file: the cache is now known
+      // to belong to a specific project's synced selection, so it must
+      // never again be read as an unclaimed legacy value up for grabs by
+      // the next project that happens to have no file yet.
+      storage.setItem(VISIBLE_STANDARDS_MIGRATED_KEY, '1');
     }
     writeVisibleStandardIds(visibleStandardIds, storage);
     return visibleStandardIds;

--- a/src/quodeq/ui/src/utils/visibleStandards.js
+++ b/src/quodeq/ui/src/utils/visibleStandards.js
@@ -16,9 +16,21 @@ export function readVisibleStandardIds(storage = localStorage) {
   }
 }
 
+// Monotonic counter bumped by every cache write (this module's own write and
+// hydrate's two write sites). hydrateVisibleStandardIds samples it right
+// before issuing its GET; if the counter has moved by the time a write would
+// happen, some other write (a toggle's persist(), or another hydrate call)
+// already landed a newer value, and this response is discarded instead of
+// clobbering it. This is a fresh sample per call, not shared mutable state a
+// test could leave dirty for the next one, so no test-only reset is needed:
+// every assertion only cares whether the counter moved *during* a given
+// call, never its absolute value.
+let writeGeneration = 0;
+
 /** Write the selection to the local cache. The server is the source of truth. */
 export function writeVisibleStandardIds(ids, storage = localStorage) {
   storage.setItem(VISIBLE_STANDARDS_STORAGE_KEY, JSON.stringify(ids));
+  writeGeneration += 1;
 }
 
 /**
@@ -31,24 +43,33 @@ export function writeVisibleStandardIds(ids, storage = localStorage) {
  *
  * Never throws: an offline/failed fetch leaves the cached value in place.
  *
- * `isStale` guards against a race: if the caller fires this for project A
- * and the user switches to project B before the request resolves, A's
- * response must not land in the (per-browser, not per-project) cache over
- * B's. Pass a function that returns true once the selection this call was
- * for is no longer the current one; it's checked right before every write,
- * including the migration PUT, so a stale call is a no-op past that point.
+ * Two independent guards run right before every write this function makes
+ * (both the normal path and the migration path's post-PUT write):
+ *
+ * - `isStale` guards against the PROJECT changing: if the caller fires this
+ *   for project A and the user switches to project B before the request
+ *   resolves, A's response must not land in the (per-browser, not
+ *   per-project) cache over B's. Pass a function that returns true once the
+ *   selection this call was for is no longer the current one.
+ * - The generation counter guards against a newer WRITE for the SAME
+ *   project already having landed: e.g. this GET was in flight when the
+ *   user toggled a standard, and persist() synchronously wrote and PUT the
+ *   toggle before this GET resolved with pre-toggle server state. `isStale`
+ *   alone can't catch this because the project never changed.
  */
 export async function hydrateVisibleStandardIds(projectId, { storage = localStorage, isStale } = {}) {
   if (!projectId) return readVisibleStandardIds(storage);
+  const generationAtStart = writeGeneration;
+  const supersededByNewerWrite = () => isStale?.() || writeGeneration !== generationAtStart;
   try {
     const { visibleStandardIds, isDefault } = await getStandardsVisibility(projectId);
-    if (isStale?.()) return readVisibleStandardIds(storage);
+    if (supersededByNewerWrite()) return readVisibleStandardIds(storage);
     const cachedRaw = storage.getItem(VISIBLE_STANDARDS_STORAGE_KEY);
     if (isDefault && cachedRaw) {
       const cached = JSON.parse(cachedRaw);
       if (Array.isArray(cached)) {
         const saved = await putStandardsVisibility(projectId, cached);
-        if (isStale?.()) return readVisibleStandardIds(storage);
+        if (supersededByNewerWrite()) return readVisibleStandardIds(storage);
         const ids = saved?.visibleStandardIds ?? cached;
         writeVisibleStandardIds(ids, storage);
         return ids;
@@ -56,7 +77,13 @@ export async function hydrateVisibleStandardIds(projectId, { storage = localStor
     }
     writeVisibleStandardIds(visibleStandardIds, storage);
     return visibleStandardIds;
-  } catch {
+  } catch (err) {
+    // Covers both an offline/failed fetch (expected, cache stays put) and a
+    // genuine bug such as a response-shape change throwing a TypeError. The
+    // two aren't cheaply distinguishable here (fetch failures and shape-change
+    // errors can both surface as TypeError), so we warn for both rather than
+    // let a real regression degrade invisibly to "serve stale cache forever".
+    console.warn('hydrateVisibleStandardIds: falling back to cached value', err);
     return readVisibleStandardIds(storage);
   }
 }

--- a/src/quodeq/ui/src/utils/visibleStandards.js
+++ b/src/quodeq/ui/src/utils/visibleStandards.js
@@ -1,4 +1,5 @@
 import { VISIBLE_STANDARDS_STORAGE_KEY, DEFAULT_VISIBLE_STANDARDS } from '../constants.js';
+import { getStandardsVisibility, putStandardsVisibility } from '../api/standards.js';
 
 /**
  * Read the visible standard IDs from localStorage.
@@ -12,6 +13,42 @@ export function readVisibleStandardIds(storage = localStorage) {
     return Array.isArray(parsed) ? parsed : DEFAULT_VISIBLE_STANDARDS;
   } catch {
     return DEFAULT_VISIBLE_STANDARDS;
+  }
+}
+
+/** Write the selection to the local cache. The server is the source of truth. */
+export function writeVisibleStandardIds(ids, storage = localStorage) {
+  storage.setItem(VISIBLE_STANDARDS_STORAGE_KEY, JSON.stringify(ids));
+}
+
+/**
+ * Sync the local cache with the server for a project.
+ *
+ * localStorage is a cache so the 8 synchronous read sites keep working; the
+ * file in the repo is authoritative. On the first run after upgrading, the
+ * server has no file yet (isDefault) while the browser may hold a real
+ * selection — that one gets pushed up rather than silently lost.
+ *
+ * Never throws: an offline/failed fetch leaves the cached value in place.
+ */
+export async function hydrateVisibleStandardIds(projectId, { storage = localStorage } = {}) {
+  if (!projectId) return readVisibleStandardIds(storage);
+  try {
+    const { visibleStandardIds, isDefault } = await getStandardsVisibility(projectId);
+    const cachedRaw = storage.getItem(VISIBLE_STANDARDS_STORAGE_KEY);
+    if (isDefault && cachedRaw) {
+      const cached = JSON.parse(cachedRaw);
+      if (Array.isArray(cached)) {
+        const saved = await putStandardsVisibility(projectId, cached);
+        const ids = saved?.visibleStandardIds ?? cached;
+        writeVisibleStandardIds(ids, storage);
+        return ids;
+      }
+    }
+    writeVisibleStandardIds(visibleStandardIds, storage);
+    return visibleStandardIds;
+  } catch {
+    return readVisibleStandardIds(storage);
   }
 }
 

--- a/src/quodeq/ui/src/utils/visibleStandards.js
+++ b/src/quodeq/ui/src/utils/visibleStandards.js
@@ -30,16 +30,25 @@ export function writeVisibleStandardIds(ids, storage = localStorage) {
  * selection — that one gets pushed up rather than silently lost.
  *
  * Never throws: an offline/failed fetch leaves the cached value in place.
+ *
+ * `isStale` guards against a race: if the caller fires this for project A
+ * and the user switches to project B before the request resolves, A's
+ * response must not land in the (per-browser, not per-project) cache over
+ * B's. Pass a function that returns true once the selection this call was
+ * for is no longer the current one; it's checked right before every write,
+ * including the migration PUT, so a stale call is a no-op past that point.
  */
-export async function hydrateVisibleStandardIds(projectId, { storage = localStorage } = {}) {
+export async function hydrateVisibleStandardIds(projectId, { storage = localStorage, isStale } = {}) {
   if (!projectId) return readVisibleStandardIds(storage);
   try {
     const { visibleStandardIds, isDefault } = await getStandardsVisibility(projectId);
+    if (isStale?.()) return readVisibleStandardIds(storage);
     const cachedRaw = storage.getItem(VISIBLE_STANDARDS_STORAGE_KEY);
     if (isDefault && cachedRaw) {
       const cached = JSON.parse(cachedRaw);
       if (Array.isArray(cached)) {
         const saved = await putStandardsVisibility(projectId, cached);
+        if (isStale?.()) return readVisibleStandardIds(storage);
         const ids = saved?.visibleStandardIds ?? cached;
         writeVisibleStandardIds(ids, storage);
         return ids;

--- a/src/quodeq/ui/src/utils/visibleStandards.test.jsx
+++ b/src/quodeq/ui/src/utils/visibleStandards.test.jsx
@@ -98,6 +98,57 @@ it('does not write a stale project response over the current project\'s cache (r
   expect(JSON.parse(storage._map[VISIBLE_STANDARDS_STORAGE_KEY])).toEqual(['reliability']);
 });
 
+it('does not migrate when the cached selection already equals the defaults', async () => {
+  // Distinct from the "no cachedRaw" case below: here cachedRaw IS present,
+  // but it carries no real user intent because it's set-equal to the ISO
+  // defaults (e.g. left over from a previous project that also had no
+  // file). PUTting it would create an untracked
+  // .quodeq/standards-visibility.json with nothing but the defaults in it.
+  getStandardsVisibility.mockResolvedValue({
+    visibleStandardIds: [...DEFAULT_VISIBLE_STANDARDS], isDefault: true,
+  });
+  const storage = fakeStorage({
+    // Reordered/duplicated but set-equal to the defaults.
+    [VISIBLE_STANDARDS_STORAGE_KEY]: JSON.stringify(
+      [...DEFAULT_VISIBLE_STANDARDS].reverse()),
+  });
+  const ids = await hydrateVisibleStandardIds('p1', { storage });
+  expect(putStandardsVisibility).not.toHaveBeenCalled();
+  expect(ids).toEqual(DEFAULT_VISIBLE_STANDARDS);
+});
+
+it('does not let a project switch bleed one project\'s selection into another (cross-project bleed)', async () => {
+  // The regression this guards: project A has a real, already-synced
+  // selection (its own file, isDefault: false). The user then switches to
+  // project B, which has no file yet (isDefault: true). B must get the ISO
+  // defaults, NOT A's ids pushed into a brand-new file in B's repo -- the
+  // shared (per-browser, not per-project) localStorage cache must not be
+  // read as "B's own pending migration" just because A's hydrate happened
+  // to leave a non-default value sitting in it.
+  getStandardsVisibility.mockImplementation((projectId) => {
+    if (projectId === 'A') {
+      return Promise.resolve({
+        visibleStandardIds: ['maintainability', 'usability'], isDefault: false,
+      });
+    }
+    return Promise.resolve({
+      visibleStandardIds: [...DEFAULT_VISIBLE_STANDARDS], isDefault: true,
+    });
+  });
+  const storage = fakeStorage();
+
+  await hydrateVisibleStandardIds('A', { storage });
+  expect(JSON.parse(storage._map[VISIBLE_STANDARDS_STORAGE_KEY]))
+    .toEqual(['maintainability', 'usability']);
+
+  const idsForB = await hydrateVisibleStandardIds('B', { storage });
+
+  expect(putStandardsVisibility).not.toHaveBeenCalled();
+  expect(idsForB).toEqual(DEFAULT_VISIBLE_STANDARDS);
+  expect(JSON.parse(storage._map[VISIBLE_STANDARDS_STORAGE_KEY]))
+    .toEqual(DEFAULT_VISIBLE_STANDARDS);
+});
+
 it('does not migrate when isDefault is true but there is no cached selection to migrate', async () => {
   // Case 3 of the migration matrix: isDefault true, but cachedRaw is absent
   // (fresh browser, nothing to push up) rather than isDefault being false.

--- a/src/quodeq/ui/src/utils/visibleStandards.test.jsx
+++ b/src/quodeq/ui/src/utils/visibleStandards.test.jsx
@@ -8,7 +8,7 @@ vi.mock('../api/standards.js', () => ({
 
 // Imported AFTER vi.mock so the mocked bindings are the ones under test.
 const { getStandardsVisibility, putStandardsVisibility } = await import('../api/standards.js');
-const { hydrateVisibleStandardIds, readVisibleStandardIds } =
+const { hydrateVisibleStandardIds, readVisibleStandardIds, writeVisibleStandardIds } =
   await import('./visibleStandards.js');
 
 function fakeStorage(initial = {}) {
@@ -96,6 +96,56 @@ it('does not write a stale project response over the current project\'s cache (r
   await hydrateA;
 
   expect(JSON.parse(storage._map[VISIBLE_STANDARDS_STORAGE_KEY])).toEqual(['reliability']);
+});
+
+it('does not migrate when isDefault is true but there is no cached selection to migrate', async () => {
+  // Case 3 of the migration matrix: isDefault true, but cachedRaw is absent
+  // (fresh browser, nothing to push up) rather than isDefault being false.
+  // Distinct from "does not migrate when the server already has a saved
+  // selection" above, which takes the false branch for the opposite reason.
+  getStandardsVisibility.mockResolvedValue({
+    visibleStandardIds: [...DEFAULT_VISIBLE_STANDARDS], isDefault: true,
+  });
+  const storage = fakeStorage();
+  const ids = await hydrateVisibleStandardIds('p1', { storage });
+  expect(putStandardsVisibility).not.toHaveBeenCalled();
+  expect(ids).toEqual(DEFAULT_VISIBLE_STANDARDS);
+  expect(JSON.parse(storage._map[VISIBLE_STANDARDS_STORAGE_KEY])).toEqual(DEFAULT_VISIBLE_STANDARDS);
+});
+
+it('does not let a hydrate GET overwrite a same-project toggle that persisted while it was in flight (race)', async () => {
+  // Reproduces the reviewer's sequence:
+  //   1. hydrate(P) fires its GET; it's slow.
+  //   2. Before it resolves, the user toggles a standard on the Standards
+  //      page. persist() synchronously writes the new list to the cache and
+  //      PUTs it — the server is now updated too.
+  //   3. The earlier GET resolves carrying PRE-TOGGLE server state.
+  // isStale() alone can't catch this: the project never changed, only P's
+  // own value did. The cache must end up holding the TOGGLED value, not the
+  // stale GET response.
+  let resolveGet;
+  const getPromise = new Promise((resolve) => { resolveGet = resolve; });
+  getStandardsVisibility.mockImplementation(() => getPromise);
+
+  const storage = fakeStorage({
+    [VISIBLE_STANDARDS_STORAGE_KEY]: JSON.stringify(['security']),
+  });
+
+  // isStale never trips here: same project throughout, mirroring the report.
+  const hydrate = hydrateVisibleStandardIds('p1', { storage, isStale: () => false });
+
+  // Simulates useVisibleStandards' persist(): synchronous cache write, then
+  // a PUT (fire-and-forget from the caller's perspective, already resolved
+  // here since it's mocked).
+  writeVisibleStandardIds(['security', 'reliability'], storage);
+  await putStandardsVisibility('p1', ['security', 'reliability']);
+
+  // The slow GET now resolves with the state the server had BEFORE the
+  // toggle above.
+  resolveGet({ visibleStandardIds: ['security'], isDefault: false });
+  await hydrate;
+
+  expect(JSON.parse(storage._map[VISIBLE_STANDARDS_STORAGE_KEY])).toEqual(['security', 'reliability']);
 });
 
 it('does not fire the migration PUT for a project the user has left', async () => {

--- a/src/quodeq/ui/src/utils/visibleStandards.test.jsx
+++ b/src/quodeq/ui/src/utils/visibleStandards.test.jsx
@@ -70,3 +70,52 @@ it('leaves the cached value in place when the request fails', async () => {
   expect(ids).toEqual(['security']);
   expect(readVisibleStandardIds(storage)).toEqual(['security']);
 });
+
+it('does not write a stale project response over the current project\'s cache (race)', async () => {
+  // Mirrors the App.jsx effect: each in-flight hydrate is given an isStale()
+  // predicate that flips true once the selected project moves on. Project A
+  // is still in flight when the user switches to B; B resolves first and
+  // caches its own selection; A resolves last and must be ignored.
+  let currentProject = 'A';
+  const isStaleFor = (projectId) => () => currentProject !== projectId;
+
+  let resolveA;
+  const aPromise = new Promise((resolve) => { resolveA = resolve; });
+  getStandardsVisibility.mockImplementation((projectId) => (
+    projectId === 'A' ? aPromise : Promise.resolve({ visibleStandardIds: ['reliability'], isDefault: false })
+  ));
+
+  const storage = fakeStorage();
+  const hydrateA = hydrateVisibleStandardIds('A', { storage, isStale: isStaleFor('A') });
+
+  currentProject = 'B';
+  await hydrateVisibleStandardIds('B', { storage, isStale: isStaleFor('B') });
+  expect(JSON.parse(storage._map[VISIBLE_STANDARDS_STORAGE_KEY])).toEqual(['reliability']);
+
+  resolveA({ visibleStandardIds: ['security'], isDefault: false });
+  await hydrateA;
+
+  expect(JSON.parse(storage._map[VISIBLE_STANDARDS_STORAGE_KEY])).toEqual(['reliability']);
+});
+
+it('does not fire the migration PUT for a project the user has left', async () => {
+  let currentProject = 'A';
+  const isStaleFor = (projectId) => () => currentProject !== projectId;
+
+  let resolveA;
+  const aPromise = new Promise((resolve) => { resolveA = resolve; });
+  getStandardsVisibility.mockImplementation((projectId) => (
+    projectId === 'A' ? aPromise : Promise.resolve({ visibleStandardIds: [...DEFAULT_VISIBLE_STANDARDS], isDefault: true })
+  ));
+
+  const storage = fakeStorage({
+    [VISIBLE_STANDARDS_STORAGE_KEY]: JSON.stringify(['security']),
+  });
+  const hydrateA = hydrateVisibleStandardIds('A', { storage, isStale: isStaleFor('A') });
+
+  currentProject = 'B';
+  resolveA({ visibleStandardIds: [...DEFAULT_VISIBLE_STANDARDS], isDefault: true });
+  await hydrateA;
+
+  expect(putStandardsVisibility).not.toHaveBeenCalled();
+});

--- a/src/quodeq/ui/src/utils/visibleStandards.test.jsx
+++ b/src/quodeq/ui/src/utils/visibleStandards.test.jsx
@@ -1,0 +1,72 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+import { VISIBLE_STANDARDS_STORAGE_KEY, DEFAULT_VISIBLE_STANDARDS } from '../constants.js';
+
+vi.mock('../api/standards.js', () => ({
+  getStandardsVisibility: vi.fn(),
+  putStandardsVisibility: vi.fn(),
+}));
+
+// Imported AFTER vi.mock so the mocked bindings are the ones under test.
+const { getStandardsVisibility, putStandardsVisibility } = await import('../api/standards.js');
+const { hydrateVisibleStandardIds, readVisibleStandardIds } =
+  await import('./visibleStandards.js');
+
+function fakeStorage(initial = {}) {
+  const map = { ...initial };
+  return {
+    getItem: (k) => (k in map ? map[k] : null),
+    setItem: (k, v) => { map[k] = v; },
+    _map: map,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+it('caches the server selection into storage', async () => {
+  getStandardsVisibility.mockResolvedValue({
+    visibleStandardIds: ['security'], isDefault: false,
+  });
+  const storage = fakeStorage();
+  const ids = await hydrateVisibleStandardIds('p1', { storage });
+  expect(ids).toEqual(['security']);
+  expect(JSON.parse(storage._map[VISIBLE_STANDARDS_STORAGE_KEY])).toEqual(['security']);
+});
+
+it('migrates an existing local selection up to the server once', async () => {
+  getStandardsVisibility.mockResolvedValue({
+    visibleStandardIds: [...DEFAULT_VISIBLE_STANDARDS], isDefault: true,
+  });
+  putStandardsVisibility.mockResolvedValue({
+    visibleStandardIds: ['security'], isDefault: false,
+  });
+  const storage = fakeStorage({
+    [VISIBLE_STANDARDS_STORAGE_KEY]: JSON.stringify(['security']),
+  });
+  const ids = await hydrateVisibleStandardIds('p1', { storage });
+  expect(putStandardsVisibility).toHaveBeenCalledWith('p1', ['security']);
+  expect(ids).toEqual(['security']);
+});
+
+it('does not migrate when the server already has a saved selection', async () => {
+  getStandardsVisibility.mockResolvedValue({
+    visibleStandardIds: ['reliability'], isDefault: false,
+  });
+  const storage = fakeStorage({
+    [VISIBLE_STANDARDS_STORAGE_KEY]: JSON.stringify(['security']),
+  });
+  const ids = await hydrateVisibleStandardIds('p1', { storage });
+  expect(putStandardsVisibility).not.toHaveBeenCalled();
+  expect(ids).toEqual(['reliability']);
+});
+
+it('leaves the cached value in place when the request fails', async () => {
+  getStandardsVisibility.mockRejectedValue(new Error('offline'));
+  const storage = fakeStorage({
+    [VISIBLE_STANDARDS_STORAGE_KEY]: JSON.stringify(['security']),
+  });
+  const ids = await hydrateVisibleStandardIds('p1', { storage });
+  expect(ids).toEqual(['security']);
+  expect(readVisibleStandardIds(storage)).toEqual(['security']);
+});

--- a/tests/api/test_assistant_shared_sessions.py
+++ b/tests/api/test_assistant_shared_sessions.py
@@ -99,15 +99,17 @@ def test_shared_get_scores_matches_shared_route(client, app, shared_clone_fixtur
     #   - ToolRegistry.dispatch wraps the handler's return in {"ok", "result"};
     #     it never itself nests a "dimensions" key, so the tool payload is
     #     read from tool_result["result"], not tool_result["dimensions"].
-    #   - _get_scores (tools/_read_tools.py) returns a dict KEYED BY dimension
-    #     name (`{"Security": {"score": ..., "grade": ..., "fromRun": ...}}`),
-    #     not a list of {"dimension": ...} objects -- so the tool's dimension
-    #     set is the dict's keys.
+    #   - _get_scores (tools/_read_tools.py) returns {"scores": {dimension:
+    #     {"score": ..., "grade": ..., "fromRun": ...}}, "hiddenStandardIds":
+    #     [...]} -- the per-dimension map moved under "scores" so it can sit
+    #     alongside "hiddenStandardIds" without mixing a non-dimension key
+    #     into a dict callers iterate. The tool's dimension set is
+    #     result["scores"]'s keys, not result's own keys.
     #   - GET /api/shared/projects/<project>/scores (get_project_scores) nests
     #     its dimension list under "accumulated" (`{"accumulated": {"dimensions":
     #     [...]}, "trend": [...], "availableRuns": [...]}`), not at the
     #     response's top level.
-    tool_dims = set(tool_result.get("result", {}).keys())
+    tool_dims = set(tool_result.get("result", {}).get("scores", {}).keys())
     route_dims = {d.get("dimension") for d in route.get("accumulated", {}).get("dimensions", [])}
     assert tool_dims == route_dims and "Security" in tool_dims
     # Score-cache isolation: rescoring under the override hits the per-clone

--- a/tests/api/test_standards_visibility_routes.py
+++ b/tests/api/test_standards_visibility_routes.py
@@ -1,0 +1,109 @@
+"""Tests for GET/PUT /api/projects/<project_id>/standards-visibility."""
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.api.app import create_app
+from quodeq.core.standards.visibility import DEFAULT_VISIBLE_STANDARDS, VISIBILITY_RELPATH
+
+# PUT is a state-changing request; the CSRF check in quodeq.api.security
+# requires a same-origin Origin header on it (see
+# tests/api/test_standards_overrides_routes.py's identical _LOCALHOST use).
+_LOCALHOST = {"Origin": "http://localhost"}
+
+
+@pytest.fixture()
+def project_id() -> str:
+    return "proj-1"
+
+
+@pytest.fixture()
+def detached_project_id() -> str:
+    """A project id with no local working copy, driving the 404 branch."""
+    return "proj-detached"
+
+
+@pytest.fixture()
+def repo_root(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture()
+def client(repo_root: Path, project_id: str, monkeypatch: pytest.MonkeyPatch):
+    """A test client with no STANDARDS_* overrides, so knownStandardIds comes
+    from the real bundled compiled standards (security, clean-architecture,
+    etc.) -- unlike test_standards_overrides_routes.py's client, which stubs
+    a tiny compiled dir because it only cares about override validation
+    against specific params, not the full known-id catalog.
+    """
+    app = create_app(test_config={"TESTING": True})
+
+    import quodeq.api.standards_visibility_routes as _mod
+    monkeypatch.setattr(
+        _mod, "resolve_repo_root",
+        lambda pid: str(repo_root) if pid == project_id else None,
+    )
+
+    with app.test_client() as c:
+        yield c
+
+
+def test_get_returns_defaults_when_no_file(client, project_id):
+    resp = client.get(f"/api/projects/{project_id}/standards-visibility")
+    assert resp.status_code == 200
+    assert resp.get_json()["visibleStandardIds"] == list(DEFAULT_VISIBLE_STANDARDS)
+    assert resp.get_json()["isDefault"] is True
+
+
+def test_get_reports_known_standard_ids(client, project_id):
+    body = client.get(f"/api/projects/{project_id}/standards-visibility").get_json()
+    assert "security" in body["knownStandardIds"]
+    assert "clean-architecture" in body["knownStandardIds"]
+
+
+def test_put_persists_and_get_reads_back(client, project_id, repo_root):
+    resp = client.put(f"/api/projects/{project_id}/standards-visibility",
+                       json={"visibleStandardIds": ["security", "clean-architecture"]},
+                       headers=_LOCALHOST)
+    assert resp.status_code == 200
+    assert resp.get_json()["isDefault"] is False
+    saved = json.loads((repo_root / VISIBILITY_RELPATH).read_text(encoding="utf-8"))
+    assert saved == {"version": 1,
+                     "visibleStandardIds": ["security", "clean-architecture"]}
+    again = client.get(f"/api/projects/{project_id}/standards-visibility").get_json()
+    assert again["visibleStandardIds"] == ["security", "clean-architecture"]
+
+
+def test_put_rejects_unknown_standard(client, project_id, repo_root):
+    resp = client.put(f"/api/projects/{project_id}/standards-visibility",
+                       json={"visibleStandardIds": ["not-a-standard"]},
+                       headers=_LOCALHOST)
+    assert resp.status_code == 400
+    assert resp.get_json()["code"] == "invalid_visibility"
+    assert not (repo_root / VISIBILITY_RELPATH).exists()
+
+
+def test_put_rejects_missing_key(client, project_id):
+    resp = client.put(f"/api/projects/{project_id}/standards-visibility", json={},
+                       headers=_LOCALHOST)
+    assert resp.status_code == 400
+    assert resp.get_json()["code"] == "bad_request"
+
+
+def test_put_accepts_empty_selection(client, project_id, repo_root):
+    resp = client.put(f"/api/projects/{project_id}/standards-visibility",
+                       json={"visibleStandardIds": []},
+                       headers=_LOCALHOST)
+    assert resp.status_code == 200
+    assert resp.get_json()["visibleStandardIds"] == []
+    assert (repo_root / VISIBILITY_RELPATH).is_file()
+
+
+def test_routes_404_when_project_has_no_local_repo(client, detached_project_id):
+    for call in (client.get, client.put):
+        resp = call(f"/api/projects/{detached_project_id}/standards-visibility",
+                    json={"visibleStandardIds": []}, headers=_LOCALHOST)
+        assert resp.status_code == 404

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -39,3 +39,8 @@ def test_system_prompt_guides_cli_agents_to_quodeq_context_tools():
     assert "Call get_context first" in prompt
     assert "retry once" in prompt
     assert "read_repo_file" in prompt
+
+
+def test_system_prompt_explains_hidden_standards():
+    prompt = build_system_prompt()
+    assert "hiddenStandardIds" in prompt

--- a/tests/assistant/test_tool_context_visibility.py
+++ b/tests/assistant/test_tool_context_visibility.py
@@ -10,6 +10,8 @@ brief, which don't exist in this repo.
 """
 from __future__ import annotations
 
+import argparse
+
 from flask import Flask
 
 from quodeq.api._assistant_helpers import build_tool_context
@@ -137,74 +139,67 @@ def test_api_helper_shared_session_never_falls_back_to_a_local_repo_root(
     assert called == []
 
 
-def _mcp_context_from_namespace(ns, tmp_path):
-    """Mirror the context construction from _build_registry_from_args.
-
-    Used to test the MCP path's context wiring without modifying the source.
-    Tests the same load_visible_standard_ids call that _build_registry_from_args uses.
+def _capture_ctx(monkeypatch):
+    """Patch the module-level ToolContext in server.py with a capturing spy,
+    so a test can call the real _build_registry_from_args and then assert on
+    the ToolContext it actually constructed (build_registry itself doesn't
+    expose ctx, so this is the only way to observe it without touching the
+    source).
     """
-    from pathlib import Path
-    from quodeq.shared._env import get_evaluations_dir
-    from quodeq.core.standards.visibility import load_visible_standard_ids
+    from quodeq.assistant.mcp import server as mcp_server
+    captured = {}
+    real = mcp_server.ToolContext
 
-    if ns.reports_dir:
-        reports_dir = Path(ns.reports_dir)
-    else:
-        reports_dir = Path(get_evaluations_dir())
-    repo_root = Path(ns.repo_root) if ns.repo_root else None
-    return ToolContext(
-        repository=AssistantRepository(Path(ns.db_path)),
-        session_id=ns.session_id,
-        run_dir=Path(ns.run_dir) if ns.run_dir else None,
-        repo_root=repo_root,
-        evaluators_dir=Path(ns.evaluators_dir),
-        compiled_dir=Path(ns.compiled_dir),
-        dimensions_file=Path(ns.dimensions_file),
-        project_id=ns.project_id or None,
-        reports_dir=reports_dir,
+    def spy(**kwargs):
+        ctx = real(**kwargs)
+        captured["ctx"] = ctx
+        return ctx
+
+    monkeypatch.setattr(mcp_server, "ToolContext", spy)
+    return captured
+
+
+def _mcp_namespace(tmp_path, **kw):
+    base = dict(
+        db_path=str(tmp_path / "a.db"),
+        session_id="mcp-test",
+        run_dir=None,
+        repo_root=None,
+        evaluators_dir=str(tmp_path / "e"),
+        compiled_dir=str(tmp_path / "c"),
+        dimensions_file=str(tmp_path / "d.json"),
+        project_id=None,
+        reports_dir="",
+        enable_write=False,
         worktree_dir=None,
         read_only=False,
-        visible_standard_ids=(
-            load_visible_standard_ids(repo_root) if repo_root is not None else None),
     )
+    base.update(kw)
+    return argparse.Namespace(**base)
 
 
-def test_mcp_path_loads_saved_selection(tmp_path):
-    """MCP path (via _build_registry_from_args) loads standards-visibility.json."""
-    import argparse
+def test_mcp_path_loads_saved_selection(tmp_path, monkeypatch):
+    """_build_registry_from_args loads standards-visibility.json onto ToolContext."""
+    from quodeq.assistant.mcp.server import _build_registry_from_args
+
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
     save_visible_standard_ids(repo_root, ["security", "clean-architecture"])
 
-    ns = argparse.Namespace(
-        db_path=str(tmp_path / "a.db"),
-        session_id="mcp-test",
-        run_dir=None,
-        repo_root=str(repo_root),
-        evaluators_dir=str(tmp_path / "e"),
-        compiled_dir=str(tmp_path / "c"),
-        dimensions_file=str(tmp_path / "d.json"),
-        project_id=None,
-        reports_dir="",
-    )
-    ctx = _mcp_context_from_namespace(ns, tmp_path)
-    assert ctx.visible_standard_ids == ("security", "clean-architecture")
+    captured = _capture_ctx(monkeypatch)
+    ns = _mcp_namespace(tmp_path, repo_root=str(repo_root))
+    _build_registry_from_args(ns)
+
+    assert captured["ctx"].visible_standard_ids == ("security", "clean-architecture")
 
 
-def test_mcp_path_no_repo_root_yields_none(tmp_path):
-    """MCP path with no --repo-root carries None (no filtering)."""
-    import argparse
-    ns = argparse.Namespace(
-        db_path=str(tmp_path / "a.db"),
-        session_id="mcp-test",
-        run_dir=None,
-        repo_root=None,  # No repo root
-        evaluators_dir=str(tmp_path / "e"),
-        compiled_dir=str(tmp_path / "c"),
-        dimensions_file=str(tmp_path / "d.json"),
-        project_id=None,
-        reports_dir="",
-    )
-    ctx = _mcp_context_from_namespace(ns, tmp_path)
-    assert ctx.repo_root is None
-    assert ctx.visible_standard_ids is None
+def test_mcp_path_no_repo_root_yields_none(tmp_path, monkeypatch):
+    """_build_registry_from_args with no --repo-root carries None (no filtering)."""
+    from quodeq.assistant.mcp.server import _build_registry_from_args
+
+    captured = _capture_ctx(monkeypatch)
+    ns = _mcp_namespace(tmp_path, repo_root=None)
+    _build_registry_from_args(ns)
+
+    assert captured["ctx"].repo_root is None
+    assert captured["ctx"].visible_standard_ids is None

--- a/tests/assistant/test_tool_context_visibility.py
+++ b/tests/assistant/test_tool_context_visibility.py
@@ -1,0 +1,137 @@
+"""ToolContext carries the visible-standards selection; build_tool_context
+(the API construction site) resolves it from the project's
+``.quodeq/standards-visibility.json``.
+
+tests/assistant has no conftest.py, and the suite's convention is a small
+local ``_ctx``/fixture helper per file (see test_registry.py, test_tools_
+overview.py) rather than shared factories -- followed here instead of the
+``tool_context_factory``/``api_tool_context`` names sketched in the task
+brief, which don't exist in this repo.
+"""
+from __future__ import annotations
+
+from flask import Flask
+
+from quodeq.api._assistant_helpers import build_tool_context
+from quodeq.assistant.tools._context import ToolContext
+from quodeq.core.standards.visibility import (
+    DEFAULT_VISIBLE_STANDARDS,
+    save_visible_standard_ids,
+)
+from quodeq.data.sqlite.assistant_repository import AssistantRepository
+from quodeq.services.shared_settings import SharedSettings
+
+
+def _ctx(tmp_path, **kw):
+    return ToolContext(
+        repository=AssistantRepository(tmp_path / "assistant.db"),
+        session_id="s", run_dir=None, repo_root=None,
+        evaluators_dir=tmp_path, compiled_dir=tmp_path,
+        dimensions_file=tmp_path / "dims.json", **kw)
+
+
+def test_field_defaults_to_none(tmp_path):
+    """None == no filtering, so every existing caller keeps today's behaviour."""
+    assert _ctx(tmp_path).visible_standard_ids is None
+
+
+def test_field_accepts_a_tuple(tmp_path):
+    ctx = _ctx(tmp_path, visible_standard_ids=("security",))
+    assert ctx.visible_standard_ids == ("security",)
+
+
+def _app(tmp_path):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["ASSISTANT_DB_PATH"] = str(tmp_path / "assistant.db")
+    app.config["STANDARDS_EVALUATORS_DIR"] = str(tmp_path / "evaluators")
+    app.config["STANDARDS_COMPILED_DIR"] = str(tmp_path / "compiled")
+    app.config["STANDARDS_DIMENSIONS_FILE"] = str(tmp_path / "dimensions.json")
+    return app
+
+
+def _session(**kw):
+    base = {"id": "s1", "run_id": None, "source": "local",
+            "project_uuid": None, "project_id": None}
+    base.update(kw)
+    return base
+
+
+def test_api_helper_loads_defaults_for_a_repo_without_a_file(tmp_path):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    app = _app(tmp_path)
+    with app.app_context():
+        ctx = build_tool_context(app, _session(project_uuid=str(repo_root)))
+    assert ctx.visible_standard_ids == DEFAULT_VISIBLE_STANDARDS
+
+
+def test_api_helper_loads_the_saved_selection(tmp_path):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    save_visible_standard_ids(repo_root, ["security", "clean-architecture"])
+    app = _app(tmp_path)
+    with app.app_context():
+        ctx = build_tool_context(app, _session(project_uuid=str(repo_root)))
+    assert ctx.visible_standard_ids == ("security", "clean-architecture")
+
+
+def test_api_helper_leaves_none_when_no_repo_resolves(tmp_path):
+    app = _app(tmp_path)
+    with app.app_context():
+        ctx = build_tool_context(app, _session(project_uuid=None, project_id=None))
+    assert ctx.repo_root is None
+    assert ctx.visible_standard_ids is None
+
+
+def test_api_helper_resolves_repo_root_via_project_id_fallback(tmp_path, monkeypatch):
+    # Overview-scoped sessions carry project_id with no project_uuid (the
+    # reason build_tool_context grew the fallback); the selection must still
+    # resolve for them, not just for run/repo-scoped sessions.
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    save_visible_standard_ids(repo_root, ["performance"])
+    monkeypatch.setattr(
+        "quodeq.api._assistant_helpers.resolve_repo_root",
+        lambda project_id: str(repo_root) if project_id == "proj-x" else None,
+    )
+    app = _app(tmp_path)
+    with app.app_context():
+        ctx = build_tool_context(
+            app, _session(project_uuid=None, project_id="proj-x"))
+    assert ctx.repo_root == repo_root
+    assert ctx.visible_standard_ids == ("performance",)
+
+
+def test_api_helper_shared_session_never_falls_back_to_a_local_repo_root(
+        tmp_path, monkeypatch):
+    # Shared sessions are guaranteed no local working copy at session-creation
+    # time (assistant_routes.create_session's shared branch never resolves a
+    # repo_root even when projectId is given). The project_id fallback added
+    # for the overview case above must not quietly undo that guarantee just
+    # because a same-named local project happens to exist on this machine.
+    called = []
+    monkeypatch.setattr(
+        "quodeq.api._assistant_helpers.resolve_repo_root",
+        lambda project_id: called.append(project_id) or str(tmp_path),
+    )
+    monkeypatch.setattr(
+        "quodeq.api._assistant_helpers.read_settings",
+        lambda: SharedSettings(url="file:///fake-origin.git"),
+    )
+    monkeypatch.setattr("quodeq.api._assistant_helpers.read_state", lambda url: "ok")
+    monkeypatch.setattr(
+        "quodeq.api._assistant_helpers.shared_evaluations_root",
+        lambda url: tmp_path / "shared",
+    )
+    monkeypatch.setattr(
+        "quodeq.api._assistant_helpers.shared_score_cache_path",
+        lambda url: tmp_path / "cache.db",
+    )
+    app = _app(tmp_path)
+    with app.app_context():
+        ctx = build_tool_context(
+            app, _session(source="shared", project_uuid=None, project_id="proj-x"))
+    assert ctx.repo_root is None
+    assert ctx.visible_standard_ids is None
+    assert called == []

--- a/tests/assistant/test_tool_context_visibility.py
+++ b/tests/assistant/test_tool_context_visibility.py
@@ -78,12 +78,15 @@ def test_api_helper_loads_the_saved_selection(tmp_path):
     assert ctx.visible_standard_ids == ("security", "clean-architecture")
 
 
-def test_api_helper_leaves_none_when_no_repo_resolves(tmp_path):
+def test_api_helper_falls_back_to_defaults_when_no_repo_resolves(tmp_path):
+    """No repo root still resolves a concrete selection (the ISO defaults),
+    not None -- a session with nothing to scope to must not read as
+    "unfiltered"."""
     app = _app(tmp_path)
     with app.app_context():
         ctx = build_tool_context(app, _session(project_uuid=None, project_id=None))
     assert ctx.repo_root is None
-    assert ctx.visible_standard_ids is None
+    assert ctx.visible_standard_ids == DEFAULT_VISIBLE_STANDARDS
 
 
 def test_api_helper_resolves_repo_root_via_project_id_fallback(tmp_path, monkeypatch):
@@ -135,8 +138,38 @@ def test_api_helper_shared_session_never_falls_back_to_a_local_repo_root(
         ctx = build_tool_context(
             app, _session(source="shared", project_uuid=None, project_id="proj-x"))
     assert ctx.repo_root is None
-    assert ctx.visible_standard_ids is None
+    # A shared session still resolves a concrete selection (the ISO
+    # defaults), not None -- it gets no filtering-off exemption just because
+    # it has no local repo.
+    assert ctx.visible_standard_ids == DEFAULT_VISIBLE_STANDARDS
     assert called == []
+
+
+def test_api_helper_shared_session_gets_defaults_not_none(tmp_path, monkeypatch):
+    """A plain shared session (no project_id fallback in play at all) still
+    resolves DEFAULT_VISIBLE_STANDARDS. Filtering being silently off for
+    shared/online/moved-repo sessions was the original bug re-surfacing in a
+    new place; the shared clone has no working copy to scope to, so it must
+    fall back to the same defaults a local repo without a file would get."""
+    monkeypatch.setattr(
+        "quodeq.api._assistant_helpers.read_settings",
+        lambda: SharedSettings(url="file:///fake-origin.git"),
+    )
+    monkeypatch.setattr("quodeq.api._assistant_helpers.read_state", lambda url: "ok")
+    monkeypatch.setattr(
+        "quodeq.api._assistant_helpers.shared_evaluations_root",
+        lambda url: tmp_path / "shared",
+    )
+    monkeypatch.setattr(
+        "quodeq.api._assistant_helpers.shared_score_cache_path",
+        lambda url: tmp_path / "cache.db",
+    )
+    app = _app(tmp_path)
+    with app.app_context():
+        ctx = build_tool_context(
+            app, _session(source="shared", project_uuid=None, project_id=None))
+    assert ctx.repo_root is None
+    assert ctx.visible_standard_ids == DEFAULT_VISIBLE_STANDARDS
 
 
 def _capture_ctx(monkeypatch):
@@ -193,8 +226,10 @@ def test_mcp_path_loads_saved_selection(tmp_path, monkeypatch):
     assert captured["ctx"].visible_standard_ids == ("security", "clean-architecture")
 
 
-def test_mcp_path_no_repo_root_yields_none(tmp_path, monkeypatch):
-    """_build_registry_from_args with no --repo-root carries None (no filtering)."""
+def test_mcp_path_no_repo_root_falls_back_to_defaults(tmp_path, monkeypatch):
+    """_build_registry_from_args with no --repo-root still carries a concrete
+    selection (the ISO defaults), not None -- an MCP caller with no repo root
+    gets the same fallback as every other unresolved-repo session."""
     from quodeq.assistant.mcp.server import _build_registry_from_args
 
     captured = _capture_ctx(monkeypatch)
@@ -202,4 +237,4 @@ def test_mcp_path_no_repo_root_yields_none(tmp_path, monkeypatch):
     _build_registry_from_args(ns)
 
     assert captured["ctx"].repo_root is None
-    assert captured["ctx"].visible_standard_ids is None
+    assert captured["ctx"].visible_standard_ids == DEFAULT_VISIBLE_STANDARDS

--- a/tests/assistant/test_tool_context_visibility.py
+++ b/tests/assistant/test_tool_context_visibility.py
@@ -135,3 +135,76 @@ def test_api_helper_shared_session_never_falls_back_to_a_local_repo_root(
     assert ctx.repo_root is None
     assert ctx.visible_standard_ids is None
     assert called == []
+
+
+def _mcp_context_from_namespace(ns, tmp_path):
+    """Mirror the context construction from _build_registry_from_args.
+
+    Used to test the MCP path's context wiring without modifying the source.
+    Tests the same load_visible_standard_ids call that _build_registry_from_args uses.
+    """
+    from pathlib import Path
+    from quodeq.shared._env import get_evaluations_dir
+    from quodeq.core.standards.visibility import load_visible_standard_ids
+
+    if ns.reports_dir:
+        reports_dir = Path(ns.reports_dir)
+    else:
+        reports_dir = Path(get_evaluations_dir())
+    repo_root = Path(ns.repo_root) if ns.repo_root else None
+    return ToolContext(
+        repository=AssistantRepository(Path(ns.db_path)),
+        session_id=ns.session_id,
+        run_dir=Path(ns.run_dir) if ns.run_dir else None,
+        repo_root=repo_root,
+        evaluators_dir=Path(ns.evaluators_dir),
+        compiled_dir=Path(ns.compiled_dir),
+        dimensions_file=Path(ns.dimensions_file),
+        project_id=ns.project_id or None,
+        reports_dir=reports_dir,
+        worktree_dir=None,
+        read_only=False,
+        visible_standard_ids=(
+            load_visible_standard_ids(repo_root) if repo_root is not None else None),
+    )
+
+
+def test_mcp_path_loads_saved_selection(tmp_path):
+    """MCP path (via _build_registry_from_args) loads standards-visibility.json."""
+    import argparse
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    save_visible_standard_ids(repo_root, ["security", "clean-architecture"])
+
+    ns = argparse.Namespace(
+        db_path=str(tmp_path / "a.db"),
+        session_id="mcp-test",
+        run_dir=None,
+        repo_root=str(repo_root),
+        evaluators_dir=str(tmp_path / "e"),
+        compiled_dir=str(tmp_path / "c"),
+        dimensions_file=str(tmp_path / "d.json"),
+        project_id=None,
+        reports_dir="",
+    )
+    ctx = _mcp_context_from_namespace(ns, tmp_path)
+    assert ctx.visible_standard_ids == ("security", "clean-architecture")
+
+
+def test_mcp_path_no_repo_root_yields_none(tmp_path):
+    """MCP path with no --repo-root carries None (no filtering)."""
+    import argparse
+    ns = argparse.Namespace(
+        db_path=str(tmp_path / "a.db"),
+        session_id="mcp-test",
+        run_dir=None,
+        repo_root=None,  # No repo root
+        evaluators_dir=str(tmp_path / "e"),
+        compiled_dir=str(tmp_path / "c"),
+        dimensions_file=str(tmp_path / "d.json"),
+        project_id=None,
+        reports_dir="",
+    )
+    ctx = _mcp_context_from_namespace(ns, tmp_path)
+    assert ctx.repo_root is None
+    assert ctx.visible_standard_ids is None

--- a/tests/assistant/test_tools_overview.py
+++ b/tests/assistant/test_tools_overview.py
@@ -11,8 +11,21 @@ from quodeq.data.sqlite.assistant_repository import AssistantRepository
 _ACCUMULATED = {
     "project": "selectives",
     "dimensions": [
-        {"dimension": "security", "overallScore": "72", "overallGrade": "C", "trend": "up"},
-        {"dimension": "maintainability", "overallScore": "88", "overallGrade": "B", "trend": None},
+        {
+            "dimension": "security", "overallScore": "72", "overallGrade": "C",
+            "trend": "up",
+            "violations": [
+                {"severity": "critical"},
+                {"severity": "major"},
+            ],
+        },
+        {
+            "dimension": "clean-architecture", "overallScore": "88",
+            "overallGrade": "B", "trend": None,
+            "violations": [
+                {"severity": "minor"},
+            ],
+        },
     ],
     "summary": {
         "overallGrade": "B", "numericAverage": 80.0, "previousNumericAverage": 78.0,
@@ -22,7 +35,8 @@ _ACCUMULATED = {
 }
 
 
-def _ctx(tmp_path, *, project_id="selectives", reports_dir=None):
+def _ctx(tmp_path, *, project_id="selectives", reports_dir=None,
+          visible_standard_ids=None):
     repo = AssistantRepository(tmp_path / "assistant.db")
     return ToolContext(
         repository=repo, session_id="s1", run_dir=None, repo_root=None,
@@ -30,6 +44,7 @@ def _ctx(tmp_path, *, project_id="selectives", reports_dir=None):
         dimensions_file=tmp_path / "d.json",
         project_id=project_id,
         reports_dir=Path(reports_dir) if reports_dir is not None else tmp_path / "reports",
+        visible_standard_ids=visible_standard_ids,
     )
 
 
@@ -47,12 +62,13 @@ def test_get_overview_trims_accumulated_payload(tmp_path, monkeypatch):
     assert out["project"] == "selectives"
     assert out["dimensions"] == [
         {"dimension": "security", "score": "72", "grade": "C", "trend": "up"},
-        {"dimension": "maintainability", "score": "88", "grade": "B", "trend": None},
+        {"dimension": "clean-architecture", "score": "88", "grade": "B", "trend": None},
     ]
     assert out["summary"] == {
         "overallGrade": "B", "numericAverage": 80.0, "totalViolations": 12,
         "dimensionCount": 2, "severity": {"critical": 1, "major": 3, "minor": 8},
     }
+    assert out["hiddenStandardIds"] == []
 
 
 def test_get_overview_passes_as_of(tmp_path, monkeypatch):
@@ -83,3 +99,42 @@ def test_get_overview_tool_error_when_no_data(tmp_path, monkeypatch):
 def test_get_overview_registered(tmp_path):
     registry = build_registry(_ctx(tmp_path))
     assert "get_overview" in registry.names()
+
+
+def test_overview_excludes_hidden_dimensions(tmp_path, monkeypatch):
+    monkeypatch.setattr("quodeq.assistant.tools._overview._fs_reports.get_accumulated",
+                        lambda *a: _ACCUMULATED)
+    out = _get_overview(_ctx(tmp_path, visible_standard_ids=("security",)))
+    assert [d["dimension"] for d in out["dimensions"]] == ["security"]
+    assert out["hiddenStandardIds"] == ["clean-architecture"]
+
+
+def test_overview_omits_aggregate_grade_when_filtering(tmp_path, monkeypatch):
+    """The dashboard derives these from trend data in JS; recomputing them here
+    would put the assistant back out of step with the screen."""
+    monkeypatch.setattr("quodeq.assistant.tools._overview._fs_reports.get_accumulated",
+                        lambda *a: _ACCUMULATED)
+    out = _get_overview(_ctx(tmp_path, visible_standard_ids=("security",)))
+    assert "overallGrade" not in out["summary"]
+    assert "numericAverage" not in out["summary"]
+    assert out["summary"]["note"]
+
+
+def test_overview_recomputes_countable_aggregates(tmp_path, monkeypatch):
+    monkeypatch.setattr("quodeq.assistant.tools._overview._fs_reports.get_accumulated",
+                        lambda *a: _ACCUMULATED)
+    out = _get_overview(_ctx(tmp_path, visible_standard_ids=("security",)))
+    # Only the "security" dimension survives the filter (2 violations: one
+    # critical, one major); "clean-architecture" (1 minor violation) is hidden.
+    assert out["summary"]["dimensionCount"] == 1
+    assert out["summary"]["totalViolations"] == 2
+    assert out["summary"]["severity"] == {"critical": 1, "major": 1, "minor": 0}
+
+
+def test_overview_keeps_full_summary_when_nothing_hidden(tmp_path, monkeypatch):
+    monkeypatch.setattr("quodeq.assistant.tools._overview._fs_reports.get_accumulated",
+                        lambda *a: _ACCUMULATED)
+    out = _get_overview(_ctx(tmp_path, visible_standard_ids=None))
+    assert out["summary"]["overallGrade"]
+    assert out["summary"]["numericAverage"] is not None
+    assert out["hiddenStandardIds"] == []

--- a/tests/assistant/test_tools_read.py
+++ b/tests/assistant/test_tools_read.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from quodeq.assistant.tools import ToolContext, build_registry
+from quodeq.assistant.tools import ToolContext, ToolError, build_registry
 from quodeq.data.sqlite.assistant_repository import AssistantRepository
 from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
 
@@ -523,4 +523,25 @@ def test_search_findings_no_selection_means_no_filtering(tmp_path):
     out = _search_findings(ctx, query="risk")
     assert {f["dimension"] for f in out["findings"]} == {"security", "reliability"}
     assert out["hiddenStandardIds"] == []
+
+
+# --- get_report / get_violations not-found errors never name hidden dims. ----
+
+
+def test_report_not_found_error_does_not_name_hidden_dimensions(tmp_path, monkeypatch):
+    from quodeq.assistant.tools._read_tools import _get_report
+    ctx = _acc_ctx(tmp_path, monkeypatch, visible_standard_ids=("security",))
+    with pytest.raises(ToolError) as exc:
+        _get_report(ctx, "usability")
+    assert "reliability" not in str(exc.value)
+    assert "security" in str(exc.value)
+
+
+def test_violations_not_found_error_does_not_name_hidden_dimensions(tmp_path, monkeypatch):
+    from quodeq.assistant.tools._read_tools import _get_violations
+    ctx = _acc_ctx(tmp_path, monkeypatch, visible_standard_ids=("security",))
+    with pytest.raises(ToolError) as exc:
+        _get_violations(ctx, dimension="usability")
+    assert "reliability" not in str(exc.value)
+    assert "security" in str(exc.value)
 

--- a/tests/assistant/test_tools_read.py
+++ b/tests/assistant/test_tools_read.py
@@ -419,6 +419,28 @@ def test_get_scores_no_scope_errors(tmp_path):
     assert "get_context" in out["error"]
 
 
+# --- _visible_only: a blank/missing dimension is always visible (Finding 2). -
+
+
+def test_visible_only_blank_dimension_kept_and_not_named_hidden(tmp_path):
+    from quodeq.assistant.tools._read_tools import _visible_only
+    ctx = _run_ctx(tmp_path, visible_standard_ids=("security",))
+    kept, hidden = _visible_only(ctx, [{"dimension": "security"}, {"nodim": 1}])
+    assert kept == [{"dimension": "security"}, {"nodim": 1}]
+    assert hidden == []
+
+
+def test_visible_only_blank_dimension_kept_alongside_a_real_hidden_one(tmp_path):
+    from quodeq.assistant.tools._read_tools import _visible_only
+    ctx = _run_ctx(tmp_path, visible_standard_ids=("security",))
+    kept, hidden = _visible_only(ctx, [
+        {"dimension": "reliability"}, {"nodim": 1}, {"dimension": "security"},
+    ])
+    assert kept == [{"nodim": 1}, {"dimension": "security"}]
+    assert hidden == ["reliability"]
+    assert "" not in hidden
+
+
 # --- Hidden-standard filtering: get_scores / get_violations / search_findings.
 # Both `ctx` (run scope) and `acc_ctx` (accumulated scope) fixtures carry two
 # dimensions, "security" and "reliability"; these tests hide "reliability" and
@@ -460,6 +482,66 @@ def test_get_scores_filename_fallback_survives_filtering(tmp_path):
     }))
     out = _get_scores(ctx)
     assert out["scores"]["no-dim-field"] == {"score": 42, "grade": "D"}
+
+
+def test_get_scores_filename_fallback_kept_when_stem_is_visible(tmp_path):
+    """A stem-derived dimension name matched against an ACTIVE selection that
+    includes it: kept, and never named in hiddenStandardIds."""
+    from quodeq.assistant.tools._read_tools import _get_scores
+    ctx = _run_ctx(tmp_path, visible_standard_ids=("security", "no-dim-field"))
+    eval_dir = ctx.run_dir / "evaluation"
+    (eval_dir / "no-dim-field.json").write_text(json.dumps({
+        "overallScore": 42, "overallGrade": "D", "violations": [],
+    }))
+    out = _get_scores(ctx)
+    assert out["scores"]["no-dim-field"] == {"score": 42, "grade": "D"}
+    assert "no-dim-field" not in out["hiddenStandardIds"]
+
+
+def test_get_scores_filename_fallback_hidden_when_stem_not_visible(tmp_path):
+    """The same stem-derived name against an ACTIVE selection that excludes
+    it: dropped, and named in hiddenStandardIds like any other dimension."""
+    from quodeq.assistant.tools._read_tools import _get_scores
+    ctx = _run_ctx(tmp_path, visible_standard_ids=("security",))
+    eval_dir = ctx.run_dir / "evaluation"
+    (eval_dir / "no-dim-field.json").write_text(json.dumps({
+        "overallScore": 42, "overallGrade": "D", "violations": [],
+    }))
+    out = _get_scores(ctx)
+    assert "no-dim-field" not in out["scores"]
+    assert "no-dim-field" in out["hiddenStandardIds"]
+
+
+def test_get_violations_filename_fallback_kept_when_stem_is_visible(tmp_path):
+    """Covers `_violations_from_run`'s use of `_raw_run_dims` (the second call
+    site the helper exists for) against an ACTIVE selection that includes the
+    stem-derived name."""
+    from quodeq.assistant.tools._read_tools import _get_violations
+    ctx = _run_ctx(tmp_path, visible_standard_ids=("security", "no-dim-field"))
+    eval_dir = ctx.run_dir / "evaluation"
+    (eval_dir / "no-dim-field.json").write_text(json.dumps({
+        "overallScore": 42, "overallGrade": "D",
+        "violations": [{"principle": "X1", "file": "f.py", "line": 1,
+                         "severity": "minor", "title": "t", "reason": "r"}],
+    }))
+    out = _get_violations(ctx)
+    assert out["by_principle"].get("X1") == 1
+    assert "no-dim-field" not in out["hiddenStandardIds"]
+
+
+def test_get_violations_filename_fallback_hidden_when_stem_not_visible(tmp_path):
+    """Same call site, ACTIVE selection that excludes the stem-derived name."""
+    from quodeq.assistant.tools._read_tools import _get_violations
+    ctx = _run_ctx(tmp_path, visible_standard_ids=("security",))
+    eval_dir = ctx.run_dir / "evaluation"
+    (eval_dir / "no-dim-field.json").write_text(json.dumps({
+        "overallScore": 42, "overallGrade": "D",
+        "violations": [{"principle": "X1", "file": "f.py", "line": 1,
+                         "severity": "minor", "title": "t", "reason": "r"}],
+    }))
+    out = _get_violations(ctx)
+    assert "X1" not in out["by_principle"]
+    assert "no-dim-field" in out["hiddenStandardIds"]
 
 
 def test_get_violations_excludes_hidden_dimensions_run_scope(tmp_path):
@@ -523,6 +605,66 @@ def test_search_findings_no_selection_means_no_filtering(tmp_path):
     out = _search_findings(ctx, query="risk")
     assert {f["dimension"] for f in out["findings"]} == {"security", "reliability"}
     assert out["hiddenStandardIds"] == []
+
+
+def test_search_findings_visible_rows_survive_hidden_rows_ahead_of_limit(tmp_path):
+    """Reviewer-proven regression: 25 matching hidden-dimension rows inserted
+    BEFORE 3 matching visible rows, with a limit smaller than the hidden
+    count. SQL orders by insertion order (id), so filtering the returned rows
+    AFTER `ORDER BY id LIMIT ?` can return zero results even though visible
+    matches exist -- the hidden rows alone fill the whole limit window.
+    The fix pushes the exclusion into the query itself, before LIMIT."""
+    from quodeq.assistant.tools._read_tools import _search_findings
+    hidden_rows = [
+        _finding(d="reliability", p=f"rel-{i}", req=f"rel-{i}",
+                 file=f"src/rel{i}.py", line=i, reason="widget flaky")
+        for i in range(25)
+    ]
+    visible_rows = [
+        _finding(d="security", p=f"sec-{i}", req=f"sec-{i}",
+                 file=f"src/sec{i}.py", line=i, reason="widget insecure")
+        for i in range(3)
+    ]
+    ctx = _run_ctx(tmp_path, visible_standard_ids=("security",),
+                    findings=hidden_rows + visible_rows)
+    out = _search_findings(ctx, query="widget", limit=20)
+    assert len(out["findings"]) == 3
+    assert {f["dimension"] for f in out["findings"]} == {"security"}
+    assert out["hiddenStandardIds"] == ["reliability"]
+
+
+def test_search_findings_hidden_dim_reported_even_with_zero_matching_hits(tmp_path):
+    """hiddenStandardIds must reflect what was withheld even when every one of
+    a hidden dimension's rows is excluded from the SQL result (the source can
+    no longer be "the rows the query returned")."""
+    from quodeq.assistant.tools._read_tools import _search_findings
+    hidden_rows = [
+        _finding(d="reliability", p=f"rel-{i}", req=f"rel-{i}",
+                 file=f"src/rel{i}.py", line=i, reason="widget flaky")
+        for i in range(5)
+    ]
+    ctx = _run_ctx(tmp_path, visible_standard_ids=("security",),
+                    findings=hidden_rows + [_finding()])
+    out = _search_findings(ctx, query="widget", limit=1)
+    assert out["findings"] == []
+    assert out["hiddenStandardIds"] == ["reliability"]
+
+
+def test_search_findings_blank_dimension_finding_always_returned(tmp_path):
+    """A blank/missing dimension is always visible and must never itself
+    surface in hiddenStandardIds (Finding 2)."""
+    from quodeq.assistant.tools._read_tools import _search_findings
+    findings = [
+        _finding(d="reliability", p="req-2", req="req-2", file="src/r.py",
+                 reason="widget risk"),
+        _finding(d="", p="req-3", req="req-3", file="src/blank.py",
+                 reason="widget risk"),
+    ]
+    ctx = _run_ctx(tmp_path, visible_standard_ids=("security",), findings=findings)
+    out = _search_findings(ctx, query="widget")
+    assert {f["file"] for f in out["findings"]} == {"src/blank.py"}
+    assert out["hiddenStandardIds"] == ["reliability"]
+    assert "" not in out["hiddenStandardIds"]
 
 
 # --- get_report / get_violations not-found errors never name hidden dims. ----

--- a/tests/assistant/test_tools_read.py
+++ b/tests/assistant/test_tools_read.py
@@ -322,6 +322,70 @@ def test_get_violations_accumulated_aggregates_when_omitted(acc_ctx):
     assert res["by_principle"] == {"S1": 1, "S2": 1, "R1": 1}
 
 
+# --- list_standards / get_standard visibility filtering. ---------------------
+
+
+def _standards_ctx(tmp_path, visible_standard_ids=None):
+    """A ctx whose StandardsService sees two custom standards: "security" and
+    "clean-architecture". evaluators_dir is real (glob'd by list_custom());
+    dimensions_file/compiled_dir are left non-existent so list_builtin()
+    degrades to [] and only the custom pair is in play."""
+    evaluators_dir = tmp_path / "evaluators"
+    evaluators_dir.mkdir(parents=True)
+    for sid in ("security", "clean-architecture"):
+        (evaluators_dir / f"{sid}.json").write_text(json.dumps({
+            "id": sid, "name": sid, "principles": [],
+        }))
+    repo = AssistantRepository(tmp_path / "assistant.db")
+    repo.create_session(session_id="s1", provider="ollama")
+    return ToolContext(
+        repository=repo, session_id="s1", run_dir=None, repo_root=None,
+        evaluators_dir=evaluators_dir, compiled_dir=tmp_path / "compiled",
+        dimensions_file=tmp_path / "dimensions.json",
+        visible_standard_ids=visible_standard_ids,
+    )
+
+
+def test_list_standards_hides_deselected(tmp_path):
+    from quodeq.assistant.tools._read_tools import _list_standards
+    ctx = _standards_ctx(tmp_path, visible_standard_ids=("security",))
+    out = _list_standards(ctx)
+    assert [s["id"] for s in out["standards"]] == ["security"]
+    assert "clean-architecture" in out["hiddenStandardIds"]
+
+
+def test_list_standards_include_hidden_returns_everything(tmp_path):
+    from quodeq.assistant.tools._read_tools import _list_standards
+    ctx = _standards_ctx(tmp_path, visible_standard_ids=("security",))
+    out = _list_standards(ctx, include_hidden=True)
+    ids = [s["id"] for s in out["standards"]]
+    assert "security" in ids and "clean-architecture" in ids
+    assert "clean-architecture" in out["hiddenStandardIds"]
+
+
+def test_list_standards_unfiltered_when_selection_is_none(tmp_path):
+    from quodeq.assistant.tools._read_tools import _list_standards
+    out = _list_standards(_standards_ctx(tmp_path, visible_standard_ids=None))
+    assert out["hiddenStandardIds"] == []
+
+
+def test_list_standards_empty_tuple_hides_everything(tmp_path):
+    # visible_standard_ids=() is a real selection ("hide everything"), distinct
+    # from None ("no filtering"). Must never be treated as falsy-equals-None.
+    from quodeq.assistant.tools._read_tools import _list_standards
+    ctx = _standards_ctx(tmp_path, visible_standard_ids=())
+    out = _list_standards(ctx)
+    assert out["standards"] == []
+    assert set(out["hiddenStandardIds"]) == {"security", "clean-architecture"}
+
+
+def test_get_standard_still_reaches_a_hidden_standard(tmp_path):
+    """The by-name escape hatch: hidden data stays reachable on explicit ask."""
+    from quodeq.assistant.tools._read_tools import _get_standard
+    ctx = _standards_ctx(tmp_path, visible_standard_ids=("security",))
+    assert _get_standard(ctx, "clean-architecture")["id"] == "clean-architecture"
+
+
 def test_get_scores_no_scope_errors(tmp_path):
     # No run AND no project scope → a clear error, not a crash.
     repo = AssistantRepository(tmp_path / "assistant.db")

--- a/tests/assistant/test_tools_read.py
+++ b/tests/assistant/test_tools_read.py
@@ -24,11 +24,17 @@ def _finding(**over):
     return base
 
 
-@pytest.fixture()
-def ctx(tmp_path):
+def _run_ctx(tmp_path, visible_standard_ids=None, findings=None):
+    """A run-scoped ctx with "security" and "reliability" evaluation reports.
+
+    `findings` overrides the SQL findings seeded for search_findings (default:
+    a single "security" finding); `visible_standard_ids` plumbs the visibility
+    selection through, mirroring `_standards_ctx` below.
+    """
     run_dir = tmp_path / "run"
-    findings = SqliteFindingsRepository(run_dir)
-    findings.insert_finding(_finding())
+    repo_findings = SqliteFindingsRepository(run_dir)
+    for f in (findings if findings is not None else [_finding()]):
+        repo_findings.insert_finding(f)
     eval_dir = run_dir / "evaluation"
     eval_dir.mkdir(parents=True)
     (eval_dir / "security.json").write_text(json.dumps({
@@ -59,7 +65,13 @@ def ctx(tmp_path):
         repository=repo, session_id="s1", run_dir=run_dir, repo_root=None,
         evaluators_dir=tmp_path / "evaluators", compiled_dir=tmp_path / "compiled",
         dimensions_file=tmp_path / "dimensions.json",
+        visible_standard_ids=visible_standard_ids,
     )
+
+
+@pytest.fixture()
+def ctx(tmp_path):
+    return _run_ctx(tmp_path)
 
 
 def test_registry_registers_expected_tools(ctx):
@@ -143,7 +155,8 @@ def test_search_findings_without_run(ctx):
 def test_get_scores_and_report(ctx):
     reg = build_registry(ctx)
     scores = reg.dispatch("get_scores", {})
-    assert scores["result"]["security"] == {"score": 61.5, "grade": "C"}
+    assert scores["result"]["scores"]["security"] == {"score": 61.5, "grade": "C"}
+    assert scores["result"]["hiddenStandardIds"] == []
     report = reg.dispatch("get_report", {"dimension": "security"})
     assert report["result"]["principles"] == [{"name": "P1", "grade": "C"}]
     missing = reg.dispatch("get_report", {"dimension": "nope"})
@@ -265,8 +278,7 @@ _ACC = {
 }
 
 
-@pytest.fixture()
-def acc_ctx(tmp_path, monkeypatch):
+def _acc_ctx(tmp_path, monkeypatch, visible_standard_ids=None):
     repo = AssistantRepository(tmp_path / "assistant.db")
     repo.create_session(session_id="s1", provider="ollama")
     monkeypatch.setattr(
@@ -277,14 +289,21 @@ def acc_ctx(tmp_path, monkeypatch):
         evaluators_dir=tmp_path / "evaluators", compiled_dir=tmp_path / "compiled",
         dimensions_file=tmp_path / "dimensions.json",
         project_id="p", reports_dir=tmp_path / "reports",
+        visible_standard_ids=visible_standard_ids,
     )
+
+
+@pytest.fixture()
+def acc_ctx(tmp_path, monkeypatch):
+    return _acc_ctx(tmp_path, monkeypatch)
 
 
 def test_get_scores_accumulated(acc_ctx):
     out = build_registry(acc_ctx).dispatch("get_scores", {})["result"]
     # Each dimension carries its own source run — they can differ.
-    assert out["security"] == {"score": "9.6/10", "grade": "Exemplary", "fromRun": "runA"}
-    assert out["reliability"] == {"score": "9.0/10", "grade": "Exemplary", "fromRun": "runB"}
+    assert out["scores"]["security"] == {"score": "9.6/10", "grade": "Exemplary", "fromRun": "runA"}
+    assert out["scores"]["reliability"] == {"score": "9.0/10", "grade": "Exemplary", "fromRun": "runB"}
+    assert out["hiddenStandardIds"] == []
 
 
 def test_get_report_accumulated(acc_ctx):
@@ -398,3 +417,110 @@ def test_get_scores_no_scope_errors(tmp_path):
     out = build_registry(ctx).dispatch("get_scores", {})
     assert out["ok"] is False
     assert "get_context" in out["error"]
+
+
+# --- Hidden-standard filtering: get_scores / get_violations / search_findings.
+# Both `ctx` (run scope) and `acc_ctx` (accumulated scope) fixtures carry two
+# dimensions, "security" and "reliability"; these tests hide "reliability" and
+# confirm it disappears from aggregate reads but is still reachable by name.
+
+
+def test_get_scores_excludes_hidden_dimensions_run_scope(tmp_path):
+    from quodeq.assistant.tools._read_tools import _get_scores
+    ctx = _run_ctx(tmp_path, visible_standard_ids=("security",))
+    out = _get_scores(ctx)
+    assert set(out["scores"]) == {"security"}
+    assert out["hiddenStandardIds"] == ["reliability"]
+
+
+def test_get_scores_excludes_hidden_dimensions_accumulated(tmp_path, monkeypatch):
+    from quodeq.assistant.tools._read_tools import _get_scores
+    ctx = _acc_ctx(tmp_path, monkeypatch, visible_standard_ids=("security",))
+    out = _get_scores(ctx)
+    assert set(out["scores"]) == {"security"}
+    assert out["hiddenStandardIds"] == ["reliability"]
+
+
+def test_get_scores_no_selection_means_no_filtering(tmp_path, monkeypatch):
+    from quodeq.assistant.tools._read_tools import _get_scores
+    out = _get_scores(_acc_ctx(tmp_path, monkeypatch, visible_standard_ids=None))
+    assert "reliability" in out["scores"]
+    assert out["hiddenStandardIds"] == []
+
+
+def test_get_scores_filename_fallback_survives_filtering(tmp_path):
+    """A report file with no "dimension" key is keyed by its filename, not
+    dropped -- even once filtering is applied. Guards `_raw_run_dims`, which
+    exists specifically to preserve this behaviour through the new filter."""
+    from quodeq.assistant.tools._read_tools import _get_scores
+    ctx = _run_ctx(tmp_path, visible_standard_ids=None)
+    eval_dir = ctx.run_dir / "evaluation"
+    (eval_dir / "no-dim-field.json").write_text(json.dumps({
+        "overallScore": 42, "overallGrade": "D", "violations": [],
+    }))
+    out = _get_scores(ctx)
+    assert out["scores"]["no-dim-field"] == {"score": 42, "grade": "D"}
+
+
+def test_get_violations_excludes_hidden_dimensions_run_scope(tmp_path):
+    from quodeq.assistant.tools._read_tools import _get_violations
+    ctx = _run_ctx(tmp_path, visible_standard_ids=("security",))
+    out = _get_violations(ctx)
+    # reliability's R1 is excluded; only security's P1/P2 counts remain.
+    assert out["by_principle"] == {"P1": 2, "P2": 1}
+    assert out["hiddenStandardIds"] == ["reliability"]
+
+
+def test_get_violations_named_hidden_dimension_still_works_run_scope(tmp_path):
+    """Explicitly naming a hidden dimension is the deliberate escape hatch."""
+    from quodeq.assistant.tools._read_tools import _get_violations
+    ctx = _run_ctx(tmp_path, visible_standard_ids=("security",))
+    out = _get_violations(ctx, dimension="reliability")
+    assert out["dimension"] == "reliability"
+    assert out["count"] == 1
+    assert out["hiddenStandardIds"] == []
+
+
+def test_get_violations_excludes_hidden_dimensions_accumulated(tmp_path, monkeypatch):
+    from quodeq.assistant.tools._read_tools import _get_violations
+    ctx = _acc_ctx(tmp_path, monkeypatch, visible_standard_ids=("security",))
+    out = _get_violations(ctx)
+    assert out["by_principle"] == {"S1": 1, "S2": 1}
+    assert out["hiddenStandardIds"] == ["reliability"]
+
+
+def test_get_violations_named_hidden_dimension_still_works_accumulated(tmp_path, monkeypatch):
+    from quodeq.assistant.tools._read_tools import _get_violations
+    ctx = _acc_ctx(tmp_path, monkeypatch, visible_standard_ids=("security",))
+    out = _get_violations(ctx, dimension="reliability")
+    assert out["dimension"] == "reliability"
+    assert out["count"] > 0
+    assert out["hiddenStandardIds"] == []
+
+
+def test_search_findings_excludes_hidden_dimensions(tmp_path):
+    from quodeq.assistant.tools._read_tools import _search_findings
+    findings = [
+        _finding(),  # dimension "security", reason "sql injection risk"
+        _finding(d="reliability", p="req-2", req="req-2", file="src/r.py",
+                 reason="reliability risk"),
+    ]
+    ctx = _run_ctx(tmp_path, visible_standard_ids=("security",), findings=findings)
+    out = _search_findings(ctx, query="risk")
+    assert len(out["findings"]) == 1
+    assert all(f["dimension"] == "security" for f in out["findings"])
+    assert out["hiddenStandardIds"] == ["reliability"]
+
+
+def test_search_findings_no_selection_means_no_filtering(tmp_path):
+    from quodeq.assistant.tools._read_tools import _search_findings
+    findings = [
+        _finding(),
+        _finding(d="reliability", p="req-2", req="req-2", file="src/r.py",
+                 reason="reliability risk"),
+    ]
+    ctx = _run_ctx(tmp_path, visible_standard_ids=None, findings=findings)
+    out = _search_findings(ctx, query="risk")
+    assert {f["dimension"] for f in out["findings"]} == {"security", "reliability"}
+    assert out["hiddenStandardIds"] == []
+

--- a/tests/core/test_standards_visibility.py
+++ b/tests/core/test_standards_visibility.py
@@ -101,3 +101,25 @@ def test_partition_with_none_hides_nothing():
     visible, hidden = partition_visible(["security", "clean-architecture"], None)
     assert visible == ["security", "clean-architecture"]
     assert hidden == []
+
+
+def test_partition_with_empty_tuple_hides_everything():
+    """() is an explicit "hide everything", distinct from None (no filtering).
+
+    Guards against a truthiness check (`if not visible`) in place of `is None`,
+    which would silently turn "hide everything" into "hide nothing".
+    """
+    visible, hidden = partition_visible(["security", "reliability"], ())
+    assert visible == []
+    assert hidden == ["security", "reliability"]
+
+
+def test_saved_file_is_pretty_printed_with_trailing_newline(tmp_path):
+    """The literal on-disk text, not just the parsed value.
+
+    The file is committed to the user's repository, so its formatting is part
+    of the contract: 2-space indent and a trailing newline keep diffs clean.
+    """
+    save_visible_standard_ids(tmp_path, ["security"])
+    text = (tmp_path / VISIBILITY_RELPATH).read_text(encoding="utf-8")
+    assert text == '{\n  "version": 1,\n  "visibleStandardIds": [\n    "security"\n  ]\n}\n'

--- a/tests/core/test_standards_visibility.py
+++ b/tests/core/test_standards_visibility.py
@@ -1,0 +1,103 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.core.standards.visibility import (
+    DEFAULT_VISIBLE_STANDARDS,
+    VISIBILITY_RELPATH,
+    load_visible_standard_ids,
+    partition_visible,
+    save_visible_standard_ids,
+    validate_visible_ids,
+)
+
+
+def test_defaults_are_the_six_iso_dimensions():
+    assert DEFAULT_VISIBLE_STANDARDS == (
+        "security", "reliability", "maintainability",
+        "performance", "usability", "flexibility",
+    )
+
+
+def test_absent_file_yields_defaults(tmp_path):
+    assert load_visible_standard_ids(tmp_path) == DEFAULT_VISIBLE_STANDARDS
+
+
+def test_none_root_yields_defaults():
+    assert load_visible_standard_ids(None) == DEFAULT_VISIBLE_STANDARDS
+
+
+def test_saved_selection_round_trips(tmp_path):
+    save_visible_standard_ids(tmp_path, ["security", "clean-architecture"])
+    assert load_visible_standard_ids(tmp_path) == ("security", "clean-architecture")
+
+
+def test_saved_file_shape_is_versioned(tmp_path):
+    save_visible_standard_ids(tmp_path, ["security"])
+    data = json.loads((tmp_path / VISIBILITY_RELPATH).read_text(encoding="utf-8"))
+    assert data == {"version": 1, "visibleStandardIds": ["security"]}
+
+
+def test_empty_selection_round_trips_as_empty(tmp_path):
+    # An explicit "hide everything" is a real state and must NOT read back as
+    # the defaults -- otherwise the user cannot deselect the last standard.
+    save_visible_standard_ids(tmp_path, [])
+    assert load_visible_standard_ids(tmp_path) == ()
+
+
+def test_ids_are_normalized_to_lowercase(tmp_path):
+    save_visible_standard_ids(tmp_path, ["Security", "CLEAN-Architecture"])
+    assert load_visible_standard_ids(tmp_path) == ("security", "clean-architecture")
+
+
+@pytest.mark.parametrize("body", ["not json{", '{"version": 1}', '{"visibleStandardIds": "x"}', "[]"])
+def test_malformed_file_degrades_to_defaults(tmp_path, body):
+    path = tmp_path / VISIBILITY_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    assert load_visible_standard_ids(tmp_path) == DEFAULT_VISIBLE_STANDARDS
+
+
+def test_non_string_entries_are_dropped(tmp_path):
+    path = tmp_path / VISIBILITY_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"version": 1, "visibleStandardIds": ["security", 3, None]}),
+                    encoding="utf-8")
+    assert load_visible_standard_ids(tmp_path) == ("security",)
+
+
+def test_validate_accepts_known_ids():
+    clean, errors = validate_visible_ids(["security"], {"security", "reliability"})
+    assert (clean, errors) == (["security"], [])
+
+
+def test_validate_rejects_unknown_id():
+    clean, errors = validate_visible_ids(["nope"], {"security"})
+    assert clean == []
+    assert errors == ["nope: unknown standard"]
+
+
+def test_validate_rejects_non_list():
+    clean, errors = validate_visible_ids({"a": 1}, {"security"})
+    assert clean == []
+    assert errors == ["visibleStandardIds must be an array"]
+
+
+def test_validate_deduplicates_preserving_order():
+    clean, errors = validate_visible_ids(
+        ["reliability", "security", "reliability"], {"security", "reliability"})
+    assert (clean, errors) == (["reliability", "security"], [])
+
+
+def test_partition_splits_visible_and_hidden():
+    visible, hidden = partition_visible(
+        ["Security", "clean-architecture"], ("security",))
+    assert visible == ["Security"]
+    assert hidden == ["clean-architecture"]
+
+
+def test_partition_with_none_hides_nothing():
+    visible, hidden = partition_visible(["security", "clean-architecture"], None)
+    assert visible == ["security", "clean-architecture"]
+    assert hidden == []

--- a/tests/core/test_visible_standards_defaults_match_ui.py
+++ b/tests/core/test_visible_standards_defaults_match_ui.py
@@ -1,0 +1,28 @@
+"""The visible-standards default is declared in two languages. Pin them.
+
+Backend filtering (quodeq.core.standards.visibility) and the dashboard's
+pre-hydration fallback (ui/src/constants.js) must agree, or the assistant and
+the Overview disagree on a fresh install -- the exact bug this file guards.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from quodeq.core.standards.visibility import DEFAULT_VISIBLE_STANDARDS
+
+_CONSTANTS = (Path(__file__).resolve().parents[2]
+              / "src" / "quodeq" / "ui" / "src" / "constants.js")
+_PATTERN = re.compile(
+    r"export const DEFAULT_VISIBLE_STANDARDS\s*=\s*\[(.*?)\]", re.DOTALL)
+
+
+def _ui_defaults() -> tuple[str, ...]:
+    match = _PATTERN.search(_CONSTANTS.read_text(encoding="utf-8"))
+    assert match, f"DEFAULT_VISIBLE_STANDARDS not found in {_CONSTANTS}"
+    return tuple(json.loads(f"[{match.group(1).replace(chr(39), chr(34)).rstrip().rstrip(chr(44))}]"))
+
+
+def test_python_defaults_match_the_ui_constant():
+    assert DEFAULT_VISIBLE_STANDARDS == _ui_defaults()

--- a/tests/data/sqlite/test_findings_repository.py
+++ b/tests/data/sqlite/test_findings_repository.py
@@ -102,6 +102,44 @@ def test_search_respects_limit(tmp_path: Path):
     assert len(hits) == 3
 
 
+def test_search_exclude_dimensions_applied_before_limit(tmp_path: Path):
+    """25 excluded-dimension matches inserted before 3 kept ones, with a limit
+    smaller than the excluded count: the excluded rows must not consume the
+    limit window (ORDER BY id LIMIT applies AFTER the exclusion, not before)."""
+    repo = SqliteFindingsRepository(tmp_path)
+    for i in range(25):
+        repo.insert_finding(_finding(p=f"hidden-{i}", d="reliability", line=i,
+                                      reason="widget flaky"))
+    for i in range(3):
+        repo.insert_finding(_finding(p=f"kept-{i}", d="security", line=100 + i,
+                                      reason="widget insecure"))
+    hits = repo.search("widget", limit=20, exclude_dimensions=["reliability"])
+    assert len(hits) == 3
+    assert {h.dimension for h in hits} == {"security"}
+
+
+def test_search_exclude_dimensions_case_insensitive(tmp_path: Path):
+    """Stored `dimension` values are not guaranteed lowercase; the exclusion
+    must match regardless of casing on either side."""
+    repo = SqliteFindingsRepository(tmp_path)
+    repo.insert_finding(_finding(p="P1", d="Security", reason="widget flaky"))
+    repo.insert_finding(_finding(p="P2", d="reliability", line=2,
+                                  reason="widget solid"))
+    hits = repo.search("widget", exclude_dimensions=["security"])
+    assert {h.practice_id for h in hits} == {"P2"}
+
+
+def test_search_exclude_dimensions_none_unaffected(tmp_path: Path):
+    """The default (no exclusion) must return exactly what it did before the
+    parameter was added."""
+    repo = SqliteFindingsRepository(tmp_path)
+    repo.insert_finding(_finding(p="P1", d="security", reason="widget flaky"))
+    repo.insert_finding(_finding(p="P2", d="reliability", line=2,
+                                  reason="widget solid"))
+    hits = repo.search("widget", exclude_dimensions=None)
+    assert {h.practice_id for h in hits} == {"P1", "P2"}
+
+
 class _SpyProjector(Projector):
     """Projector that records ensure_projected invocations."""
 

--- a/tests/integration/test_assistant_hidden_standards.py
+++ b/tests/integration/test_assistant_hidden_standards.py
@@ -1,0 +1,165 @@
+"""Issue #883: the assistant must not answer with standards the dashboard hides.
+
+Pins the issue's own reproduction end to end: once a standard is hidden via
+`save_visible_standard_ids`, it must disappear from every general-purpose
+read tool (get_overview, get_scores, list_standards) while staying reachable
+when named explicitly (get_standard, get_violations) -- the deliberate escape
+hatch. Also pins that the overview's summary omits `overallGrade` and
+`numericAverage` once anything is filtered: the dashboard derives those from
+trend data in JS, so a Python-computed value here could contradict the
+screen.
+
+Dispatches through the real `ToolRegistry` (`quodeq.assistant.tools.build_registry`
++ `ToolRegistry.dispatch`), the same seam the MCP server and the CLI/API
+adapters use, rather than calling the private `_get_overview`/`_get_scores`/
+`_list_standards` functions directly -- this proves the wiring the model
+actually goes through, matching the pattern in
+tests/assistant/test_registry.py and tests/assistant/test_tools_read.py.
+
+No `@pytest.mark.integration` marker: nothing here spawns a real subprocess
+or needs an external resource (accumulated report data is monkeypatched at
+the same `_fs_reports.get_accumulated` seam tests/assistant/test_tools_overview.py
+and test_tools_read.py already use; everything else is tmp_path + sqlite),
+matching every other file already in tests/integration/ (see e.g. the module
+docstrings of test_assistant_end_to_end.py and test_assistant_cli_end_to_end.py):
+CI runs with `-m "not integration"`, which only deselects marked tests, so
+this one still runs.
+"""
+import json
+
+from quodeq.assistant.tools import ToolContext, build_registry
+from quodeq.core.standards.visibility import load_visible_standard_ids, save_visible_standard_ids
+from quodeq.data.sqlite.assistant_repository import AssistantRepository
+
+# Accumulated (cross-run) payload backing get_overview/get_scores/get_violations
+# in this file: three dimensions, one of which ("clean-architecture") the
+# tests below hide via the saved visibility selection.
+_ACCUMULATED = {
+    "project": "acme",
+    "dimensions": [
+        {
+            "dimension": "security", "overallScore": 72, "overallGrade": "C",
+            "trend": "up",
+            "violations": [{"severity": "critical"}, {"severity": "major"}],
+        },
+        {
+            "dimension": "reliability", "overallScore": 80, "overallGrade": "B",
+            "trend": "flat",
+            "violations": [{"severity": "minor"}],
+        },
+        {
+            "dimension": "clean-architecture", "overallScore": 88, "overallGrade": "B",
+            "trend": None,
+            "violations": [{"severity": "minor"}],
+        },
+    ],
+    "summary": {
+        "overallGrade": "B", "numericAverage": 80.0, "previousNumericAverage": 78.0,
+        "totalViolations": 4, "totalCompliance": 40, "dimensionCount": 3,
+        "severity": {"critical": 1, "major": 1, "minor": 2},
+    },
+}
+
+
+def _evaluators_dir(tmp_path):
+    """Real on-disk custom-standard files, glob'd by StandardsService.list_custom()
+    (matching tests/assistant/test_tools_read.py::_standards_ctx) so
+    list_standards/get_standard have real data to filter and fetch, not a mock."""
+    evaluators_dir = tmp_path / "evaluators"
+    evaluators_dir.mkdir(parents=True)
+    for sid in ("security", "reliability", "clean-architecture"):
+        (evaluators_dir / f"{sid}.json").write_text(json.dumps({
+            "id": sid, "name": sid, "principles": [],
+        }))
+    return evaluators_dir
+
+
+def _build_registry(tmp_path, repo_root, monkeypatch):
+    """An accumulated-scope registry (no run_dir selected -- the default
+    dashboard/overview view) whose visible_standard_ids is loaded through the
+    REAL load path: `load_visible_standard_ids(repo_root)`, the same call
+    `_build_registry_from_args` makes in quodeq.assistant.mcp.server, rather
+    than hand-setting the tuple.
+
+    get_overview/get_scores read accumulated data through
+    `services._fs_reports.get_accumulated`; that function's own filesystem
+    behaviour is covered elsewhere (services tests), so it is monkeypatched
+    here exactly as tests/assistant/test_tools_overview.py and
+    test_tools_read.py's `acc_ctx` already do -- this test's job is the
+    hidden-standards wiring on top of it, not re-proving accumulation.
+    """
+    monkeypatch.setattr(
+        "quodeq.assistant.tools._overview._fs_reports.get_accumulated",
+        lambda *a: _ACCUMULATED)
+    monkeypatch.setattr(
+        "quodeq.assistant.tools._read_tools._fs_reports.get_accumulated",
+        lambda *a: _ACCUMULATED)
+    repo = AssistantRepository(tmp_path / "assistant.db")
+    repo.create_session(session_id="s1", provider="ollama")
+    ctx = ToolContext(
+        repository=repo, session_id="s1", run_dir=None, repo_root=repo_root,
+        evaluators_dir=_evaluators_dir(tmp_path), compiled_dir=tmp_path / "compiled",
+        dimensions_file=tmp_path / "dimensions.json",
+        project_id="acme", reports_dir=tmp_path / "reports",
+        visible_standard_ids=load_visible_standard_ids(repo_root),
+    )
+    return build_registry(ctx)
+
+
+def test_hidden_standard_is_absent_from_every_general_answer(tmp_path, monkeypatch):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    save_visible_standard_ids(repo_root, ["security", "reliability"])
+
+    registry = _build_registry(tmp_path, repo_root, monkeypatch)
+
+    overview_out = registry.dispatch("get_overview", {})
+    scores_out = registry.dispatch("get_scores", {})
+    standards_out = registry.dispatch("list_standards", {})
+    assert overview_out["ok"], overview_out
+    assert scores_out["ok"], scores_out
+    assert standards_out["ok"], standards_out
+    overview, scores, standards = (
+        overview_out["result"], scores_out["result"], standards_out["result"])
+
+    assert [d["dimension"] for d in overview["dimensions"]] == ["security", "reliability"]
+    assert set(scores["scores"]) == {"security", "reliability"}
+    assert {s["id"] for s in standards["standards"]} == {"security", "reliability"}
+
+    for payload in (overview, scores, standards):
+        assert payload["hiddenStandardIds"] == ["clean-architecture"]
+        assert "clean-architecture" not in json.dumps(
+            [d for k, d in payload.items() if k != "hiddenStandardIds"])
+
+    # Deliberate omission: the dashboard derives these from the filtered
+    # TREND in the browser (ui/src/utils/scoreFiltering.js), not from these
+    # dimensions -- a Python-recomputed value here could contradict the
+    # number on screen, which is the exact divergence issue #883 reported.
+    assert "overallGrade" not in overview["summary"]
+    assert "numericAverage" not in overview["summary"]
+    assert overview["summary"]["note"]
+    # Counts are exact even under filtering, so they're recomputed rather
+    # than dropped: only security (2 violations) + reliability (1) survive.
+    assert overview["summary"]["totalViolations"] == 3
+    assert overview["summary"]["dimensionCount"] == 2
+    assert overview["summary"]["severity"] == {"critical": 1, "major": 1, "minor": 1}
+
+
+def test_hidden_standard_is_reachable_when_named(tmp_path, monkeypatch):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    save_visible_standard_ids(repo_root, ["security", "reliability"])
+
+    registry = _build_registry(tmp_path, repo_root, monkeypatch)
+
+    detail_out = registry.dispatch("get_standard", {"standard_id": "clean-architecture"})
+    assert detail_out["ok"], detail_out
+    assert detail_out["result"]["id"] == "clean-architecture"
+
+    violations_out = registry.dispatch("get_violations", {"dimension": "clean-architecture"})
+    assert violations_out["ok"], violations_out
+    assert violations_out["result"]["dimension"] == "clean-architecture"
+    assert violations_out["result"]["count"] == 1
+    # Naming it explicitly is the escape hatch: it is not reported as hidden
+    # in a payload where it was the very thing asked for.
+    assert violations_out["result"]["hiddenStandardIds"] == []

--- a/tests/services/test_scoring_parity.py
+++ b/tests/services/test_scoring_parity.py
@@ -294,7 +294,7 @@ def test_assistant_tools_agree_after_dismissal(tmp_path):
     # Run scope: get_scores / get_report / get_violations.
     run_ctx = _assistant_ctx(tmp_path, reports_root, project, run_dir)
     run_reg = build_registry(run_ctx)
-    scores = run_reg.dispatch("get_scores", {})["result"]
+    scores = run_reg.dispatch("get_scores", {})["result"]["scores"]
     assert _num(scores[_DIM]["score"]) == accumulated, (
         f"assistant run-scope get_scores {scores[_DIM]['score']} != accumulated {accumulated}")
 
@@ -309,7 +309,7 @@ def test_assistant_tools_agree_after_dismissal(tmp_path):
     # Overview (accumulated) scope: get_scores + get_overview.
     over_ctx = dc_replace(run_ctx, run_dir=None)
     over_reg = build_registry(over_ctx)
-    over_scores = over_reg.dispatch("get_scores", {})["result"]
+    over_scores = over_reg.dispatch("get_scores", {})["result"]["scores"]
     assert _num(over_scores[_DIM]["score"]) == accumulated, (
         f"assistant overview get_scores {over_scores[_DIM]['score']} != accumulated {accumulated}")
 


### PR DESCRIPTION
Closes #883.

The Assistant answered general questions using every standard, including the ones hidden on the Standards page, so its dimensions, scores and totals disagreed with the dashboard. The selection was frontend-only, in localStorage, and the backend had no access to it.

This promotes the selection to per-project server state at `<repo>/.quodeq/standards-visibility.json`, alongside the existing `standards-overrides.json`, and filters the Assistant's read tools by it.

## Why persist instead of sending it per turn

The issue proposed plumbing the localStorage value through each request. That makes the Assistant a third place implementing the same rule, leaves the CLI blind, and bakes in a permanent behaviour fork between UI and non-UI callers. One file read by every consumer avoids all three.

It also fixes the case nobody chose: `dimensions.json` ships 8 built-ins but the default selection is only the 6 ISO dimensions, so `clean-architecture` and `domain-driven-design` were hidden on every fresh install. An absent file therefore means the 6 defaults, not "everything".

## What changed

Backend:

- `core/standards/visibility.py` loads, validates and saves the selection. Mirrors `overrides.py`: degrade to defaults on a malformed file, all-or-nothing validation on writes.
- `GET`/`PUT /api/projects/<id>/standards-visibility`.
- `ToolContext.visible_standard_ids`, resolved at both construction sites.
- `list_standards`, `get_scores`, `get_violations`, `search_findings` and `get_overview` filter to the visible set and report `hiddenStandardIds`. `get_report`'s not-found error no longer enumerates hidden dimension ids.

Escape hatches, so hidden data stays reachable on request: `get_standard(standard_id)`, `get_report(dimension)`, `get_violations(dimension)`, and `list_standards(include_hidden=true)`. A system-prompt paragraph tells the model to offer the withheld standards rather than omit them silently.

Frontend: localStorage becomes a cache of server state. The 8 synchronous read sites are untouched, so `readVisibleStandardIds()` keeps its signature; only its backing store changes. A pre-existing browser selection is pushed up to the server once rather than lost.

## Two deliberate decisions worth reviewing

**`get_overview` omits `overallGrade` and `numericAverage` when anything is hidden.** The Overview header does not derive those from the dimension scores. `utils/scoreFiltering.js` takes `numericAverage` from the filtered trend, so any value recomputed in Python could contradict the number on screen, which is the bug this PR is fixing. `totalViolations`, `dimensionCount` and `severity` are exact, so they are recomputed. Cost: the Assistant cannot answer "what's my overall grade?" while a hidden standard exists. Follow-up issue to expose the filtered aggregate rather than reimplement the trend maths in a second language.

**`get_scores` now returns `{"scores": {...}, "hiddenStandardIds": [...]}`.** It was the only read tool returning a bare map; hanging metadata off it would put a non-dimension entry in a dict callers iterate. Two existing consumers were updated.

## Two things found in review, called out because they are easy to get wrong again

Resolving `repo_root` from `project_id` must stay gated to local sessions. Unguarded, a shared read-only session could resolve a coincidentally same-named local project and read local files.

`search_findings` had to push the exclusion into SQL. Filtering after the query truncates first: 25 hidden findings ahead of 3 visible ones with `limit=20` returned nothing, so the Assistant would report no matches when matches existed.

## Scope

A visibility toggle still does not propagate to other surfaces without a remount. `App.jsx` memoizes its read with empty deps and there is no refresh signal today, so this is unchanged, not introduced. Worth its own issue.

## Verification

    uv run pytest tests/ -m "not integration"          # 5134 passed, 1 skipped
    uv run pytest tests/tools/test_import_layers.py    # 2 passed, baseline untouched
    cd src/quodeq/ui && npm run test:all               # 339 node, 1319 vitest

`tests/api/test_terminal_routes.py::test_ws_gate_refusal_close_uses_dedicated_code` fails under parallel full-suite load on macOS. Pre-existing, documented in #886 as untouched; passes 3/3 in isolation and the file passes 17/17. Nothing here touches that area.

Rebased on `develop` at v1.7.2, no file overlap.
