### PR TITLE
Model chip right-aligned, terminal top inset

### DIFF
--- a/src/quodeq/ui/src/features/assistant/AssistantHeader.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantHeader.jsx
@@ -50,19 +50,6 @@ export default function AssistantHeader({ selectedProject, onOpenSettings }) {
           {selectedProject ? `project · ${selectedProject}` : 'no project selected'}
         </div>
       </div>
-      {modelLabel && (
-        <button type="button" className="assistant-model-chip"
-          title={`${modelLabel} — change in Settings`}
-          onClick={() => {
-            // Jump to Settings AND tuck the panel away: the drawer would
-            // otherwise cover the provider section the user is heading to.
-            onOpenSettings?.();
-            closeActiveTab();
-          }}>
-          <span className="assistant-model-dot" aria-hidden="true" />
-          <span className="assistant-model-name">{modelLabel}</span>
-        </button>
-      )}
       {readOnly && (
         <Badge variant="tag" tone="info" title="Remote project session: read tools only">
           read-only
@@ -86,6 +73,21 @@ export default function AssistantHeader({ selectedProject, onOpenSettings }) {
         </button>
       )}
       <div className="assistant-drawer-controls">
+        {/* Model chip leads the right-side cluster, aligned with the action
+            buttons; status badges stay on the left with the identity. */}
+        {modelLabel && (
+          <button type="button" className="assistant-model-chip"
+            title={`${modelLabel} — change in Settings`}
+            onClick={() => {
+              // Jump to Settings AND tuck the panel away: the drawer would
+              // otherwise cover the provider section the user is heading to.
+              onOpenSettings?.();
+              closeActiveTab();
+            }}>
+            <span className="assistant-model-dot" aria-hidden="true" />
+            <span className="assistant-model-name">{modelLabel}</span>
+          </button>
+        )}
         <button type="button" className="assistant-drawer-btn"
           onClick={resetConversation}
           aria-label="New conversation"

--- a/src/quodeq/ui/src/features/drawer/BottomDrawer.test.jsx
+++ b/src/quodeq/ui/src/features/drawer/BottomDrawer.test.jsx
@@ -76,10 +76,12 @@ it('the maximized-restore glyph is distinct from the hide chevron', () => {
   drawer.maximized = false;
 });
 
-it('the model chip sits in the identity area on the left, not in the right controls', () => {
+it('the model chip leads the right-side controls cluster', () => {
   render(<BottomDrawer uiState={{}} />);
   const chip = screen.getByTitle(/Ollama · m/);
-  expect(chip.closest('.assistant-drawer-controls')).toBeNull();
+  const controls = chip.closest('.assistant-drawer-controls');
+  expect(controls).not.toBeNull();
+  expect(controls.firstElementChild).toBe(chip);
 });
 
 it('the model chip opens Settings AND hides the panel (drawer must not cover the settings page)', () => {

--- a/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
@@ -152,6 +152,9 @@ it('resets xterm on every socket (re)open so a live-backend reconnect does not d
   expect(typeof lastSocketOpts.onOpen).toBe('function');
   lastSocketOpts.onOpen();
   expect(fakeTerm.reset).toHaveBeenCalled();
+  // Top breathing room: one blank buffer row ahead of the replayed content
+  // (scrolls away with the scrollback, unlike a fixed CSS inset).
+  expect(fakeTerm.write).toHaveBeenCalledWith('\r\n');
   expect(fakeTerm.options.disableStdin).toBe(false);
 });
 

--- a/src/quodeq/ui/src/features/terminal/TerminalSessionView.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalSessionView.jsx
@@ -45,7 +45,13 @@ export default function TerminalSessionView({ sessionId, active, live, onGone, r
     onOpen: () => {
       const term = termRef.current;
       if (!term) return;
-      try { term.reset(); } catch { /* noop */ }
+      try {
+        term.reset();
+        // One blank buffer row before the (re)played content: top breathing
+        // room that scrolls away with the scrollback instead of being a fixed
+        // viewport inset (which CSS padding on xterm would be).
+        term.write('\r\n');
+      } catch { /* noop */ }
       term.options.disableStdin = false;
     },
   });

--- a/src/quodeq/ui/src/styles/assistant.css
+++ b/src/quodeq/ui/src/styles/assistant.css
@@ -271,16 +271,20 @@
   text-overflow: ellipsis;
 }
 
-/* Model chip: a real button — click opens Settings. */
+/* Model chip: a real button — click opens Settings. Lives in the right-side
+   controls cluster; matches the action buttons' height and sits just before
+   them with a hair of separation. */
 .assistant-model-chip {
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
-  padding: 0.25rem 0.6rem;
+  height: 1.5rem;
+  padding: 0 0.6rem;
+  margin-right: 0.25rem;
   max-width: 15rem;
   background: var(--color-surface-alt);
   border: 1px solid var(--color-border);
-  border-radius: 0.5rem;
+  border-radius: 0.375rem;
   cursor: pointer;
   flex-shrink: 1;
   min-width: 0;


### PR DESCRIPTION
Two last UI touches before 1.7.3.

- Assistant header: the model chip moves into the right-side cluster, leading the action buttons and height-matched to them. Status badges (read-only, no repo, changes) stay on the left with the identity.
- Terminal: one blank buffer row is written on every (re)connect before the scrollback replay, giving the first line breathing room from the top. Because it's buffer content, it scrolls away with the scrollback — a fixed CSS inset on xterm's viewport could not do that.