### PR TITLE
chore: sync develop with v1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.7.3] - 2026-07-27
+
+### Features
+- **Multi-session terminal**: run up to 6 shell sessions as tabs, each its own shell with its own history. Sessions live server-side, so they survive page reloads and closing the drawer; closing a tab kills that shell. With a single session the tab strip stays out of the way and a + in the header opens the second.
+- **Terminal panel redesign**: the terminal gets its own header with a working copy button, session tabs, and a status bar showing the shell, session count, working directory and the localhost-only sandbox note.
+- **Assistant panel redesign**: new header with the Quodeq mark, project name and a model chip that jumps to Settings; tappable suggestion cards in the empty state; avatars and a thinking indicator in the transcript; a card-style composer with auto-grow and a proper send button.
+- **Terminal colors**: terminal output now renders with a full 16-color ANSI palette that follows the app theme in light and dark.
+
+### Improvements
+- **Faster assistant skills on local models**: providers without native tool-calling now receive the full tool catalog and exact action payload formats in the prompt instead of guessing them one failed attempt at a time. Suggested actions appear only on views where they can actually run.
+- **Drawer chrome**: the shared drawer header is gone; each panel carries its own controls, with a compact Assistant/Terminal switcher when both are open.
+
 ## [1.7.2] - 2026-07-26
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <h2 align="center">AI-powered code quality and security scanner</h2>
-<p align="center"><strong>v1.7.2</strong></p>
+<p align="center"><strong>v1.7.3</strong></p>
 <p align="center">
   <a href="https://github.com/quodeq/quodeq/actions/workflows/test.yml"><img src="https://github.com/quodeq/quodeq/actions/workflows/test.yml/badge.svg" alt="Tests" /></a>
   <a href="https://github.com/quodeq/quodeq/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>

--- a/packaging/macos/launcher.sh
+++ b/packaging/macos/launcher.sh
@@ -63,7 +63,7 @@ if [ -z "$QUODEQ" ]; then
         # ranges. The release skill bumps this on every cut (see
         # .claude/skills/release/SKILL.md).
         # TODO: ship requirements.txt with hashes in the .app bundle.
-        python3 -m pip install --user --only-binary :all: --no-deps "quodeq==1.7.2" 2>&1
+        python3 -m pip install --user --only-binary :all: --no-deps "quodeq==1.7.3" 2>&1
     fi
     export PATH="$PATH:$(python3 -m site --user-base)/bin"
     QUODEQ=$(command -v quodeq 2>/dev/null)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quodeq"
-version = "1.7.2"
+version = "1.7.3"
 description = "Source code quality evaluation platform powered by AI"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -843,7 +843,7 @@ wheels = [
 
 [[package]]
 name = "quodeq"
-version = "1.7.2"
+version = "1.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
Brings the v1.7.3 release commit (changelog + version bumps) back into develop.