### PR TITLE
Assistant skill latency fixes + welcome slash list removal

### DIFF
--- a/src/quodeq/assistant/adapters/_api.py
+++ b/src/quodeq/assistant/adapters/_api.py
@@ -14,8 +14,8 @@ import httpx
 import openai
 
 from quodeq.assistant.adapters._fallback import (
-    FALLBACK_CONTRACT,
     extract_prompted_tool_call,
+    fallback_contract,
 )
 from quodeq.assistant.cancel import CancelToken, TurnCancelled
 from quodeq.assistant.guard import MAX_TOOL_ITERATIONS, guard_tool_result
@@ -153,9 +153,10 @@ def run_api_turn(*, messages: list[dict], config: ApiTurnConfig,
     cancel = cancel or CancelToken()
     convo = list(messages)
     if not config.native_tools:
-        convo = [dict(convo[0], content=convo[0]["content"] + FALLBACK_CONTRACT),
+        contract = fallback_contract(registry.openai_tools())
+        convo = [dict(convo[0], content=convo[0]["content"] + contract),
                  *convo[1:]] if convo and convo[0]["role"] == "system" else (
-            [{"role": "system", "content": FALLBACK_CONTRACT.strip()}, *convo])
+            [{"role": "system", "content": contract.strip()}, *convo])
     factory = client_factory or _default_client
     text = ""
     with factory(config) as client:

--- a/src/quodeq/assistant/adapters/_fallback.py
+++ b/src/quodeq/assistant/adapters/_fallback.py
@@ -12,6 +12,24 @@ FALLBACK_CONTRACT = (
     "enough information, answer normally without a tool_call object."
 )
 
+
+def fallback_contract(tools: list[dict]) -> str:
+    """The contract plus the actual tool catalog (names + argument schemas).
+
+    Native-tools providers get the schemas via the API's `tools` parameter;
+    prompted-JSON models otherwise never see a tool name or argument shape and
+    must guess them from prose, burning a full generation on every rejected
+    call (worst for draft_action, whose payload is validated strictly).
+    """
+    lines = []
+    for tool in tools:
+        fn = tool["function"]
+        schema = json.dumps(fn.get("parameters") or {}, ensure_ascii=False)
+        lines.append(f"- {fn['name']}: {fn['description']}\n  arguments schema: {schema}")
+    if not lines:
+        return FALLBACK_CONTRACT
+    return FALLBACK_CONTRACT + "\n\n# Available tools\n" + "\n".join(lines)
+
 _JSON_BLOCK = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
 
 

--- a/src/quodeq/data/assistant/skills/explain-finding.md
+++ b/src/quodeq/data/assistant/skills/explain-finding.md
@@ -2,7 +2,7 @@
 name: explain-finding
 description: Explain a finding in depth, with code context
 argument_hint: [file:line or search terms]
-views: violations
+views: overview, violations
 ---
 The user wants to understand one finding (usually the one selected in
 `[ui-state]`). Use `search_findings` to fetch it, then `read_repo_file` on the

--- a/src/quodeq/data/assistant/skills/verify-finding.md
+++ b/src/quodeq/data/assistant/skills/verify-finding.md
@@ -2,7 +2,7 @@
 name: verify-finding
 description: Adversarially verify a finding, then dismiss it or mark it verified
 argument_hint: [file:line or search terms]
-views: violations
+views: overview, violations
 requires_write: true
 ---
 The user wants to know whether one finding (usually the one selected in
@@ -16,8 +16,12 @@ The user wants to know whether one finding (usually the one selected in
 4. Argue adversarially: try to refute the finding before accepting it. State
    REAL or FALSE POSITIVE with a confidence (high, medium, low) and the
    decisive evidence.
-5. Draft exactly one action with `draft_action`: FALSE POSITIVE ->
-   `dismiss_finding` with your reasoning as the reason; REAL ->
-   `verify_finding` with a one-line note. The user approves or rejects the
-   card; never claim the action was applied.
+5. Draft exactly one action with `draft_action`. The payload's `req`, `file`
+   and `line` must be copied verbatim from the finding you located in step 1
+   (`req` may be empty when the finding has none); made-up keys are rejected.
+   FALSE POSITIVE -> `action_type: "dismiss_finding"`, payload
+   `{req, file, line, reason}` with your reasoning as the reason.
+   REAL -> `action_type: "verify_finding"`, payload `{req, file, line, note}`
+   with a one-line note. The user approves or rejects the card;
+   never claim the action was applied.
 Keep the reply under ~250 words and quote at most a few lines of code.

--- a/src/quodeq/data/assistant/skills/verify-finding.md
+++ b/src/quodeq/data/assistant/skills/verify-finding.md
@@ -2,7 +2,6 @@
 name: verify-finding
 description: Adversarially verify a finding, then dismiss it or mark it verified
 argument_hint: [file:line or search terms]
-views: overview, violations
 requires_write: true
 ---
 The user wants to know whether one finding (usually the one selected in

--- a/src/quodeq/ui/src/features/assistant/AssistantWelcome.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantWelcome.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { VISIBLE_META_COMMANDS, pillsForView } from './commands.js';
+import { pillsForView } from './commands.js';
 import { QMarkIcon } from '../../components/QMarkIcon.jsx';
 
 // Dot tints cycle so neighboring cards read as distinct entry points.
@@ -50,22 +50,8 @@ export function AssistantWelcome({ catalog, view, onPick, readOnly = false }) {
           </div>
         </div>
       )}
-      <div className="assistant-welcome-section">
-        <div className="assistant-welcome-label">Slash commands</div>
-        <div className="assistant-cmd-list">
-          {VISIBLE_META_COMMANDS.map((c) => (
-            <button
-              key={c.name}
-              type="button"
-              className="assistant-cmd-row"
-              onClick={() => onPick(`/${c.name} `)}
-            >
-              <code className="assistant-cmd-badge">/{c.name}</code>
-              <span className="assistant-cmd-desc">{c.description}</span>
-            </button>
-          ))}
-        </div>
-      </div>
+      {/* No slash-command list here: typing "/" in the composer opens the
+          live CommandMenu autocomplete, which is the same catalog searchable. */}
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/assistant/AssistantWelcome.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantWelcome.test.jsx
@@ -12,13 +12,15 @@ const catalog = {
   actions: [],
 };
 
-it('shows skills as suggestion cards and no slash-command list (the composer "/" menu covers that)', () => {
+it('shows view-matching skills as suggestion cards; no slash list, no off-view cards', () => {
   render(<AssistantWelcome catalog={catalog} view="overview" onPick={() => {}} />);
   expect(screen.queryByText('/help')).toBeNull();
   expect(screen.queryByText('/clear')).toBeNull();
   expect(screen.queryByText('/explain-score')).toBeNull(); // skills are cards, not text
   expect(screen.getByRole('button', { name: 'Explain score' })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Create standard' })).toBeInTheDocument();
+  // create-standard is standards-view only: offering it here would invite a
+  // guaranteed-to-fail first tool call.
+  expect(screen.queryByRole('button', { name: 'Create standard' })).toBeNull();
 });
 
 it('pill click pre-fills, does not send', () => {
@@ -36,8 +38,10 @@ it('renders without a catalog (fetch failed): intro only, no cards', () => {
 });
 
 const RO_CATALOG = { skills: [
-  { name: 'explain-score', description: 'd', views: ['overview'], requiresWrite: false },
-  { name: 'verify-finding', description: 'd', views: ['violations'], requiresWrite: true },
+  // views mirror the real catalog (explain-score and verify-finding span
+  // overview + violations).
+  { name: 'explain-score', description: 'd', views: ['overview', 'violations'], requiresWrite: false },
+  { name: 'verify-finding', description: 'd', views: ['overview', 'violations'], requiresWrite: true },
   { name: 'create-standard', description: 'd', views: ['standards'], requiresWrite: true },
 ] };
 

--- a/src/quodeq/ui/src/features/assistant/AssistantWelcome.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantWelcome.test.jsx
@@ -12,12 +12,11 @@ const catalog = {
   actions: [],
 };
 
-it('lists meta commands as text, skills as pills only', () => {
+it('shows skills as suggestion cards and no slash-command list (the composer "/" menu covers that)', () => {
   render(<AssistantWelcome catalog={catalog} view="overview" onPick={() => {}} />);
-  expect(screen.getByText('/help')).toBeInTheDocument();
-  expect(screen.getByText('/clear')).toBeInTheDocument();
-  expect(screen.queryByText('/actions')).toBeNull(); // hidden meta stays out
-  expect(screen.queryByText('/explain-score')).toBeNull(); // skills are pills, not text
+  expect(screen.queryByText('/help')).toBeNull();
+  expect(screen.queryByText('/clear')).toBeNull();
+  expect(screen.queryByText('/explain-score')).toBeNull(); // skills are cards, not text
   expect(screen.getByRole('button', { name: 'Explain score' })).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Create standard' })).toBeInTheDocument();
 });
@@ -29,19 +28,11 @@ it('pill click pre-fills, does not send', () => {
   expect(onPick).toHaveBeenCalledWith('/explain-score ');
 });
 
-it('renders without a catalog (fetch failed)', () => {
+it('renders without a catalog (fetch failed): intro only, no cards', () => {
   const { container } = render(<AssistantWelcome catalog={null} view="overview" onPick={() => {}} />);
-  expect(screen.getByText('/help')).toBeInTheDocument();
-  // No suggestion cards without a catalog (slash-command rows still render).
+  expect(screen.getByText(/explain scores/i)).toBeInTheDocument();
   expect(container.querySelector('.assistant-suggest-card')).toBeNull();
   expect(screen.queryByText('Suggested')).toBeNull();
-});
-
-it('slash-command row click pre-fills the composer', () => {
-  const onPick = vi.fn();
-  render(<AssistantWelcome catalog={catalog} view="overview" onPick={onPick} />);
-  fireEvent.click(screen.getByText('/help'));
-  expect(onPick).toHaveBeenCalledWith('/help ');
 });
 
 const RO_CATALOG = { skills: [

--- a/src/quodeq/ui/src/features/assistant/commands.js
+++ b/src/quodeq/ui/src/features/assistant/commands.js
@@ -65,9 +65,10 @@ export function pillsForView(catalog, view, { readOnly = false } = {}) {
   // Read-only (remote) sessions have no draft_action server-side, so
   // write-shaped skills would dead-end; hide their pills entirely.
   const skills = (catalog?.skills ?? []).filter((s) => !readOnly || !s.requiresWrite);
-  const matching = skills.filter((s) => (s.views ?? []).includes(view));
-  const rest = skills.filter((s) => !(s.views ?? []).includes(view));
-  return [...matching, ...rest]
+  // Only skills declared for this view: a padded pill whose skill cannot run
+  // in the current scope invites a guaranteed-to-fail first tool call.
+  return skills
+    .filter((s) => (s.views ?? []).includes(view))
     .slice(0, 4)
     .map((s) => ({
       label: s.name.replace(/-/g, ' ').replace(/^./, (ch) => ch.toUpperCase()),

--- a/src/quodeq/ui/src/features/assistant/commands.test.js
+++ b/src/quodeq/ui/src/features/assistant/commands.test.js
@@ -84,15 +84,14 @@ test('buildMetaResponse /skills hides requiresWrite skills when readOnly; /help 
   assert.match(helpDefault, /\/create-standard/);
 });
 
-test('pillsForView leads with view-matching skills, then the rest, max 4', () => {
+test('pillsForView offers only view-matching skills, max 4', () => {
   const pills = pillsForView(catalog, 'overview');
-  assert.deepEqual(pills.map((p) => p.fill), ['/explain-score ', '/create-standard ']);
+  assert.deepEqual(pills.map((p) => p.fill), ['/explain-score ']);
   assert.equal(pills[0].label, 'Explain score');
-  // standards view reorders: create-standard first, remaining skills after
   assert.deepEqual(pillsForView(catalog, 'standards').map((p) => p.fill),
-    ['/create-standard ', '/explain-score ']);
-  // no view match: every skill still offered, catalog order
-  assert.deepEqual(pillsForView(catalog, 'map').map((p) => p.fill),
-    ['/explain-score ', '/create-standard ']);
+    ['/create-standard ']);
+  // No view match: no pills. A padded pill whose skill cannot run in the
+  // current scope invites a guaranteed-to-fail first tool call.
+  assert.deepEqual(pillsForView(catalog, 'map'), []);
   assert.deepEqual(pillsForView(null, 'overview'), []);
 });

--- a/src/quodeq/ui/src/styles/assistant.css
+++ b/src/quodeq/ui/src/styles/assistant.css
@@ -727,42 +727,6 @@
   color: var(--color-text-muted);
 }
 
-/* Slash commands: a bordered menu of full-width rows. */
-.assistant-cmd-list {
-  border: 1px solid var(--color-border);
-  border-radius: 0.7rem;
-  overflow: hidden;
-}
-.assistant-cmd-row {
-  display: flex;
-  align-items: center;
-  gap: 0.7rem;
-  width: 100%;
-  text-align: left;
-  padding: 0.55rem 0.8rem;
-  background: var(--color-surface);
-  border: none;
-  border-bottom: 1px solid var(--color-border);
-  cursor: pointer;
-}
-.assistant-cmd-row:last-child { border-bottom: none; }
-.assistant-cmd-row:hover { background: var(--color-surface-alt); }
-.assistant-cmd-badge {
-  font-family: var(--font-data);
-  font-size: 0.71875rem;
-  font-weight: 500;
-  color: var(--color-accent);
-  background: var(--color-accent-soft);
-  border: 1px solid color-mix(in srgb, var(--color-accent) 20%, transparent);
-  border-radius: 0.375rem;
-  padding: 0.1rem 0.5rem;
-  flex-shrink: 0;
-}
-.assistant-cmd-desc {
-  font-family: var(--font-sans);
-  font-size: 0.75rem;
-  color: var(--color-text-muted);
-}
 
 .assistant-command-menu { position: absolute; bottom: 100%; left: 0; right: 0; margin-bottom: 4px; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; z-index: 10; }
 .assistant-command-item { display: flex; align-items: baseline; gap: 8px; width: 100%; text-align: left; padding: 6px 10px; background: none; border: none; color: var(--color-text); cursor: pointer; font-size: 12px; }

--- a/tests/assistant/test_api_adapter.py
+++ b/tests/assistant/test_api_adapter.py
@@ -94,7 +94,14 @@ def test_fallback_mode_uses_prompted_json_and_no_tools_param():
                         emit=lambda f: None, client_factory=lambda c: client)
     assert text == "C grade"
     assert "tools" not in client.calls[0]
-    assert "tool_call" in client.calls[0]["messages"][0]["content"]  # contract in system
+    system = client.calls[0]["messages"][0]["content"]
+    assert "tool_call" in system  # contract in system
+    # The tool CATALOG must be in the prompt too: without the API tools param
+    # the model otherwise never sees a tool name or argument schema and has to
+    # guess them, burning a full generation per rejected call.
+    assert "# Available tools" in system
+    assert "get_scores" in system
+    assert "arguments schema:" in system
 
 
 def test_tool_call_frame_carries_args_summary():

--- a/tests/assistant/test_skills.py
+++ b/tests/assistant/test_skills.py
@@ -55,9 +55,11 @@ def test_builtin_skills_have_views_and_hints():
 
 def test_verify_finding_skill_loads():
     skill = load_skills()["verify-finding"]
-    # Also offered on overview: search_findings falls back to get_violations
-    # in accumulated scope, and draft_action validates against it there too.
-    assert skill.views == ("overview", "violations")
+    # No views: deliberately NOT offered as a suggestion card (the freeform
+    # paste-a-finding path it invites is the skill's slowest entry; a
+    # row-level "Verify with assistant" button is the planned promoted path).
+    # Still reachable as /verify-finding via the composer autocomplete.
+    assert skill.views == ()
     assert skill.argument_hint
 
 

--- a/tests/assistant/test_skills.py
+++ b/tests/assistant/test_skills.py
@@ -55,7 +55,9 @@ def test_builtin_skills_have_views_and_hints():
 
 def test_verify_finding_skill_loads():
     skill = load_skills()["verify-finding"]
-    assert skill.views == ("violations",)
+    # Also offered on overview: search_findings falls back to get_violations
+    # in accumulated scope, and draft_action validates against it there too.
+    assert skill.views == ("overview", "violations")
     assert skill.argument_hint
 
 


### PR DESCRIPTION
Fixes the "Verify finding takes forever" report. Root causes found by audit; ranked worst first.

1. **Local models never saw the tool formats.** Providers without native tool-calling (ollama/gemma) get a prompted-JSON fallback whose contract named zero tools. The exact `draft_action` payload verify-finding needs lived only in schemas that were never sent, so the model guessed, validation rejected, and it retried full generations up to the 12-iteration cap. The fallback system prompt now carries the whole tool catalog (names, descriptions, argument schemas). Benefits all skills on all local models.
2. **verify-finding.md now spells out the draft_action payloads** (`{req, file, line, reason|note}`, copied verbatim from the located finding), mirroring what create-standard.md already did.
3. **The welcome only offers skills valid for the current view** instead of padding to four — an off-view pill invited a guaranteed-to-fail first tool call. explain-finding now declares `overview` too (it works there via `get_violations` in accumulated scope).
4. **verify-finding is no longer a suggested card at all.** The freeform paste path it invites is its slowest entry; it stays reachable as `/verify-finding` (autocomplete, /help). A row-level "Verify with assistant" button pre-filling `req/file/line` is the planned promoted path (follow-up).

Also carries the welcome slash-command list removal (commit from #893's branch that missed the merge — typing / in the composer opens the same catalog live).

Not in this PR (follow-ups): the row-level verify button, pinning num_ctx for assistant turns, per-tool timing in the stream.