### PR TITLE
release: v1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.7.3] - 2026-07-27
+
+### Features
+- **Multi-session terminal**: run up to 6 shell sessions as tabs, each its own shell with its own history. Sessions live server-side, so they survive page reloads and closing the drawer; closing a tab kills that shell. With a single session the tab strip stays out of the way and a + in the header opens the second.
+- **Terminal panel redesign**: the terminal gets its own header with a working copy button, session tabs, and a status bar showing the shell, session count, working directory and the localhost-only sandbox note.
+- **Assistant panel redesign**: new header with the Quodeq mark, project name and a model chip that jumps to Settings; tappable suggestion cards in the empty state; avatars and a thinking indicator in the transcript; a card-style composer with auto-grow and a proper send button.
+- **Terminal colors**: terminal output now renders with a full 16-color ANSI palette that follows the app theme in light and dark.
+
+### Improvements
+- **Faster assistant skills on local models**: providers without native tool-calling now receive the full tool catalog and exact action payload formats in the prompt instead of guessing them one failed attempt at a time. Suggested actions appear only on views where they can actually run.
+- **Drawer chrome**: the shared drawer header is gone; each panel carries its own controls, with a compact Assistant/Terminal switcher when both are open.
+
 ## [1.7.2] - 2026-07-26
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <h2 align="center">AI-powered code quality and security scanner</h2>
-<p align="center"><strong>v1.7.2</strong></p>
+<p align="center"><strong>v1.7.3</strong></p>
 <p align="center">
   <a href="https://github.com/quodeq/quodeq/actions/workflows/test.yml"><img src="https://github.com/quodeq/quodeq/actions/workflows/test.yml/badge.svg" alt="Tests" /></a>
   <a href="https://github.com/quodeq/quodeq/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>

--- a/packaging/macos/launcher.sh
+++ b/packaging/macos/launcher.sh
@@ -63,7 +63,7 @@ if [ -z "$QUODEQ" ]; then
         # ranges. The release skill bumps this on every cut (see
         # .claude/skills/release/SKILL.md).
         # TODO: ship requirements.txt with hashes in the .app bundle.
-        python3 -m pip install --user --only-binary :all: --no-deps "quodeq==1.7.2" 2>&1
+        python3 -m pip install --user --only-binary :all: --no-deps "quodeq==1.7.3" 2>&1
     fi
     export PATH="$PATH:$(python3 -m site --user-base)/bin"
     QUODEQ=$(command -v quodeq 2>/dev/null)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quodeq"
-version = "1.7.2"
+version = "1.7.3"
 description = "Source code quality evaluation platform powered by AI"
 readme = "README.md"
 license = "MIT"

--- a/src/quodeq/api/terminal_routes.py
+++ b/src/quodeq/api/terminal_routes.py
@@ -23,7 +23,7 @@ from quodeq.terminal.links import (
     resolve_path,
     safe_editor_path,
 )
-from quodeq.terminal.manager import TerminalManager
+from quodeq.terminal.sessions import TerminalSessionRegistry, shell_name
 
 _logger = logging.getLogger(__name__)
 
@@ -53,8 +53,9 @@ def _gate_reason() -> str | None:
 # App-specific WS close codes (4000-4999 range). The client's auto-reconnect
 # keys off these: a retry against a held lock or a closed gate can never
 # succeed, so it must not loop — only unexpected drops are retried.
-_WS_CLOSE_BUSY = 4002     # single-connection lock held by another window
-_WS_CLOSE_REFUSED = 4003  # terminal gate refused the handshake
+_WS_CLOSE_BUSY = 4002      # per-session connection lock held by another window
+_WS_CLOSE_REFUSED = 4003   # terminal gate refused the handshake
+_WS_CLOSE_NOT_FOUND = 4004  # unknown session id; client reconciles via /sessions
 
 
 def _coerce_int(value) -> int | None:
@@ -86,27 +87,55 @@ def _apply_control(manager, payload: str) -> None:
         return
 
 
-def register_terminal_routes(app: Flask, manager: TerminalManager | None = None) -> None:
+def register_terminal_routes(app: Flask, registry: TerminalSessionRegistry | None = None) -> None:
     sock = Sock(app)
-    manager = manager or TerminalManager()
-    app.extensions["terminal_manager"] = manager
-    # Don't let a live shell outlive the server process.
-    atexit.register(manager.kill)
-
-    # Only one WS client may drain the single PTY at a time; a second concurrent
-    # reader would race the first and produce garbled/doubled output.
-    _conn_lock = threading.Lock()
+    registry = registry or TerminalSessionRegistry()
+    app.extensions["terminal_registry"] = registry
+    # Don't let live shells outlive the server process.
+    atexit.register(registry.kill_all)
 
     @app.get("/api/terminal/status")
     def terminal_status():
         reason = _env_reason()
-        return jsonify({"enabled": reason is None, "running": manager.alive, "reason": reason})
+        return jsonify({
+            "enabled": reason is None,
+            "running": registry.any_alive,
+            "reason": reason,
+            "shell": shell_name(),
+        })
+
+    @app.get("/api/terminal/sessions")
+    def terminal_sessions():
+        # _env_reason, not the full gate: same-origin GETs carry no Origin
+        # header (same reasoning as /status).
+        if _env_reason() is not None:
+            return jsonify({"error": "forbidden"}), 403
+        return jsonify({"sessions": registry.list(), "max": registry.MAX_SESSIONS})
+
+    @app.post("/api/terminal/sessions")
+    def terminal_session_create():
+        if _gate_reason() is not None:
+            return jsonify({"error": "forbidden"}), 403
+        session = registry.create()
+        if session is None:
+            return jsonify({"error": "session limit reached"}), 409
+        return jsonify({"id": session.id, "name": session.name}), 201
+
+    @app.post("/api/terminal/sessions/<sid>/kill")
+    def terminal_session_kill(sid):
+        if _gate_reason() is not None:
+            return jsonify({"error": "forbidden"}), 403
+        if not registry.kill(sid):
+            return jsonify({"error": "unknown session"}), 404
+        return jsonify({"ok": True})
 
     @app.post("/api/terminal/kill")
     def terminal_kill():
+        # Kills EVERY session — this backs Settings' "Restart terminal", which
+        # is a full reset; the client reconciles its tabs via /sessions after.
         if _gate_reason() is not None:
             return jsonify({"error": "forbidden"}), 403
-        manager.kill()
+        registry.kill_all()
         return jsonify({"ok": True})
 
     @app.post("/api/terminal/resolve")
@@ -122,7 +151,8 @@ def register_terminal_routes(app: Flask, manager: TerminalManager | None = None)
         paths = body.get("paths")
         if not isinstance(paths, list):
             return jsonify({"error": "paths must be a list"}), 400
-        bases = resolve_bases(manager.pid)
+        sid = body.get("session")
+        bases = resolve_bases(registry.pid_for(sid if isinstance(sid, str) else None))
         resolved = []
         for token in paths:
             if not isinstance(token, str) or not token:
@@ -146,7 +176,10 @@ def register_terminal_routes(app: Flask, manager: TerminalManager | None = None)
         # cwd, server cwd, home) and normalize the untrusted path to its real,
         # canonical form. Everything below uses this sanitized value, never the
         # raw client string. Outside the bases -> refuse.
-        safe = safe_editor_path(path, resolve_bases(manager.pid))
+        sid = body.get("session")
+        safe = safe_editor_path(
+            path, resolve_bases(registry.pid_for(sid if isinstance(sid, str) else None))
+        )
         # Never launch on a non-file, even though the client only sends paths it
         # got back as exists=true — the state could have changed, and this is the
         # authoritative check before spawning a process.
@@ -174,7 +207,22 @@ def register_terminal_routes(app: Flask, manager: TerminalManager | None = None)
         if _gate_reason() is not None:
             ws.close(_WS_CLOSE_REFUSED)
             return
-        if not _conn_lock.acquire(blocking=False):
+        sid = request.args.get("session")
+        if sid:
+            session = registry.get(sid)
+            if session is None:
+                # Stale tab id (e.g. server restarted). The client must not
+                # retry this URL — it refetches /sessions and rebuilds tabs.
+                ws.close(_WS_CLOSE_NOT_FOUND)
+                return
+        else:
+            # Pre-multi-session clients connect without an id.
+            session = registry.get_or_create_default()
+        manager = session.manager
+        # Only one WS client may drain a session's PTY at a time; a second
+        # concurrent reader would race the first and produce garbled/doubled
+        # output. Other sessions are unaffected.
+        if not session.conn_lock.acquire(blocking=False):
             try:
                 ws.send("0\r\n[terminal already open in another window]\r\n")
             finally:
@@ -239,4 +287,4 @@ def register_terminal_routes(app: Flask, manager: TerminalManager | None = None)
                 # sleep), so this returns promptly; bound it regardless.
                 reader.join(timeout=2)
         finally:
-            _conn_lock.release()
+            session.conn_lock.release()

--- a/src/quodeq/assistant/adapters/_api.py
+++ b/src/quodeq/assistant/adapters/_api.py
@@ -14,8 +14,8 @@ import httpx
 import openai
 
 from quodeq.assistant.adapters._fallback import (
-    FALLBACK_CONTRACT,
     extract_prompted_tool_call,
+    fallback_contract,
 )
 from quodeq.assistant.cancel import CancelToken, TurnCancelled
 from quodeq.assistant.guard import MAX_TOOL_ITERATIONS, guard_tool_result
@@ -153,9 +153,10 @@ def run_api_turn(*, messages: list[dict], config: ApiTurnConfig,
     cancel = cancel or CancelToken()
     convo = list(messages)
     if not config.native_tools:
-        convo = [dict(convo[0], content=convo[0]["content"] + FALLBACK_CONTRACT),
+        contract = fallback_contract(registry.openai_tools())
+        convo = [dict(convo[0], content=convo[0]["content"] + contract),
                  *convo[1:]] if convo and convo[0]["role"] == "system" else (
-            [{"role": "system", "content": FALLBACK_CONTRACT.strip()}, *convo])
+            [{"role": "system", "content": contract.strip()}, *convo])
     factory = client_factory or _default_client
     text = ""
     with factory(config) as client:

--- a/src/quodeq/assistant/adapters/_fallback.py
+++ b/src/quodeq/assistant/adapters/_fallback.py
@@ -12,6 +12,24 @@ FALLBACK_CONTRACT = (
     "enough information, answer normally without a tool_call object."
 )
 
+
+def fallback_contract(tools: list[dict]) -> str:
+    """The contract plus the actual tool catalog (names + argument schemas).
+
+    Native-tools providers get the schemas via the API's `tools` parameter;
+    prompted-JSON models otherwise never see a tool name or argument shape and
+    must guess them from prose, burning a full generation on every rejected
+    call (worst for draft_action, whose payload is validated strictly).
+    """
+    lines = []
+    for tool in tools:
+        fn = tool["function"]
+        schema = json.dumps(fn.get("parameters") or {}, ensure_ascii=False)
+        lines.append(f"- {fn['name']}: {fn['description']}\n  arguments schema: {schema}")
+    if not lines:
+        return FALLBACK_CONTRACT
+    return FALLBACK_CONTRACT + "\n\n# Available tools\n" + "\n".join(lines)
+
 _JSON_BLOCK = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
 
 

--- a/src/quodeq/data/assistant/skills/explain-finding.md
+++ b/src/quodeq/data/assistant/skills/explain-finding.md
@@ -2,7 +2,7 @@
 name: explain-finding
 description: Explain a finding in depth, with code context
 argument_hint: [file:line or search terms]
-views: violations
+views: overview, violations
 ---
 The user wants to understand one finding (usually the one selected in
 `[ui-state]`). Use `search_findings` to fetch it, then `read_repo_file` on the

--- a/src/quodeq/data/assistant/skills/verify-finding.md
+++ b/src/quodeq/data/assistant/skills/verify-finding.md
@@ -2,7 +2,7 @@
 name: verify-finding
 description: Adversarially verify a finding, then dismiss it or mark it verified
 argument_hint: [file:line or search terms]
-views: violations
+views: overview, violations
 requires_write: true
 ---
 The user wants to know whether one finding (usually the one selected in
@@ -16,8 +16,12 @@ The user wants to know whether one finding (usually the one selected in
 4. Argue adversarially: try to refute the finding before accepting it. State
    REAL or FALSE POSITIVE with a confidence (high, medium, low) and the
    decisive evidence.
-5. Draft exactly one action with `draft_action`: FALSE POSITIVE ->
-   `dismiss_finding` with your reasoning as the reason; REAL ->
-   `verify_finding` with a one-line note. The user approves or rejects the
-   card; never claim the action was applied.
+5. Draft exactly one action with `draft_action`. The payload's `req`, `file`
+   and `line` must be copied verbatim from the finding you located in step 1
+   (`req` may be empty when the finding has none); made-up keys are rejected.
+   FALSE POSITIVE -> `action_type: "dismiss_finding"`, payload
+   `{req, file, line, reason}` with your reasoning as the reason.
+   REAL -> `action_type: "verify_finding"`, payload `{req, file, line, note}`
+   with a one-line note. The user approves or rejects the card;
+   never claim the action was applied.
 Keep the reply under ~250 words and quote at most a few lines of code.

--- a/src/quodeq/data/assistant/skills/verify-finding.md
+++ b/src/quodeq/data/assistant/skills/verify-finding.md
@@ -2,7 +2,6 @@
 name: verify-finding
 description: Adversarially verify a finding, then dismiss it or mark it verified
 argument_hint: [file:line or search terms]
-views: overview, violations
 requires_write: true
 ---
 The user wants to know whether one finding (usually the one selected in

--- a/src/quodeq/terminal/sessions.py
+++ b/src/quodeq/terminal/sessions.py
@@ -1,0 +1,136 @@
+# src/quodeq/terminal/sessions.py
+"""Registry of embedded-terminal sessions.
+
+Each session is one TerminalManager (PTY + scrollback ring + decoder) plus a
+per-session single-client lock: two windows must not drain the same PTY, but
+two different sessions are independent and may stream concurrently. The
+registry is the server-side source of truth for the tab strip — the client
+reconciles against ``list()`` rather than persisting its own session list.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+import uuid
+
+from quodeq.terminal.links import child_cwd
+from quodeq.terminal.manager import TerminalManager
+
+
+def shell_name() -> str:
+    """Display name of the shell the PTY backends will spawn (e.g. "zsh")."""
+    if sys.platform == "win32":
+        from quodeq.terminal._pty_windows import resolve_shell
+
+        path = resolve_shell()
+    else:
+        from quodeq.terminal._pty_unix import resolve_shell
+
+        path = resolve_shell()[0]
+    base = os.path.basename(path)
+    return base[:-4] if base.lower().endswith(".exe") else base
+
+
+class TerminalSession:
+    def __init__(self, sid: str, name: str, manager: TerminalManager, ordinal: int = 0):
+        self.id = sid
+        self.name = name
+        self.ordinal = ordinal
+        self.manager = manager
+        # One WS client per session (a second reader on the same PTY garbles
+        # output); independent sessions each have their own lock.
+        self.conn_lock = threading.Lock()
+        self.created_at = time.time()
+
+    def to_dict(self) -> dict:
+        cwd = child_cwd(self.manager.pid)
+        home = os.path.expanduser("~")
+        if cwd and home != "~" and (cwd == home or cwd.startswith(home + os.sep)):
+            cwd = "~" + cwd[len(home):]
+        return {
+            "id": self.id,
+            "name": self.name,
+            "alive": self.manager.alive,
+            "createdAt": self.created_at,
+            "cwd": cwd,
+        }
+
+
+class TerminalSessionRegistry:
+    MAX_SESSIONS = 6
+
+    def __init__(self, *, manager_factory=TerminalManager):
+        self._factory = manager_factory
+        self._sessions: dict[str, TerminalSession] = {}
+        self._lock = threading.Lock()
+
+    def create(self) -> TerminalSession | None:
+        """New session, or None when at MAX_SESSIONS."""
+        with self._lock:
+            if len(self._sessions) >= self.MAX_SESSIONS:
+                return None
+            # Lowest free ordinal, like real terminal tabs: close "zsh · 2"
+            # and the next new session is "zsh · 2" again, so numbers stay
+            # within 1..MAX_SESSIONS instead of growing forever.
+            used = {s.ordinal for s in self._sessions.values()}
+            ordinal = 1
+            while ordinal in used:
+                ordinal += 1
+            sid = uuid.uuid4().hex[:8]
+            session = TerminalSession(
+                sid, f"{shell_name()} · {ordinal}", self._factory(), ordinal
+            )
+            self._sessions[sid] = session
+            return session
+
+    def get(self, sid: str) -> TerminalSession | None:
+        with self._lock:
+            return self._sessions.get(sid)
+
+    def get_or_create_default(self) -> TerminalSession:
+        """First existing session, else a fresh one. Back-compat path for WS
+        clients that connect without a session id (pre-multi-session bundles)."""
+        with self._lock:
+            for session in self._sessions.values():
+                return session
+        return self.create() or next(iter(self._sessions.values()))
+
+    def list(self) -> list[dict]:
+        with self._lock:
+            sessions = list(self._sessions.values())
+        return [s.to_dict() for s in sessions]
+
+    def kill(self, sid: str) -> bool:
+        """Kill one session's PTY and remove it. False if unknown."""
+        with self._lock:
+            session = self._sessions.pop(sid, None)
+        if session is None:
+            return False
+        session.manager.kill()
+        return True
+
+    def kill_all(self) -> None:
+        with self._lock:
+            sessions = list(self._sessions.values())
+            self._sessions.clear()
+        for session in sessions:
+            session.manager.kill()
+
+    def pid_for(self, sid: str | None) -> int | None:
+        """PID of session ``sid``'s shell, falling back to the first live
+        session (for pre-multi-session clients that send no session id)."""
+        with self._lock:
+            if sid is not None:
+                session = self._sessions.get(sid)
+                return session.manager.pid if session is not None else None
+            for session in self._sessions.values():
+                if session.manager.alive:
+                    return session.manager.pid
+        return None
+
+    @property
+    def any_alive(self) -> bool:
+        with self._lock:
+            return any(s.manager.alive for s in self._sessions.values())

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -1128,7 +1128,8 @@ export default function App() {
             <LlamaCppLogProvider>
               <VerifiedFindingsProvider project={state.selectedProject} source={state.selectedSource}>
               <AppShell
-          drawer={<BottomDrawer uiState={assistantCtx.uiState} />}
+          drawer={<BottomDrawer uiState={assistantCtx.uiState} projectName={resolvedDisplayName}
+            onOpenSettings={() => navTab('settings')} />}
           sidebar={
             <Sidebar
               activeTab={activeTab}

--- a/src/quodeq/ui/src/api/terminal.js
+++ b/src/quodeq/ui/src/api/terminal.js
@@ -1,8 +1,9 @@
 import { request, BASE } from './request.js';
 
-export function terminalSocketUrl(loc = window.location) {
+export function terminalSocketUrl(loc = window.location, sessionId = null) {
   const u = new URL(`${BASE}/terminal/ws`, loc.href);
   u.protocol = (loc.protocol === 'https:' || u.protocol === 'https:') ? 'wss:' : 'ws:';
+  if (sessionId) u.searchParams.set('session', sessionId);
   return u.toString();
 }
 
@@ -10,23 +11,38 @@ export function terminalStatus() {
   return request('/terminal/status');
 }
 
+// Kills EVERY session (backs Settings' "Restart terminal" full reset).
 export function killTerminal() {
   return request('/terminal/kill', { method: 'POST' });
 }
 
+// Server-side session list — the source of truth the tab strip reconciles
+// against. Returns { sessions: [{ id, name, alive, createdAt, cwd }], max }.
+export function listTerminalSessions() {
+  return request('/terminal/sessions');
+}
+
+export function createTerminalSession() {
+  return request('/terminal/sessions', { method: 'POST' });
+}
+
+export function killTerminalSession(id) {
+  return request(`/terminal/sessions/${encodeURIComponent(id)}/kill`, { method: 'POST' });
+}
+
 // Verify which detected path tokens are real files (backend resolves them
 // against the shell's live cwd). Returns [{ input, abs, exists }].
-export function resolveTerminalPaths(paths) {
+export function resolveTerminalPaths(paths, sessionId = null) {
   return request('/terminal/resolve', {
     method: 'POST',
-    body: JSON.stringify({ paths }),
+    body: JSON.stringify(sessionId ? { paths, session: sessionId } : { paths }),
   }).then((r) => r.resolved || []);
 }
 
 // Open an already-resolved absolute path in the user's editor at line[:col].
-export function openInEditor(path, line, col) {
+export function openInEditor(path, line, col, sessionId = null) {
   return request('/terminal/open', {
     method: 'POST',
-    body: JSON.stringify({ path, line, col }),
+    body: JSON.stringify(sessionId ? { path, line, col, session: sessionId } : { path, line, col }),
   });
 }

--- a/src/quodeq/ui/src/api/terminal.test.jsx
+++ b/src/quodeq/ui/src/api/terminal.test.jsx
@@ -9,3 +9,11 @@ it('upgrades to wss on https', () => {
   const url = terminalSocketUrl({ href: 'https://host:9/', protocol: 'https:' });
   expect(url.startsWith('wss://host:9/')).toBe(true);
 });
+it('appends the session id as a query param when given', () => {
+  const url = terminalSocketUrl({ href: 'http://localhost:7863/', protocol: 'http:' }, 'abc123');
+  expect(url).toBe('ws://localhost:7863/api/terminal/ws?session=abc123');
+});
+it('omits the session param when not given (back-compat default session)', () => {
+  const url = terminalSocketUrl({ href: 'http://localhost:7863/', protocol: 'http:' });
+  expect(url.includes('session')).toBe(false);
+});

--- a/src/quodeq/ui/src/components/AssistantLauncherButton.jsx
+++ b/src/quodeq/ui/src/components/AssistantLauncherButton.jsx
@@ -1,6 +1,6 @@
 import { useAssistantDrawer } from '../features/assistant/AssistantDrawerProvider.jsx';
 import useAssistantProvider from '../features/settings/hooks/useAssistantProvider.js';
-import { SparkleIcon } from './CopyButton.jsx';
+import { QMarkIcon } from './QMarkIcon.jsx';
 
 export function AssistantLauncherButton() {
   const { openPanels, toggleTopbar } = useAssistantDrawer();
@@ -22,7 +22,10 @@ export function AssistantLauncherButton() {
       title="Assistant (Ctrl+`)"
       onClick={() => toggleTopbar('assistant')}
     >
-      <SparkleIcon />
+      {/* 11px, not the 12px of the stroke icons: the Q fills its tight
+          viewBox edge-to-edge while stroke icons carry built-in padding, so
+          equal pixel sizes read visually larger. */}
+      <QMarkIcon size={11} />
     </button>
   );
 }

--- a/src/quodeq/ui/src/components/CopyButton.jsx
+++ b/src/quodeq/ui/src/components/CopyButton.jsx
@@ -43,6 +43,31 @@ export function TerminalIcon() {
   );
 }
 
+export function PlusIcon() {
+  return (
+    <svg width={ICON_SIZE} height={ICON_SIZE} viewBox={ICON_VIEWBOX} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M12 5v14M5 12h14" />
+    </svg>
+  );
+}
+
+export function XIcon() {
+  return (
+    <svg width={ICON_SIZE} height={ICON_SIZE} viewBox={ICON_VIEWBOX} fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" aria-hidden="true">
+      <path d="M6 6l12 12M18 6L6 18" />
+    </svg>
+  );
+}
+
+export function LockIcon() {
+  return (
+    <svg width={ICON_SIZE} height={ICON_SIZE} viewBox={ICON_VIEWBOX} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="4" y="11" width="16" height="9" rx="2" />
+      <path d="M8 11V8a4 4 0 0 1 8 0v3" />
+    </svg>
+  );
+}
+
 // The drawer's hide control: a chevron-down (the panel is hidden, nothing is
 // killed), so maximize/restore use the distinct expand/shrink glyphs below
 // instead of chevrons.

--- a/src/quodeq/ui/src/components/LoadingScreen.jsx
+++ b/src/quodeq/ui/src/components/LoadingScreen.jsx
@@ -1,3 +1,5 @@
+import { QMarkIcon } from './QMarkIcon.jsx';
+
 /**
  * @param {{ message?: string }} props
  *
@@ -9,14 +11,7 @@
 export default function LoadingScreen({ message }) {
   return (
     <div className="loading-screen" role="status" aria-live="polite">
-      <svg className="loading-logo" viewBox="288 209 965 588" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-        <path
-          d="M7347 7895 c-421 -51 -848 -208 -1192 -437 -514 -342 -923 -889 -1083 -1449 -82 -285 -107 -484 -99 -789 6 -255 21 -365 77 -586 50 -195 94 -313 190 -509 212 -432 526 -792 922 -1055 713 -474 1602 -586 2428 -305 89 30 100 31 149 5 166 -84 533 -188 821 -231 158 -24 466 -31 613 -16 l79 9 -39 26 c-104 69 -293 257 -411 409 -90 116 -252 354 -252 370 0 6 6 13 14 16 22 9 237 254 320 366 221 297 383 652 456 996 36 170 50 293 56 485 23 701 -228 1336 -732 1860 -442 458 -1035 753 -1677 835 -145 18 -487 18 -640 0z m643 -551 c628 -93 1210 -469 1534 -994 143 -230 235 -481 283 -769 24 -146 24 -443 -1 -601 -83 -527 -331 -972 -731 -1310 -230 -194 -532 -349 -830 -426 -180 -46 -294 -63 -475 -70 -360 -15 -699 57 -1025 215 -426 208 -750 530 -966 957 -254 505 -298 1067 -122 1594 44 132 153 357 230 475 294 447 746 764 1278 894 249 61 561 74 825 35z"
-          transform="translate(0 1024) scale(0.1 -0.1)"
-          fill="var(--logo-q)"
-          fillRule="evenodd"
-        />
-      </svg>
+      <QMarkIcon className="loading-logo" />
       {message && <p className="loading-message">{message}</p>}
     </div>
   );

--- a/src/quodeq/ui/src/components/QMarkIcon.jsx
+++ b/src/quodeq/ui/src/components/QMarkIcon.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+/**
+ * The Quodeq "Q" mark without the compass needle — the same silhouette the
+ * loading screen pulses. This is the assistant's identity icon (topbar
+ * launcher, drawer panel switcher, panel header, avatars). Fill follows
+ * currentColor so it tints with its context; pass className to size/animate.
+ */
+export function QMarkIcon({ size = 14, className }) {
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="497 233 543 540"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      fillRule="evenodd"
+      aria-hidden="true"
+    >
+      <path
+        d="M7347 7895 c-421 -51 -848 -208 -1192 -437 -514 -342 -923 -889 -1083 -1449 -82 -285 -107 -484 -99 -789 6 -255 21 -365 77 -586 50 -195 94 -313 190 -509 212 -432 526 -792 922 -1055 713 -474 1602 -586 2428 -305 89 30 100 31 149 5 166 -84 533 -188 821 -231 158 -24 466 -31 613 -16 l79 9 -39 26 c-104 69 -293 257 -411 409 -90 116 -252 354 -252 370 0 6 6 13 14 16 22 9 237 254 320 366 221 297 383 652 456 996 36 170 50 293 56 485 23 701 -228 1336 -732 1860 -442 458 -1035 753 -1677 835 -145 18 -487 18 -640 0z m643 -551 c628 -93 1210 -469 1534 -994 143 -230 235 -481 283 -769 24 -146 24 -443 -1 -601 -83 -527 -331 -972 -731 -1310 -230 -194 -532 -349 -830 -426 -180 -46 -294 -63 -475 -70 -360 -15 -699 57 -1025 215 -426 208 -750 530 -966 957 -254 505 -298 1067 -122 1594 44 132 153 357 230 475 294 447 746 764 1278 894 249 61 561 74 825 35z"
+        transform="translate(0 1024) scale(0.1 -0.1)"
+      />
+    </svg>
+  );
+}

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawer.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawer.jsx
@@ -6,6 +6,14 @@ import { AssistantWelcome } from './AssistantWelcome.jsx';
 import { buildMetaResponse, matchCommands, parseMetaCommand } from './commands.js';
 import { StopIcon } from '../../components/CopyButton.jsx';
 
+function SendIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M12 19V5M5 12l7-7 7 7" />
+    </svg>
+  );
+}
+
 /**
  * Residual assistant content rendered inside the shared BottomDrawer host.
  * The shell (aside, drag-resize, header controls, isOpen gating) lives in
@@ -38,6 +46,16 @@ export function AssistantPane({ uiState, active = true }) {
   useEffect(() => {
     if (active && !streaming) inputRef.current?.focus();
   }, [active, streaming]);
+
+  // Auto-grow the composer with its content (capped in CSS via max-height).
+  // Keyed on draft so external prefills (welcome cards, slash rows) resize
+  // too, not only direct typing.
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
+  }, [draft]);
 
   const suggestions = useMemo(
     () => (streaming ? [] : matchCommands(catalog, draft, { readOnly })),
@@ -90,23 +108,37 @@ export function AssistantPane({ uiState, active = true }) {
         {menuVisible && (
           <CommandMenu suggestions={suggestions} selectedIndex={menuIndex} onPick={acceptSuggestion} />
         )}
-        <textarea
-          ref={inputRef}
-          className="assistant-drawer-input"
-          placeholder="Ask the assistant…"
-          value={draft}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          disabled={streaming}
-          rows={1}
-        />
-        {streaming && (
-          <button type="button" className="assistant-stop-btn"
-            onClick={stopTurn}
-            aria-label="Stop generating" title="Stop generating">
-            <StopIcon />
-          </button>
-        )}
+        <div className="assistant-composer">
+          <span className="assistant-composer-slash" aria-hidden="true">/</span>
+          <textarea
+            ref={inputRef}
+            className="assistant-drawer-input"
+            placeholder="Ask the assistant, or type / for commands…"
+            value={draft}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            disabled={streaming}
+            rows={1}
+          />
+          {streaming ? (
+            <button type="button" className="assistant-send-btn assistant-stop-btn"
+              onClick={stopTurn}
+              aria-label="Stop generating" title="Stop generating">
+              <StopIcon />
+            </button>
+          ) : (
+            <button type="button"
+              className={`assistant-send-btn${draft.trim() ? ' assistant-send-btn--ready' : ''}`}
+              onClick={handleSend}
+              disabled={!draft.trim()}
+              aria-label="Send" title="Send (Enter)">
+              <SendIcon />
+            </button>
+          )}
+        </div>
+        <div className="assistant-composer-hint">
+          Enter to send · Shift+Enter for newline · runs locally on your model
+        </div>
       </div>
     </>
   );

--- a/src/quodeq/ui/src/features/assistant/AssistantHeader.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantHeader.jsx
@@ -50,19 +50,6 @@ export default function AssistantHeader({ selectedProject, onOpenSettings }) {
           {selectedProject ? `project · ${selectedProject}` : 'no project selected'}
         </div>
       </div>
-      {modelLabel && (
-        <button type="button" className="assistant-model-chip"
-          title={`${modelLabel} — change in Settings`}
-          onClick={() => {
-            // Jump to Settings AND tuck the panel away: the drawer would
-            // otherwise cover the provider section the user is heading to.
-            onOpenSettings?.();
-            closeActiveTab();
-          }}>
-          <span className="assistant-model-dot" aria-hidden="true" />
-          <span className="assistant-model-name">{modelLabel}</span>
-        </button>
-      )}
       {readOnly && (
         <Badge variant="tag" tone="info" title="Remote project session: read tools only">
           read-only
@@ -86,6 +73,21 @@ export default function AssistantHeader({ selectedProject, onOpenSettings }) {
         </button>
       )}
       <div className="assistant-drawer-controls">
+        {/* Model chip leads the right-side cluster, aligned with the action
+            buttons; status badges stay on the left with the identity. */}
+        {modelLabel && (
+          <button type="button" className="assistant-model-chip"
+            title={`${modelLabel} — change in Settings`}
+            onClick={() => {
+              // Jump to Settings AND tuck the panel away: the drawer would
+              // otherwise cover the provider section the user is heading to.
+              onOpenSettings?.();
+              closeActiveTab();
+            }}>
+            <span className="assistant-model-dot" aria-hidden="true" />
+            <span className="assistant-model-name">{modelLabel}</span>
+          </button>
+        )}
         <button type="button" className="assistant-drawer-btn"
           onClick={resetConversation}
           aria-label="New conversation"

--- a/src/quodeq/ui/src/features/assistant/AssistantHeader.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantHeader.jsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { useAssistantDrawer } from './AssistantDrawerProvider.jsx';
+import { useSidePane, workspaceDiffSpec } from '../side-pane/index.js';
+import PanelSwitcher from '../drawer/PanelSwitcher.jsx';
+import Badge from '../../components/Badge.jsx';
+import {
+  ChevronDownIcon, GlobeIcon, MaximizeIcon, MinimizeIcon, PencilIcon, RotateCcwIcon,
+} from '../../components/CopyButton.jsx';
+import { QMarkIcon } from '../../components/QMarkIcon.jsx';
+
+// Providers where the web toggle does something: claude flips its native
+// WebSearch/WebFetch; local providers get in-process search_web/fetch_url.
+// Mirrors the backend gate (LOCAL_PROVIDERS in llm_bridge/_providers.py plus
+// the claude argv path in adapters/_cli_command.py) — keep the two in sync.
+const WEB_PROVIDERS = new Set(['claude', 'ollama', 'omlx', 'llamacpp']);
+
+/**
+ * The assistant panel's own header: panel switcher, animated compass
+ * identity, the live model chip (click opens Settings), the session-state
+ * chips, and the window controls that used to live in the shared drawer
+ * header.
+ */
+export default function AssistantHeader({ selectedProject, onOpenSettings }) {
+  const { closeActiveTab, maximized, toggleMaximized, provider, model,
+          openPanels, streaming, webEnabled, toggleWebEnabled,
+          writeEnabled, toggleWriteEnabled, repoInfo, workspace, refreshWorkspace,
+          sessionId, sessionReady, resetConversation, readOnly } = useAssistantDrawer();
+  const { addWindow } = useSidePane();
+
+  // Chip label: "Provider · model" (provider capitalized for display, e.g.
+  // "Claude · sonnet"). Falls back to whichever half is present.
+  const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+  const modelLabel = [cap(provider), model].filter(Boolean).join(' · ');
+
+  return (
+    <header className="assistant-panel-header">
+      <PanelSwitcher />
+      {/* Identity icon only while the switcher is absent (single open panel):
+          with both panels open the switcher already carries the Q mark, and
+          the same glyph must never appear twice in one header. */}
+      {openPanels.length < 2 && (
+        <span className="assistant-compass-block" aria-hidden="true">
+          {streaming && <span className="assistant-think-ring" />}
+          <QMarkIcon className={`assistant-compass${streaming ? ' assistant-compass--think' : ''}`} />
+        </span>
+      )}
+      <div className="assistant-panel-identity">
+        <div className="assistant-panel-title">Assistant</div>
+        <div className="assistant-panel-subtitle">
+          {selectedProject ? `project · ${selectedProject}` : 'no project selected'}
+        </div>
+      </div>
+      {modelLabel && (
+        <button type="button" className="assistant-model-chip"
+          title={`${modelLabel} — change in Settings`}
+          onClick={() => {
+            // Jump to Settings AND tuck the panel away: the drawer would
+            // otherwise cover the provider section the user is heading to.
+            onOpenSettings?.();
+            closeActiveTab();
+          }}>
+          <span className="assistant-model-dot" aria-hidden="true" />
+          <span className="assistant-model-name">{modelLabel}</span>
+        </button>
+      )}
+      {readOnly && (
+        <Badge variant="tag" tone="info" title="Remote project session: read tools only">
+          read-only
+        </Badge>
+      )}
+      {/* Repo attachment is the NORMAL case — only the exception is worth a
+          chip. When the session has no repo the assistant's code-reading
+          tools are dead, so surface that as a warning with the server's
+          reason; stay silent when everything is fine. */}
+      {repoInfo && !repoInfo.attached && (
+        <Badge variant="tag" tone="warning"
+          title={`Repository not attached: ${repoInfo.reason || 'unknown'}`}>
+          no repo access
+        </Badge>
+      )}
+      {workspace?.filesChanged > 0 && (
+        <button type="button" className="badge badge--tag badge--danger drawer-changes-chip"
+          onClick={() => addWindow(workspaceDiffSpec({ sessionId, key: workspace.createdAt, onChanged: refreshWorkspace }))}
+          title="Review pending changes">
+          {workspace.filesChanged} file{workspace.filesChanged === 1 ? '' : 's'} changed
+        </button>
+      )}
+      <div className="assistant-drawer-controls">
+        <button type="button" className="assistant-drawer-btn"
+          onClick={resetConversation}
+          aria-label="New conversation"
+          title="New conversation (clears the model context)"
+          disabled={streaming || !sessionReady}>
+          <RotateCcwIcon />
+        </button>
+        {repoInfo?.writeAvailable && (
+          <button type="button" className="assistant-drawer-btn assistant-drawer-write"
+            onClick={toggleWriteEnabled}
+            aria-pressed={writeEnabled}
+            aria-label="Allow repository edits for this conversation"
+            title="Allow repository edits for this conversation (isolated worktree, you review before anything lands)"
+            disabled={streaming}>
+            <PencilIcon />
+          </button>
+        )}
+        {WEB_PROVIDERS.has(provider) && (
+          <button type="button" className="assistant-drawer-btn assistant-drawer-web"
+            onClick={toggleWebEnabled}
+            aria-pressed={webEnabled}
+            aria-label="Allow web access for this conversation"
+            title="Allow web access for this conversation"
+            disabled={streaming}>
+            <GlobeIcon />
+          </button>
+        )}
+        <button type="button" className="assistant-drawer-btn" onClick={toggleMaximized}
+          aria-label={maximized ? 'Restore drawer' : 'Maximize drawer'}
+          aria-pressed={maximized}
+          title={maximized ? 'Restore' : 'Maximize'}>
+          {maximized ? <MinimizeIcon /> : <MaximizeIcon />}
+        </button>
+        {/* Chevron-down, NOT an ×: neither panel is killed by this. An
+            in-flight assistant turn keeps running server-side; reopening the
+            tab reattaches to it. */}
+        <button type="button" className="assistant-drawer-btn" onClick={closeActiveTab}
+          aria-label="Hide tab" title="Hide (keeps running in the background)">
+          <ChevronDownIcon />
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/quodeq/ui/src/features/assistant/AssistantWelcome.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantWelcome.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { VISIBLE_META_COMMANDS, pillsForView } from './commands.js';
+import { pillsForView } from './commands.js';
 import { QMarkIcon } from '../../components/QMarkIcon.jsx';
 
 // Dot tints cycle so neighboring cards read as distinct entry points.
@@ -50,22 +50,8 @@ export function AssistantWelcome({ catalog, view, onPick, readOnly = false }) {
           </div>
         </div>
       )}
-      <div className="assistant-welcome-section">
-        <div className="assistant-welcome-label">Slash commands</div>
-        <div className="assistant-cmd-list">
-          {VISIBLE_META_COMMANDS.map((c) => (
-            <button
-              key={c.name}
-              type="button"
-              className="assistant-cmd-row"
-              onClick={() => onPick(`/${c.name} `)}
-            >
-              <code className="assistant-cmd-badge">/{c.name}</code>
-              <span className="assistant-cmd-desc">{c.description}</span>
-            </button>
-          ))}
-        </div>
-      </div>
+      {/* No slash-command list here: typing "/" in the composer opens the
+          live CommandMenu autocomplete, which is the same catalog searchable. */}
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/assistant/AssistantWelcome.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantWelcome.jsx
@@ -1,41 +1,71 @@
 import React from 'react';
 import { VISIBLE_META_COMMANDS, pillsForView } from './commands.js';
+import { QMarkIcon } from '../../components/QMarkIcon.jsx';
+
+// Dot tints cycle so neighboring cards read as distinct entry points.
+const DOT_TONES = ['info', 'accent', 'warning', 'success'];
 
 /**
- * Empty-transcript state of the assistant pane: a one-line intro, the
- * meta-command list, and skill pills (view-relevant first). Skills appear
- * only as pills, never as text lines. Pure UI, never persisted, never sent
- * to the model; reappears on every fresh session.
+ * Empty-transcript state of the assistant pane: an intro row, skill
+ * suggestions as tappable cards (view-relevant first), and the meta-command
+ * menu. Clicking anything pre-fills the composer, never sends. Pure UI,
+ * never persisted, never sent to the model; reappears on every fresh
+ * session.
  */
 export function AssistantWelcome({ catalog, view, onPick, readOnly = false }) {
   const pills = pillsForView(catalog, view, { readOnly });
   return (
     <div className="assistant-welcome">
-      <p className="assistant-welcome-intro">
-        {readOnly
-          ? 'I can explain scores and dig into findings for this remote project.'
-          : 'I can explain scores, dig into findings, and draft standards for this project.'}
-      </p>
-      <ul className="assistant-welcome-commands">
-        {VISIBLE_META_COMMANDS.map((c) => (
-          <li key={c.name}><code>/{c.name}</code> {c.description}</li>
-        ))}
-      </ul>
+      <div className="assistant-welcome-hero">
+        <span className="assistant-compass-block" aria-hidden="true">
+          <QMarkIcon className="assistant-compass" />
+        </span>
+        <p className="assistant-welcome-intro">
+          {readOnly
+            ? 'I can explain scores and dig into findings for this remote project.'
+            : 'I can explain scores, dig into findings, and draft standards for this project.'}
+          {' '}Pick a starting point or ask me anything.
+        </p>
+      </div>
       {pills.length > 0 && (
-        <div className="assistant-welcome-pills">
-          {pills.map((p) => (
+        <div className="assistant-welcome-section">
+          <div className="assistant-welcome-label">Suggested</div>
+          <div className="assistant-suggest-grid">
+            {pills.map((p, i) => (
+              <button
+                key={p.fill}
+                type="button"
+                className="assistant-suggest-card"
+                aria-label={p.label}
+                title={p.description}
+                onClick={() => onPick(p.fill)}
+              >
+                <span className={`assistant-suggest-dot assistant-suggest-dot--${DOT_TONES[i % DOT_TONES.length]}`} aria-hidden="true" />
+                <span className="assistant-suggest-text">
+                  <span className="assistant-suggest-title">{p.label}</span>
+                  {p.description && <span className="assistant-suggest-desc">{p.description}</span>}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+      <div className="assistant-welcome-section">
+        <div className="assistant-welcome-label">Slash commands</div>
+        <div className="assistant-cmd-list">
+          {VISIBLE_META_COMMANDS.map((c) => (
             <button
-              key={p.fill}
+              key={c.name}
               type="button"
-              className="assistant-pill"
-              title={p.description}
-              onClick={() => onPick(p.fill)}
+              className="assistant-cmd-row"
+              onClick={() => onPick(`/${c.name} `)}
             >
-              {p.label}
+              <code className="assistant-cmd-badge">/{c.name}</code>
+              <span className="assistant-cmd-desc">{c.description}</span>
             </button>
           ))}
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/assistant/AssistantWelcome.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantWelcome.test.jsx
@@ -12,13 +12,15 @@ const catalog = {
   actions: [],
 };
 
-it('shows skills as suggestion cards and no slash-command list (the composer "/" menu covers that)', () => {
+it('shows view-matching skills as suggestion cards; no slash list, no off-view cards', () => {
   render(<AssistantWelcome catalog={catalog} view="overview" onPick={() => {}} />);
   expect(screen.queryByText('/help')).toBeNull();
   expect(screen.queryByText('/clear')).toBeNull();
   expect(screen.queryByText('/explain-score')).toBeNull(); // skills are cards, not text
   expect(screen.getByRole('button', { name: 'Explain score' })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Create standard' })).toBeInTheDocument();
+  // create-standard is standards-view only: offering it here would invite a
+  // guaranteed-to-fail first tool call.
+  expect(screen.queryByRole('button', { name: 'Create standard' })).toBeNull();
 });
 
 it('pill click pre-fills, does not send', () => {
@@ -36,8 +38,10 @@ it('renders without a catalog (fetch failed): intro only, no cards', () => {
 });
 
 const RO_CATALOG = { skills: [
-  { name: 'explain-score', description: 'd', views: ['overview'], requiresWrite: false },
-  { name: 'verify-finding', description: 'd', views: ['violations'], requiresWrite: true },
+  // views mirror the real catalog (explain-score and verify-finding span
+  // overview + violations).
+  { name: 'explain-score', description: 'd', views: ['overview', 'violations'], requiresWrite: false },
+  { name: 'verify-finding', description: 'd', views: ['overview', 'violations'], requiresWrite: true },
   { name: 'create-standard', description: 'd', views: ['standards'], requiresWrite: true },
 ] };
 

--- a/src/quodeq/ui/src/features/assistant/AssistantWelcome.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantWelcome.test.jsx
@@ -12,12 +12,11 @@ const catalog = {
   actions: [],
 };
 
-it('lists meta commands as text, skills as pills only', () => {
+it('shows skills as suggestion cards and no slash-command list (the composer "/" menu covers that)', () => {
   render(<AssistantWelcome catalog={catalog} view="overview" onPick={() => {}} />);
-  expect(screen.getByText('/help')).toBeInTheDocument();
-  expect(screen.getByText('/clear')).toBeInTheDocument();
-  expect(screen.queryByText('/actions')).toBeNull(); // hidden meta stays out
-  expect(screen.queryByText('/explain-score')).toBeNull(); // skills are pills, not text
+  expect(screen.queryByText('/help')).toBeNull();
+  expect(screen.queryByText('/clear')).toBeNull();
+  expect(screen.queryByText('/explain-score')).toBeNull(); // skills are cards, not text
   expect(screen.getByRole('button', { name: 'Explain score' })).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'Create standard' })).toBeInTheDocument();
 });
@@ -29,19 +28,11 @@ it('pill click pre-fills, does not send', () => {
   expect(onPick).toHaveBeenCalledWith('/explain-score ');
 });
 
-it('renders without a catalog (fetch failed)', () => {
+it('renders without a catalog (fetch failed): intro only, no cards', () => {
   const { container } = render(<AssistantWelcome catalog={null} view="overview" onPick={() => {}} />);
-  expect(screen.getByText('/help')).toBeInTheDocument();
-  // No suggestion cards without a catalog (slash-command rows still render).
+  expect(screen.getByText(/explain scores/i)).toBeInTheDocument();
   expect(container.querySelector('.assistant-suggest-card')).toBeNull();
   expect(screen.queryByText('Suggested')).toBeNull();
-});
-
-it('slash-command row click pre-fills the composer', () => {
-  const onPick = vi.fn();
-  render(<AssistantWelcome catalog={catalog} view="overview" onPick={onPick} />);
-  fireEvent.click(screen.getByText('/help'));
-  expect(onPick).toHaveBeenCalledWith('/help ');
 });
 
 const RO_CATALOG = { skills: [

--- a/src/quodeq/ui/src/features/assistant/AssistantWelcome.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantWelcome.test.jsx
@@ -30,9 +30,18 @@ it('pill click pre-fills, does not send', () => {
 });
 
 it('renders without a catalog (fetch failed)', () => {
-  render(<AssistantWelcome catalog={null} view="overview" onPick={() => {}} />);
+  const { container } = render(<AssistantWelcome catalog={null} view="overview" onPick={() => {}} />);
   expect(screen.getByText('/help')).toBeInTheDocument();
-  expect(screen.queryByRole('button')).toBeNull(); // no pills without catalog
+  // No suggestion cards without a catalog (slash-command rows still render).
+  expect(container.querySelector('.assistant-suggest-card')).toBeNull();
+  expect(screen.queryByText('Suggested')).toBeNull();
+});
+
+it('slash-command row click pre-fills the composer', () => {
+  const onPick = vi.fn();
+  render(<AssistantWelcome catalog={catalog} view="overview" onPick={onPick} />);
+  fireEvent.click(screen.getByText('/help'));
+  expect(onPick).toHaveBeenCalledWith('/help ');
 });
 
 const RO_CATALOG = { skills: [

--- a/src/quodeq/ui/src/features/assistant/MessageList.jsx
+++ b/src/quodeq/ui/src/features/assistant/MessageList.jsx
@@ -2,6 +2,17 @@ import React, { useEffect, useRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { ActionPreviewCard } from './ActionPreviewCard.jsx';
+import { QMarkIcon } from '../../components/QMarkIcon.jsx';
+
+// Q-mark avatar column next to assistant-authored content.
+function CompassAvatar({ thinking = false }) {
+  return (
+    <span className="assistant-msg-avatar" aria-hidden="true">
+      {thinking && <span className="assistant-think-ring" />}
+      <QMarkIcon className={`assistant-compass${thinking ? ' assistant-compass--think' : ''}`} />
+    </span>
+  );
+}
 
 const mdComponents = {
   a: ({ node, ...props }) => <a {...props} target="_blank" rel="noopener noreferrer" />,
@@ -18,10 +29,13 @@ function MessageItem({ message }) {
       return <div className="assistant-msg assistant-msg-user">{message.text}</div>;
     case 'assistant':
       return (
-        <div className="assistant-msg assistant-msg-assistant assistant-md">
-          <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
-            {message.text}
-          </ReactMarkdown>
+        <div className="assistant-msg-row">
+          <CompassAvatar />
+          <div className="assistant-msg assistant-msg-assistant assistant-md">
+            <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
+              {message.text}
+            </ReactMarkdown>
+          </div>
         </div>
       );
     case 'tool':
@@ -72,9 +86,8 @@ export function MessageList({ messages, streaming }) {
       ))}
       {streaming && (
         <div className="assistant-streaming-indicator" role="status" aria-live="polite">
-          <span className="assistant-streaming-dot" />
-          <span className="assistant-streaming-dot" />
-          <span className="assistant-streaming-dot" />
+          <CompassAvatar thinking />
+          <span className="assistant-streaming-text" aria-hidden="true">Consulting the project…</span>
           <span className="sr-only">Assistant is responding…</span>
         </div>
       )}

--- a/src/quodeq/ui/src/features/assistant/commands.js
+++ b/src/quodeq/ui/src/features/assistant/commands.js
@@ -65,9 +65,10 @@ export function pillsForView(catalog, view, { readOnly = false } = {}) {
   // Read-only (remote) sessions have no draft_action server-side, so
   // write-shaped skills would dead-end; hide their pills entirely.
   const skills = (catalog?.skills ?? []).filter((s) => !readOnly || !s.requiresWrite);
-  const matching = skills.filter((s) => (s.views ?? []).includes(view));
-  const rest = skills.filter((s) => !(s.views ?? []).includes(view));
-  return [...matching, ...rest]
+  // Only skills declared for this view: a padded pill whose skill cannot run
+  // in the current scope invites a guaranteed-to-fail first tool call.
+  return skills
+    .filter((s) => (s.views ?? []).includes(view))
     .slice(0, 4)
     .map((s) => ({
       label: s.name.replace(/-/g, ' ').replace(/^./, (ch) => ch.toUpperCase()),

--- a/src/quodeq/ui/src/features/assistant/commands.test.js
+++ b/src/quodeq/ui/src/features/assistant/commands.test.js
@@ -84,15 +84,14 @@ test('buildMetaResponse /skills hides requiresWrite skills when readOnly; /help 
   assert.match(helpDefault, /\/create-standard/);
 });
 
-test('pillsForView leads with view-matching skills, then the rest, max 4', () => {
+test('pillsForView offers only view-matching skills, max 4', () => {
   const pills = pillsForView(catalog, 'overview');
-  assert.deepEqual(pills.map((p) => p.fill), ['/explain-score ', '/create-standard ']);
+  assert.deepEqual(pills.map((p) => p.fill), ['/explain-score ']);
   assert.equal(pills[0].label, 'Explain score');
-  // standards view reorders: create-standard first, remaining skills after
   assert.deepEqual(pillsForView(catalog, 'standards').map((p) => p.fill),
-    ['/create-standard ', '/explain-score ']);
-  // no view match: every skill still offered, catalog order
-  assert.deepEqual(pillsForView(catalog, 'map').map((p) => p.fill),
-    ['/explain-score ', '/create-standard ']);
+    ['/create-standard ']);
+  // No view match: no pills. A padded pill whose skill cannot run in the
+  // current scope invites a guaranteed-to-fail first tool call.
+  assert.deepEqual(pillsForView(catalog, 'map'), []);
   assert.deepEqual(pillsForView(null, 'overview'), []);
 });

--- a/src/quodeq/ui/src/features/drawer/BottomDrawer.jsx
+++ b/src/quodeq/ui/src/features/drawer/BottomDrawer.jsx
@@ -1,35 +1,21 @@
 import React, { useCallback, useEffect, useRef, lazy, Suspense } from 'react';
 import { useAssistantDrawer } from '../assistant/AssistantDrawerProvider.jsx';
 import { AssistantPane } from '../assistant/AssistantDrawer.jsx';
-import { ChevronDownIcon, GlobeIcon, MaximizeIcon, MinimizeIcon, PencilIcon, RotateCcwIcon } from '../../components/CopyButton.jsx';
-import { useSidePane, workspaceDiffSpec } from '../side-pane/index.js';
-import Badge from '../../components/Badge.jsx';
+import AssistantHeader from '../assistant/AssistantHeader.jsx';
 
 const TerminalPane = lazy(() => import('../terminal/TerminalPane.jsx'));
 
-const TAB_LABELS = { assistant: '✦ Assistant', terminal: '❯_ Terminal' };
-
-// Providers where the web toggle does something: claude flips its native
-// WebSearch/WebFetch; local providers get in-process search_web/fetch_url.
-// Mirrors the backend gate (LOCAL_PROVIDERS in llm_bridge/_providers.py plus
-// the claude argv path in adapters/_cli_command.py) — keep the two in sync.
-const WEB_PROVIDERS = new Set(['claude', 'ollama', 'omlx', 'llamacpp']);
-
 /**
  * Shared bottom drawer host: a resizable full-width shell that hosts the
- * open panels. The title bar shows a tab per OPEN panel (both only when both
- * are selected on the topbar); clicking a tab activates it. The active panel
- * is shown; any other open panel is kept mounted and hidden with
- * `display:none` (never unmounted) so the terminal's xterm buffer and
- * PTY-attached socket survive a tab switch.
+ * open panels. There is no shared header — each panel renders its own (with
+ * a compact panel switcher inside it). The active panel is shown; any other
+ * open panel is kept mounted and hidden with `display:none` (never
+ * unmounted) so the terminal's xterm buffers and PTY-attached sockets
+ * survive a tab switch.
  */
-export function BottomDrawer({ uiState }) {
-  const { isOpen, height, setHeight, closeActiveTab, openPanels, activeTab, selectTab,
-          maximized, toggleMaximized, setMaximized, provider, model,
-          streaming, webEnabled, toggleWebEnabled,
-          writeEnabled, toggleWriteEnabled, repoInfo, workspace, refreshWorkspace,
-          sessionId, sessionReady, resetConversation, readOnly } = useAssistantDrawer();
-  const { addWindow } = useSidePane();
+export function BottomDrawer({ uiState, projectName, onOpenSettings }) {
+  const { isOpen, height, setHeight, openPanels, activeTab,
+          maximized, setMaximized } = useAssistantDrawer();
   const dragRef = useRef(null);
 
   const handleDragMove = useCallback((event) => {
@@ -64,101 +50,15 @@ export function BottomDrawer({ uiState }) {
   if (!isOpen) return null;
   // Guard against a transient render where activeTab isn't (yet) an open panel.
   const active = openPanels.includes(activeTab) ? activeTab : openPanels[openPanels.length - 1];
-  // Header pill: "Provider · model" (provider capitalized for display, e.g.
-  // "Claude · sonnet"). Falls back to whichever half is present.
-  const cap = (s) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
-  const modelLabel = [cap(provider), model].filter(Boolean).join(' · ');
 
   return (
     <aside className={`bottom-drawer assistant-drawer${maximized ? ' bottom-drawer--maximized' : ''}`}
       style={maximized ? undefined : { height }}>
       <div className="assistant-drawer-drag" onPointerDown={handleDragStart}
         role="separator" aria-orientation="horizontal" aria-label="Resize drawer" />
-      <header className="assistant-drawer-header">
-        {/* One tab per OPEN panel (both only when both are selected on the
-            topbar). Clicking a tab activates it without deselecting the other;
-            the topbar launchers add/remove panels. */}
-        <div className="drawer-tabs" role="tablist">
-          {openPanels.map((t) => (
-            <button key={t} type="button" role="tab" aria-selected={t === active}
-              className={`drawer-tab${t === active ? ' drawer-tab--active' : ''}`}
-              onClick={() => selectTab(t)}>{TAB_LABELS[t]}</button>
-          ))}
-        </div>
-        {active === 'assistant' && modelLabel && (
-          <Badge variant="tag" tone="accent" className="drawer-model-chip" title={modelLabel}>
-            {modelLabel}
-          </Badge>
-        )}
-        {active === 'assistant' && readOnly && (
-          <Badge variant="tag" tone="info" title="Remote project session: read tools only">
-            read-only
-          </Badge>
-        )}
-        {/* Repo attachment is the NORMAL case — only the exception is worth a
-            chip. When the session has no repo the assistant's code-reading
-            tools are dead, so surface that as a warning with the server's
-            reason; stay silent when everything is fine. */}
-        {active === 'assistant' && repoInfo && !repoInfo.attached && (
-          <Badge variant="tag" tone="warning"
-            title={`Repository not attached: ${repoInfo.reason || 'unknown'}`}>
-            no repo access
-          </Badge>
-        )}
-        {active === 'assistant' && workspace?.filesChanged > 0 && (
-          <button type="button" className="badge badge--tag badge--danger drawer-changes-chip"
-            onClick={() => addWindow(workspaceDiffSpec({ sessionId, key: workspace.createdAt, onChanged: refreshWorkspace }))}
-            title="Review pending changes">
-            {workspace.filesChanged} file{workspace.filesChanged === 1 ? '' : 's'} changed
-          </button>
-        )}
-        <div className="assistant-drawer-controls">
-          {active === 'assistant' && (
-            <button type="button" className="assistant-drawer-btn"
-              onClick={resetConversation}
-              aria-label="New conversation"
-              title="New conversation (clears the model context)"
-              disabled={streaming || !sessionReady}>
-              <RotateCcwIcon />
-            </button>
-          )}
-          {active === 'assistant' && repoInfo?.writeAvailable && (
-            <button type="button" className="assistant-drawer-btn assistant-drawer-write"
-              onClick={toggleWriteEnabled}
-              aria-pressed={writeEnabled}
-              aria-label="Allow repository edits for this conversation"
-              title="Allow repository edits for this conversation (isolated worktree, you review before anything lands)"
-              disabled={streaming}>
-              <PencilIcon />
-            </button>
-          )}
-          {active === 'assistant' && WEB_PROVIDERS.has(provider) && (
-            <button type="button" className="assistant-drawer-btn assistant-drawer-web"
-              onClick={toggleWebEnabled}
-              aria-pressed={webEnabled}
-              aria-label="Allow web access for this conversation"
-              title="Allow web access for this conversation"
-              disabled={streaming}>
-              <GlobeIcon />
-            </button>
-          )}
-          <button type="button" className="assistant-drawer-btn" onClick={toggleMaximized}
-            aria-label={maximized ? 'Restore drawer' : 'Maximize drawer'}
-            aria-pressed={maximized}
-            title={maximized ? 'Restore' : 'Maximize'}>
-            {maximized ? <MinimizeIcon /> : <MaximizeIcon />}
-          </button>
-          {/* Chevron-down, NOT an ×: neither panel is killed by this. The
-              terminal's PTY shell and an in-flight assistant turn keep running
-              server-side; reopening the tab reattaches to them. */}
-          <button type="button" className="assistant-drawer-btn" onClick={closeActiveTab}
-            aria-label="Hide tab" title="Hide (keeps running in the background)">
-            <ChevronDownIcon />
-          </button>
-        </div>
-      </header>
       {openPanels.includes('assistant') && (
         <div className="drawer-panel" style={{ display: active === 'assistant' ? 'flex' : 'none' }}>
+          <AssistantHeader selectedProject={projectName ?? uiState?.selectedProject} onOpenSettings={onOpenSettings} />
           <AssistantPane uiState={uiState} active={active === 'assistant'} />
         </div>
       )}

--- a/src/quodeq/ui/src/features/drawer/BottomDrawer.test.jsx
+++ b/src/quodeq/ui/src/features/drawer/BottomDrawer.test.jsx
@@ -76,10 +76,12 @@ it('the maximized-restore glyph is distinct from the hide chevron', () => {
   drawer.maximized = false;
 });
 
-it('the model chip sits in the identity area on the left, not in the right controls', () => {
+it('the model chip leads the right-side controls cluster', () => {
   render(<BottomDrawer uiState={{}} />);
   const chip = screen.getByTitle(/Ollama · m/);
-  expect(chip.closest('.assistant-drawer-controls')).toBeNull();
+  const controls = chip.closest('.assistant-drawer-controls');
+  expect(controls).not.toBeNull();
+  expect(controls.firstElementChild).toBe(chip);
 });
 
 it('the model chip opens Settings AND hides the panel (drawer must not cover the settings page)', () => {

--- a/src/quodeq/ui/src/features/drawer/BottomDrawer.test.jsx
+++ b/src/quodeq/ui/src/features/drawer/BottomDrawer.test.jsx
@@ -25,12 +25,18 @@ it('shows a tab for each OPEN panel (both, since both are open)', () => {
   expect(screen.getByRole('tab', { name: /Terminal/ })).toBeInTheDocument();
 });
 
-it('only shows a tab for the single open panel when only one is open', () => {
+it('hides the switcher entirely when only one panel is open (identity icon instead, no duplicates)', () => {
   drawer.openPanels = ['assistant'];
-  render(<BottomDrawer uiState={{}} />);
-  expect(screen.getByRole('tab', { name: /Assistant/ })).toBeInTheDocument();
-  expect(screen.queryByRole('tab', { name: /Terminal/ })).toBeNull();
+  const { container } = render(<BottomDrawer uiState={{}} />);
+  expect(screen.queryByRole('tab')).toBeNull();
+  expect(container.querySelector('.assistant-panel-header .assistant-compass-block')).not.toBeNull();
   drawer.openPanels = ['assistant', 'terminal'];  // restore for other tests
+});
+
+it('hides the identity icon when both panels are open (the switcher already carries the glyph)', () => {
+  const { container } = render(<BottomDrawer uiState={{}} />);
+  expect(screen.getByRole('tab', { name: /Assistant/ })).toBeInTheDocument();
+  expect(container.querySelector('.assistant-panel-header .assistant-compass-block')).toBeNull();
 });
 
 it('clicking an inactive tab activates it (without deselecting the other)', () => {
@@ -70,11 +76,19 @@ it('the maximized-restore glyph is distinct from the hide chevron', () => {
   drawer.maximized = false;
 });
 
-it('the model chip sits with the tabs on the left, not in the right controls', () => {
+it('the model chip sits in the identity area on the left, not in the right controls', () => {
   render(<BottomDrawer uiState={{}} />);
-  const chip = screen.getByTitle('Ollama · m');
+  const chip = screen.getByTitle(/Ollama · m/);
   expect(chip.closest('.assistant-drawer-controls')).toBeNull();
-  expect(chip.previousElementSibling).toHaveClass('drawer-tabs');
+});
+
+it('the model chip opens Settings AND hides the panel (drawer must not cover the settings page)', () => {
+  const onOpenSettings = vi.fn();
+  drawer.closeActiveTab = vi.fn();
+  render(<BottomDrawer uiState={{}} onOpenSettings={onOpenSettings} />);
+  fireEvent.click(screen.getByTitle(/Ollama · m/));
+  expect(onOpenSettings).toHaveBeenCalled();
+  expect(drawer.closeActiveTab).toHaveBeenCalled();
 });
 
 it('shows the web toggle for web-capable providers and toggles it', () => {
@@ -108,26 +122,26 @@ it('disables the web toggle while a turn is streaming', () => {
 
 it('the new-conversation control resets the conversation', () => {
   render(<BottomDrawer uiState={{}} />);
-  fireEvent.click(screen.getByRole('button', { name: /new conversation/i }));
+  fireEvent.click(screen.getByRole('button', { name: "New conversation" }));
   expect(drawer.resetConversation).toHaveBeenCalled();
 });
 
 it('disables the new-conversation control while streaming and before a session exists', () => {
   drawer.streaming = true;
   const { unmount } = render(<BottomDrawer uiState={{}} />);
-  expect(screen.getByRole('button', { name: /new conversation/i })).toBeDisabled();
+  expect(screen.getByRole('button', { name: "New conversation" })).toBeDisabled();
   drawer.streaming = false;
   unmount();
   drawer.sessionReady = false;
   render(<BottomDrawer uiState={{}} />);
-  expect(screen.getByRole('button', { name: /new conversation/i })).toBeDisabled();
+  expect(screen.getByRole('button', { name: "New conversation" })).toBeDisabled();
   drawer.sessionReady = true;
 });
 
 it('hides the new-conversation control while the terminal tab is active', () => {
   drawer.activeTab = 'terminal';
   render(<BottomDrawer uiState={{}} />);
-  expect(screen.queryByRole('button', { name: /new conversation/i })).toBeNull();
+  expect(screen.queryByRole('button', { name: "New conversation" })).toBeNull();
   drawer.activeTab = 'assistant';
 });
 
@@ -148,9 +162,12 @@ it('warns with "no repo access" and the server reason when not attached', () => 
   drawer.repoInfo = null;
 });
 
-it('the model chip is an accent Badge', () => {
+it('the model chip shows a live status dot and the mono model label', () => {
   render(<BottomDrawer uiState={{}} />);
-  expect(screen.getByTitle('Ollama · m')).toHaveClass('badge', 'badge--tag', 'badge--accent', 'drawer-model-chip');
+  const chip = screen.getByTitle(/Ollama · m/);
+  expect(chip).toHaveClass('assistant-model-chip');
+  expect(chip.querySelector('.assistant-model-dot')).not.toBeNull();
+  expect(chip).toHaveTextContent('Ollama · m');
 });
 
 it('shows a read-only info badge when the session is read-only', () => {

--- a/src/quodeq/ui/src/features/drawer/PanelSwitcher.jsx
+++ b/src/quodeq/ui/src/features/drawer/PanelSwitcher.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { TerminalIcon } from '../../components/CopyButton.jsx';
+import { QMarkIcon } from '../../components/QMarkIcon.jsx';
+import { useAssistantDrawer } from '../assistant/AssistantDrawerProvider.jsx';
+
+/**
+ * Compact icon toggle between the drawer's open panels, rendered inside each
+ * panel's own header (there is no shared drawer header). Renders ONLY when
+ * both panels are open — with a single panel the header shows that panel's
+ * identity icon instead, so the same glyph never appears twice. The topbar
+ * launchers add/remove panels; this only changes which is frontmost.
+ */
+export default function PanelSwitcher() {
+  const { openPanels, activeTab, selectTab, streaming } = useAssistantDrawer();
+  if (openPanels.length < 2) return null;
+  const active = openPanels.includes(activeTab) ? activeTab : openPanels[openPanels.length - 1];
+  const meta = {
+    // The assistant's Q mark wobbles while a turn streams, so activity shows
+    // even when the terminal panel is frontmost.
+    assistant: { label: 'Assistant', icon: <QMarkIcon size={11} className={streaming ? 'assistant-q--think' : undefined} /> },
+    terminal: { label: 'Terminal', icon: <TerminalIcon /> },
+  };
+  return (
+    <div className="drawer-switch" role="tablist">
+      {openPanels.map((t) => {
+        const m = meta[t];
+        if (!m) return null;
+        return (
+          <button key={t} type="button" role="tab" aria-selected={t === active}
+            aria-label={m.label} title={m.label}
+            className={`drawer-switch-btn${t === active ? ' drawer-switch-btn--active' : ''}`}
+            onClick={() => selectTab(t)}>
+            {m.icon}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/terminal/TerminalHeader.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalHeader.jsx
@@ -2,7 +2,7 @@ import React, { useRef, useState } from 'react';
 import { useAssistantDrawer } from '../assistant/AssistantDrawerProvider.jsx';
 import PanelSwitcher from '../drawer/PanelSwitcher.jsx';
 import {
-  COPY_FEEDBACK_MS, ChevronDownIcon, CopyIcon, LockIcon, MaximizeIcon, MinimizeIcon, PlusIcon,
+  COPY_FEEDBACK_MS, ChevronDownIcon, CopyIcon, MaximizeIcon, MinimizeIcon, PlusIcon,
 } from '../../components/CopyButton.jsx';
 
 /**
@@ -41,12 +41,6 @@ export default function TerminalHeader({ onCopy, onNewSession }) {
           <PlusIcon />
         </button>
       )}
-      {/* The gate only ever admits loopback clients (terminal/gate.py); say so
-          where the user can see it instead of leaving the sandboxing implicit. */}
-      <span className="tty-localhost-pill" title="The embedded terminal only works on localhost">
-        <LockIcon />
-        localhost only
-      </span>
       <div className="tty-panel-controls">
         <button type="button" className={`assistant-drawer-btn${copied ? ' tty-copy-btn--done' : ''}`}
           onClick={handleCopy}

--- a/src/quodeq/ui/src/features/terminal/TerminalHeader.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalHeader.jsx
@@ -1,0 +1,72 @@
+import React, { useRef, useState } from 'react';
+import { useAssistantDrawer } from '../assistant/AssistantDrawerProvider.jsx';
+import PanelSwitcher from '../drawer/PanelSwitcher.jsx';
+import {
+  COPY_FEEDBACK_MS, ChevronDownIcon, CopyIcon, LockIcon, MaximizeIcon, MinimizeIcon, PlusIcon,
+} from '../../components/CopyButton.jsx';
+
+/**
+ * The terminal panel's own header: panel switcher, identity, the sandbox
+ * pill, and the window controls (copy / maximize / hide) that used to live
+ * in the shared drawer header.
+ */
+export default function TerminalHeader({ onCopy, onNewSession }) {
+  const { maximized, toggleMaximized, closeActiveTab, openPanels } = useAssistantDrawer();
+  const [copied, setCopied] = useState(false);
+  const copyTimer = useRef(null);
+
+  const handleCopy = () => {
+    if (!onCopy?.()) return;
+    setCopied(true);
+    if (copyTimer.current) clearTimeout(copyTimer.current);
+    copyTimer.current = setTimeout(() => { copyTimer.current = null; setCopied(false); }, COPY_FEEDBACK_MS);
+  };
+
+  return (
+    <header className="tty-panel-header">
+      <PanelSwitcher />
+      {/* Identity icon only while the switcher is absent (single open panel):
+          the switcher already shows a >_ glyph, never render it twice. */}
+      {openPanels.length < 2 && (
+        <span className="tty-icon-block" aria-hidden="true">&gt;_</span>
+      )}
+      <div className="tty-panel-title">Terminal</div>
+      {/* With a single session the tab strip is hidden and the "+" lives up
+          here; creating a second session reveals the strip, which carries its
+          own "+" from then on. */}
+      {onNewSession && (
+        <button type="button" className="tty-tab-add tty-header-add"
+          onClick={onNewSession}
+          aria-label="New session" title="New session">
+          <PlusIcon />
+        </button>
+      )}
+      {/* The gate only ever admits loopback clients (terminal/gate.py); say so
+          where the user can see it instead of leaving the sandboxing implicit. */}
+      <span className="tty-localhost-pill" title="The embedded terminal only works on localhost">
+        <LockIcon />
+        localhost only
+      </span>
+      <div className="tty-panel-controls">
+        <button type="button" className={`assistant-drawer-btn${copied ? ' tty-copy-btn--done' : ''}`}
+          onClick={handleCopy}
+          aria-label="Copy terminal output"
+          title={copied ? 'Copied' : 'Copy selection (or visible output)'}>
+          <CopyIcon />
+        </button>
+        <button type="button" className="assistant-drawer-btn" onClick={toggleMaximized}
+          aria-label={maximized ? 'Restore drawer' : 'Maximize drawer'}
+          aria-pressed={maximized}
+          title={maximized ? 'Restore' : 'Maximize'}>
+          {maximized ? <MinimizeIcon /> : <MaximizeIcon />}
+        </button>
+        {/* Chevron-down, NOT an ×: the shell keeps running server-side;
+            reopening the tab reattaches to it. */}
+        <button type="button" className="assistant-drawer-btn" onClick={closeActiveTab}
+          aria-label="Hide tab" title="Hide (keeps running in the background)">
+          <ChevronDownIcon />
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/quodeq/ui/src/features/terminal/TerminalPane.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.jsx
@@ -1,257 +1,117 @@
-import React, { useEffect, useRef, useState, useCallback } from 'react';
-import { Terminal } from '@xterm/xterm';
-import { FitAddon } from '@xterm/addon-fit';
-import '@xterm/xterm/css/xterm.css';
-import { useTerminalSocket } from './useTerminalSocket.js';
-import { terminalStatus, resolveTerminalPaths, openInEditor } from '../../api/terminal.js';
-import { createUrlLinkProvider, createFileLinkProvider } from './terminalLinks.js';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { terminalStatus } from '../../api/terminal.js';
+import { useTerminalSessions } from './useTerminalSessions.js';
+import TerminalSessionView from './TerminalSessionView.jsx';
+import TerminalHeader from './TerminalHeader.jsx';
+import { PlusIcon, XIcon } from '../../components/CopyButton.jsx';
 
-// Two drawer chords are reserved for the host; return false so xterm lets them
-// bubble to the window handler instead of typing into the shell.
-function isReservedChord(e) {
-  return e.code === 'Backquote' && (e.ctrlKey || e.metaKey);
-}
-
-// True when the element isn't laid out (display:none / zero-size). Fitting xterm
-// to a hidden box measures a 0x0 cell and drives the PTY to a bogus size, so the
-// shell floods the prompt with cursor-position queries ("14;3R…"). Every fit
-// path guards on this.
-function isHidden(el) {
-  return !el || el.offsetParent === null || el.clientWidth === 0 || el.clientHeight === 0;
-}
-
-function themeFromCss() {
-  const s = getComputedStyle(document.documentElement);
-  const v = (name, fb) => (s.getPropertyValue(name).trim() || fb);
-  return {
-    background: v('--color-surface-alt', '#1e1e1e'),
-    foreground: v('--color-text', '#dcdcdc'),
-    cursor: v('--color-accent', '#dcdcdc'),
-  };
-}
-
+/**
+ * The terminal panel: header, session tab strip, one TerminalSessionView per
+ * server-side session, and a status bar. Each session is its own shell with
+ * its own history; inactive sessions are hidden (display:none), never
+ * unmounted, so their buffers and PTY sockets survive tab switches. The
+ * whole panel likewise stays mounted while backgrounded behind the assistant
+ * panel — `active` only gates fitting/focus in the views.
+ */
 export default function TerminalPane({ active }) {
-  const rootRef = useRef(null);
-  const termRef = useRef(null);
-  const fitRef = useRef(null);
   const [reason, setReason] = useState(null);
   const [checked, setChecked] = useState(false);
-  // Bumped to reconnect the socket after a restart (kill → fresh PTY).
-  const [restartKey, setRestartKey] = useState(0);
+  const [shell, setShell] = useState('');
 
   useEffect(() => {
     let alive = true;
-    terminalStatus().then((s) => { if (alive) { setReason(s.enabled ? null : s.reason); setChecked(true); } })
-      .catch(() => { if (alive) { setReason('Terminal unavailable'); setChecked(true); } });
+    terminalStatus().then((s) => {
+      if (!alive) return;
+      setReason(s.enabled ? null : s.reason);
+      setShell(s.shell || '');
+      setChecked(true);
+    }).catch(() => { if (alive) { setReason('Terminal unavailable'); setChecked(true); } });
     return () => { alive = false; };
   }, []);
 
-  // "Restart terminal" (from Settings): clear the screen and reconnect. The
-  // server session was already killed, so the reconnect spawns a fresh PTY.
+  const paneLive = checked && reason === null;
+  const { sessions, activeId, max, openSession, closeSession, selectSession, reconcile } =
+    useTerminalSessions({ enabled: paneLive });
+
+  // "Restart terminal" (from Settings) killed EVERY session server-side; the
+  // stale views' sockets are about to report 'gone'. Reconcile immediately:
+  // stale tabs drop, a fresh session is created, new views mount clean.
   useEffect(() => {
-    const onRestart = () => {
-      try { termRef.current?.reset(); } catch { /* noop */ }
-      setRestartKey((k) => k + 1);
-    };
+    const onRestart = () => reconcile();
     window.addEventListener('quodeq:terminal-restart', onRestart);
     return () => window.removeEventListener('quodeq:terminal-restart', onRestart);
+  }, [reconcile]);
+
+  // Copy support: each view registers its copy source; the header copies from
+  // whichever session is frontmost.
+  const viewApis = useRef({});
+  const registerApi = useCallback((id, api) => {
+    if (api) viewApis.current[id] = api;
+    else delete viewApis.current[id];
   }, []);
+  const handleCopy = useCallback(() => {
+    const text = viewApis.current[activeId]?.getCopyText() || '';
+    if (!text) return false;
+    navigator.clipboard?.writeText(text).catch(() => {});
+    return true;
+  }, [activeId]);
 
-  // The socket + xterm live as long as the terminal PANEL is open — NOT only
-  // while it's the frontmost tab. Gating this on `active` would dispose the
-  // terminal and drop the PTY socket on every tab switch (a backgrounded pane
-  // is display:none, never unmounted), losing scrollback and the running shell.
-  // `active` is used ONLY to gate fitting (the fit effects below).
-  const paneLive = checked && reason === null;
+  const handleGone = useCallback(() => { reconcile(); }, [reconcile]);
 
-  const { status, send, resize, reconnectNow } = useTerminalSocket({
-    active: paneLive,
-    restartKey,
-    onData: (s) => termRef.current?.write(s),
-    // Reset the screen on every (re)connect before the server replays
-    // scrollback, so a reconnect to a still-alive backend repaints history
-    // instead of appending a duplicate copy under it. Also re-enable input
-    // (it's disabled while disconnected — see the status effect below).
-    onOpen: () => {
-      const term = termRef.current;
-      if (!term) return;
-      try { term.reset(); } catch { /* noop */ }
-      term.options.disableStdin = false;
-    },
-  });
-
-  // The size must reach the PTY only once the socket is OPEN. The resize sent
-  // during mount is dropped (socket still connecting), which would leave the
-  // PTY at the backend's default 80x24 while xterm renders the real (smaller)
-  // drawer size — so full-screen TUIs like `claude`/`vim` draw off-screen and
-  // look clipped. Re-fit and re-sync when the socket opens (and on reconnect).
-  useEffect(() => {
-    const el = rootRef.current;
-    if (status !== 'open' || !fitRef.current || !termRef.current || isHidden(el)) return;
-    try {
-      fitRef.current.fit();
-      resize(termRef.current.cols, termRef.current.rows);
-    } catch { /* noop */ }
-  }, [status, resize]);
-
-  // Mount xterm once the terminal panel is live (open + enabled). It stays
-  // mounted across tab switches (the pane is only hidden, never unmounted).
-  useEffect(() => {
-    if (!paneLive || termRef.current || !rootRef.current) return undefined;
-    let disposed = false;
-    let ro = null;
-    let mo = null;
-    let fitTimer = null;
-    const linkProviders = [];
-
-    const setup = () => {
-      if (disposed || termRef.current || !rootRef.current) return;
-      // A real terminal font (Menlo = macOS Terminal default, Monaco = iTerm's
-      // classic default), NOT the code-panel's JetBrains Mono. All system fonts
-      // — available synchronously, so xterm measures the cell correctly with no
-      // webfont race (JBM, a Google webfont, caused the extra-spacing bug).
-      const term = new Terminal({
-        scrollback: 5000,
-        fontFamily: 'Menlo, Monaco, "SF Mono", "SFMono-Regular", Consolas, "DejaVu Sans Mono", monospace',
-        fontSize: 13,
-        // iTerm-tight vertical rhythm. 1.5 read like a text editor (too airy);
-        // iTerm's default is ~1.0 — 1.1 keeps a hair of breathing room.
-        lineHeight: 1.1,
-        cursorBlink: true,
-        cursorStyle: 'bar',     // sleeker than the default square block
-        theme: themeFromCss(),
-      });
-      const fit = new FitAddon();
-      term.loadAddon(fit);
-      term.open(rootRef.current);
-      term.attachCustomKeyEventHandler((e) => !isReservedChord(e));
-      term.onData((d) => send(d));
-      termRef.current = term; fitRef.current = fit;
-
-      // Clickable links: cmd/ctrl-click a URL to open it in the system browser,
-      // or a real file path to open it in the user's editor. The file provider
-      // asks the backend which candidates are real files before lighting them
-      // up (see terminalLinks.js). y is a 1-based buffer line number.
-      const readLine = (y) => term.buffer.active.getLine(y - 1)?.translateToString(true) ?? '';
-      linkProviders.push(
-        term.registerLinkProvider(createUrlLinkProvider({
-          readLine,
-          openUrl: (url) => window.open(url, '_blank', 'noopener,noreferrer'),
-        })),
-        term.registerLinkProvider(createFileLinkProvider({
-          readLine,
-          resolvePaths: resolveTerminalPaths,
-          openFile: (abs, line, col) => { openInEditor(abs, line, col).catch(() => {}); },
-        })),
-      );
-      // Fit only when visible. If the pane mounts on a hidden/background tab,
-      // fitting measures a 0x0 box (bogus PTY size); the status-open and
-      // tab-activation effects both fit once the pane is actually shown.
-      if (!isHidden(rootRef.current)) {
-        try { fit.fit(); resize(term.cols, term.rows); } catch { /* noop */ }
-      }
-      // Debounce refits: during the sidebar-expand transition (and manual drag)
-      // the container resizes every frame; refitting each frame thrashes xterm
-      // and SIGWINCHes the PTY ~12x, so a running TUI redraws repeatedly and
-      // "scratches". Fit ONCE after the size settles. (ResizeObserver isn't in
-      // JSDOM; guard so tests and any lacking environment don't crash.)
-      const scheduleFit = () => {
-        if (fitTimer) clearTimeout(fitTimer);
-        fitTimer = setTimeout(() => {
-          fitTimer = null;
-          // Never fit/resize while hidden (inactive tab / closed drawer): see
-          // isHidden — a 0x0 fit drives the PTY to a bogus size and the shell
-          // floods the prompt with cursor-position replies (the "14;3R…" garbage).
-          if (isHidden(rootRef.current)) return;
-          try { fit.fit(); resize(term.cols, term.rows); } catch { /* noop */ }
-        }, 150);
-      };
-      ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(scheduleFit) : null;
-      ro?.observe(rootRef.current);
-      const onTheme = () => { term.options.theme = themeFromCss(); };
-      mo = typeof MutationObserver !== 'undefined' ? new MutationObserver(onTheme) : null;
-      mo?.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
-    };
-
-    // System fonts are available synchronously, so there's no webfont-load race
-    // to wait for — build immediately.
-    setup();
-
-    return () => {
-      disposed = true;
-      if (fitTimer) clearTimeout(fitTimer);
-      ro?.disconnect(); mo?.disconnect();
-      linkProviders.forEach((d) => { try { d.dispose(); } catch { /* noop */ } });
-      if (termRef.current) { termRef.current.dispose(); }
-      termRef.current = null; fitRef.current = null;
-    };
-  }, [paneLive, send, resize]);
-
-  // Refit + re-sync the PTY when the tab becomes active again (it was hidden,
-  // where we deliberately skip fitting). Guard on visibility so a stray call
-  // while still hidden can't resize to 0.
-  useEffect(() => {
-    const el = rootRef.current;
-    if (!active || !fitRef.current || !termRef.current || isHidden(el)) return;
-    try { fitRef.current.fit(); resize(termRef.current.cols, termRef.current.rows); } catch { /* noop */ }
-  }, [active, resize]);
-
-  // Give xterm keyboard focus when the terminal becomes the frontmost tab
-  // (drawer open or tab switch) so the user can type immediately without
-  // clicking into it. Gated on `active` so a backgrounded pane never steals
-  // focus; `paneLive` is a dep so this runs once the terminal has mounted on
-  // first open (termRef is set by the mount effect declared above). No
-  // isHidden guard: focus() doesn't resize the PTY, and an active tab is
-  // visible by definition.
-  useEffect(() => {
-    if (!active || !paneLive || !termRef.current) return;
-    try { termRef.current.focus(); } catch { /* noop */ }
-  }, [active, paneLive]);
-
-  // While the socket is not open, disable xterm input. send() already no-ops
-  // when disconnected, so keystrokes would otherwise vanish silently into a
-  // dead shell (and buffering them is unsafe — the line would land in a fresh
-  // shell on reconnect). disableStdin makes xterm ignore input while the
-  // "disconnected" overlay explains why. Declared after the mount effect so
-  // termRef is set when this first runs. `paneLive` is a dep so it re-runs
-  // once the terminal has mounted.
-  useEffect(() => {
-    const term = termRef.current;
-    if (!term) return;
-    term.options.disableStdin = status !== 'open';
-  }, [status, paneLive]);
-
-  // Bubble phase (NOT capture): xterm's textarea must receive the keydown
-  // first so special keys (Delete/Backspace/arrows/Enter) work; we then stop
-  // it bubbling to the window so the app's global handlers (Ctrl+[ history,
-  // Escape closes the side pane) don't fire on terminal input. Reserved drawer
-  // chords are left to bubble so Ctrl+` still toggles the drawer.
-  const containerKeyDown = useCallback((e) => { if (!isReservedChord(e)) e.stopPropagation(); }, []);
+  const onTabKeyDown = (e, id) => {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); selectSession(id); }
+  };
 
   if (!checked) return null;
   if (reason) {
     return <div className="tty-disabled" data-testid="tty-disabled">{reason}</div>;
   }
-  // A dead socket swallows keystrokes with no visual cue, so any not-connected
-  // state after mount gets an explicit banner. 'connecting' is excluded: the
-  // initial handshake resolves in milliseconds and a flash would be noise.
-  const overlay = {
-    reconnecting: { text: 'Terminal disconnected. Reconnecting…', btn: 'Retry now' },
-    // Only one window may hold the single PTY. There is no takeover, so the
-    // button offers an honest Retry (which succeeds once the other window is
-    // closed) rather than a "Use it here" that silently does nothing.
-    busy: { text: 'Terminal is open in another window. Close it there, then retry.', btn: 'Retry' },
-    refused: { text: 'Terminal connection refused by the server.', btn: 'Retry' },
-  }[status];
+
+  const activeSession = sessions.find((s) => s.id === activeId);
+  // A lone session needs no tab strip — its "+" lives in the header instead;
+  // the strip (with its own "+") appears once there are sessions to switch.
+  const showTabs = sessions.length > 1;
   return (
-    <div className="tty-wrap" onKeyDown={containerKeyDown}>
-      <div ref={rootRef} className="tty-root" data-testid="tty-root" />
-      {overlay && (
-        <div className="tty-overlay" data-testid="tty-overlay" role="status">
-          <span>{overlay.text}</span>
-          <button type="button" className="tty-overlay-btn" onClick={reconnectNow}>{overlay.btn}</button>
+    <div className="tty-shell">
+      <TerminalHeader onCopy={handleCopy} onNewSession={showTabs ? null : openSession} />
+      {showTabs && (
+        <div className="tty-tabs" role="tablist" aria-label="Terminal sessions">
+          {sessions.map((s) => (
+            <div key={s.id} role="tab" aria-selected={s.id === activeId} tabIndex={0}
+              className={`tty-tab${s.id === activeId ? ' tty-tab--active' : ''}`}
+              onClick={() => selectSession(s.id)}
+              onKeyDown={(e) => onTabKeyDown(e, s.id)}>
+              <span className="tty-tab-dot" aria-hidden="true" />
+              <span className="tty-tab-name">{s.name}</span>
+              <button type="button" className="tty-tab-close"
+                aria-label={`Close ${s.name}`} title="Close session"
+                onClick={(e) => { e.stopPropagation(); closeSession(s.id); }}>
+                <XIcon />
+              </button>
+            </div>
+          ))}
+          <button type="button" className="tty-tab-add" onClick={openSession}
+            disabled={sessions.length >= max}
+            aria-label="New session"
+            title={sessions.length >= max ? `Limit of ${max} sessions reached` : 'New session'}>
+            <PlusIcon />
+          </button>
         </div>
       )}
+      <div className="tty-views">
+        {sessions.map((s) => (
+          <TerminalSessionView key={s.id} sessionId={s.id} live={paneLive}
+            active={active && s.id === activeId}
+            onGone={handleGone} registerApi={registerApi} />
+        ))}
+      </div>
+      <div className="tty-statusbar">
+        {shell && <span>{shell}</span>}
+        {shell && <span className="tty-statusbar-sep" aria-hidden="true">·</span>}
+        <span>{sessions.length} session{sessions.length === 1 ? '' : 's'}</span>
+        <span className="tty-statusbar-spacer" />
+        {activeSession?.cwd && <span className="tty-statusbar-cwd" title={activeSession.cwd}>{activeSession.cwd}</span>}
+      </div>
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/terminal/TerminalPane.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.jsx
@@ -3,7 +3,7 @@ import { terminalStatus } from '../../api/terminal.js';
 import { useTerminalSessions } from './useTerminalSessions.js';
 import TerminalSessionView from './TerminalSessionView.jsx';
 import TerminalHeader from './TerminalHeader.jsx';
-import { PlusIcon, XIcon } from '../../components/CopyButton.jsx';
+import { LockIcon, PlusIcon, XIcon } from '../../components/CopyButton.jsx';
 
 /**
  * The terminal panel: header, session tab strip, one TerminalSessionView per
@@ -109,6 +109,14 @@ export default function TerminalPane({ active }) {
         {shell && <span>{shell}</span>}
         {shell && <span className="tty-statusbar-sep" aria-hidden="true">·</span>}
         <span>{sessions.length} session{sessions.length === 1 ? '' : 's'}</span>
+        <span className="tty-statusbar-sep" aria-hidden="true">·</span>
+        {/* The gate only ever admits loopback clients (terminal/gate.py); a
+            shell in a browser deserves a visible, if quiet, answer to "who
+            else can reach this?". */}
+        <span className="tty-statusbar-lock" title="The embedded terminal only works on localhost">
+          <LockIcon />
+          localhost only
+        </span>
         <span className="tty-statusbar-spacer" />
         {activeSession?.cwd && <span className="tty-statusbar-cwd" title={activeSession.cwd}>{activeSession.cwd}</span>}
       </div>

--- a/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
@@ -1,47 +1,81 @@
-import { it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 
 const fakeTerm = { open: vi.fn(), write: vi.fn(), dispose: vi.fn(), loadAddon: vi.fn(),
   onData: vi.fn(), onResize: vi.fn(), focus: vi.fn(), attachCustomKeyEventHandler: vi.fn(),
-  reset: vi.fn(),
+  reset: vi.fn(), getSelection: vi.fn(() => ''),
   registerLinkProvider: vi.fn(() => ({ dispose: vi.fn() })),
-  buffer: { active: { getLine: () => ({ translateToString: () => '' }) } },
+  buffer: { active: { getLine: () => ({ translateToString: () => '' }), viewportY: 0 } },
   cols: 80, rows: 24, options: {} };
 // Use `function` (not arrow) implementations so vi.fn() produces a constructible
-// mock: xterm's Terminal/FitAddon are always invoked with `new` in TerminalPane.
+// mock: xterm's Terminal/FitAddon are always invoked with `new` in the views.
 vi.mock('@xterm/xterm', () => ({ Terminal: vi.fn(function Terminal() { return fakeTerm; }) }));
 vi.mock('@xterm/addon-fit', () => ({
   FitAddon: vi.fn(function FitAddon() { return { fit: vi.fn(), proposeDimensions: () => ({ cols: 80, rows: 24 }) }; }),
 }));
+
+// Server-side session registry stub the pane reconciles against.
+let fakeSessions = [];
+let nextSession = 2;
+const listTerminalSessions = vi.fn(async () => ({ sessions: fakeSessions, max: 6 }));
+const createTerminalSession = vi.fn(async () => {
+  const s = { id: `s${nextSession}`, name: `zsh · ${nextSession}`, alive: true, cwd: '~/proj' };
+  nextSession += 1;
+  fakeSessions = fakeSessions.concat([s]);
+  return { id: s.id, name: s.name };
+});
+const killTerminalSession = vi.fn(async (id) => { fakeSessions = fakeSessions.filter((s) => s.id !== id); return { ok: true }; });
+
 vi.mock('../../api/terminal.js', () => ({
-  terminalStatus: vi.fn(async () => ({ enabled: true, running: false, reason: null })),
+  terminalStatus: vi.fn(async () => ({ enabled: true, running: false, reason: null, shell: 'zsh' })),
   killTerminal: vi.fn(async () => ({ ok: true })),
   terminalSocketUrl: () => 'ws://localhost/api/terminal/ws',
+  listTerminalSessions: (...a) => listTerminalSessions(...a),
+  createTerminalSession: (...a) => createTerminalSession(...a),
+  killTerminalSession: (...a) => killTerminalSession(...a),
   resolveTerminalPaths: vi.fn(async () => []),
   openInEditor: vi.fn(async () => ({ opened: true, editor: 'code' })),
 }));
 // Mock the socket hook: jsdom has no real terminal WS to reach, and the
 // overlay tests need to drive each connection status directly. lastSocketOpts
-// captures the options so a test can invoke the pane's onOpen callback.
+// captures the options so a test can invoke a view's onOpen callback.
 const socketState = { status: 'open', send: vi.fn(), resize: vi.fn(), reconnectNow: vi.fn() };
 let lastSocketOpts = null;
 vi.mock('./useTerminalSocket.js', () => ({
   useTerminalSocket: vi.fn((opts) => { lastSocketOpts = opts; return socketState; }),
 }));
+// The header/panel switcher read the drawer context; the pane is rendered
+// bare here, so stub the hook.
+const drawerCtx = {
+  openPanels: ['terminal'], activeTab: 'terminal', selectTab: vi.fn(),
+  maximized: false, toggleMaximized: vi.fn(), closeActiveTab: vi.fn(),
+};
+vi.mock('../assistant/AssistantDrawerProvider.jsx', () => ({
+  useAssistantDrawer: () => drawerCtx,
+}));
 import TerminalPane from './TerminalPane.jsx';
+
+beforeEach(() => {
+  fakeSessions = [{ id: 's1', name: 'zsh · 1', alive: true, cwd: '~/proj' }];
+  nextSession = 2;
+  listTerminalSessions.mockClear();
+  createTerminalSession.mockClear();
+  killTerminalSession.mockClear();
+  socketState.status = 'open';
+});
 
 it('mounts an xterm terminal when active', async () => {
   const { Terminal } = await import('@xterm/xterm');
+  Terminal.mockClear();
   render(<TerminalPane active />);
-  // allow the status effect to resolve
+  // allow the status + session-list effects to resolve
   await screen.findByTestId('tty-root');
   expect(Terminal).toHaveBeenCalled();
   expect(fakeTerm.open).toHaveBeenCalled();
 });
 
 it('focuses xterm when it is the active tab so the user can type without clicking in', async () => {
-  socketState.status = 'open';
   fakeTerm.focus.mockClear();
   render(<TerminalPane active />);
   await screen.findByTestId('tty-root');
@@ -49,7 +83,6 @@ it('focuses xterm when it is the active tab so the user can type without clickin
 });
 
 it('does not focus xterm while backgrounded (active=false)', async () => {
-  socketState.status = 'open';
   fakeTerm.focus.mockClear();
   render(<TerminalPane active={false} />);
   await screen.findByTestId('tty-root');
@@ -80,7 +113,6 @@ it('shows the gate reason and does not mount xterm when disabled', async () => {
 });
 
 it('shows no overlay while the socket is open or on the initial connect', async () => {
-  socketState.status = 'open';
   render(<TerminalPane active />);
   await screen.findByTestId('tty-root');
   expect(screen.queryByTestId('tty-overlay')).toBeNull();
@@ -111,13 +143,11 @@ it('shows a busy banner and an honest Retry (not a fake takeover) when another w
 });
 
 it('resets xterm on every socket (re)open so a live-backend reconnect does not duplicate scrollback', async () => {
-  const { vi: _vi } = await import('vitest');
-  socketState.status = 'open';
   fakeTerm.reset.mockClear();
   fakeTerm.options = {};
   render(<TerminalPane active />);
   await screen.findByTestId('tty-root');
-  // Simulate the socket (re)opening: the pane's onOpen must reset the screen
+  // Simulate the socket (re)opening: the view's onOpen must reset the screen
   // BEFORE the server's scrollback replay lands, and re-enable input.
   expect(typeof lastSocketOpts.onOpen).toBe('function');
   lastSocketOpts.onOpen();
@@ -131,4 +161,104 @@ it('disables stdin while disconnected so keystrokes are not silently swallowed',
   render(<TerminalPane active />);
   await screen.findByTestId('tty-root');
   expect(fakeTerm.options.disableStdin).toBe(true);
+});
+
+// ── multi-session ────────────────────────────────────────────────────────
+
+it('renders one tab per server session and passes each id to its own socket', async () => {
+  fakeSessions = [
+    { id: 's1', name: 'zsh · 1', alive: true, cwd: '~/proj' },
+    { id: 's9', name: 'zsh · 9', alive: true, cwd: '~/other' },
+  ];
+  render(<TerminalPane active />);
+  await screen.findByRole('tab', { name: /zsh · 1/ });
+  expect(screen.getByRole('tab', { name: /zsh · 9/ })).toBeInTheDocument();
+  expect(screen.getAllByTestId('tty-root')).toHaveLength(2);
+  // Every view opened a socket for ITS session (the mock captures the last).
+  const { useTerminalSocket } = await import('./useTerminalSocket.js');
+  const ids = useTerminalSocket.mock.calls.map(([opts]) => opts.sessionId);
+  expect(ids).toContain('s1');
+  expect(ids).toContain('s9');
+});
+
+it('creates a session on the header "+" and reveals the tab strip with the new one active', async () => {
+  const { userEvent } = await import('@testing-library/user-event').then((m) => ({ userEvent: m.default }));
+  render(<TerminalPane active />);
+  await screen.findByTestId('tty-root');
+  await userEvent.click(screen.getByRole('button', { name: 'New session' }));
+  expect(createTerminalSession).toHaveBeenCalled();
+  const newTab = await screen.findByRole('tab', { name: /zsh · 2/ });
+  expect(newTab).toHaveAttribute('aria-selected', 'true');
+  expect(screen.getByRole('tab', { name: /zsh · 1/ })).toBeInTheDocument();
+});
+
+it('creates one session automatically when the server has none (never zero sessions)', async () => {
+  fakeSessions = [];
+  render(<TerminalPane active />);
+  await screen.findByTestId('tty-root');   // the auto-created session's view
+  expect(createTerminalSession).toHaveBeenCalled();
+});
+
+it('hides the tab strip with a single session and shows the "+" in the header instead', async () => {
+  render(<TerminalPane active />);
+  await screen.findByTestId('tty-root');
+  expect(screen.queryByRole('tablist', { name: 'Terminal sessions' })).toBeNull();
+  const add = screen.getByRole('button', { name: 'New session' });
+  expect(add.closest('.tty-panel-header')).not.toBeNull();
+});
+
+it('closing a tab kills that session server-side and keeps the neighbor', async () => {
+  const { userEvent } = await import('@testing-library/user-event').then((m) => ({ userEvent: m.default }));
+  fakeSessions = [
+    { id: 's1', name: 'zsh · 1', alive: true, cwd: '~/proj' },
+    { id: 's9', name: 'zsh · 9', alive: true, cwd: '~/other' },
+  ];
+  render(<TerminalPane active />);
+  await screen.findByRole('tab', { name: /zsh · 9/ });
+  await userEvent.click(screen.getByRole('button', { name: 'Close zsh · 9' }));
+  expect(killTerminalSession).toHaveBeenCalledWith('s9');
+  await waitFor(() => expect(screen.queryByRole('tab', { name: /zsh · 9/ })).toBeNull());
+  // Down to one session the strip collapses; the survivor's view remains.
+  expect(screen.getAllByTestId('tty-root')).toHaveLength(1);
+  expect(screen.getByText('1 session')).toBeInTheDocument();
+});
+
+it('a lone session exposes no close button (the panel never shows zero sessions)', async () => {
+  render(<TerminalPane active />);
+  await screen.findByTestId('tty-root');
+  expect(screen.queryByRole('button', { name: /Close zsh/ })).toBeNull();
+});
+
+it('only the active session view is visible; the other stays mounted but hidden', async () => {
+  const { userEvent } = await import('@testing-library/user-event').then((m) => ({ userEvent: m.default }));
+  fakeSessions = [
+    { id: 's1', name: 'zsh · 1', alive: true, cwd: '~/proj' },
+    { id: 's9', name: 'zsh · 9', alive: true, cwd: '~/other' },
+  ];
+  render(<TerminalPane active />);
+  await screen.findByRole('tab', { name: /zsh · 9/ });
+  await userEvent.click(screen.getByRole('tab', { name: /zsh · 9/ }));
+  const wraps = screen.getAllByTestId('tty-root').map((el) => el.parentElement);
+  const hidden = wraps.filter((w) => w.style.display === 'none');
+  expect(wraps).toHaveLength(2);   // both mounted (PTYs survive the switch)
+  expect(hidden).toHaveLength(1);  // exactly one hidden
+});
+
+it('copy button copies the active session selection to the clipboard', async () => {
+  const { userEvent } = await import('@testing-library/user-event').then((m) => ({ userEvent: m.default }));
+  const writeText = vi.fn(async () => {});
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+  fakeTerm.getSelection.mockReturnValue('picked text');
+  render(<TerminalPane active />);
+  await screen.findByTestId('tty-root');
+  await userEvent.click(screen.getByRole('button', { name: 'Copy terminal output' }));
+  expect(writeText).toHaveBeenCalledWith('picked text');
+});
+
+it('shows shell, session count and active cwd in the status bar', async () => {
+  render(<TerminalPane active />);
+  await screen.findByTestId('tty-root');
+  expect(screen.getByText('zsh')).toBeInTheDocument();
+  expect(screen.getByText('1 session')).toBeInTheDocument();
+  expect(screen.getByText('~/proj')).toBeInTheDocument();
 });

--- a/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
@@ -255,10 +255,11 @@ it('copy button copies the active session selection to the clipboard', async () 
   expect(writeText).toHaveBeenCalledWith('picked text');
 });
 
-it('shows shell, session count and active cwd in the status bar', async () => {
+it('shows shell, session count, sandbox note and active cwd in the status bar', async () => {
   render(<TerminalPane active />);
   await screen.findByTestId('tty-root');
   expect(screen.getByText('zsh')).toBeInTheDocument();
   expect(screen.getByText('1 session')).toBeInTheDocument();
+  expect(screen.getByText('localhost only')).toBeInTheDocument();
   expect(screen.getByText('~/proj')).toBeInTheDocument();
 });

--- a/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
@@ -152,6 +152,9 @@ it('resets xterm on every socket (re)open so a live-backend reconnect does not d
   expect(typeof lastSocketOpts.onOpen).toBe('function');
   lastSocketOpts.onOpen();
   expect(fakeTerm.reset).toHaveBeenCalled();
+  // Top breathing room: one blank buffer row ahead of the replayed content
+  // (scrolls away with the scrollback, unlike a fixed CSS inset).
+  expect(fakeTerm.write).toHaveBeenCalledWith('\r\n');
   expect(fakeTerm.options.disableStdin).toBe(false);
 });
 

--- a/src/quodeq/ui/src/features/terminal/TerminalSessionView.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalSessionView.jsx
@@ -1,0 +1,251 @@
+import React, { useEffect, useRef, useCallback } from 'react';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import '@xterm/xterm/css/xterm.css';
+import { useTerminalSocket } from './useTerminalSocket.js';
+import { resolveTerminalPaths, openInEditor } from '../../api/terminal.js';
+import { createUrlLinkProvider, createFileLinkProvider } from './terminalLinks.js';
+import { themeFromCss } from './xtermTheme.js';
+
+// Two drawer chords are reserved for the host; return false so xterm lets them
+// bubble to the window handler instead of typing into the shell.
+function isReservedChord(e) {
+  return e.code === 'Backquote' && (e.ctrlKey || e.metaKey);
+}
+
+// True when the element isn't laid out (display:none / zero-size). Fitting xterm
+// to a hidden box measures a 0x0 cell and drives the PTY to a bogus size, so the
+// shell floods the prompt with cursor-position queries ("14;3R…"). Every fit
+// path guards on this. A display:none ANCESTOR (inactive session tab or
+// backgrounded panel) also makes offsetParent null, so one guard covers both.
+function isHidden(el) {
+  return !el || el.offsetParent === null || el.clientWidth === 0 || el.clientHeight === 0;
+}
+
+/**
+ * One shell session: an xterm instance bound to one server-side PTY over its
+ * own WebSocket. Lives as long as the session exists — an inactive session
+ * tab hides this view with display:none but never unmounts it, so the buffer
+ * and socket survive tab switches (both between sessions and between the
+ * drawer's panels). Unmounting is the disposal path when a session is closed.
+ */
+export default function TerminalSessionView({ sessionId, active, live, onGone, registerApi }) {
+  const rootRef = useRef(null);
+  const termRef = useRef(null);
+  const fitRef = useRef(null);
+
+  const { status, send, resize, reconnectNow } = useTerminalSocket({
+    active: live,
+    sessionId,
+    onData: (s) => termRef.current?.write(s),
+    // Reset the screen on every (re)connect before the server replays
+    // scrollback, so a reconnect to a still-alive backend repaints history
+    // instead of appending a duplicate copy under it. Also re-enable input
+    // (it's disabled while disconnected — see the status effect below).
+    onOpen: () => {
+      const term = termRef.current;
+      if (!term) return;
+      try { term.reset(); } catch { /* noop */ }
+      term.options.disableStdin = false;
+    },
+  });
+
+  // The session evaporated server-side (server restart). Tell the owner so it
+  // reconciles the tab strip against /terminal/sessions; retrying is futile.
+  useEffect(() => {
+    if (status === 'gone') onGone?.(sessionId);
+  }, [status, sessionId, onGone]);
+
+  // Expose the copy source to the header's Copy button: the selection when
+  // there is one, else the visible viewport.
+  useEffect(() => {
+    if (!registerApi) return undefined;
+    const getCopyText = () => {
+      const term = termRef.current;
+      if (!term) return '';
+      const sel = term.getSelection?.();
+      if (sel) return sel;
+      const buf = term.buffer?.active;
+      if (!buf) return '';
+      const lines = [];
+      for (let i = 0; i < term.rows; i += 1) {
+        const line = buf.getLine(buf.viewportY + i);
+        if (line) lines.push(line.translateToString(true));
+      }
+      return lines.join('\n').replace(/\n+$/, '');
+    };
+    registerApi(sessionId, { getCopyText });
+    return () => registerApi(sessionId, null);
+  }, [registerApi, sessionId]);
+
+  // The size must reach the PTY only once the socket is OPEN. The resize sent
+  // during mount is dropped (socket still connecting), which would leave the
+  // PTY at the backend's default 80x24 while xterm renders the real (smaller)
+  // drawer size — so full-screen TUIs like `claude`/`vim` draw off-screen and
+  // look clipped. Re-fit and re-sync when the socket opens (and on reconnect).
+  useEffect(() => {
+    const el = rootRef.current;
+    if (status !== 'open' || !fitRef.current || !termRef.current || isHidden(el)) return;
+    try {
+      fitRef.current.fit();
+      resize(termRef.current.cols, termRef.current.rows);
+    } catch { /* noop */ }
+  }, [status, resize]);
+
+  // Mount xterm once the session is live. It stays mounted across tab
+  // switches (the view is only hidden, never unmounted, while the session
+  // exists).
+  useEffect(() => {
+    if (!live || termRef.current || !rootRef.current) return undefined;
+    let disposed = false;
+    let ro = null;
+    let mo = null;
+    let fitTimer = null;
+    const linkProviders = [];
+
+    const setup = () => {
+      if (disposed || termRef.current || !rootRef.current) return;
+      // A real terminal font (Menlo = macOS Terminal default, Monaco = iTerm's
+      // classic default), NOT the code-panel's JetBrains Mono. All system fonts
+      // — available synchronously, so xterm measures the cell correctly with no
+      // webfont race (JBM, a Google webfont, caused the extra-spacing bug).
+      const term = new Terminal({
+        scrollback: 5000,
+        fontFamily: 'Menlo, Monaco, "SF Mono", "SFMono-Regular", Consolas, "DejaVu Sans Mono", monospace',
+        fontSize: 13,
+        // iTerm-tight vertical rhythm. 1.5 read like a text editor (too airy);
+        // iTerm's default is ~1.0 — 1.1 keeps a hair of breathing room.
+        lineHeight: 1.1,
+        cursorBlink: true,
+        cursorStyle: 'bar',     // sleeker than the default square block
+        theme: themeFromCss(),
+      });
+      const fit = new FitAddon();
+      term.loadAddon(fit);
+      term.open(rootRef.current);
+      term.attachCustomKeyEventHandler((e) => !isReservedChord(e));
+      term.onData((d) => send(d));
+      termRef.current = term; fitRef.current = fit;
+
+      // Clickable links: cmd/ctrl-click a URL to open it in the system browser,
+      // or a real file path to open it in the user's editor. The file provider
+      // asks the backend which candidates are real files before lighting them
+      // up (see terminalLinks.js); resolution runs against THIS session's shell
+      // cwd. y is a 1-based buffer line number.
+      const readLine = (y) => term.buffer.active.getLine(y - 1)?.translateToString(true) ?? '';
+      linkProviders.push(
+        term.registerLinkProvider(createUrlLinkProvider({
+          readLine,
+          openUrl: (url) => window.open(url, '_blank', 'noopener,noreferrer'),
+        })),
+        term.registerLinkProvider(createFileLinkProvider({
+          readLine,
+          resolvePaths: (paths) => resolveTerminalPaths(paths, sessionId),
+          openFile: (abs, line, col) => { openInEditor(abs, line, col, sessionId).catch(() => {}); },
+        })),
+      );
+      // Fit only when visible. If the view mounts hidden (background session
+      // tab or backgrounded panel), fitting measures a 0x0 box (bogus PTY
+      // size); the status-open and activation effects both fit once shown.
+      if (!isHidden(rootRef.current)) {
+        try { fit.fit(); resize(term.cols, term.rows); } catch { /* noop */ }
+      }
+      // Debounce refits: during the sidebar-expand transition (and manual drag)
+      // the container resizes every frame; refitting each frame thrashes xterm
+      // and SIGWINCHes the PTY ~12x, so a running TUI redraws repeatedly and
+      // "scratches". Fit ONCE after the size settles. (ResizeObserver isn't in
+      // JSDOM; guard so tests and any lacking environment don't crash.)
+      const scheduleFit = () => {
+        if (fitTimer) clearTimeout(fitTimer);
+        fitTimer = setTimeout(() => {
+          fitTimer = null;
+          // Never fit/resize while hidden (inactive tab / closed drawer): see
+          // isHidden — a 0x0 fit drives the PTY to a bogus size and the shell
+          // floods the prompt with cursor-position replies (the "14;3R…" garbage).
+          if (isHidden(rootRef.current)) return;
+          try { fit.fit(); resize(term.cols, term.rows); } catch { /* noop */ }
+        }, 150);
+      };
+      ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(scheduleFit) : null;
+      ro?.observe(rootRef.current);
+      const onTheme = () => { term.options.theme = themeFromCss(); };
+      mo = typeof MutationObserver !== 'undefined' ? new MutationObserver(onTheme) : null;
+      mo?.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+    };
+
+    // System fonts are available synchronously, so there's no webfont-load race
+    // to wait for — build immediately.
+    setup();
+
+    return () => {
+      disposed = true;
+      if (fitTimer) clearTimeout(fitTimer);
+      ro?.disconnect(); mo?.disconnect();
+      linkProviders.forEach((d) => { try { d.dispose(); } catch { /* noop */ } });
+      if (termRef.current) { termRef.current.dispose(); }
+      termRef.current = null; fitRef.current = null;
+    };
+  }, [live, sessionId, send, resize]);
+
+  // Refit + re-sync the PTY when this session becomes visible again (it was
+  // hidden, where we deliberately skip fitting). Guard on visibility so a
+  // stray call while still hidden can't resize to 0.
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!active || !fitRef.current || !termRef.current || isHidden(el)) return;
+    try { fitRef.current.fit(); resize(termRef.current.cols, termRef.current.rows); } catch { /* noop */ }
+  }, [active, resize]);
+
+  // Give xterm keyboard focus when this session becomes the frontmost one so
+  // the user can type immediately without clicking into it. Gated on `active`
+  // so a backgrounded view never steals focus; `live` is a dep so this runs
+  // once the terminal has mounted on first open. No isHidden guard: focus()
+  // doesn't resize the PTY, and an active view is visible by definition.
+  useEffect(() => {
+    if (!active || !live || !termRef.current) return;
+    try { termRef.current.focus(); } catch { /* noop */ }
+  }, [active, live]);
+
+  // While the socket is not open, disable xterm input. send() already no-ops
+  // when disconnected, so keystrokes would otherwise vanish silently into a
+  // dead shell (and buffering them is unsafe — the line would land in a fresh
+  // shell on reconnect). disableStdin makes xterm ignore input while the
+  // "disconnected" overlay explains why.
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+    term.options.disableStdin = status !== 'open';
+  }, [status, live]);
+
+  // Bubble phase (NOT capture): xterm's textarea must receive the keydown
+  // first so special keys (Delete/Backspace/arrows/Enter) work; we then stop
+  // it bubbling to the window so the app's global handlers (Ctrl+[ history,
+  // Escape closes the side pane) don't fire on terminal input. Reserved drawer
+  // chords are left to bubble so Ctrl+` still toggles the drawer.
+  const containerKeyDown = useCallback((e) => { if (!isReservedChord(e)) e.stopPropagation(); }, []);
+
+  // A dead socket swallows keystrokes with no visual cue, so any not-connected
+  // state after mount gets an explicit banner. 'connecting' is excluded: the
+  // initial handshake resolves in milliseconds and a flash would be noise.
+  // 'gone' is excluded too: the owner is already reconciling this view away.
+  const overlay = {
+    reconnecting: { text: 'Terminal disconnected. Reconnecting…', btn: 'Retry now' },
+    // Only one window may hold a session's PTY. There is no takeover, so the
+    // button offers an honest Retry (which succeeds once the other window is
+    // closed) rather than a "Use it here" that silently does nothing.
+    busy: { text: 'Terminal is open in another window. Close it there, then retry.', btn: 'Retry' },
+    refused: { text: 'Terminal connection refused by the server.', btn: 'Retry' },
+  }[status];
+
+  return (
+    <div className="tty-wrap" onKeyDown={containerKeyDown} style={{ display: active ? undefined : 'none' }}>
+      <div ref={rootRef} className="tty-root" data-testid="tty-root" />
+      {overlay && (
+        <div className="tty-overlay" data-testid="tty-overlay" role="status">
+          <span>{overlay.text}</span>
+          <button type="button" className="tty-overlay-btn" onClick={reconnectNow}>{overlay.btn}</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/terminal/TerminalSessionView.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalSessionView.jsx
@@ -45,7 +45,13 @@ export default function TerminalSessionView({ sessionId, active, live, onGone, r
     onOpen: () => {
       const term = termRef.current;
       if (!term) return;
-      try { term.reset(); } catch { /* noop */ }
+      try {
+        term.reset();
+        // One blank buffer row before the (re)played content: top breathing
+        // room that scrolls away with the scrollback instead of being a fixed
+        // viewport inset (which CSS padding on xterm would be).
+        term.write('\r\n');
+      } catch { /* noop */ }
       term.options.disableStdin = false;
     },
   });

--- a/src/quodeq/ui/src/features/terminal/useTerminalSessions.js
+++ b/src/quodeq/ui/src/features/terminal/useTerminalSessions.js
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { listTerminalSessions, createTerminalSession, killTerminalSession } from '../../api/terminal.js';
+
+/**
+ * Client side of the session tab strip. The SERVER owns the canonical session
+ * list (sessions survive page reloads and drawer closes); this hook reconciles
+ * local state against it instead of persisting its own copy:
+ *  - on mount: fetch the list, creating one session if it's empty (the panel
+ *    never shows zero tabs);
+ *  - on 'gone' sockets or a Settings restart (kill-all): refetch, drop stale
+ *    ids, recreate one session if everything died;
+ *  - on tab activation: refetch lazily so the status bar's cwd stays fresh
+ *    without polling.
+ */
+export function useTerminalSessions({ enabled }) {
+  const [sessions, setSessions] = useState([]);
+  const [activeId, setActiveId] = useState(null);
+  const [max, setMax] = useState(6);
+  const sessionsRef = useRef(sessions);
+  sessionsRef.current = sessions;
+  // Serialize reconciles: a burst (N sockets all reporting 'gone' after a
+  // server restart) must not fan out into N concurrent create calls.
+  const reconcilingRef = useRef(null);
+
+  const reconcile = useCallback(({ createIfEmpty = true } = {}) => {
+    if (!reconcilingRef.current) {
+      reconcilingRef.current = (async () => {
+        try {
+          let r = await listTerminalSessions();
+          if (!(r.sessions || []).length && createIfEmpty) {
+            await createTerminalSession().catch(() => {});
+            r = await listTerminalSessions();
+          }
+          const list = r.sessions || [];
+          setSessions(list);
+          if (r.max) setMax(r.max);
+          setActiveId((prev) => (list.some((s) => s.id === prev) ? prev : (list[list.length - 1]?.id ?? null)));
+        } catch { /* server unreachable: keep current tabs; sockets surface it */ }
+        finally { reconcilingRef.current = null; }
+      })();
+    }
+    return reconcilingRef.current;
+  }, []);
+
+  useEffect(() => {
+    if (enabled) reconcile();
+  }, [enabled, reconcile]);
+
+  const openSession = useCallback(async () => {
+    try {
+      const created = await createTerminalSession();
+      await reconcile();
+      if (created?.id) setActiveId(created.id);
+    } catch {
+      // 409 at the cap (or a race): the server is the source of truth.
+      await reconcile();
+    }
+  }, [reconcile]);
+
+  const closeSession = useCallback(async (id) => {
+    // Drop it locally FIRST: unmounting the view closes its socket and
+    // disposes xterm before the server kill, so the socket never sees the
+    // kill as an unexpected drop and starts reconnect backoff into a 4004.
+    const prev = sessionsRef.current;
+    const idx = prev.findIndex((s) => s.id === id);
+    const next = prev.filter((s) => s.id !== id);
+    const neighbor = (next[idx - 1] || next[0])?.id ?? null;
+    setSessions(next);
+    setActiveId((cur) => (cur === id ? neighbor : cur));
+    await killTerminalSession(id).catch(() => {});
+    // Recreates a fresh session when the last tab was closed.
+    await reconcile();
+  }, [reconcile]);
+
+  const selectSession = useCallback((id) => {
+    setActiveId(id);
+    // Lazy cwd refresh for the status bar; no polling.
+    reconcile({ createIfEmpty: false });
+  }, [reconcile]);
+
+  return { sessions, activeId, max, openSession, closeSession, selectSession, reconcile };
+}

--- a/src/quodeq/ui/src/features/terminal/useTerminalSocket.js
+++ b/src/quodeq/ui/src/features/terminal/useTerminalSocket.js
@@ -5,14 +5,15 @@ import { terminalSocketUrl } from '../../api/terminal.js';
 // They mean a reconnect cannot succeed right now, so the hook reports the
 // state instead of retrying — a busy loop here would ping-pong against the
 // server's single-connection lock and spam the other window's terminal.
-const CLOSE_BUSY = 4002;     // another window holds the single PTY connection
+const CLOSE_BUSY = 4002;     // another window holds this session's connection
 const CLOSE_REFUSED = 4003;  // gate refused (non-loopback host / bad Origin)
+const CLOSE_GONE = 4004;     // unknown session id (e.g. server restarted)
 
 const RETRY_BASE_MS = 500;
 const RETRY_MAX_MS = 5000;
 
-// status: 'idle' | 'connecting' | 'open' | 'reconnecting' | 'busy' | 'refused'
-export function useTerminalSocket({ active, onData, onOpen, restartKey = 0 }) {
+// status: 'idle' | 'connecting' | 'open' | 'reconnecting' | 'busy' | 'refused' | 'gone'
+export function useTerminalSocket({ active, onData, onOpen, restartKey = 0, sessionId = null }) {
   const [status, setStatus] = useState('idle');
   // Bumped internally to open a fresh socket after an unexpected close.
   const [gen, setGen] = useState(0);
@@ -36,7 +37,7 @@ export function useTerminalSocket({ active, onData, onOpen, restartKey = 0 }) {
   // current socket and opens a fresh one (restart from Settings / auto-retry).
   useEffect(() => {
     if (!active) return undefined;
-    const ws = new WebSocket(terminalSocketUrl());
+    const ws = new WebSocket(terminalSocketUrl(window.location, sessionId));
     wsRef.current = ws;
     setStatus(attemptsRef.current > 0 ? 'reconnecting' : 'connecting');
     ws.onopen = () => {
@@ -50,6 +51,9 @@ export function useTerminalSocket({ active, onData, onOpen, restartKey = 0 }) {
       if (wsRef.current === ws) wsRef.current = null;
       if (e?.code === CLOSE_BUSY) { setStatus('busy'); return; }
       if (e?.code === CLOSE_REFUSED) { setStatus('refused'); return; }
+      // Session no longer exists server-side. Retrying this URL can never
+      // succeed; the owner reconciles against /terminal/sessions instead.
+      if (e?.code === CLOSE_GONE) { setStatus('gone'); return; }
       // Unexpected drop (server restart/crash/sleep). A dead socket swallows
       // keystrokes silently, so surface it and retry with capped exponential
       // backoff — the local server can come back at any moment.
@@ -71,7 +75,7 @@ export function useTerminalSocket({ active, onData, onOpen, restartKey = 0 }) {
       try { ws.close(); } catch { /* noop */ }
       if (wsRef.current === ws) wsRef.current = null;
     };
-  }, [active, restartKey, gen]);
+  }, [active, restartKey, gen, sessionId]);
 
   const send = useCallback((data) => {
     const ws = wsRef.current;

--- a/src/quodeq/ui/src/features/terminal/useTerminalSocket.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/useTerminalSocket.test.jsx
@@ -93,6 +93,22 @@ it('reports busy and does not retry when another window owns the terminal', () =
   expect(MockWS.instances.length).toBe(1);      // no auto-retry ping-pong
 });
 
+it('connects to the session-specific url when given a sessionId', () => {
+  renderHook(() => useTerminalSocket({ active: true, onData: () => {}, sessionId: 's1' }));
+  expect(MockWS.instances[0].url).toContain('session=s1');
+});
+
+it('reports gone and does not retry when the session no longer exists', () => {
+  // Server restarted: the tab's session id is stale. Retrying the same URL
+  // can never succeed — the owner reconciles via the sessions list instead.
+  vi.useFakeTimers();
+  const { result } = renderHook(() => useTerminalSocket({ active: true, onData: () => {}, sessionId: 's1' }));
+  act(() => MockWS.instances[0]._drop(4004));
+  expect(result.current.status).toBe('gone');
+  act(() => vi.advanceTimersByTime(60000));
+  expect(MockWS.instances.length).toBe(1);
+});
+
 it('reports refused and does not retry when the gate rejects the connection', () => {
   vi.useFakeTimers();
   const { result } = renderHook(() => useTerminalSocket({ active: true, onData: () => {} }));

--- a/src/quodeq/ui/src/features/terminal/xtermTheme.js
+++ b/src/quodeq/ui/src/features/terminal/xtermTheme.js
@@ -1,0 +1,30 @@
+// Builds the xterm theme from the live CSS tokens so the console follows the
+// app-level theme (data-theme attribute). All --tty-ansi-* tokens resolve to
+// plain hex/rgba in tokens.css — xterm parses colors itself and cannot
+// evaluate color-mix()/var() indirection.
+export function themeFromCss() {
+  const s = getComputedStyle(document.documentElement);
+  const v = (name, fb) => (s.getPropertyValue(name).trim() || fb);
+  return {
+    background: v('--color-surface-alt', '#1e1e1e'),
+    foreground: v('--color-text', '#dcdcdc'),
+    cursor: v('--color-accent', '#dcdcdc'),
+    selectionBackground: v('--tty-selection', 'rgba(255,255,255,0.22)'),
+    black: v('--tty-ansi-black', '#1a2230'),
+    red: v('--tty-ansi-red', '#e05c4b'),
+    green: v('--tty-ansi-green', '#4caf7d'),
+    yellow: v('--tty-ansi-yellow', '#fbbf24'),
+    blue: v('--tty-ansi-blue', '#5aa2e8'),
+    magenta: v('--tty-ansi-magenta', '#c987c9'),
+    cyan: v('--tty-ansi-cyan', '#22d3ee'),
+    white: v('--tty-ansi-white', '#d4e0f0'),
+    brightBlack: v('--tty-ansi-bright-black', '#4a6a88'),
+    brightRed: v('--tty-ansi-bright-red', '#f05078'),
+    brightGreen: v('--tty-ansi-bright-green', '#6fd49a'),
+    brightYellow: v('--tty-ansi-bright-yellow', '#fcd34d'),
+    brightBlue: v('--tty-ansi-bright-blue', '#82bcf4'),
+    brightMagenta: v('--tty-ansi-bright-magenta', '#dfa8df'),
+    brightCyan: v('--tty-ansi-bright-cyan', '#67e3f9'),
+    brightWhite: v('--tty-ansi-bright-white', '#ffffff'),
+  };
+}

--- a/src/quodeq/ui/src/styles/assistant.css
+++ b/src/quodeq/ui/src/styles/assistant.css
@@ -727,42 +727,6 @@
   color: var(--color-text-muted);
 }
 
-/* Slash commands: a bordered menu of full-width rows. */
-.assistant-cmd-list {
-  border: 1px solid var(--color-border);
-  border-radius: 0.7rem;
-  overflow: hidden;
-}
-.assistant-cmd-row {
-  display: flex;
-  align-items: center;
-  gap: 0.7rem;
-  width: 100%;
-  text-align: left;
-  padding: 0.55rem 0.8rem;
-  background: var(--color-surface);
-  border: none;
-  border-bottom: 1px solid var(--color-border);
-  cursor: pointer;
-}
-.assistant-cmd-row:last-child { border-bottom: none; }
-.assistant-cmd-row:hover { background: var(--color-surface-alt); }
-.assistant-cmd-badge {
-  font-family: var(--font-data);
-  font-size: 0.71875rem;
-  font-weight: 500;
-  color: var(--color-accent);
-  background: var(--color-accent-soft);
-  border: 1px solid color-mix(in srgb, var(--color-accent) 20%, transparent);
-  border-radius: 0.375rem;
-  padding: 0.1rem 0.5rem;
-  flex-shrink: 0;
-}
-.assistant-cmd-desc {
-  font-family: var(--font-sans);
-  font-size: 0.75rem;
-  color: var(--color-text-muted);
-}
 
 .assistant-command-menu { position: absolute; bottom: 100%; left: 0; right: 0; margin-bottom: 4px; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; z-index: 10; }
 .assistant-command-item { display: flex; align-items: baseline; gap: 8px; width: 100%; text-align: left; padding: 6px 10px; background: none; border: none; color: var(--color-text); cursor: pointer; font-size: 12px; }

--- a/src/quodeq/ui/src/styles/assistant.css
+++ b/src/quodeq/ui/src/styles/assistant.css
@@ -141,18 +141,165 @@
   background: var(--color-border);
 }
 
-.assistant-drawer-header {
+/* ── Panel switcher (shared by both panels' headers) ────── */
+.drawer-switch {
+  display: flex;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--color-border);
+  border-radius: 0.4rem;
+  background: var(--color-surface-alt);
+  flex-shrink: 0;
+}
+
+.drawer-switch-btn {
+  width: 1.5rem;
+  height: 1.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 0.3rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 0;
+}
+.drawer-switch-btn:hover { color: var(--color-text); }
+.drawer-switch-btn--active {
+  background: var(--color-surface);
+  color: var(--color-accent);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+.drawer-switch-btn:focus-visible {
+  outline: 1px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
+/* ── Assistant panel header ─────────────────────────────── */
+.assistant-panel-header {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.375rem 1rem;
+  gap: 0.6rem;
+  padding: 0.5rem 1rem;
+  background: var(--color-surface);
   border-bottom: 1px solid var(--color-border);
 }
 
-.assistant-drawer-title {
+.assistant-compass-block {
+  position: relative;
+  width: 1.75rem;
+  height: 1.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: 0.5rem;
+  background: var(--color-accent-soft);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 25%, transparent);
+  color: var(--color-accent);   /* tints the Q mark (currentColor fill) */
+}
+
+.assistant-compass {
+  /* Same optical proportion as the topbar launcher (11px in a 24px button,
+     ~46%): the solid Q fills its viewBox edge-to-edge, so it must sit
+     smaller in its container than stroke icons do. 1.75rem block -> 0.85rem. */
+  width: 0.85rem;
+  height: 0.85rem;
+  position: relative;
+  /* SVG rotation animations must spin around the glyph's own center. */
+  transform-origin: 50% 50%;
+  transform-box: fill-box;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes assistant-compass-sway {
+    0%, 100% { transform: rotate(-6deg); }
+    50% { transform: rotate(6deg); }
+  }
+  @keyframes assistant-compass-wobble {
+    0% { transform: rotate(0deg); }
+    14% { transform: rotate(-36deg); }
+    30% { transform: rotate(24deg); }
+    46% { transform: rotate(-14deg); }
+    62% { transform: rotate(9deg); }
+    78% { transform: rotate(-4deg); }
+    100% { transform: rotate(0deg); }
+  }
+  @keyframes assistant-think-pulse {
+    0% { transform: scale(0.7); opacity: 0.5; }
+    100% { transform: scale(1.6); opacity: 0; }
+  }
+  .assistant-compass { animation: assistant-compass-sway 4s ease-in-out infinite; }
+  .assistant-compass--think { animation: assistant-compass-wobble 1.9s cubic-bezier(0.4, 0.1, 0.3, 1) infinite; }
+  /* Panel switcher's Q mark while a turn streams (no idle sway there). */
+  .assistant-q--think {
+    transform-origin: 50% 50%;
+    transform-box: fill-box;
+    animation: assistant-compass-wobble 1.9s cubic-bezier(0.4, 0.1, 0.3, 1) infinite;
+  }
+  .assistant-think-ring {
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    width: 1rem;
+    height: 1rem;
+    border-radius: 50%;
+    border: 1.5px solid var(--color-accent);
+    animation: assistant-think-pulse 1.8s ease-out infinite;
+  }
+}
+
+.assistant-panel-identity {
+  line-height: 1.2;
+  min-width: 0;
+}
+.assistant-panel-title {
+  font-family: var(--font-sans);
+  font-weight: 600;
   font-size: 0.8125rem;
-  color: var(--color-console-text);
+  color: var(--color-text);
+  white-space: nowrap;
+}
+.assistant-panel-subtitle {
+  font-family: var(--font-data);
+  font-size: 0.625rem;
+  color: var(--color-text-subtle);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Model chip: a real button — click opens Settings. */
+.assistant-model-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.25rem 0.6rem;
+  max-width: 15rem;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  flex-shrink: 1;
+  min-width: 0;
+}
+.assistant-model-chip:hover {
+  border-color: color-mix(in srgb, var(--color-accent) 35%, transparent);
+  background: var(--color-surface);
+}
+.assistant-model-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-success);
+  flex-shrink: 0;
+}
+.assistant-model-name {
+  font-family: var(--font-data);
+  font-size: 0.6875rem;
+  color: var(--color-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -217,11 +364,42 @@
 
 .assistant-msg-user {
   align-self: flex-end;
-  max-width: 80%;
-  padding: 0.375rem 0.625rem;
+  max-width: 78%;
+  padding: 0.5rem 0.8rem;
   background: var(--color-surface);
+  border: 1px solid var(--color-border);
   color: var(--color-text);
-  border-radius: 0.5rem;
+  /* Speech-bubble radius: soft everywhere, tucked at the trailing corner. */
+  border-radius: 0.875rem 0.875rem 0.25rem 0.875rem;
+}
+
+/* Assistant-authored content sits next to a compass avatar column. */
+.assistant-msg-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  min-width: 0;
+}
+.assistant-msg-row .assistant-msg { min-width: 0; flex: 1 1 auto; }
+
+.assistant-msg-avatar {
+  position: relative;
+  width: 1.5rem;
+  height: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+  border-radius: 0.45rem;
+  background: var(--color-accent-soft);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 25%, transparent);
+  color: var(--color-accent);   /* tints the Q mark (currentColor fill) */
+}
+.assistant-msg-avatar .assistant-compass {
+  /* 1.5rem container, same ~46% proportion as the topbar. */
+  width: 0.7rem;
+  height: 0.7rem;
 }
 
 .assistant-msg-assistant {
@@ -316,29 +494,17 @@
   color: var(--color-text-muted);
 }
 
-/* ── Streaming indicator ─────────────────────────────── */
+/* ── Streaming ("thinking") indicator ─────────────────── */
 .assistant-streaming-indicator {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 0.6rem;
   padding: 0.25rem 0;
 }
 
-.assistant-streaming-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--color-accent);
-  opacity: 0.4;
-  animation: assistant-streaming-pulse 1s ease-in-out infinite;
-}
-
-.assistant-streaming-dot:nth-child(2) { animation-delay: 0.15s; }
-.assistant-streaming-dot:nth-child(3) { animation-delay: 0.3s; }
-
-@keyframes assistant-streaming-pulse {
-  0%, 80%, 100% { opacity: 0.3; transform: scale(0.85); }
-  40% { opacity: 1; transform: scale(1); }
+.assistant-streaming-text {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
 }
 
 /* ── Error banner ─────────────────────────────────────── */
@@ -350,20 +516,53 @@
   border-top: 1px solid var(--color-border);
 }
 
-/* ── Prompt input ─────────────────────────────────────── */
+/* ── Composer ─────────────────────────────────────────── */
 .assistant-drawer-input-row {
   flex: 0 0 auto;
-  padding: 0.5rem 1rem 0.75rem;
+  padding: 0.5rem 1rem 0.6rem;
   border-top: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+/* Card-style input: leading slash badge, borderless auto-growing textarea,
+   circular send button. Focus lights the card, not the textarea. */
+.assistant-composer {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.6rem;
+  padding: 0.35rem 0.35rem 0.35rem 0.7rem;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: 0.8rem;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.assistant-composer:focus-within {
+  border-color: var(--color-accent);
+  background: var(--color-surface);
+}
+
+.assistant-composer-slash {
+  font-family: var(--font-data);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 20%, transparent);
+  border-radius: 0.375rem;
+  padding: 0.1rem 0.45rem;
+  margin-bottom: 0.3rem;
+  flex-shrink: 0;
+  user-select: none;
 }
 
 .assistant-drawer-input {
-  width: 100%;
+  flex: 1 1 auto;
+  min-width: 0;
   resize: none;
   background: transparent;
-  border: 1px solid var(--color-border);
-  border-radius: 0.375rem;
-  padding: 0.5rem 0.75rem;
+  border: none;
+  padding: 0.4rem 0;
+  max-height: 120px;
   color: var(--color-console-text);
   font-family: var(--font-mono);
   font-size: 0.8125rem;
@@ -375,38 +574,48 @@
   opacity: 1;
 }
 
-.assistant-drawer-input:focus {
-  outline: none;
-  border-color: var(--color-accent);
-}
+.assistant-drawer-input:focus { outline: none; }
 
 .assistant-drawer-input:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }
 
-/* Stop button: overlays the right edge of the (disabled) input while a turn
-   streams. The row is position:relative, so anchor to it. */
-.assistant-stop-btn {
-  position: absolute;
-  right: 1.5rem;
-  top: 50%;
-  transform: translateY(-50%);
+/* Send (and its streaming replacement, Stop): a compact round action at the
+   card's trailing edge. Muted until there is something to send. */
+.assistant-send-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 1.9rem;
+  height: 1.9rem;
   padding: 0;
-  border: 1px solid var(--color-border);
-  border-radius: 0.375rem;
-  background: var(--color-surface-alt);
-  color: var(--color-accent);
+  flex-shrink: 0;
+  border: none;
+  border-radius: 0.55rem;
+  background: color-mix(in srgb, var(--color-text-muted) 30%, transparent);
+  color: var(--color-on-accent);
+  cursor: default;
+  transition: background 120ms ease;
+}
+.assistant-send-btn--ready {
+  background: var(--color-accent);
   cursor: pointer;
 }
+.assistant-send-btn--ready:hover { background: var(--color-accent-hover); }
 
-.assistant-stop-btn:hover {
-  border-color: var(--color-accent);
+.assistant-stop-btn {
+  background: var(--color-accent);
+  cursor: pointer;
+}
+.assistant-stop-btn:hover { background: var(--color-accent-hover); }
+
+.assistant-composer-hint {
+  margin-top: 0.35rem;
+  padding: 0 0.15rem;
+  font-family: var(--font-data);
+  font-size: 0.625rem;
+  color: var(--color-text-subtle);
 }
 
 .sr-only {
@@ -421,58 +630,139 @@
   border: 0;
 }
 
-/* ── Tab strip (one tab per OPEN panel) + tab panels ───── */
-.drawer-tabs { display: flex; gap: 2px; align-items: stretch; }
-.drawer-tab {
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--color-text-muted);
-  font-family: var(--font-mono);
-  font-size: 0.8125rem;
-  line-height: 1.4;
-  padding: 4px 12px;
-  cursor: pointer;
-  border-radius: 5px 5px 0 0;
-  white-space: nowrap;
-  transition: color 0.12s ease, background 0.12s ease, border-color 0.12s ease;
-}
-.drawer-tab:hover {
-  color: var(--color-text);
-  background: color-mix(in srgb, var(--color-text) 6%, transparent);
-}
-.drawer-tab--active {
-  color: var(--color-accent);
-  border-bottom-color: var(--color-accent);
-  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
-}
+/* ── Tab panels (one per OPEN panel; hidden ones stay mounted) ───── */
 .drawer-panel { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
-/* Model tag in the drawer header (Assistant tab): a compact squared accent
-   tag next to the tabs, integrating the provider/model without a subtitle. */
-.drawer-model-chip {
-  display: inline-block;   /* Badge's base class sets inline-flex, and
-                               text-overflow: ellipsis is inert on a flex
-                               container; inline-block here restores the
-                               ellipsis truncation below over that default */
-  align-self: center;
-  max-width: 14rem;   /* px-based cap so short model names show in full (a %
-                         would resolve against a content-sized flex box and
-                         ellipsize even short names) */
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
 
 /* --- Command layer: welcome panel, pills, autocomplete, local messages --- */
 .assistant-drawer-input-row { position: relative; }
 
-.assistant-welcome { flex: 1; overflow-y: auto; padding: 12px 16px; color: var(--color-text); }
-.assistant-welcome-intro { margin: 0 0 8px; color: var(--color-text-muted); font-size: 13px; }
-.assistant-welcome-commands { list-style: none; margin: 0 0 12px; padding: 0; font-size: 12px; }
-.assistant-welcome-commands li { margin: 3px 0; color: var(--color-text-muted); }
-.assistant-welcome-commands code { font-family: var(--font-mono); color: var(--color-text); margin-right: 6px; }
-.assistant-welcome-pills { display: flex; flex-wrap: wrap; gap: 6px; justify-content: center; }
-.assistant-pill { border: 1px solid var(--color-border); background: var(--color-surface-alt); color: var(--color-text); border-radius: 6px; padding: 4px 10px; font-size: 12px; cursor: pointer; }
-.assistant-pill:hover { border-color: var(--color-accent); }
+.assistant-welcome {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.1rem 1.25rem 1rem;
+  color: var(--color-text);
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.assistant-welcome-hero {
+  display: flex;
+  gap: 0.7rem;
+  align-items: flex-start;
+}
+.assistant-welcome-hero .assistant-compass-block { margin-top: 1px; }
+.assistant-welcome-intro {
+  margin: 0;
+  padding-top: 0.25rem;
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: 0.8125rem;
+  line-height: 1.55;
+}
+
+.assistant-welcome-label {
+  font-family: var(--font-data);
+  font-size: 0.625rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-subtle);
+  margin-bottom: 0.55rem;
+}
+
+/* Suggested skills: tappable two-column cards. */
+.assistant-suggest-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.55rem;
+}
+@media (max-width: 900px) {
+  .assistant-suggest-grid { grid-template-columns: 1fr; }
+}
+.assistant-suggest-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  text-align: left;
+  padding: 0.65rem 0.75rem;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: 0.7rem;
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease, transform 120ms ease, box-shadow 120ms ease;
+}
+.assistant-suggest-card:hover {
+  border-color: color-mix(in srgb, var(--color-accent) 35%, transparent);
+  background: var(--color-surface);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+}
+.assistant-suggest-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-top: 4px;
+  flex-shrink: 0;
+}
+.assistant-suggest-dot--accent { background: var(--color-accent); }
+.assistant-suggest-dot--info { background: var(--color-info); }
+.assistant-suggest-dot--warning { background: var(--color-warning); }
+.assistant-suggest-dot--success { background: var(--color-success); }
+.assistant-suggest-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.assistant-suggest-title {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 0.8125rem;
+  color: var(--color-text);
+}
+.assistant-suggest-desc {
+  font-family: var(--font-sans);
+  font-size: 0.71875rem;
+  line-height: 1.4;
+  color: var(--color-text-muted);
+}
+
+/* Slash commands: a bordered menu of full-width rows. */
+.assistant-cmd-list {
+  border: 1px solid var(--color-border);
+  border-radius: 0.7rem;
+  overflow: hidden;
+}
+.assistant-cmd-row {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  width: 100%;
+  text-align: left;
+  padding: 0.55rem 0.8rem;
+  background: var(--color-surface);
+  border: none;
+  border-bottom: 1px solid var(--color-border);
+  cursor: pointer;
+}
+.assistant-cmd-row:last-child { border-bottom: none; }
+.assistant-cmd-row:hover { background: var(--color-surface-alt); }
+.assistant-cmd-badge {
+  font-family: var(--font-data);
+  font-size: 0.71875rem;
+  font-weight: 500;
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 20%, transparent);
+  border-radius: 0.375rem;
+  padding: 0.1rem 0.5rem;
+  flex-shrink: 0;
+}
+.assistant-cmd-desc {
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
 
 .assistant-command-menu { position: absolute; bottom: 100%; left: 0; right: 0; margin-bottom: 4px; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; z-index: 10; }
 .assistant-command-item { display: flex; align-items: baseline; gap: 8px; width: 100%; text-align: left; padding: 6px 10px; background: none; border: none; color: var(--color-text); cursor: pointer; font-size: 12px; }

--- a/src/quodeq/ui/src/styles/assistant.css
+++ b/src/quodeq/ui/src/styles/assistant.css
@@ -271,16 +271,20 @@
   text-overflow: ellipsis;
 }
 
-/* Model chip: a real button — click opens Settings. */
+/* Model chip: a real button — click opens Settings. Lives in the right-side
+   controls cluster; matches the action buttons' height and sits just before
+   them with a hair of separation. */
 .assistant-model-chip {
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
-  padding: 0.25rem 0.6rem;
+  height: 1.5rem;
+  padding: 0 0.6rem;
+  margin-right: 0.25rem;
   max-width: 15rem;
   background: var(--color-surface-alt);
   border: 1px solid var(--color-border);
-  border-radius: 0.5rem;
+  border-radius: 0.375rem;
   cursor: pointer;
   flex-shrink: 1;
   min-width: 0;

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1879,6 +1879,7 @@ textarea:focus {
 .loading-logo {
   width: 80px;
   height: auto;
+  color: var(--logo-q);   /* QMarkIcon fills with currentColor */
   opacity: 0.15;
   animation: loading-pulse 1.8s ease-in-out infinite;
 }

--- a/src/quodeq/ui/src/styles/drawer.css
+++ b/src/quodeq/ui/src/styles/drawer.css
@@ -79,10 +79,10 @@
   font-family: var(--font-mono, monospace);
 }
 
-/* ── Drawer-header chips ──────────────────────────────────────────────
+/* ── Panel-header chips ───────────────────────────────────────────────
    Visual identity comes from .badge--tag tones (badge.css); only layout
    and interactivity live here. */
-.assistant-drawer-header .badge {
+.assistant-panel-header .badge {
   align-self: center;
 }
 .drawer-changes-chip {

--- a/src/quodeq/ui/src/styles/index.css
+++ b/src/quodeq/ui/src/styles/index.css
@@ -13,3 +13,4 @@
 @import './help.css';
 @import './assistant.css';
 @import './drawer.css';
+@import './terminal-drawer.css';

--- a/src/quodeq/ui/src/styles/terminal-drawer.css
+++ b/src/quodeq/ui/src/styles/terminal-drawer.css
@@ -45,21 +45,6 @@
   white-space: nowrap;
 }
 
-.tty-localhost-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  padding: 0.125rem 0.55rem;
-  border: 1px solid var(--color-border);
-  border-radius: 999px;
-  background: var(--color-surface-alt);
-  color: var(--color-text-muted);
-  font-family: var(--font-data);
-  font-size: 0.625rem;
-  white-space: nowrap;
-}
-.tty-localhost-pill svg { color: var(--color-success); }
-
 .tty-panel-controls {
   display: flex;
   gap: 0.25rem;
@@ -191,6 +176,17 @@
 }
 .tty-statusbar-sep { color: var(--color-border); }
 .tty-statusbar-spacer { flex: 1; }
+.tty-statusbar-lock {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  white-space: nowrap;
+}
+.tty-statusbar-lock svg {
+  width: 9px;
+  height: 9px;
+  color: var(--color-success);
+}
 .tty-statusbar-cwd {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/quodeq/ui/src/styles/terminal-drawer.css
+++ b/src/quodeq/ui/src/styles/terminal-drawer.css
@@ -1,0 +1,198 @@
+/* Terminal panel chrome: its own header, session tab strip, and status bar
+   (the shared drawer header is gone — each panel carries its own). Class
+   prefix tty- matches drawer.css; everything themes through semantic tokens,
+   the mockup's hardcoded palette maps onto --color-accent and friends. */
+
+.tty-shell {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Header ─────────────────────────────────────────────── */
+.tty-panel-header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 1rem;
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.tty-icon-block {
+  width: 1.5rem;
+  height: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: 0.4rem;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-family: var(--font-data);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.tty-panel-title {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 0.8125rem;
+  color: var(--color-text);
+  white-space: nowrap;
+}
+
+.tty-localhost-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.125rem 0.55rem;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-surface-alt);
+  color: var(--color-text-muted);
+  font-family: var(--font-data);
+  font-size: 0.625rem;
+  white-space: nowrap;
+}
+.tty-localhost-pill svg { color: var(--color-success); }
+
+.tty-panel-controls {
+  display: flex;
+  gap: 0.25rem;
+  margin-left: auto;
+}
+
+.tty-copy-btn--done {
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+
+/* ── Session tab strip ──────────────────────────────────── */
+.tty-tabs {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+  padding: 0 0.5rem;
+  background: var(--color-surface);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.tty-tabs::-webkit-scrollbar { display: none; }
+
+.tty-tab {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem 0.35rem;
+  cursor: pointer;
+  white-space: nowrap;
+  color: var(--color-text-muted);
+  border-top: 2px solid transparent;
+  font-family: var(--font-data);
+  font-size: 0.75rem;
+  user-select: none;
+}
+.tty-tab:hover { color: var(--color-text); }
+.tty-tab:focus-visible {
+  outline: 1px solid var(--color-accent);
+  outline-offset: -1px;
+}
+
+/* The active tab visually connects to the console below: same background,
+   accent rule on top. */
+.tty-tab--active {
+  background: var(--color-console-bg);
+  color: var(--color-console-text);
+  border-top-color: var(--color-accent);
+  border-left: 1px solid var(--color-border);
+  border-right: 1px solid var(--color-border);
+  border-radius: 0 0 2px 2px;
+}
+
+.tty-tab-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--color-border);
+}
+.tty-tab--active .tty-tab-dot { background: var(--color-success); }
+
+.tty-tab-close {
+  width: 1.05rem;
+  height: 1.05rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 0.25rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 0;
+}
+.tty-tab-close:hover { color: var(--color-danger); }
+.tty-tab-close svg { width: 9px; height: 9px; }
+
+.tty-tab-add {
+  align-self: center;
+  width: 1.4rem;
+  height: 1.4rem;
+  margin-left: 0.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  border-radius: 0.35rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 0;
+}
+.tty-tab-add:hover:not(:disabled) {
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+.tty-tab-add:disabled { opacity: 0.4; cursor: default; }
+
+/* The header-row "+" shown while the tab strip is hidden (single session). */
+.tty-header-add { margin-left: 0; }
+
+/* ── Session views ──────────────────────────────────────── */
+.tty-views {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+/* .tty-wrap keeps its 100%-height rules from drawer.css; inside the column
+   flexbox that means it fills whatever the chrome rows leave over. */
+.tty-views .tty-wrap { flex: 1 1 auto; height: auto; }
+
+/* ── Status bar ─────────────────────────────────────────── */
+.tty-statusbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.25rem 1rem;
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  font-family: var(--font-data);
+  font-size: 0.625rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+.tty-statusbar-sep { color: var(--color-border); }
+.tty-statusbar-spacer { flex: 1; }
+.tty-statusbar-cwd {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 40%;
+}

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -326,6 +326,29 @@
   --color-console-bg:   #0d1117;
   --color-console-text: color-mix(in srgb, var(--color-accent) 35%, #dce8f2);
 
+  /* Embedded terminal ANSI palette (xterm reads these via JS, so they must
+     resolve to plain colors — no color-mix/var indirection xterm can't parse).
+     Two palettes total: this light set, and one dark override below shared by
+     every dark theme family. Light values are darkened for contrast on the
+     light console surface the drawer remaps to. */
+  --tty-ansi-black:          #1a1816;
+  --tty-ansi-red:            #c0392b;
+  --tty-ansi-green:          #2d7a4f;
+  --tty-ansi-yellow:         #b45309;
+  --tty-ansi-blue:           #2563a8;
+  --tty-ansi-magenta:        #8b3a8f;
+  --tty-ansi-cyan:           #0e6d8a;
+  --tty-ansi-white:          #d4ccc0;
+  --tty-ansi-bright-black:   #3d3a37;
+  --tty-ansi-bright-red:     #e05c4b;
+  --tty-ansi-bright-green:   #3f9d6b;
+  --tty-ansi-bright-yellow:  #d97706;
+  --tty-ansi-bright-blue:    #3b82c4;
+  --tty-ansi-bright-magenta: #a855a8;
+  --tty-ansi-bright-cyan:    #22a3c4;
+  --tty-ansi-bright-white:   #efe9e1;
+  --tty-selection:           rgba(26, 24, 22, 0.18);
+
   /* On-accent text (theme-invariant) */
   --color-on-accent: #ffffff;
 
@@ -447,6 +470,52 @@
     --logo-needle:         var(--primitive-flynn-accent);
     --logo-needle-dark:    var(--primitive-flynn-accent-dark);
   }
+}
+
+/* Terminal ANSI palette — dark variant. Every dark theme's data-theme value
+   ends in "dark" ("dark", "ifrit-dark", "neo-dark", …), so one suffix
+   selector covers all families; the media query covers the OS-driven case
+   when no explicit theme is set. Plain hex only (see the light block). */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --tty-ansi-black:          #1a2230;
+    --tty-ansi-red:            #e05c4b;
+    --tty-ansi-green:          #4caf7d;
+    --tty-ansi-yellow:         #fbbf24;
+    --tty-ansi-blue:           #5aa2e8;
+    --tty-ansi-magenta:        #c987c9;
+    --tty-ansi-cyan:           #22d3ee;
+    --tty-ansi-white:          #d4e0f0;
+    --tty-ansi-bright-black:   #4a6a88;
+    --tty-ansi-bright-red:     #f05078;
+    --tty-ansi-bright-green:   #6fd49a;
+    --tty-ansi-bright-yellow:  #fcd34d;
+    --tty-ansi-bright-blue:    #82bcf4;
+    --tty-ansi-bright-magenta: #dfa8df;
+    --tty-ansi-bright-cyan:    #67e3f9;
+    --tty-ansi-bright-white:   #ffffff;
+    --tty-selection:           rgba(255, 255, 255, 0.22);
+  }
+}
+
+html[data-theme$="dark"]:root, [data-theme$="dark"] {
+  --tty-ansi-black:          #1a2230;
+  --tty-ansi-red:            #e05c4b;
+  --tty-ansi-green:          #4caf7d;
+  --tty-ansi-yellow:         #fbbf24;
+  --tty-ansi-blue:           #5aa2e8;
+  --tty-ansi-magenta:        #c987c9;
+  --tty-ansi-cyan:           #22d3ee;
+  --tty-ansi-white:          #d4e0f0;
+  --tty-ansi-bright-black:   #4a6a88;
+  --tty-ansi-bright-red:     #f05078;
+  --tty-ansi-bright-green:   #6fd49a;
+  --tty-ansi-bright-yellow:  #fcd34d;
+  --tty-ansi-bright-blue:    #82bcf4;
+  --tty-ansi-bright-magenta: #dfa8df;
+  --tty-ansi-bright-cyan:    #67e3f9;
+  --tty-ansi-bright-white:   #ffffff;
+  --tty-selection:           rgba(255, 255, 255, 0.22);
 }
 
 /* ── 4. Explicit theme overrides (user preference) ────────

--- a/tests/api/test_terminal_links.py
+++ b/tests/api/test_terminal_links.py
@@ -9,6 +9,7 @@ import pytest
 from flask import Flask
 
 from quodeq.api.terminal_routes import register_terminal_routes
+from quodeq.terminal.sessions import TerminalSessionRegistry
 from quodeq.terminal.links import (
     Editor,
     build_open_argv,
@@ -245,7 +246,11 @@ def app():
     app = Flask(__name__)
     app.config["QUODEQ_API_KEY"] = None
     app.config["QUODEQ_BIND_HOST"] = "127.0.0.1"
-    register_terminal_routes(app, manager=_FakeManager())
+    registry = TerminalSessionRegistry(manager_factory=_FakeManager)
+    # /resolve and /open with no explicit session fall back to the first LIVE
+    # session's pid — mirror the old always-present manager.
+    registry.create().manager._alive = True
+    register_terminal_routes(app, registry=registry)
     return app
 
 

--- a/tests/api/test_terminal_routes.py
+++ b/tests/api/test_terminal_routes.py
@@ -6,6 +6,7 @@ import pytest
 from flask import Flask
 
 from quodeq.api.terminal_routes import _apply_control, register_terminal_routes
+from quodeq.terminal.sessions import TerminalSessionRegistry
 from tests._timeouts import budget
 
 try:
@@ -29,6 +30,8 @@ class _FakeManager:
     def kill(self): self.killed = True; self._alive = False
     @property
     def alive(self): return self._alive
+    @property
+    def pid(self): return None
 
 
 @pytest.fixture()
@@ -36,7 +39,9 @@ def app():
     app = Flask(__name__)
     app.config["QUODEQ_API_KEY"] = None
     app.config["QUODEQ_BIND_HOST"] = "127.0.0.1"
-    register_terminal_routes(app, manager=_FakeManager())
+    # Real registry, fake PTYs: the registry is cheap and its locking/naming
+    # behavior is part of what the routes rely on.
+    register_terminal_routes(app, registry=TerminalSessionRegistry(manager_factory=_FakeManager))
     return app
 
 
@@ -44,7 +49,9 @@ def test_status_allowed_on_loopback(app):
     c = app.test_client()
     r = c.get("/api/terminal/status", headers={"Origin": "http://localhost"}, base_url="http://localhost")
     assert r.status_code == 200
-    assert r.get_json()["enabled"] is True
+    body = r.get_json()
+    assert body["enabled"] is True
+    assert isinstance(body["shell"], str) and body["shell"]
 
 
 def test_status_enabled_without_origin_header(app):
@@ -73,12 +80,62 @@ def test_kill_refused_when_gated(app):
     assert r.status_code == 403
 
 
-def test_kill_ok_on_loopback(app):
-    manager = app.extensions["terminal_manager"]
+def test_kill_kills_all_sessions(app):
+    registry = app.extensions["terminal_registry"]
+    a = registry.create(); b = registry.create()
     c = app.test_client()
     r = c.post("/api/terminal/kill", headers={"Origin": "http://localhost"}, base_url="http://localhost")
     assert r.status_code == 200
-    assert manager.killed is True
+    assert a.manager.killed and b.manager.killed
+    assert registry.list() == []
+
+
+# --- session CRUD routes ---
+
+def test_sessions_list_without_origin_header(app):
+    # Same-origin GET like /status: must NOT require an Origin header.
+    c = app.test_client()
+    r = c.get("/api/terminal/sessions", base_url="http://localhost")
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["sessions"] == [] and body["max"] == TerminalSessionRegistry.MAX_SESSIONS
+
+
+def test_session_create_and_list(app):
+    c = app.test_client()
+    r = c.post("/api/terminal/sessions", headers={"Origin": "http://localhost"}, base_url="http://localhost")
+    assert r.status_code == 201
+    created = r.get_json()
+    assert created["id"] and "· 1" in created["name"]
+    listed = c.get("/api/terminal/sessions", base_url="http://localhost").get_json()["sessions"]
+    assert [s["id"] for s in listed] == [created["id"]]
+
+
+def test_session_create_refused_past_cap(app):
+    c = app.test_client()
+    for _ in range(TerminalSessionRegistry.MAX_SESSIONS):
+        assert c.post("/api/terminal/sessions", headers={"Origin": "http://localhost"},
+                      base_url="http://localhost").status_code == 201
+    r = c.post("/api/terminal/sessions", headers={"Origin": "http://localhost"}, base_url="http://localhost")
+    assert r.status_code == 409
+
+
+def test_session_kill_removes_only_that_session(app):
+    registry = app.extensions["terminal_registry"]
+    a = registry.create(); b = registry.create()
+    c = app.test_client()
+    r = c.post(f"/api/terminal/sessions/{a.id}/kill",
+               headers={"Origin": "http://localhost"}, base_url="http://localhost")
+    assert r.status_code == 200
+    assert a.manager.killed and not b.manager.killed
+    assert [s["id"] for s in registry.list()] == [b.id]
+
+
+def test_session_kill_unknown_is_404(app):
+    c = app.test_client()
+    r = c.post("/api/terminal/sessions/nope/kill",
+               headers={"Origin": "http://localhost"}, base_url="http://localhost")
+    assert r.status_code == 404
 
 
 class _ResizeRecorder:
@@ -120,7 +177,7 @@ def test_apply_control_clamps_out_of_range_resize(payload):
     assert 1 <= rows <= 65535
 
 
-# --- WebSocket integration (single-connection guard + spawn-failure handling) ---
+# --- WebSocket integration (per-session connection guard + spawn-failure handling) ---
 
 class _LiveManager:
     """Stays alive; scrollback is a sync beacon proving the handler holds the lock."""
@@ -134,6 +191,8 @@ class _LiveManager:
     def kill(self): self._alive = False
     @property
     def alive(self): return self._alive
+    @property
+    def pid(self): return None
 
 
 class _FlakyManager(_LiveManager):
@@ -149,28 +208,30 @@ class _FlakyManager(_LiveManager):
 
 
 @contextlib.contextmanager
-def _serve(manager):
+def _serve(manager_factory):
     app = Flask(__name__)
     app.config["QUODEQ_API_KEY"] = None
     app.config["QUODEQ_BIND_HOST"] = "127.0.0.1"
-    register_terminal_routes(app, manager=manager)
+    registry = TerminalSessionRegistry(manager_factory=manager_factory)
+    register_terminal_routes(app, registry=registry)
     srv = make_server("127.0.0.1", 0, app, threaded=True)
     t = threading.Thread(target=srv.serve_forever, daemon=True)
     t.start()
     try:
-        yield srv.server_port
+        yield srv.server_port, registry
     finally:
         srv.shutdown()
         t.join(timeout=budget(2))
 
 
 @contextlib.contextmanager
-def _connect(port):
+def _connect(port, session=None):
     # werkzeug's WS handshake exposes request.host without the port, so the
     # Origin must match that (browsers keep Host+Origin consistent for real).
-    c = _Client(
-        f"ws://127.0.0.1:{port}/api/terminal/ws",
-        headers={"Origin": "http://127.0.0.1"})
+    url = f"ws://127.0.0.1:{port}/api/terminal/ws"
+    if session is not None:
+        url += f"?session={session}"
+    c = _Client(url, headers={"Origin": "http://127.0.0.1"})
     try:
         yield c
     finally:
@@ -206,11 +267,11 @@ if _WS_OK:
 
 
 @_ws_test
-def test_ws_single_active_connection_refuses_second():
-    with _serve(_LiveManager()) as port:
-        with _connect(port) as a:
+def test_ws_single_active_connection_refuses_second_same_session():
+    with _serve(_LiveManager) as (port, _):
+        with _connect(port) as a:      # no id -> default session
             assert a.receive(timeout=budget(_RECV_TIMEOUT)) == "0ready\n"   # A acquired the conn lock
-            with _connect(port) as b:
+            with _connect(port) as b:  # no id -> SAME default session
                 msg = None
                 with contextlib.suppress(simple_websocket.ConnectionClosed):
                     msg = b.receive(timeout=budget(_RECV_TIMEOUT))
@@ -221,7 +282,7 @@ def test_ws_single_active_connection_refuses_second():
 def test_ws_busy_close_uses_dedicated_code():
     # The client must NOT auto-reconnect against a held lock (it would ping-pong
     # and spam the other window), so the refusal carries close code 4002.
-    with _serve(_LiveManager()) as port:
+    with _serve(_LiveManager) as (port, _):
         with _connect(port) as a:
             assert a.receive(timeout=budget(2)) == "0ready\n"
             with _connect(port) as b:
@@ -232,10 +293,33 @@ def test_ws_busy_close_uses_dedicated_code():
 
 
 @_ws_test
+def test_ws_two_sessions_stream_concurrently():
+    # The busy lock is per session: a client on session A must not block a
+    # client on session B.
+    with _serve(_LiveManager) as (port, registry):
+        sa = registry.create(); sb = registry.create()
+        with _connect(port, session=sa.id) as a:
+            assert a.receive(timeout=budget(_RECV_TIMEOUT)) == "0ready\n"
+            with _connect(port, session=sb.id) as b:
+                assert b.receive(timeout=budget(_RECV_TIMEOUT)) == "0ready\n"
+
+
+@_ws_test
+def test_ws_unknown_session_closes_with_not_found_code():
+    # Stale tab id (server restarted): close 4004 tells the client to reconcile
+    # via /sessions instead of retrying the dead URL.
+    with _serve(_LiveManager) as (port, _):
+        with _connect(port, session="deadbeef") as c:
+            with pytest.raises(simple_websocket.ConnectionClosed) as exc:
+                c.receive(timeout=budget(2))
+            assert exc.value.reason == 4004
+
+
+@_ws_test
 def test_ws_gate_refusal_close_uses_dedicated_code():
     # Bad Origin -> gate refuses the handshake with close code 4003 so the
     # client reports it instead of retrying forever.
-    with _serve(_LiveManager()) as port:
+    with _serve(_LiveManager) as (port, _):
         c = simple_websocket.Client(
             f"ws://127.0.0.1:{port}/api/terminal/ws",
             headers={"Origin": "http://evil.example"})
@@ -250,7 +334,7 @@ def test_ws_gate_refusal_close_uses_dedicated_code():
 
 @_ws_test
 def test_ws_spawn_failure_closes_cleanly_and_frees_lock():
-    with _serve(_FlakyManager()) as port:
+    with _serve(_FlakyManager) as (port, _):
         with _connect(port) as first:       # ensure_session raises -> clean close
             with contextlib.suppress(simple_websocket.ConnectionClosed):
                 first.receive(timeout=budget(_RECV_TIMEOUT))    # must not hang / must not 500

--- a/tests/assistant/test_api_adapter.py
+++ b/tests/assistant/test_api_adapter.py
@@ -94,7 +94,14 @@ def test_fallback_mode_uses_prompted_json_and_no_tools_param():
                         emit=lambda f: None, client_factory=lambda c: client)
     assert text == "C grade"
     assert "tools" not in client.calls[0]
-    assert "tool_call" in client.calls[0]["messages"][0]["content"]  # contract in system
+    system = client.calls[0]["messages"][0]["content"]
+    assert "tool_call" in system  # contract in system
+    # The tool CATALOG must be in the prompt too: without the API tools param
+    # the model otherwise never sees a tool name or argument schema and has to
+    # guess them, burning a full generation per rejected call.
+    assert "# Available tools" in system
+    assert "get_scores" in system
+    assert "arguments schema:" in system
 
 
 def test_tool_call_frame_carries_args_summary():

--- a/tests/assistant/test_skills.py
+++ b/tests/assistant/test_skills.py
@@ -55,9 +55,11 @@ def test_builtin_skills_have_views_and_hints():
 
 def test_verify_finding_skill_loads():
     skill = load_skills()["verify-finding"]
-    # Also offered on overview: search_findings falls back to get_violations
-    # in accumulated scope, and draft_action validates against it there too.
-    assert skill.views == ("overview", "violations")
+    # No views: deliberately NOT offered as a suggestion card (the freeform
+    # paste-a-finding path it invites is the skill's slowest entry; a
+    # row-level "Verify with assistant" button is the planned promoted path).
+    # Still reachable as /verify-finding via the composer autocomplete.
+    assert skill.views == ()
     assert skill.argument_hint
 
 

--- a/tests/assistant/test_skills.py
+++ b/tests/assistant/test_skills.py
@@ -55,7 +55,9 @@ def test_builtin_skills_have_views_and_hints():
 
 def test_verify_finding_skill_loads():
     skill = load_skills()["verify-finding"]
-    assert skill.views == ("violations",)
+    # Also offered on overview: search_findings falls back to get_violations
+    # in accumulated scope, and draft_action validates against it there too.
+    assert skill.views == ("overview", "violations")
     assert skill.argument_hint
 
 

--- a/tests/terminal/test_sessions.py
+++ b/tests/terminal/test_sessions.py
@@ -1,0 +1,142 @@
+"""TerminalSessionRegistry: creation, naming, cap, kill semantics, isolation."""
+
+from quodeq.terminal.sessions import TerminalSessionRegistry, shell_name
+
+
+class _FakeManager:
+    def __init__(self):
+        self.killed = False
+        self._alive = True
+        self.written = b""
+
+    def write(self, data):
+        self.written += data
+
+    def kill(self):
+        self.killed = True
+        self._alive = False
+
+    @property
+    def alive(self):
+        return self._alive
+
+    @property
+    def pid(self):
+        return None
+
+
+def _registry():
+    return TerminalSessionRegistry(manager_factory=_FakeManager)
+
+
+def test_create_assigns_unique_ids_and_sequential_names():
+    reg = _registry()
+    a = reg.create()
+    b = reg.create()
+    assert a.id != b.id
+    assert a.name.endswith("· 1") and b.name.endswith("· 2")
+
+
+def test_closing_frees_the_ordinal_for_reuse():
+    # Like real terminal tabs: close "zsh · 2" and the next new session is
+    # "zsh · 2" again — numbers stay within 1..MAX_SESSIONS forever.
+    reg = _registry()
+    reg.create()
+    b = reg.create()
+    c = reg.create()
+    reg.kill(b.id)
+    d = reg.create()
+    assert d.name.endswith("· 2")
+    assert c.name.endswith("· 3")
+    # next one takes the next free slot, not a duplicate
+    assert reg.create().name.endswith("· 4")
+
+
+def test_ordinals_never_exceed_the_cap():
+    reg = _registry()
+    for _ in range(3):
+        sessions = [reg.create() for _ in range(TerminalSessionRegistry.MAX_SESSIONS)]
+        assert all(
+            1 <= s.ordinal <= TerminalSessionRegistry.MAX_SESSIONS for s in sessions
+        )
+        reg.kill_all()
+
+
+def test_create_returns_none_at_cap():
+    reg = _registry()
+    for _ in range(TerminalSessionRegistry.MAX_SESSIONS):
+        assert reg.create() is not None
+    assert reg.create() is None
+    # killing one frees a slot
+    victim = reg.list()[0]["id"]
+    assert reg.kill(victim)
+    assert reg.create() is not None
+
+
+def test_list_reflects_sessions():
+    reg = _registry()
+    assert reg.list() == []
+    a = reg.create()
+    listed = reg.list()
+    assert len(listed) == 1
+    item = listed[0]
+    assert item["id"] == a.id and item["name"] == a.name
+    assert item["alive"] is True and item["createdAt"] == a.created_at
+
+
+def test_kill_removes_and_kills_only_target():
+    reg = _registry()
+    a = reg.create()
+    b = reg.create()
+    assert reg.kill(a.id) is True
+    assert a.manager.killed and not b.manager.killed
+    assert reg.get(a.id) is None and reg.get(b.id) is b
+
+
+def test_kill_unknown_returns_false():
+    assert _registry().kill("nope") is False
+
+
+def test_kill_all_empties_registry():
+    reg = _registry()
+    sessions = [reg.create() for _ in range(3)]
+    reg.kill_all()
+    assert reg.list() == []
+    assert all(s.manager.killed for s in sessions)
+    assert reg.any_alive is False
+
+
+def test_sessions_have_independent_managers_and_locks():
+    reg = _registry()
+    a = reg.create()
+    b = reg.create()
+    assert a.manager is not b.manager
+    a.manager.write(b"only-a")
+    assert b.manager.written == b""
+    # A's held connection lock must not block B's.
+    assert a.conn_lock.acquire(blocking=False)
+    try:
+        assert b.conn_lock.acquire(blocking=False)
+        b.conn_lock.release()
+    finally:
+        a.conn_lock.release()
+
+
+def test_get_or_create_default_reuses_existing():
+    reg = _registry()
+    first = reg.get_or_create_default()
+    assert reg.get_or_create_default() is first
+    assert len(reg.list()) == 1
+
+
+def test_pid_for_falls_back_to_first_alive():
+    reg = _registry()
+    assert reg.pid_for(None) is None       # empty registry
+    a = reg.create()
+    assert reg.pid_for(a.id) == a.manager.pid
+    assert reg.pid_for("unknown") is None  # explicit unknown id: no fallback
+
+
+def test_shell_name_is_plain_basename():
+    name = shell_name()
+    assert name and "/" not in name and "\\" not in name

--- a/uv.lock
+++ b/uv.lock
@@ -843,7 +843,7 @@ wheels = [
 
 [[package]]
 name = "quodeq"
-version = "1.7.2"
+version = "1.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
## [1.7.3] - 2026-07-27

### Features
- **Multi-session terminal**: run up to 6 shell sessions as tabs, each its own shell with its own history. Sessions live server-side, so they survive page reloads and closing the drawer; closing a tab kills that shell. With a single session the tab strip stays out of the way and a + in the header opens the second.
- **Terminal panel redesign**: the terminal gets its own header with a working copy button, session tabs, and a status bar showing the shell, session count, working directory and the localhost-only sandbox note.
- **Assistant panel redesign**: new header with the Quodeq mark, project name and a model chip that jumps to Settings; tappable suggestion cards in the empty state; avatars and a thinking indicator in the transcript; a card-style composer with auto-grow and a proper send button.
- **Terminal colors**: terminal output now renders with a full 16-color ANSI palette that follows the app theme in light and dark.

### Improvements
- **Faster assistant skills on local models**: providers without native tool-calling now receive the full tool catalog and exact action payload formats in the prompt instead of guessing them one failed attempt at a time. Suggested actions appear only on views where they can actually run.
- **Drawer chrome**: the shared drawer header is gone; each panel carries its own controls, with a compact Assistant/Terminal switcher when both are open.