### PR TITLE
fix: unlimited time limit dies at exactly 10 minutes

### DIFF
--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -325,12 +325,13 @@ class FsEvaluationMixin:
             built_env["SUBAGENT_MODEL"] = subagent_model
         if not options.verify_findings:
             built_env["QUODEQ_NO_VERIFY"] = "1"
-        # Always propagate a positive limit. The CLI subprocess uses this to
-        # set the run-level deadline (lifecycle.set_deadline + analyzing_start
-        # marker) that the dashboard's countdown timer depends on. Skipping
-        # the default value left dashboard runs with no deadline, freezing
-        # the UI timer at the static budget.
-        if options.time_limit and options.time_limit > 0:
+        # Always propagate the limit, including 0 (unlimited). The CLI
+        # subprocess uses positive values to set the run-level deadline
+        # (lifecycle.set_deadline + analyzing_start marker) that the
+        # dashboard's countdown depends on. An absent env var resolves to
+        # None in the CLI and the pool substitutes its 600s default, so
+        # skipping 0 turned "unlimited" into a 10-minute run.
+        if options.time_limit is not None and options.time_limit >= 0:
             built_env["QUODEQ_TIME_LIMIT"] = str(options.time_limit)
         if options.per_dimension:
             built_env["QUODEQ_NO_CONSOLIDATE"] = "1"

--- a/tests/services/test_evaluation_mixin.py
+++ b/tests/services/test_evaluation_mixin.py
@@ -154,12 +154,16 @@ class TestBuildEvalEnv:
         env = m._build_eval_env("/repo", opts, env={})
         assert env["QUODEQ_TIME_LIMIT"] == str(_DEFAULT_TIME_LIMIT)
 
-    def test_unlimited_time_limit_not_set(self):
-        # 0 means "unlimited" — no deadline should be propagated.
+    def test_unlimited_time_limit_propagated_as_zero(self):
+        # 0 means "unlimited". It must reach the subprocess explicitly:
+        # with the env var absent the CLI resolves the limit to None and
+        # the pool substitutes the 600s default, so "unlimited" runs died
+        # at exactly 10 minutes. Downstream treats 0 as unlimited and
+        # sets no deadline.
         m = self._mixin()
         opts = EvaluationOptions(time_limit=0)
         env = m._build_eval_env("/repo", opts, env={})
-        assert "QUODEQ_TIME_LIMIT" not in env
+        assert env["QUODEQ_TIME_LIMIT"] == "0"
 
     def test_per_dimension(self):
         m = self._mixin()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -239,6 +239,27 @@ class TestBuildRunConfig:
         # Legacy QUODEQ_POOL_BUDGET still routes into time_limit via the env-var fallback.
         assert config.options.time_limit == 300
 
+    @patch("quodeq._cli_evaluation.default_paths")
+    @patch("quodeq._cli_evaluation.get_ai_model", return_value="model-x")
+    def test_env_time_limit_zero_is_unlimited(self, mock_model, mock_paths, tmp_path):
+        # Contract pin: the dashboard propagates unlimited as
+        # QUODEQ_TIME_LIMIT=0. It must resolve to 0 (not None), otherwise
+        # the pool substitutes its 600s default and unlimited runs die at
+        # 10 minutes.
+        from quodeq.cli import _build_run_config, ResolvedInputs
+        mock_paths_obj = MagicMock()
+        mock_paths_obj.standards_dir.exists.return_value = False
+        mock_paths_obj.evaluators_dir = tmp_path
+        mock_paths.return_value = mock_paths_obj
+        args = argparse.Namespace(
+            dimensions=None, no_consolidated=False, no_verify=False,
+            max_turns=None, max_duration=None, n_subagents=5,
+            pool_budget=None, clean_scan=True, legacy_incremental=False,
+        )
+        inputs = ResolvedInputs(src=tmp_path, language="python", manifest=None, dims_data={})
+        config = _build_run_config(args, inputs=inputs, evidence_dir=tmp_path, env={"QUODEQ_TIME_LIMIT": "0"})
+        assert config.options.time_limit == 0
+
 
 # ---------------------------------------------------------------------------
 # run_evaluate tests

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -20,7 +20,7 @@ src/quodeq/services/_violations_jsonl.py:12:analysis
 src/quodeq/services/_violations_stream.py:10:analysis
 src/quodeq/services/_violations_stream.py:11:analysis
 src/quodeq/services/evaluation_mixin.py:22:analysis
-src/quodeq/services/evaluation_mixin.py:521:analysis
+src/quodeq/services/evaluation_mixin.py:522:analysis
 src/quodeq/services/jobs.py:20:analysis
 src/quodeq/services/scan_progress.py:23:analysis
 src/quodeq/services/tooling_mixin.py:17:analysis


### PR DESCRIPTION
## Problem

Scans with the time limit set to Unlimited always stopped at exactly 10 minutes, on every provider (Claude CLI and local LLMs). Reported by Jair.

## Cause

The dashboard encodes unlimited as `time_limit=0`. The value survives the UI, the HTTP layer and `EvaluationOptions`, but `_build_eval_env` only exported `QUODEQ_TIME_LIMIT` for positive values. With the env var absent, the CLI subprocess resolved the limit to `None` and the subagent pool substituted its 600s default, so the run exited with `exit_reason=time_limit` at 10 minutes.

## Fix

Export `QUODEQ_TIME_LIMIT=0` as well. The CLI and pool already treat 0 as unlimited (no deadline, no spawn cutoff), verified across `_pool_launcher`, `pool.py`, `_pool_scaling`, `_consolidated` and the pipeline deadline gate, so no downstream changes are needed.

## Tests

- Rewrote `test_unlimited_time_limit_not_set` (which asserted the buggy behavior) into `test_unlimited_time_limit_propagated_as_zero`. Watched it fail before the fix.
- Added `test_env_time_limit_zero_is_unlimited` pinning the CLI side of the contract (`QUODEQ_TIME_LIMIT=0` resolves to 0, not None).
- Full suite: 4955 passed. Import baseline regenerated (a comment shifted a grandfathered import one line).

## Out of scope (noted for follow-up)

- Countdown reads the active provider's localStorage instead of the running job's budget (needs `JobSnapshot` to carry the budget).
- Elapsed/progress desync (three independent clocks, deadline stamped after setup).
- Wizard `timeLimit` in `App.jsx` is dead code (`preparePayload` always overwrites it).