### PR TITLE
Pre-release polish: terminal localhost note, welcome slash list

### DIFF
--- a/src/quodeq/ui/src/features/terminal/TerminalHeader.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalHeader.jsx
@@ -2,7 +2,7 @@ import React, { useRef, useState } from 'react';
 import { useAssistantDrawer } from '../assistant/AssistantDrawerProvider.jsx';
 import PanelSwitcher from '../drawer/PanelSwitcher.jsx';
 import {
-  COPY_FEEDBACK_MS, ChevronDownIcon, CopyIcon, LockIcon, MaximizeIcon, MinimizeIcon, PlusIcon,
+  COPY_FEEDBACK_MS, ChevronDownIcon, CopyIcon, MaximizeIcon, MinimizeIcon, PlusIcon,
 } from '../../components/CopyButton.jsx';
 
 /**
@@ -41,12 +41,6 @@ export default function TerminalHeader({ onCopy, onNewSession }) {
           <PlusIcon />
         </button>
       )}
-      {/* The gate only ever admits loopback clients (terminal/gate.py); say so
-          where the user can see it instead of leaving the sandboxing implicit. */}
-      <span className="tty-localhost-pill" title="The embedded terminal only works on localhost">
-        <LockIcon />
-        localhost only
-      </span>
       <div className="tty-panel-controls">
         <button type="button" className={`assistant-drawer-btn${copied ? ' tty-copy-btn--done' : ''}`}
           onClick={handleCopy}

--- a/src/quodeq/ui/src/features/terminal/TerminalPane.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.jsx
@@ -3,7 +3,7 @@ import { terminalStatus } from '../../api/terminal.js';
 import { useTerminalSessions } from './useTerminalSessions.js';
 import TerminalSessionView from './TerminalSessionView.jsx';
 import TerminalHeader from './TerminalHeader.jsx';
-import { PlusIcon, XIcon } from '../../components/CopyButton.jsx';
+import { LockIcon, PlusIcon, XIcon } from '../../components/CopyButton.jsx';
 
 /**
  * The terminal panel: header, session tab strip, one TerminalSessionView per
@@ -109,6 +109,14 @@ export default function TerminalPane({ active }) {
         {shell && <span>{shell}</span>}
         {shell && <span className="tty-statusbar-sep" aria-hidden="true">·</span>}
         <span>{sessions.length} session{sessions.length === 1 ? '' : 's'}</span>
+        <span className="tty-statusbar-sep" aria-hidden="true">·</span>
+        {/* The gate only ever admits loopback clients (terminal/gate.py); a
+            shell in a browser deserves a visible, if quiet, answer to "who
+            else can reach this?". */}
+        <span className="tty-statusbar-lock" title="The embedded terminal only works on localhost">
+          <LockIcon />
+          localhost only
+        </span>
         <span className="tty-statusbar-spacer" />
         {activeSession?.cwd && <span className="tty-statusbar-cwd" title={activeSession.cwd}>{activeSession.cwd}</span>}
       </div>

--- a/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
@@ -255,10 +255,11 @@ it('copy button copies the active session selection to the clipboard', async () 
   expect(writeText).toHaveBeenCalledWith('picked text');
 });
 
-it('shows shell, session count and active cwd in the status bar', async () => {
+it('shows shell, session count, sandbox note and active cwd in the status bar', async () => {
   render(<TerminalPane active />);
   await screen.findByTestId('tty-root');
   expect(screen.getByText('zsh')).toBeInTheDocument();
   expect(screen.getByText('1 session')).toBeInTheDocument();
+  expect(screen.getByText('localhost only')).toBeInTheDocument();
   expect(screen.getByText('~/proj')).toBeInTheDocument();
 });

--- a/src/quodeq/ui/src/styles/terminal-drawer.css
+++ b/src/quodeq/ui/src/styles/terminal-drawer.css
@@ -45,21 +45,6 @@
   white-space: nowrap;
 }
 
-.tty-localhost-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  padding: 0.125rem 0.55rem;
-  border: 1px solid var(--color-border);
-  border-radius: 999px;
-  background: var(--color-surface-alt);
-  color: var(--color-text-muted);
-  font-family: var(--font-data);
-  font-size: 0.625rem;
-  white-space: nowrap;
-}
-.tty-localhost-pill svg { color: var(--color-success); }
-
 .tty-panel-controls {
   display: flex;
   gap: 0.25rem;
@@ -191,6 +176,17 @@
 }
 .tty-statusbar-sep { color: var(--color-border); }
 .tty-statusbar-spacer { flex: 1; }
+.tty-statusbar-lock {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  white-space: nowrap;
+}
+.tty-statusbar-lock svg {
+  width: 9px;
+  height: 9px;
+  color: var(--color-success);
+}
 .tty-statusbar-cwd {
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
Two small cuts before 1.7.3, follow-ups to #892.

- Terminal: the "localhost only" pill moves from the header into the status bar (lock + text next to shell and session count, same tooltip). Header was louder than the fact deserved.
- Assistant welcome: the static slash-command list is gone. Typing / in the composer opens the live CommandMenu over the same catalog, so the list was a duplicate.