### PR TITLE
fix: evaluation pipeline and results-display audit, batch 1

### DIFF
--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -492,6 +492,10 @@ def _run_pipeline_with_cleanup(
                     # Resolve from CLI args OR env vars — dashboard runs pass
                     # QUODEQ_TIME_LIMIT via env, not the CLI flag.
                     budget_s = _resolve_time_limit(args)
+                    if budget_s is not None:
+                        # Persist the budget itself (0 = unlimited) so
+                        # index-served snapshots can surface it.
+                        lifecycle.set_time_limit(budget_s)
                     if budget_s is not None and budget_s > 0:
                         from datetime import datetime, timedelta, timezone
                         deadline_iso = (

--- a/src/quodeq/analysis/_report_io.py
+++ b/src/quodeq/analysis/_report_io.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from pathlib import Path
 
 from quodeq.core.types import ScoringResult
@@ -12,12 +14,29 @@ from quodeq.analysis._report_assembly import build_full_report, build_dashboard_
 
 
 def _persist_json(data: dict, path: Path) -> None:
-    """Write a report dict as formatted JSON to *path* (I/O adapter)."""
+    """Atomically write a report dict as formatted JSON to *path*.
+
+    Dashboard readers poll these files and treat a parse failure as "the
+    dimension does not exist", so the destination must never hold a partial
+    write: serialize to a same-directory temp file and publish via rename.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent), suffix=".tmp", prefix=f".{path.name}.",
+    )
     try:
-        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, str(path))
+        tmp_path = None
     except OSError as exc:
         raise OSError(f"Failed to write report to {path}: {exc}") from exc
+    finally:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
 
 def write_reports(

--- a/src/quodeq/analysis/subagents/file_queue.py
+++ b/src/quodeq/analysis/subagents/file_queue.py
@@ -38,7 +38,14 @@ class FileQueue:
         cleanup_stale_lock(self._lock_path)
 
         if files is not None:
-            state: dict = {"version": _QUEUE_VERSION, "pending": list(files), "taken": []}
+            state: dict = {
+                "version": _QUEUE_VERSION,
+                "pending": list(files),
+                "taken": [],
+                # Dim-start timestamp for progress reporting. The file's own
+                # mtime can't serve: every take atomically rewrites the file.
+                "created_at": time.time(),
+            }
             if max_files_per_agent > 0:
                 state["max_files_per_agent"] = max_files_per_agent
             write_state(state, self._path)

--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -198,17 +198,13 @@ def register_evaluation_item_routes(app: Flask, provider: ActionProvider) -> Non
         if run_dir is None:
             body, status = error_response("Job not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
             return jsonify(body), status
-        # Time limit for the running dim's bar — only available for jobs the
-        # JobManager started; external runs surface no budget metadata.
+        # Time limit for the running dim's bar. The snapshot carries the
+        # budget for both internal jobs (JobManager) and index-served runs
+        # (read from status.json). 0 = unlimited -> no bar.
         time_limit_s: int | None = None
         snapshot = provider.get_evaluation_status(job_id, reports_dir=_reports_dir())
         if snapshot is not None:
-            options = getattr(snapshot, "options", None) or {}
-            # Read new key first; fall back to legacy `poolBudget` for back-compat.
-            raw = (
-                options.get("timeLimit", options.get("poolBudget"))
-                if isinstance(options, dict) else None
-            )
+            raw = getattr(snapshot, "time_limit_s", None)
             if isinstance(raw, int) and raw > 0:
                 time_limit_s = raw
         progress = build_scan_progress(

--- a/src/quodeq/ci/review.py
+++ b/src/quodeq/ci/review.py
@@ -135,7 +135,8 @@ def handle_review(args) -> int:
     dims = getattr(args, "dimensions", None)
     if dims:
         eval_parser_argv.extend(["--dimensions", expand_dimension_aliases(dims)])
-    time_limit = getattr(args, "pool_budget", None) or 300
+    pool_budget = getattr(args, "pool_budget", None)
+    time_limit = pool_budget if pool_budget is not None else 300
     eval_parser_argv.extend(["--time-limit", str(time_limit)])
 
     parser = build_parser()

--- a/src/quodeq/core/types/job.py
+++ b/src/quodeq/core/types/job.py
@@ -23,3 +23,5 @@ class JobSnapshot:
     exit_reason: str | None = None
     ai_provider: str | None = None
     ai_model: str | None = None
+    # Run budget in seconds. 0 = explicitly unlimited, None = unknown.
+    time_limit_s: int | None = None

--- a/src/quodeq/data/fs/report_parser/runs.py
+++ b/src/quodeq/data/fs/report_parser/runs.py
@@ -194,8 +194,13 @@ def list_runs(reports_root: Path, project: str, *, limit: int = _DEFAULT_RUN_LIM
         if not entry.is_dir() or entry.name.startswith("."):
             continue
         run_dir = Path(entry.path)
-        manifest_exists = (run_dir / "evidence" / "manifest.json").exists()
-        if not manifest_exists:
+        # A run is real when it has a manifest OR a status.json. Runs started
+        # without a prescan never write evidence/manifest.json, and the SQLite
+        # index (History) already accepts any run with a status.json — the two
+        # enumerators must agree or the Overview 404s on runs History shows.
+        is_run = (run_dir / "evidence" / "manifest.json").exists() \
+            or (run_dir / "status.json").is_file()
+        if not is_run:
             continue
         # Status precedence:
         #   1. status.json state is terminal (done/failed/cancelled) → honor it,

--- a/src/quodeq/services/_evaluations_index.py
+++ b/src/quodeq/services/_evaluations_index.py
@@ -338,6 +338,7 @@ class EvaluationsIndex:
         deadline_at: str | None = None
         ai_provider: str | None = None
         ai_model: str | None = None
+        time_limit_s: int | None = None
         if row.run_dir:
             run_dir_path = Path(row.run_dir)
             try:
@@ -356,6 +357,10 @@ class EvaluationsIndex:
                 ai_provider, ai_model = _read_provider_model_from_status(run_dir_path)
             except (OSError, ValueError):
                 ai_provider, ai_model = None, None
+            try:
+                time_limit_s = _read_time_limit_from_status(run_dir_path)
+            except (OSError, ValueError):
+                time_limit_s = None
         return JobSnapshot(
             job_id=row.job_id,
             status=row.state,
@@ -375,6 +380,7 @@ class EvaluationsIndex:
             exit_reason=row.exit_reason,
             ai_provider=ai_provider,
             ai_model=ai_model,
+            time_limit_s=time_limit_s,
         )
 
 
@@ -393,7 +399,14 @@ def _tail_run_log(run_dir: Path, max_lines: int = 500) -> list[str]:
 
 
 def _read_dimensions_from_status(run_dir: Path) -> list[str] | None:
-    """Read the `dimensions` list from status.json, or None if unavailable."""
+    """Read the `dimensions` list from status.json, or None if unavailable.
+
+    "All dimensions" runs record an empty list (the raw, unresolved CLI
+    filter is None). The UI fetches per-dim evals from this list, so an
+    empty one blanks the live findings feed for every full scan served via
+    the index. Recover the resolved list from the per-dim sidecars, the
+    same fallback scan_progress uses.
+    """
     status_path = run_dir / "status.json"
     if not status_path.is_file():
         return None
@@ -402,7 +415,31 @@ def _read_dimensions_from_status(run_dir: Path) -> list[str] | None:
     except (OSError, ValueError):
         return None
     dims = data.get("dimensions")
-    return dims if isinstance(dims, list) else None
+    if not isinstance(dims, list):
+        return None
+    if dims:
+        return dims
+    from quodeq.shared.dim_estimates_io import read_dim_estimates
+    from quodeq.shared.dimensions_state import read_dimensions
+    recovered: dict[str, None] = {}
+    dim_records = read_dimensions(run_dir).get("dimensions")
+    record_keys = dim_records.keys() if isinstance(dim_records, dict) else ()
+    for key in (*record_keys, *read_dim_estimates(run_dir).keys()):
+        recovered.setdefault(key, None)
+    return list(recovered) if recovered else dims
+
+
+def _read_time_limit_from_status(run_dir: Path) -> int | None:
+    """Read the run budget (`time_limit_s`) from status.json, or None."""
+    status_path = run_dir / "status.json"
+    if not status_path.is_file():
+        return None
+    try:
+        data = json.loads(status_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    raw = data.get("time_limit_s")
+    return raw if isinstance(raw, int) else None
 
 
 def _read_deadline_from_status(run_dir: Path) -> str | None:

--- a/src/quodeq/services/_job_model.py
+++ b/src/quodeq/services/_job_model.py
@@ -45,6 +45,7 @@ class Job:
     dimensions: list[str] | None = None
     ai_provider: str | None = None
     ai_model: str | None = None
+    time_limit_s: int | None = None  # 0 = unlimited, None = unknown
 
     def complete(self, exit_code: int, ended_at: str) -> None:
         """Transition job to a terminal state based on exit code."""
@@ -87,6 +88,7 @@ class Job:
             dimensions=self.dimensions,
             ai_provider=self.ai_provider,
             ai_model=self.ai_model,
+            time_limit_s=self.time_limit_s,
         )
 
 
@@ -190,6 +192,7 @@ def _job_to_json(job: Job) -> dict:
         "dimensions": job.dimensions,
         "ai_provider": job.ai_provider,
         "ai_model": job.ai_model,
+        "time_limit_s": job.time_limit_s,
     }
 
 
@@ -212,6 +215,7 @@ def _job_from_json(data: dict) -> Job:
         dimensions=data.get("dimensions"),
         ai_provider=data.get("ai_provider"),
         ai_model=data.get("ai_model"),
+        time_limit_s=data.get("time_limit_s"),
     )
 
 

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -66,6 +66,7 @@ class EvaluationDispatcher(Protocol):
         env: dict[str, str] | None = None,
         ai_provider: str | None = None,
         ai_model: str | None = None,
+        time_limit_s: int | None = None,
     ) -> JobSnapshot:
         """Submit an evaluation command and return the initial job state."""
         ...
@@ -85,10 +86,12 @@ class SubprocessDispatcher:
         env: dict[str, str] | None = None,
         ai_provider: str | None = None,
         ai_model: str | None = None,
+        time_limit_s: int | None = None,
     ) -> JobSnapshot:
         return self._jobs.start_job(
             cmd, cwd=cwd, env=env,
             ai_provider=ai_provider, ai_model=ai_model,
+            time_limit_s=time_limit_s,
         )
 
 
@@ -386,6 +389,7 @@ class FsEvaluationMixin:
             cmd, cwd=cwd, env=env,
             ai_provider=options.ai_cmd,
             ai_model=options.ai_model,
+            time_limit_s=options.time_limit,
         )
 
     def get_evaluation_status(self, job_id: str, reports_dir: str | None = None) -> JobSnapshot | None:
@@ -434,7 +438,10 @@ class FsEvaluationMixin:
         reports_root = Path(reports_dir) if reports_dir else None
         job = self.get_evaluation_status(job_id, reports_dir=reports_dir)
         ok = self._jobs.cancel_job(job_id, reports_root=reports_root)
-        if ok and reports_dir and job:
+        # A job cancelled before the report_path marker landed has no
+        # output_project/output_run_id yet — there is no run dir to wait on,
+        # score, or discard.
+        if ok and reports_dir and job and job.output_project and job.output_run_id:
             run_dir = Path(reports_dir) / job.output_project / job.output_run_id
             _wait_for_terminal_status(run_dir)
             if discard_partial:

--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -102,7 +102,7 @@ class JobManager:
         """
         self._reports_root = path
 
-    def start_job(self, cmd: list[str], *, cwd: str | None = None, env: dict[str, str] | None = None, ai_provider: str | None = None, ai_model: str | None = None) -> JobSnapshot:
+    def start_job(self, cmd: list[str], *, cwd: str | None = None, env: dict[str, str] | None = None, ai_provider: str | None = None, ai_model: str | None = None, time_limit_s: int | None = None) -> JobSnapshot:
         """Spawn a subprocess and return its initial job state."""
         job_id = str(uuid.uuid4())
         job = Job(
@@ -114,6 +114,7 @@ class JobManager:
             exit_code=None,
             ai_provider=ai_provider,
             ai_model=ai_model,
+            time_limit_s=time_limit_s,
         )
 
         try:
@@ -216,6 +217,20 @@ class JobManager:
             if not job:
                 return None
             return job.to_dict()
+
+    def delete(self, job_id: str) -> bool:
+        """Drop a terminal job from the store. Refuses running jobs.
+
+        Called by ``EvaluationsIndex.delete`` after a discard-cancel removes
+        the run dir and index row, so the job stops resurfacing in
+        ``/api/evaluations`` from the persisted job store.
+        """
+        with self._lock:
+            job = self._store.get(job_id)
+            if not job or job.status == STATUS_RUNNING:
+                return False
+            self._store.delete(job_id)
+            return True
 
     def list_jobs(
         self,

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -134,39 +134,69 @@ def _parse_started_at(status: dict) -> datetime | None:
     if not isinstance(raw, str) or not raw:
         return None
     try:
-        return datetime.fromisoformat(raw)
+        parsed = datetime.fromisoformat(raw)
     except ValueError:
         return None
+    # Legacy status files can carry naive timestamps; subtracting one from an
+    # aware now() raises TypeError. Treat naive as UTC.
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _queue_take_timestamps(qstate: dict) -> list[float]:
+    """Extract valid take-log timestamps from a queue state dict."""
+    taken = qstate.get("taken")
+    if not isinstance(taken, list):
+        return []
+    return [
+        e["ts"] for e in taken
+        if isinstance(e, dict) and isinstance(e.get("ts"), (int, float))
+    ]
 
 
 def _dim_elapsed_s(dim_id: str, run_dir: Path, state: str) -> float | None:
-    """Per-dim elapsed time, derived from queue file mtime / status timing.
+    """Per-dim elapsed time, derived from queue-state timestamps.
 
-    Best-effort: queue creation time approximates the dimension start. For done
-    dims we use the youngest agent-stream mtime as the end. For running dims we
-    use now. For pending dims we return None.
+    The queue file is atomically rewritten on every take (new inode, fresh
+    mtime), so its mtime tracks the *last* take, not the dim start — using it
+    as the start made the running clock reset toward zero on every take.
+    Start comes from the queue's ``created_at`` (stamped at init), falling
+    back to the earliest take timestamp, then the file mtime for legacy
+    queues. For done dims the end is the latest activity signal we still
+    have: last take, evidence-file mtime, or any surviving agent streams
+    (streams are deleted at dim completion, so they rarely survive).
     """
     if state == "pending":
         return None
     queue = run_dir / "evidence" / f"{dim_id}_queue.json"
-    if not queue.is_file():
+    qstate = _read_json(queue)
+    if qstate is None:
         return None
-    try:
-        start = queue.stat().st_mtime
-    except OSError:
-        return None
+    take_ts = _queue_take_timestamps(qstate)
+    start = qstate.get("created_at")
+    if not isinstance(start, (int, float)):
+        if take_ts:
+            start = min(take_ts)
+        else:
+            try:
+                start = queue.stat().st_mtime
+            except OSError:
+                return None
     if state == "running":
         return max(0.0, time.time() - start)
-    # done: use latest agent-stream mtime
+    # done: latest activity signal still on disk
     end = start
-    try:
-        for s in (run_dir / "evidence").glob(f"{dim_id}_agent-*.stream"):
-            try:
-                end = max(end, s.stat().st_mtime)
-            except OSError:
-                continue
-    except OSError:
-        pass
+    if take_ts:
+        end = max(end, max(take_ts))
+    for candidate in (
+        run_dir / "evidence" / f"{dim_id}_evidence.jsonl",
+        *(run_dir / "evidence").glob(f"{dim_id}_agent-*.stream"),
+    ):
+        try:
+            end = max(end, candidate.stat().st_mtime)
+        except OSError:
+            continue
     return max(0.0, end - start)
 
 
@@ -206,6 +236,8 @@ def build_scan_progress(
     elif started_at and status.get("finalized_at"):
         try:
             end = datetime.fromisoformat(status["finalized_at"])
+            if end.tzinfo is None:
+                end = end.replace(tzinfo=timezone.utc)
             total_elapsed_s = max(0.0, (end - started_at).total_seconds())
         except (ValueError, TypeError):
             total_elapsed_s = None

--- a/src/quodeq/shared/run_lifecycle.py
+++ b/src/quodeq/shared/run_lifecycle.py
@@ -68,6 +68,7 @@ class RunLifecycleContext:
         self._phase: str | None = None
         self._current_dimension: str | None = None
         self._deadline_at: str | None = None
+        self._time_limit_s: int | None = None
         self._ai_provider = ai_provider
         self._ai_model = ai_model
         self._heartbeat = HeartbeatThread(run_dir, interval=heartbeat_interval)
@@ -155,6 +156,16 @@ class RunLifecycleContext:
         self._deadline_at = deadline_at
         self._write(self._current_state)
 
+    def set_time_limit(self, seconds: int | None) -> None:
+        """Record the run budget in seconds (0 = explicitly unlimited).
+
+        Persisted in status.json so index-served snapshots (external runs,
+        dashboard runs after a server restart) can surface the budget the
+        run was actually started with.
+        """
+        self._time_limit_s = seconds
+        self._write(self._current_state)
+
     def set_exit_reason(self, reason: str | None) -> None:
         """Record a non-failure exit reason to apply at the next terminal transition.
 
@@ -185,6 +196,7 @@ class RunLifecycleContext:
             deadline_at=self._deadline_at,
             ai_provider=self._ai_provider,
             ai_model=self._ai_model,
+            time_limit_s=self._time_limit_s,
         )
 
     def _seed_dimension_states(self) -> None:
@@ -235,6 +247,7 @@ class RunLifecycleContext:
                 deadline_at=self._deadline_at,
                 ai_provider=self._ai_provider,
                 ai_model=self._ai_model,
+                time_limit_s=self._time_limit_s,
             )
             self._current_state = RunState.CANCELLED
             raise SystemExit(128 + signum)
@@ -277,6 +290,7 @@ class RunLifecycleContext:
             deadline_at=self._deadline_at,
             ai_provider=self._ai_provider,
             ai_model=self._ai_model,
+            time_limit_s=self._time_limit_s,
         )
 
     def _deregister_atexit(self) -> None:

--- a/src/quodeq/shared/run_status.py
+++ b/src/quodeq/shared/run_status.py
@@ -90,6 +90,7 @@ def write_status(
     deadline_at: str | None = None,
     ai_provider: str | None = None,
     ai_model: str | None = None,
+    time_limit_s: int | None = None,
 ) -> None:
     """Atomically write status.json with *state* and metadata.
 
@@ -115,6 +116,8 @@ def write_status(
         "exit_reason": exit_reason,
         "deadline_at": deadline_at,
     }
+    if time_limit_s is not None:
+        payload["time_limit_s"] = time_limit_s
     if ai_provider is not None:
         payload["ai_provider"] = ai_provider
     if ai_model is not None:

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -271,6 +271,7 @@ export function buildDashboardDataBundle({ state, sharedHasContent = false }) {
     selectedProject: state.selectedProject, selectedSource: state.selectedSource, selectedRun: state.selectedRun, projects: state.projects,
     projectsLoaded: state.projectsLoaded,
     dashboard: state.dashboard, accumulated: state.accumulated, latestAccumulated: state.latestAccumulated, loading: state.loading, isFetching: state.isFetching, error: state.error,
+    onRetry: state.refreshDashboardActive,
     scoresPending: state.scoresPending,
     sharedProjectInfo: state.sharedProjectInfo,
     availableRuns: state.availableRuns, dailyRuns: state.dailyRuns, overviewRunIndex: state.overviewRunIndex,
@@ -578,7 +579,7 @@ function ViolationsRoute({ params, props }) {
 // ROUTE_RENDERERS.file(params, props) just builds the React element tree; it
 // doesn't render, so the returned element's props can be asserted on directly.
 export const ROUTE_RENDERERS = {
-  overview: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate, onRunSelect: props.navigation.handleRunSelect, onProjectsReload: props.navigation.loadProjects }} runMode={false} />,
+  overview: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate, onRunSelect: props.navigation.handleRunSelect, onProjectsReload: props.navigation.loadProjects, onRetry: props.dashboardData.onRetry }} runMode={false} />,
   violations: (params, props) => <ViolationsRoute params={params} props={props} />,
   map: (params, props) => {
     const acc = props.dashboardData.latestAccumulated || props.dashboardData.accumulated;
@@ -600,7 +601,7 @@ export const ROUTE_RENDERERS = {
       tabKey={params._tabKey || 0}
     />;
   },
-  run: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate }} runMode={true} />,
+  run: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate, onRetry: props.dashboardData.onRetry }} runMode={true} />,
   history: (params, props) => {
     const trend = props.dashboardData.dashboard?.trend || [];
     const runs = props.dashboardData.availableRuns || [];
@@ -638,7 +639,7 @@ export const ROUTE_RENDERERS = {
       />
     );
   },
-  'history-run': (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate }} runMode={true} />,
+  'history-run': (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate, onRetry: props.dashboardData.onRetry }} runMode={true} />,
   explorer: (params, props) => (
     <ExplorerPage
       project={params.fromProject || props.navigation.selectedProject}

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -189,7 +189,10 @@ export function getEvaluationProgress(jobId) {
  */
 export function cancelEvaluation(jobId, opts = {}) {
   const qs = opts.discard ? '?intent=cancel&discard=true' : '?intent=cancel';
-  return request(`/evaluations/${encodeURIComponent(jobId)}${qs}`, { method: 'DELETE' });
+  // The server-side cancel path can block for the full SIGTERM grace window
+  // (~30s) plus the terminal-status wait before responding; the default 30s
+  // request timeout aborted client-side right before the backend finished.
+  return request(`/evaluations/${encodeURIComponent(jobId)}${qs}`, { method: 'DELETE', timeout: 45000 });
 }
 
 /**

--- a/src/quodeq/ui/src/api/request.js
+++ b/src/quodeq/ui/src/api/request.js
@@ -30,7 +30,11 @@ export async function request(path, options = {}) {
     const payload = await res.json().catch(() => ({}));
 
     if (!res.ok) {
-      throw new Error(payload.error || `Request failed: ${res.status}`);
+      const err = new Error(payload.error || `Request failed: ${res.status}`);
+      // Callers branch on this (e.g. the cancel flow treats 409 as "job no
+      // longer cancellable" but keeps the job on transient failures).
+      err.status = res.status;
+      throw err;
     }
 
     return payload;

--- a/src/quodeq/ui/src/api/request.test.jsx
+++ b/src/quodeq/ui/src/api/request.test.jsx
@@ -27,3 +27,22 @@ it('aborts on the internal timeout when no caller signal is given', async () => 
   await expect(p).rejects.toThrow();
   vi.useRealTimers();
 });
+
+it('attaches the HTTP status to thrown errors so callers can branch on it', async () => {
+  // The cancel flow needs to distinguish "409 job no longer cancellable"
+  // (drop the job) from a transient 500/timeout (keep it); a bare Error
+  // forced callers to treat every failure as fatal.
+  const fetchMock = vi.fn(async () => ({
+    ok: false,
+    status: 409,
+    json: async () => ({ error: 'not cancellable' }),
+  }));
+  vi.stubGlobal('fetch', fetchMock);
+  await request('/x').then(
+    () => { throw new Error('expected rejection'); },
+    (err) => {
+      expect(err.message).toBe('not cancellable');
+      expect(err.status).toBe(409);
+    },
+  );
+});

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -213,6 +213,21 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   }
   const projectName = projectInfo?.displayName || projectInfo?.name || selectedProject;
   if (!loading && !isFetching && !dashboard) {
+    // A failed fetch also lands here (dashboard === null, queries settled).
+    // It must render as an error: claiming "No evaluations yet" on a
+    // 404/500/timeout tells the user their existing evaluations are gone.
+    if (error) {
+      return (
+        <div className="dashboard-page dashboard-fade dashboard-ready">
+          <EmptyState
+            title="Couldn't load this project"
+            description={error}
+            actionLabel="Retry"
+            onAction={() => callbacks.onRetry?.()}
+          />
+        </div>
+      );
+    }
     return (
       <div className="dashboard-page dashboard-fade dashboard-ready">
         <IncompleteSetupCard projectInfo={projectInfo} onComplete={handleSetupComplete} />

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -111,6 +111,48 @@ describe('DashboardPage no-completed-evaluation empty state', () => {
   });
 });
 
+describe('DashboardPage fetch-failure state', () => {
+  // A failed dashboard query leaves dashboard === null with loading and
+  // isFetching settled. That used to fall into the "No evaluations yet"
+  // empty state, so a 404/500/timeout told the user their evaluations
+  // didn't exist (they did). Errors must render as errors.
+  const errorData = {
+    projectsLoaded: true,
+    projects: [{ id: 'p1', name: 'p1' }],
+    selectedProject: 'p1',
+    dashboard: null,
+    accumulated: null,
+    loading: false,
+    isFetching: false,
+    error: 'Failed to load dashboard data. Check your connection and try refreshing.',
+    availableRuns: [],
+  };
+
+  it('renders an error state, not "No evaluations yet"', () => {
+    const { getByText, queryByText } = render(
+      <DashboardPage data={errorData} callbacks={{}} runMode={false} />,
+    );
+    expect(queryByText('No evaluations yet')).toBeNull();
+    expect(getByText("Couldn't load this project")).toBeTruthy();
+  });
+
+  it('offers a Retry action wired to onRetry', () => {
+    const onRetry = vi.fn();
+    const { getByText } = render(
+      <DashboardPage data={errorData} callbacks={{ onRetry }} runMode={false} />,
+    );
+    fireEvent.click(getByText('Retry'));
+    expect(onRetry).toHaveBeenCalled();
+  });
+
+  it('without an error, the settled empty state still says No evaluations yet', () => {
+    const { getByText } = render(
+      <DashboardPage data={{ ...errorData, error: null }} callbacks={{}} runMode={false} />,
+    );
+    expect(getByText('No evaluations yet')).toBeTruthy();
+  });
+});
+
 // Teammate persona (shared-repo onboarding): a teammate with ZERO local
 // projects selects a shared project. The local-list empty-state gate must not
 // wall off the Overview when the selection is shared -- the shared data loads

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -46,13 +46,24 @@ export function readBudgetSeconds(storage = localStorage) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+const TERMINAL_STATUSES = new Set(['done', 'failed', 'cancelled', 'lost', 'completed']);
+
 function EvaluateHeader({ job, onGoToSettings }) {
   // Page title stays steady ("evaluate"); the live "in progress / failed /
   // done" state is carried by the JobHeader card title below to avoid
   // doubling the same status on screen.
   const deadlineAt = job?.deadlineAt ?? null;
-  const phase = job?.phase ?? job?.status ?? null;
-  const budgetSeconds = readBudgetSeconds();
+  // job.phase never turns terminal (the CLI leaves it at "scoring"), so a
+  // finished run kept the countdown pinned at 0:00. Key off status once the
+  // run ends; phase still wins while it runs.
+  const phase = TERMINAL_STATUSES.has(job?.status)
+    ? job.status
+    : (job?.phase ?? job?.status ?? null);
+  // Prefer the running job's own budget (carried on the snapshot) so
+  // changing provider/limit in Settings mid-run can't alter or hide the
+  // countdown of an already-running scan. Settings remain the fallback for
+  // jobs that predate the field.
+  const budgetSeconds = typeof job?.timeLimitS === 'number' ? job.timeLimitS : readBudgetSeconds();
   return (
     <header className="evaluate-header evaluate-header--terminal">
       <div className="evaluate-header__left">

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreenCountdown.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreenCountdown.test.jsx
@@ -1,0 +1,84 @@
+import { render, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Capture the props EvaluateHeader hands to CountdownTimer.
+const captured = vi.hoisted(() => ({ calls: [] }));
+vi.mock('./CountdownTimer.jsx', () => ({
+  default: (props) => {
+    captured.calls.push(props);
+    return null;
+  },
+}));
+vi.mock('./EvaluationStatus.jsx', () => ({ default: () => null }));
+vi.mock('./ReEvaluateCard.jsx', () => ({ default: () => null }));
+vi.mock('../../../components/terminal/index.js', () => ({ TermHeader: () => null }));
+vi.mock('../../../constants.js', () => ({
+  ACTIVE_PROVIDER_KEY: 'active-provider',
+  DEFAULT_TIME_LIMIT_S: 3600,
+  LOCAL_API_PROVIDERS: new Set(['ollama', 'llamacpp', 'omlx']),
+  providerKey: (p, k) => `${p}-${k}`,
+}));
+
+import EvaluateScreen from './EvaluateScreen.jsx';
+
+const baseContext = { selectedProject: null, projectInfo: null, jobProjectInfo: null };
+const baseActions = {
+  onStart: vi.fn(), onDismiss: vi.fn(), onCancel: vi.fn(),
+  onGoToProjects: vi.fn(), onGoToSettings: vi.fn(),
+};
+
+function renderWithJob(job) {
+  return render(
+    <EvaluateScreen
+      evaluation={{ job, jobError: null, liveViolations: [] }}
+      context={baseContext}
+      actions={baseActions}
+    />,
+  );
+}
+
+describe('EvaluateHeader -> CountdownTimer wiring', () => {
+  beforeEach(() => {
+    captured.calls.length = 0;
+    localStorage.clear();
+    cleanup();
+  });
+
+  it('passes a terminal phase when the job status is terminal', () => {
+    // job.phase is never terminal (the CLI leaves it at "scoring"), so the
+    // countdown must key off status once the run ends; before this fix a
+    // finished run kept a red 0:00 pinned in the header forever.
+    renderWithJob({
+      status: 'done', phase: 'scoring',
+      deadlineAt: '2026-07-27T10:00:00+00:00', timeLimitS: 600,
+    });
+    expect(captured.calls.at(-1).phase).toBe('done');
+  });
+
+  it('prefers the running job own budget over the active-provider settings', () => {
+    // The snapshot now carries timeLimitS. Reading localStorage instead
+    // meant switching provider/limit mid-run changed or hid the countdown
+    // of an already-running scan.
+    localStorage.setItem('active-provider', 'claude');
+    localStorage.setItem('claude-time-limit', '1200');
+    renderWithJob({
+      status: 'running', phase: 'analyzing',
+      deadlineAt: '2026-07-27T10:00:00+00:00', timeLimitS: 300,
+    });
+    expect(captured.calls.at(-1).budgetSeconds).toBe(300);
+  });
+
+  it('job budget 0 (unlimited) wins over a limited settings value', () => {
+    localStorage.setItem('active-provider', 'claude');
+    localStorage.setItem('claude-time-limit', '600');
+    renderWithJob({ status: 'running', phase: 'analyzing', deadlineAt: null, timeLimitS: 0 });
+    expect(captured.calls.at(-1).budgetSeconds).toBe(0);
+  });
+
+  it('falls back to settings when the job carries no budget', () => {
+    localStorage.setItem('active-provider', 'claude');
+    localStorage.setItem('claude-time-limit', '900');
+    renderWithJob({ status: 'running', phase: 'analyzing', deadlineAt: null });
+    expect(captured.calls.at(-1).budgetSeconds).toBe(900);
+  });
+});

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -258,11 +258,15 @@ export function useEvaluation() {
     },
     onError: (err) => {
       // The backend returns 409 when the job is no longer cancellable
-      // (process gone, status already terminal, etc.). Without this handler
-      // the user is trapped: status stays "running", Cancel does nothing
-      // visible. Surface the message and clear locally so the panel closes.
+      // (process gone, status already terminal) and 404 when it is unknown.
+      // Only those mean the job is really over — clear it so the panel
+      // closes. A transient failure (500, network, the 30s request timeout
+      // racing the ~33s server-side kill path) must KEEP the job: clearing
+      // it hid a still-running scan and let a second concurrent scan start
+      // on the same project.
       const msg = err?.message || "Could not cancel evaluation";
       setJobError(msg);
+      if (err?.status !== 409 && err?.status !== 404) return;
       const id = jobId;
       if (id) queryClient.removeQueries({ queryKey: evaluationKeys.evaluation(id) });
       setJobId(null);

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -21,7 +21,7 @@
  *     terminal surface in the dashboard so users can close and reopen the UI
  *     without losing visibility into an in-progress scan.
  */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useApi } from "../../../api/ApiContext.jsx";
 import { chooseDialog } from "../../../utils/chooseDialog.js";
@@ -38,6 +38,19 @@ import {
 const SSE_ENABLED = import.meta.env?.VITE_USE_SSE_EVENTS === "true";
 const JOB_POLL_MS = 1500;
 const DIM_POLL_MS = 2000;
+
+/**
+ * Poll interval for the live findings query. Exported for tests.
+ *
+ * Polling must stop once the job is terminal: without the gate a finished
+ * run kept re-fetching every full evaluation/<dim>.json payload every 2s
+ * for as long as the Evaluate card stayed mounted.
+ */
+export function findingsRefetchInterval(job, sseEnabled = SSE_ENABLED) {
+  if (sseEnabled) return false;
+  if (job?.status && job.status !== "running") return false;
+  return DIM_POLL_MS;
+}
 const DEFAULT_OLLAMA_SUBAGENTS = "1";
 const DEFAULT_CLI_SUBAGENTS = String(DEFAULT_MAX_SUBAGENTS);
 const DEFAULT_OLLAMA_BUDGET = "0";
@@ -157,8 +170,24 @@ export function useEvaluation() {
     },
     enabled: !!jobId && (SSE_ENABLED || !!job?.outputProject),
     staleTime: SSE_ENABLED ? Infinity : 0,
-    refetchInterval: SSE_ENABLED ? false : DIM_POLL_MS,
+    refetchInterval: findingsRefetchInterval(job),
   });
+
+  // One final fetch on the running->terminal edge: the last dimension's
+  // report usually lands between the final running poll and the terminal
+  // transition, and stopping cold would freeze the feed just short of it.
+  const { refetch: refetchFindings } = findingsQuery;
+  const findingsSettledRef = useRef(false);
+  const isJobTerminal = !!job?.status && job.status !== "running";
+  useEffect(() => {
+    if (!jobId || SSE_ENABLED) return;
+    if (isJobTerminal && !findingsSettledRef.current) {
+      findingsSettledRef.current = true;
+      refetchFindings();
+    } else if (!isJobTerminal) {
+      findingsSettledRef.current = false;
+    }
+  }, [jobId, isJobTerminal, refetchFindings]);
 
   // Group findings into the legacy { [dim]: [violations] } shape.
   const findings = findingsQuery.data || [];

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
@@ -325,3 +325,19 @@ describe("useEvaluation", () => {
     expect(result.current.jobError).toBeNull();
   });
 });
+
+describe("findingsRefetchInterval", () => {
+  it("polls while the job runs, stops when it reaches any terminal status", async () => {
+    const { findingsRefetchInterval } = await import("./useEvaluation.js");
+    expect(findingsRefetchInterval({ status: "running" }, false)).toBe(2000);
+    expect(findingsRefetchInterval(null, false)).toBe(2000);
+    for (const status of ["done", "failed", "cancelled", "lost", "completed"]) {
+      expect(findingsRefetchInterval({ status }, false)).toBe(false);
+    }
+  });
+
+  it("never polls under SSE", async () => {
+    const { findingsRefetchInterval } = await import("./useEvaluation.js");
+    expect(findingsRefetchInterval({ status: "running" }, true)).toBe(false);
+  });
+});

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
@@ -244,7 +244,11 @@ describe("useEvaluation", () => {
     expect(result.current.job).not.toBeNull();
   });
 
-  it("cancelEvaluation surfaces an error and clears the job when the API rejects", async () => {
+  it("cancelEvaluation surfaces an error and keeps the job on a status-less rejection", async () => {
+    // A rejection without an HTTP status (network drop, request timeout)
+    // is transient: the scan may still be running server-side, so the job
+    // must stay visible. Only 409/404 clear it (see the cancel failure
+    // handling suite below).
     fakeApi.startEvaluation.mockResolvedValue({
       jobId: "j-stuck",
       status: "running",
@@ -263,8 +267,8 @@ describe("useEvaluation", () => {
 
     await waitFor(() => {
       expect(result.current.jobError).toMatch(/cancel/i);
-      expect(result.current.job).toBeNull();
     });
+    expect(result.current.job?.jobId).toBe("j-stuck");
   });
 
   it("startEvaluation surfaces a useful error when no provider is configured", async () => {
@@ -339,5 +343,43 @@ describe("findingsRefetchInterval", () => {
   it("never polls under SSE", async () => {
     const { findingsRefetchInterval } = await import("./useEvaluation.js");
     expect(findingsRefetchInterval({ status: "running" }, true)).toBe(false);
+  });
+});
+
+describe("cancel failure handling", () => {
+  async function startJob(result) {
+    fakeApi.startEvaluation.mockResolvedValue({ jobId: "j-c", status: "running", dimensions: [] });
+    await act(async () => {
+      await result.current.startEvaluation({ repo: "x", dimensions: [] });
+    });
+    await waitFor(() => expect(result.current.job?.jobId).toBe("j-c"));
+  }
+
+  it("keeps the job when cancel fails transiently (500/timeout)", async () => {
+    // Clearing the job on ANY rejection let a slow SIGTERM-ignoring run be
+    // dropped client-side (30s request timeout vs ~33s server cancel path),
+    // unblocking a second concurrent scan on the same project.
+    const err = new Error("boom");
+    err.status = 500;
+    fakeApi.cancelEvaluation.mockRejectedValue(err);
+    const { result } = renderHook(() => useEvaluation(), { wrapper: makeWrapper() });
+    await startJob(result);
+    await act(async () => {
+      await result.current.cancelEvaluation();
+    });
+    await waitFor(() => expect(result.current.jobError).toBeTruthy());
+    expect(result.current.job?.jobId).toBe("j-c");
+  });
+
+  it("drops the job when the backend says it is no longer cancellable (409)", async () => {
+    const err = new Error("not cancellable");
+    err.status = 409;
+    fakeApi.cancelEvaluation.mockRejectedValue(err);
+    const { result } = renderHook(() => useEvaluation(), { wrapper: makeWrapper() });
+    await startJob(result);
+    await act(async () => {
+      await result.current.cancelEvaluation();
+    });
+    await waitFor(() => expect(result.current.job).toBeNull());
   });
 });

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -126,6 +126,18 @@ export default function ExplorerPage({
 
   if (d.loading) return <LoadingScreen />;
   if (d.error) return <div className="inline-error">Failed to load evaluation data. Please try again or check the console for details.</div>;
+  if (d.waiting) {
+    // 202 from the backend: the run exists but this dimension's report
+    // isn't written (still running, or the run stopped before reaching it).
+    // Rendering it as data would show SCORE — / 0 violations and read as a
+    // clean pass.
+    return (
+      <div className="empty-state">
+        <h2>Report not ready</h2>
+        <p>This dimension has no written report yet. The run may still be in progress, or it stopped before this dimension was scored.</p>
+      </div>
+    );
+  }
   if (!d.evalData) return <div className="empty-state"><h2>No data found</h2></div>;
 
   const dim = String(d.evalData.dimension || '').toLowerCase();

--- a/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.js
+++ b/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.js
@@ -125,10 +125,21 @@ export function useExplorerData(project, dimension, runId, refreshSignal, select
     // the previous run's data on screen and toggle isFetching so the
     // caller can dim the page during the background refetch (matches
     // the Overview placeholderData behaviour).
+    // The stale flag drops responses that resolve after a newer request
+    // (run-navigator clicks re-fire this effect); without it a slow earlier
+    // response could park another run's findings under the current header.
+    let stale = false;
     setIsFetching(true);
     fetchAndRescore(project, runId, dimension, fetchDimensionEval, fetchRunScores)
-      .then((data) => { setEvalData(data); setLoading(false); setIsFetching(false); })
-      .catch((err) => { setError(err.message); setLoading(false); setIsFetching(false); });
+      .then((data) => {
+        if (stale) return;
+        setEvalData(data); setLoading(false); setIsFetching(false);
+      })
+      .catch((err) => {
+        if (stale) return;
+        setError(err.message); setLoading(false); setIsFetching(false);
+      });
+    return () => { stale = true; };
   }, [project, dimension, runId, fetchDimensionEval, fetchRunScores]);
 
   const initialRef = useRef(refreshSignal);
@@ -164,6 +175,10 @@ export function useExplorerData(project, dimension, runId, refreshSignal, select
   const stats = useDerivedExplorerStats(evalData, allViolations);
   return {
     evalData, loading, isFetching, error,
+    // 202 sentinel: the run dir exists but evaluation/<dim>.json isn't
+    // written (yet). Callers must not render this as a real, zero-finding
+    // report.
+    waiting: !!evalData?.waiting,
     overallGrade, principleGrades, allViolations,
     applyRescoredPayload,
     ...stats,

--- a/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.test.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.test.jsx
@@ -158,3 +158,47 @@ describe('useExplorerData source-aware fetch selection', () => {
     expect(fakeApi.getRunScores).not.toHaveBeenCalled();
   });
 });
+
+describe('useExplorerData response handling', () => {
+  it('ignores a stale response that resolves after a newer request', async () => {
+    // Run-navigator clicks re-fire the fetch with no cancellation; a slow
+    // earlier response resolving last used to park another run's findings
+    // under the current header.
+    const resolvers = {};
+    const fakeApi = {
+      getDimensionEval: vi.fn((p, r) => new Promise((res) => { resolvers[r] = res; })),
+      getRunScores: vi.fn(async () => null),
+      sharedGetDimensionEval: vi.fn(),
+      sharedGetRunScores: vi.fn(),
+    };
+    const { result, rerender } = renderHook(
+      ({ runId }) => useExplorerData('proj', 'security', runId, null),
+      {
+        initialProps: { runId: 'r1' },
+        wrapper: ({ children }) => <ApiProvider value={fakeApi}>{children}</ApiProvider>,
+      },
+    );
+    rerender({ runId: 'r2' });
+    await act(async () => { resolvers.r2({ dimension: 'security', marker: 'r2' }); });
+    await act(async () => { resolvers.r1({ dimension: 'security', marker: 'r1' }); });
+    expect(result.current.evalData?.marker).toBe('r2');
+  });
+
+  it('flags a waiting (202) payload instead of presenting it as a report', async () => {
+    // The backend returns {waiting: true} while evaluation/<dim>.json is not
+    // written yet; rendering it as data showed SCORE — / 0 violations,
+    // indistinguishable from a genuinely clean dimension.
+    const fakeApi = {
+      getDimensionEval: vi.fn(async () => ({ waiting: true, project: 'proj', run: 'r1', dimension: 'security' })),
+      getRunScores: vi.fn(async () => null),
+      sharedGetDimensionEval: vi.fn(),
+      sharedGetRunScores: vi.fn(),
+    };
+    const { result } = renderHook(
+      () => useExplorerData('proj', 'security', 'r1', null),
+      { wrapper: ({ children }) => <ApiProvider value={fakeApi}>{children}</ApiProvider> },
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.waiting).toBe(true);
+  });
+});

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -206,7 +206,7 @@ export function useAppState() {
     currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect, prefetchHandlers,
     headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId,
     historySelectedRun, setHistorySelectedRun,
-    evalLifecycle, settings, activeTab, showProjectHeader, showRunNav, refreshDashboard, scheduleDashboardReconcile,
+    evalLifecycle, settings, activeTab, showProjectHeader, showRunNav, refreshDashboard, refreshDashboardActive, scheduleDashboardReconcile,
     granularity, onGranularityChange: handleGranularityChange,
   };
 }

--- a/src/quodeq/ui/src/models/job.js
+++ b/src/quodeq/ui/src/models/job.js
@@ -44,8 +44,10 @@ export function createJob(raw) {
     deadlineAt:       raw.deadlineAt ?? null,
     exitCode:         raw.exitCode ?? null,
     error:            raw.error ?? null,
+    exitReason:       raw.exitReason ?? null,
     source:           raw.source ?? 'internal',
     aiProvider:       raw.aiProvider ?? null,
     aiModel:          raw.aiModel ?? null,
+    timeLimitS:       typeof raw.timeLimitS === 'number' ? raw.timeLimitS : null,
   };
 }

--- a/src/quodeq/ui/src/models/job.test.js
+++ b/src/quodeq/ui/src/models/job.test.js
@@ -14,3 +14,14 @@ test('createJob leaves aiProvider/aiModel null when API omits them', () => {
   assert.equal(job.aiProvider, null);
   assert.equal(job.aiModel, null);
 });
+
+test('createJob maps timeLimitS, including 0 (unlimited)', () => {
+  assert.equal(createJob({ jobId: 'j1', timeLimitS: 600 }).timeLimitS, 600);
+  assert.equal(createJob({ jobId: 'j1', timeLimitS: 0 }).timeLimitS, 0);
+  assert.equal(createJob({ jobId: 'j1' }).timeLimitS, null);
+});
+
+test('createJob maps exitReason from API response', () => {
+  assert.equal(createJob({ jobId: 'j1', exitReason: 'deadline' }).exitReason, 'deadline');
+  assert.equal(createJob({ jobId: 'j1' }).exitReason, null);
+});

--- a/tests/analysis/test_report_io.py
+++ b/tests/analysis/test_report_io.py
@@ -1,0 +1,37 @@
+"""Tests for analysis._report_io — atomic report persistence.
+
+Dashboard readers poll evaluation/<dim>.json every 250ms-2s and treat a parse
+failure as "dimension does not exist", so a report write must never expose a
+truncated or partial file at the destination path.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.analysis._report_io import _persist_json
+
+
+class TestPersistJsonAtomicity:
+    def test_writes_valid_json(self, tmp_path):
+        target = tmp_path / "security.json"
+        _persist_json({"dimension": "security", "totals": {"violationCount": 3}}, target)
+        assert json.loads(target.read_text(encoding="utf-8"))["dimension"] == "security"
+
+    def test_failed_publish_preserves_previous_report(self, tmp_path):
+        # If the atomic rename fails (disk full, permissions), the previous
+        # report must survive untouched and no temp files may be left behind.
+        # With a plain write_text the destination is truncated first and a
+        # concurrent reader sees a missing/partial dimension.
+        target = tmp_path / "security.json"
+        _persist_json({"version": 1}, target)
+
+        with patch("quodeq.analysis._report_io.os.replace", side_effect=OSError("disk full")):
+            with pytest.raises(OSError):
+                _persist_json({"version": 2}, target)
+
+        assert json.loads(target.read_text(encoding="utf-8")) == {"version": 1}
+        leftovers = [p for p in tmp_path.iterdir() if p.name != "security.json"]
+        assert leftovers == []

--- a/tests/api/test_evaluation_progress_budget.py
+++ b/tests/api/test_evaluation_progress_budget.py
@@ -1,0 +1,125 @@
+"""GET /api/evaluations/<id>/progress resolves the run budget from the snapshot.
+
+The route used to read `snapshot.options`, a field JobSnapshot never had, so
+`time_limit_s` was always None and the per-dim budget bar never rendered.
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from quodeq.api.app import create_app
+from quodeq.core.types import JobSnapshot
+from quodeq.services.base import ActionProvider
+
+
+@pytest.fixture(autouse=True)
+def _disable_auth(monkeypatch):
+    monkeypatch.delenv("QUODEQ_API_KEY", raising=False)
+
+
+@pytest.fixture()
+def reports_root(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmp:
+        monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", tmp)
+        yield Path(tmp)
+
+
+def _make_provider(run_dir: Path, time_limit_s):
+    class _Provider(ActionProvider):
+        def list_projects(self, reports_dir):
+            return {"projects": []}
+
+        def get_project_info(self, reports_dir, project):
+            return {"project": project}
+
+        def get_dashboard(self, reports_dir, project, run):
+            return {}
+
+        def get_accumulated(self, reports_dir, project, as_of):
+            return {"summary": {"dimensionCount": 0}}
+
+        def get_dimension_eval(self, reports_dir, project, run_id, dimension):
+            return {}
+
+        def get_run_plan(self, reports_dir, project, run_id):
+            return {}
+
+        def get_violations(self, reports_dir, project, run_id):
+            return {"total": 0, "critical": 0, "major": 0, "minor": 0, "files": []}
+
+        def start_evaluation(self, repo, reports_dir, options):
+            return {"jobId": "job-1", "status": "running", "logs": []}
+
+        def get_evaluation_status(self, job_id, reports_dir=None):
+            if job_id != "job-1":
+                return None
+            return JobSnapshot(
+                job_id="job-1", status="running", logs=[],
+                output_project="proj", output_run_id="run-1",
+                time_limit_s=time_limit_s,
+            )
+
+        def get_log_run_dir(self, job_id):
+            return run_dir if job_id == "job-1" else None
+
+        def cancel_evaluation(self, job_id, reports_dir=None, *, discard_partial=False):
+            return False
+
+        def list_evaluations(self, *, limit=0, reports_dir=None, states=None):
+            return []
+
+        def delete_project(self, reports_dir, project):
+            return False
+
+        def browse_repo(self, path=None):
+            return {"current": "/", "parent": None, "directories": [], "isGitRepo": False}
+
+        def get_ai_clients(self):
+            return {"clients": []}
+
+        def get_client_models(self, client_id):
+            return {"models": []}
+
+    return _Provider()
+
+
+def _write_running_run(reports_root: Path) -> Path:
+    run_dir = reports_root / "proj" / "run-1"
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "status.json").write_text(
+        json.dumps({
+            "schema_version": 1,
+            "job_id": "job-1",
+            "state": "running",
+            "started_at": "2026-04-26T12:00:00+00:00",
+            "dimensions": ["security"],
+            "phase": "analyzing",
+        }),
+        encoding="utf-8",
+    )
+    (run_dir / "evidence" / "security_queue.json").write_text(
+        json.dumps({"taken": [], "pending": ["a.py"]}), encoding="utf-8",
+    )
+    return run_dir
+
+
+def test_budget_resolved_from_snapshot(reports_root: Path):
+    run_dir = _write_running_run(reports_root)
+    client = create_app(_make_provider(run_dir, 600)).test_client()
+    response = client.get("/api/evaluations/job-1/progress")
+    assert response.status_code == 200
+    dims = response.get_json()["dimensions"]
+    assert dims[0]["budgetS"] == 600
+
+
+def test_unlimited_budget_stays_absent(reports_root: Path):
+    run_dir = _write_running_run(reports_root)
+    client = create_app(_make_provider(run_dir, 0)).test_client()
+    response = client.get("/api/evaluations/job-1/progress")
+    assert response.status_code == 200
+    dims = response.get_json()["dimensions"]
+    assert dims[0].get("budgetS") is None

--- a/tests/api/test_power_selector_backend.py
+++ b/tests/api/test_power_selector_backend.py
@@ -64,7 +64,7 @@ class TestEvaluationMixinSubagentModel:
         from quodeq.services.filesystem import FilesystemActionProvider
 
         class StubJobs:
-            def start_job(self, cmd, *, cwd=None, env=None, ai_provider=None, ai_model=None):
+            def start_job(self, cmd, *, cwd=None, env=None, ai_provider=None, ai_model=None, time_limit_s=None):
                 captured["cmd"] = cmd
                 captured["env"] = env
                 return {"jobId": "test"}

--- a/tests/api/test_power_selector_e2e.py
+++ b/tests/api/test_power_selector_e2e.py
@@ -193,7 +193,7 @@ class _StubJobManager:
     def __init__(self):
         self.captured_env: dict = {}
 
-    def start_job(self, cmd, *, cwd=None, env=None, ai_provider=None, ai_model=None):
+    def start_job(self, cmd, *, cwd=None, env=None, ai_provider=None, ai_model=None, time_limit_s=None):
         self.captured_env = env
         return {"jobId": "test"}
 

--- a/tests/ci/test_review.py
+++ b/tests/ci/test_review.py
@@ -315,3 +315,61 @@ def test_handle_review_excludes_dismissed_finding(tmp_path, monkeypatch, capsys)
     assert rc == 0
     out = capsys.readouterr().out
     assert "1 violation(s) found in diff" in out
+
+
+def test_handle_review_time_limit_zero_means_unlimited(tmp_path):
+    """--time-limit 0 is documented as unlimited; the `or 300` fallback must
+    not swallow it (same falsy-drop bug as the dashboard's unlimited runs)."""
+    from unittest.mock import MagicMock, patch
+    import json
+    import argparse
+
+    args = argparse.Namespace(
+        pr=None,
+        dimensions=None,
+        pool_budget=0,
+        output=str(tmp_path),
+        dry_run=True,
+    )
+
+    pr_result = MagicMock()
+    pr_result.stdout = json.dumps({"number": 7, "baseRefName": "main"})
+    repo_result = MagicMock()
+    repo_result.stdout = json.dumps({"owner": {"login": "org"}, "name": "repo"})
+
+    captured_argv = []
+
+    def fake_parse_args(argv):
+        captured_argv.extend(argv)
+        return argparse.Namespace(
+            dimensions=None,
+            repo=".",
+            incremental=True,
+            output=str(tmp_path),
+            pool_budget=0,
+            mode=None,
+            max_turns=None,
+            max_duration=None,
+            n_subagents=1,
+            no_verify=False,
+            no_consolidated=False,
+            dry_run=True,
+            evidence_only=False,
+            no_prescan=False,
+            language=None,
+            branch=None,
+            scope=None,
+        )
+
+    with patch("quodeq.ci.review.subprocess.run", side_effect=[pr_result, repo_result]), \
+         patch("quodeq.cli_parser.build_parser") as mock_build_parser, \
+         patch("quodeq._cli_evaluation.run_evaluate", return_value=0):
+        mock_parser = MagicMock()
+        mock_parser.parse_args.side_effect = fake_parse_args
+        mock_build_parser.return_value = mock_parser
+
+        from quodeq.ci.review import handle_review
+        handle_review(args)
+
+    idx = captured_argv.index("--time-limit")
+    assert captured_argv[idx + 1] == "0"

--- a/tests/data/fs/test_runs.py
+++ b/tests/data/fs/test_runs.py
@@ -198,3 +198,29 @@ def test_list_runs_mixes_historical_and_in_progress(tmp_path: Path) -> None:
         "run-historical": "complete",
         "run-live": "in_progress",
     }
+
+
+def test_list_runs_accepts_status_json_without_manifest(tmp_path: Path) -> None:
+    """A run with status.json but no manifest is a real run.
+
+    Runs started without a prescan never write evidence/manifest.json, and a
+    failed manifest write is swallowed. The SQLite index (History) accepts any
+    run with a status.json, so the Overview's enumerator skipping the same run
+    made the two views disagree: visible in History, "No evaluations yet" in
+    the Overview (a 404 when the finished run was the pinned selection).
+    """
+    import json as _json
+    from quodeq.data.fs.report_parser.runs import list_runs
+
+    project_uuid = "proj-3"
+    run_dir = tmp_path / project_uuid / "run-nomanifest"
+    run_dir.mkdir(parents=True)
+    (run_dir / "status.json").write_text(
+        _json.dumps({"schema_version": 1, "state": "done", "job_id": "ext-x",
+                     "started_at": "2026-07-01T00:00:00+00:00", "dimensions": []}),
+        encoding="utf-8",
+    )
+
+    runs = list_runs(tmp_path, project_uuid)
+    assert [r.run_id for r in runs] == ["run-nomanifest"]
+    assert runs[0].status == "complete"

--- a/tests/engine/test_file_queue_rotation.py
+++ b/tests/engine/test_file_queue_rotation.py
@@ -75,3 +75,22 @@ class TestMaxFilesPerAgent:
         # Only 2 left in budget even though requesting 5
         batch2 = q.take(5, agent_id="agent-0")
         assert len(batch2) == 2
+
+
+class TestQueueCreatedAt:
+    def test_init_stamps_created_at_and_takes_preserve_it(self, tmp_path):
+        # scan_progress uses created_at as the dim-start clock; the file's
+        # mtime can't serve because every take rewrites the file.
+        import json
+        import time
+
+        queue_path = tmp_path / "queue.json"
+        before = time.time()
+        FileQueue(queue_path, ["a.py", "b.py"])
+        state = json.loads(queue_path.read_text(encoding="utf-8"))
+        assert before <= state["created_at"] <= time.time()
+
+        created = state["created_at"]
+        FileQueue(queue_path).take(1, agent_id="agent-0")
+        state = json.loads(queue_path.read_text(encoding="utf-8"))
+        assert state["created_at"] == created

--- a/tests/services/test_action_provider_fs_evaluations.py
+++ b/tests/services/test_action_provider_fs_evaluations.py
@@ -18,7 +18,7 @@ class StubJobs:
     def __init__(self):
         self.captured: dict = {}
 
-    def start_job(self, cmd, *, cwd=None, env=None, ai_provider=None, ai_model=None):
+    def start_job(self, cmd, *, cwd=None, env=None, ai_provider=None, ai_model=None, time_limit_s=None):
         self.captured["cmd"] = cmd
         self.captured["cwd"] = cwd
         self.captured["env"] = env

--- a/tests/services/test_action_provider_jobs.py
+++ b/tests/services/test_action_provider_jobs.py
@@ -128,7 +128,7 @@ def test_start_evaluation_forwards_provider_and_model(tmp_path: Path) -> None:
     captured: dict = {}
 
     class _SpyDispatcher:
-        def dispatch(self, cmd, *, cwd=None, env=None, ai_provider=None, ai_model=None):
+        def dispatch(self, cmd, *, cwd=None, env=None, ai_provider=None, ai_model=None, time_limit_s=None):
             captured["ai_provider"] = ai_provider
             captured["ai_model"] = ai_model
             return JobSnapshot(job_id="job-1", status="running")

--- a/tests/services/test_evaluation_mixin.py
+++ b/tests/services/test_evaluation_mixin.py
@@ -199,7 +199,15 @@ class TestSubprocessDispatcher:
         assert result == expected
         mock_mgr.start_job.assert_called_once_with(
             ["cmd"], cwd="/tmp", env={"A": "1"}, ai_provider=None, ai_model=None,
+            time_limit_s=None,
         )
+
+    def test_forwards_time_limit(self):
+        mock_mgr = MagicMock()
+        mock_mgr.start_job.return_value = JobSnapshot(job_id="j1", status="running")
+        dispatcher = SubprocessDispatcher(mock_mgr)
+        dispatcher.dispatch(["cmd"], time_limit_s=0)
+        assert mock_mgr.start_job.call_args.kwargs["time_limit_s"] == 0
 
 
 # ---------------------------------------------------------------------------
@@ -249,6 +257,15 @@ class TestStartEvaluation:
         opts = EvaluationOptions()
         snap = m.start_evaluation(str(tmp_path), str(tmp_path / "reports"), opts)
         assert snap.job_id == "j1"
+
+    @patch("quodeq.services.evaluation_mixin._register_project")
+    def test_start_passes_time_limit_to_dispatcher(self, mock_reg, tmp_path: Path):
+        # The job snapshot is the only channel through which the progress
+        # route and the UI can learn the run's budget.
+        m = self._setup_mixin()
+        opts = EvaluationOptions(time_limit=900)
+        m.start_evaluation(str(tmp_path), str(tmp_path / "reports"), opts)
+        assert m._dispatcher.dispatch.call_args.kwargs["time_limit_s"] == 900
 
     def test_nonexistent_local_path_raises(self):
         m = self._setup_mixin()
@@ -301,6 +318,23 @@ class TestCancelEvaluation:
         m._jobs.get_job.return_value = JobSnapshot(job_id="j1", status="running")
         result = m.cancel_evaluation("j1")
         assert result is True
+
+    def test_cancel_before_report_path_marker_does_not_raise(self):
+        # A job cancelled in its first seconds has no output_project /
+        # output_run_id yet (the report_path marker hasn't been parsed).
+        # Building the run_dir path with None segments raised TypeError and
+        # turned the cancel into an HTTP 500 after the process was already
+        # killed.
+        m = FsEvaluationMixin()
+        m._jobs = MagicMock()
+        m._jobs.cancel_job.return_value = True
+        m._jobs.get_job.return_value = JobSnapshot(job_id="j1", status="running")
+        with patch("quodeq.services.evaluation_mixin._score_completed_evidence") as mock_score, \
+             patch("quodeq.services.evaluation_mixin._wait_for_terminal_status") as mock_wait:
+            result = m.cancel_evaluation("j1", reports_dir="/reports")
+        assert result is True
+        mock_wait.assert_not_called()
+        mock_score.assert_not_called()
 
     def test_cancel_scores_external_jobs_via_get_evaluation_status(self):
         """External (ext-) cancels must still score completed dimensions.

--- a/tests/services/test_evaluation_mixin_register.py
+++ b/tests/services/test_evaluation_mixin_register.py
@@ -205,7 +205,7 @@ class _FakeDispatcher:
     def __init__(self):
         self.calls = []
 
-    def dispatch(self, cmd, *, cwd=None, env=None, ai_provider=None, ai_model=None):
+    def dispatch(self, cmd, *, cwd=None, env=None, ai_provider=None, ai_model=None, time_limit_s=None):
         self.calls.append(cmd)
         return {"id": "fake-job"}
 

--- a/tests/services/test_evaluations_index_dimensions.py
+++ b/tests/services/test_evaluations_index_dimensions.py
@@ -1,0 +1,68 @@
+"""Dimension recovery for index-served run snapshots.
+
+"All dimensions" runs record `dimensions: []` in status.json (the raw,
+unresolved CLI filter is None). The UI's live findings feed fetches per-dim
+evals from `job.dimensions`, so an empty list left the feed permanently blank
+and the finished-run strip showing VIOLATIONS 0 for every full scan served
+via the index. scan_progress already recovers the resolved list from the
+per-dim sidecars; the index snapshot path must do the same.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.services._evaluations_index import _read_dimensions_from_status
+
+
+def _write_status(run_dir: Path, dimensions: list[str]) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "status.json").write_text(
+        json.dumps({"schema_version": 1, "state": "running", "dimensions": dimensions}),
+        encoding="utf-8",
+    )
+
+
+class TestReadDimensionsFromStatus:
+    def test_explicit_dimensions_returned_as_is(self, tmp_path: Path) -> None:
+        _write_status(tmp_path, ["security"])
+        assert _read_dimensions_from_status(tmp_path) == ["security"]
+
+    def test_empty_dimensions_recovered_from_dimensions_json(self, tmp_path: Path) -> None:
+        _write_status(tmp_path, [])
+        (tmp_path / "dimensions.json").write_text(
+            json.dumps({
+                "schema_version": 1,
+                "dimensions": {"security": {"state": "done"}, "reliability": {"state": "running"}},
+            }),
+            encoding="utf-8",
+        )
+        assert _read_dimensions_from_status(tmp_path) == ["security", "reliability"]
+
+    def test_empty_dimensions_recovered_from_dim_estimates(self, tmp_path: Path) -> None:
+        _write_status(tmp_path, [])
+        (tmp_path / "dim_estimates.json").write_text(
+            json.dumps({"security": {"count": 10, "reason": "incremental"}}),
+            encoding="utf-8",
+        )
+        assert _read_dimensions_from_status(tmp_path) == ["security"]
+
+    def test_empty_dimensions_no_sidecars_stays_empty(self, tmp_path: Path) -> None:
+        _write_status(tmp_path, [])
+        assert _read_dimensions_from_status(tmp_path) == []
+
+
+class TestReadTimeLimitFromStatus:
+    def test_reads_time_limit(self, tmp_path: Path) -> None:
+        from quodeq.services._evaluations_index import _read_time_limit_from_status
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "status.json").write_text(
+            json.dumps({"schema_version": 1, "state": "running", "time_limit_s": 900}),
+            encoding="utf-8",
+        )
+        assert _read_time_limit_from_status(tmp_path) == 900
+
+    def test_missing_field_returns_none(self, tmp_path: Path) -> None:
+        from quodeq.services._evaluations_index import _read_time_limit_from_status
+        _write_status(tmp_path, [])
+        assert _read_time_limit_from_status(tmp_path) is None

--- a/tests/services/test_job_manager.py
+++ b/tests/services/test_job_manager.py
@@ -178,6 +178,54 @@ class TestGetAndListJobs:
         assert {j.job_id for j in jobs} == {"j1", "j2"}
 
 
+class TestDeleteJob:
+    # EvaluationsIndex.delete drops the run dir and index row, then calls
+    # JobManager.delete to remove the in-memory/persisted job entry. Before
+    # this method existed the hasattr-guarded call was a silent no-op, so a
+    # discarded run kept resurfacing in /api/evaluations for up to 24h from
+    # the persisted job store.
+    def test_delete_removes_terminal_job(self):
+        store = InMemoryJobStore()
+        store.put(Job("j1", "done", [], "now", "later", 0))
+        mgr = JobManager(job_store=store)
+        assert mgr.delete("j1") is True
+        assert mgr.get_job("j1") is None
+
+    def test_delete_refuses_running_job(self):
+        store = InMemoryJobStore()
+        store.put(Job("j1", "running", [], "now", None, None))
+        mgr = JobManager(job_store=store)
+        assert mgr.delete("j1") is False
+        assert mgr.get_job("j1") is not None
+
+    def test_delete_missing_job_returns_false(self):
+        mgr = JobManager(job_store=InMemoryJobStore())
+        assert mgr.delete("nope") is False
+
+
+class TestStartJobTimeLimit:
+    def test_time_limit_carried_into_snapshot(self):
+        # The progress route resolves the per-dim budget bar from the job
+        # snapshot; before this field existed it read a nonexistent
+        # `options` attribute and the budget was always None.
+        def bad_spawn(*args, **kwargs):
+            raise OSError("boom")
+
+        # Spawn-failure path avoids threads; time_limit_s is set before spawn
+        # so it must survive into the failure snapshot too.
+        mgr = JobManager(spawn_impl=bad_spawn, job_store=InMemoryJobStore())
+        snap = mgr.start_job(["cmd"], time_limit_s=600)
+        assert snap.time_limit_s == 600
+
+    def test_time_limit_zero_carried(self):
+        def bad_spawn(*args, **kwargs):
+            raise OSError("boom")
+
+        mgr = JobManager(spawn_impl=bad_spawn, job_store=InMemoryJobStore())
+        snap = mgr.start_job(["cmd"], time_limit_s=0)
+        assert snap.time_limit_s == 0
+
+
 # ---------------------------------------------------------------------------
 # _apply_marker
 # ---------------------------------------------------------------------------

--- a/tests/services/test_job_model.py
+++ b/tests/services/test_job_model.py
@@ -207,7 +207,7 @@ class TestSerialization:
             "job_id", "status", "command", "started_at", "ended_at",
             "exit_code", "logs", "output_project", "output_run_id",
             "phase", "deadline_at", "current_dimension", "dimensions",
-            "ai_provider", "ai_model",
+            "ai_provider", "ai_model", "time_limit_s",
         }
         assert set(data.keys()) == expected_keys
 

--- a/tests/services/test_scan_progress.py
+++ b/tests/services/test_scan_progress.py
@@ -326,3 +326,86 @@ class TestCoverageFields:
         dim = payload["dimensions"][0]
         assert dim["filesCached"] == 80
         assert dim["filesProjectTotal"] == 100
+
+
+class TestTotalElapsed:
+    def test_naive_started_at_does_not_raise(self, tmp_path: Path) -> None:
+        # Legacy/hand-written status.json can carry a naive timestamp.
+        # Subtracting it from an aware now() raised TypeError on every
+        # progress poll, turning the endpoint into a 500.
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"])
+        status = json.loads((run_dir / "status.json").read_text(encoding="utf-8"))
+        status["started_at"] = "2026-04-26T12:00:00"  # no tz offset
+        (run_dir / "status.json").write_text(json.dumps(status), encoding="utf-8")
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        assert progress.total_elapsed_s is not None
+        assert progress.total_elapsed_s >= 0.0
+
+
+class TestDimElapsed:
+    """Per-dim elapsed must come from queue timestamps, not file mtimes.
+
+    The queue file is atomically rewritten on every take (new inode, fresh
+    mtime), so an mtime-based start made the running clock reset toward zero
+    every few seconds. Done dims read 0:00 because the agent stream files
+    (the old end signal) are deleted when the dim completes.
+    """
+
+    def _write_queue(self, run_dir: Path, dim: str, payload: dict) -> None:
+        (run_dir / "evidence" / f"{dim}_queue.json").write_text(
+            json.dumps(payload), encoding="utf-8",
+        )
+
+    def test_running_dim_elapsed_from_created_at(self, tmp_path: Path) -> None:
+        import time as _t
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"])
+        now = _t.time()
+        self._write_queue(run_dir, "security", {
+            "created_at": now - 300,
+            "taken": [{"files": ["a.py"], "agent": "a1", "ts": now - 2}],
+            "pending": ["b.py"],
+        })
+        progress = build_scan_progress("j1", run_dir)
+        dim = progress.dimensions[0]
+        assert dim.state == "running"
+        # mtime of the just-written queue file is "now"; created_at is 5 min ago.
+        assert dim.elapsed_s is not None
+        assert 295 <= dim.elapsed_s <= 310
+
+    def test_done_dim_elapsed_from_take_log(self, tmp_path: Path) -> None:
+        import time as _t
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"], state="done")
+        now = _t.time()
+        self._write_queue(run_dir, "security", {
+            "created_at": now - 400,
+            "taken": [
+                {"files": ["a.py"], "agent": "a1", "ts": now - 350},
+                {"files": ["b.py"], "agent": "a1", "ts": now - 100},
+            ],
+            "pending": [],
+        })
+        progress = build_scan_progress("j1", run_dir)
+        dim = progress.dimensions[0]
+        assert dim.state == "done"
+        # end >= last take (now-100); start = created_at (now-400) -> >= 300s.
+        assert dim.elapsed_s is not None
+        assert dim.elapsed_s >= 300
+
+    def test_legacy_queue_without_created_at_uses_first_take(self, tmp_path: Path) -> None:
+        import time as _t
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"])
+        now = _t.time()
+        self._write_queue(run_dir, "security", {
+            "taken": [{"files": ["a.py"], "agent": "a1", "ts": now - 120}],
+            "pending": ["b.py"],
+        })
+        progress = build_scan_progress("j1", run_dir)
+        dim = progress.dimensions[0]
+        assert dim.elapsed_s is not None
+        assert 115 <= dim.elapsed_s <= 130

--- a/tests/shared/test_run_lifecycle_deadline.py
+++ b/tests/shared/test_run_lifecycle_deadline.py
@@ -27,3 +27,29 @@ def test_no_deadline_set_writes_none(tmp_path: Path) -> None:
         data = read_status(tmp_path)
         assert data is not None
         assert data.get("deadline_at") is None
+
+
+def test_set_time_limit_writes_to_status_json(tmp_path: Path) -> None:
+    with RunLifecycleContext(
+        run_dir=tmp_path,
+        job_id="j1",
+        dimensions=["a"],
+    ) as lifecycle:
+        lifecycle.set_time_limit(600)
+        data = read_status(tmp_path)
+        assert data is not None
+        assert data["time_limit_s"] == 600
+
+
+def test_set_time_limit_zero_preserved(tmp_path: Path) -> None:
+    # 0 = unlimited must survive verbatim so readers can distinguish
+    # "explicitly unlimited" from "unknown budget" (None).
+    with RunLifecycleContext(
+        run_dir=tmp_path,
+        job_id="j1",
+        dimensions=["a"],
+    ) as lifecycle:
+        lifecycle.set_time_limit(0)
+        data = read_status(tmp_path)
+        assert data is not None
+        assert data["time_limit_s"] == 0

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -10,7 +10,7 @@ src/quodeq/api/llm_bridge_routes.py:8:llm_bridge
 src/quodeq/data/fs/project_resolver.py:17:services
 src/quodeq/data/fs/repo_clone.py:19:context
 src/quodeq/data/fs/report_parser/runs.py:190:services
-src/quodeq/data/fs/report_parser/runs.py:211:services
+src/quodeq/data/fs/report_parser/runs.py:216:services
 src/quodeq/data/projection/grade_projector.py:132:services
 src/quodeq/data/projection/grade_projector.py:20:services
 src/quodeq/data/sqlite/state_store.py:272:services

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -20,7 +20,7 @@ src/quodeq/services/_violations_jsonl.py:12:analysis
 src/quodeq/services/_violations_stream.py:10:analysis
 src/quodeq/services/_violations_stream.py:11:analysis
 src/quodeq/services/evaluation_mixin.py:22:analysis
-src/quodeq/services/evaluation_mixin.py:522:analysis
+src/quodeq/services/evaluation_mixin.py:529:analysis
 src/quodeq/services/jobs.py:20:analysis
 src/quodeq/services/scan_progress.py:23:analysis
 src/quodeq/services/tooling_mixin.py:17:analysis


### PR DESCRIPTION
First batch of fixes from a full audit of the evaluation pipeline and the results UI. Every fix is test-driven; backend suite 5037 passed, UI suite 1328 passed.

## User-visible bugs fixed

**Overview says "No evaluations yet" while evaluations exist** (Jair's screenshot). Two causes:
- Any dashboard fetch failure (404/500/timeout) rendered as the empty state; the error banner below it was unreachable. Now errors render as errors, with a Retry action.
- The Overview's run enumerator (`list_runs`) skipped runs without `evidence/manifest.json`, while History's enumerator (SQLite index) accepts any run with a `status.json`. Runs without a prescan never write a manifest, so they showed in History and 404ed the Overview. The enumerators now agree.

**Per-dimension timer resets toward zero every few seconds** (the "times not in sync" report). The clock used the queue file's mtime as the dim start, but the queue is atomically rewritten on every take. Completed dims always showed 0:00 because the end signal (agent stream files) is deleted at dim completion. The queue now stamps `created_at` at init and the reader uses take-log timestamps.

**Countdown pinned at red 0:00 after a run finishes.** `job.phase` never turns terminal; the countdown now keys off status once the run ends. It also binds to the running job's own budget (new `timeLimitS` on the snapshot) instead of the active provider's localStorage, so changing Settings mid-run can't alter a running scan's countdown.

**Empty live findings feed for full scans.** "All dimensions" runs record `dimensions: []` in status.json; index-served snapshots now recover the resolved list from the run's sidecars (same fallback scan_progress uses).

**Explorer showed a fake clean report** (SCORE — / 0 violations) for a dimension whose report wasn't written yet (HTTP 202 waiting payload). Now renders "Report not ready". Dimension fetches also drop stale responses, so a slow earlier request can't park another run's findings under the current header.

**Cancel flow**: cancelling in the first seconds 500ed (run path built from None segments); any cancel failure silently dropped a still-running job from the UI, allowing a second concurrent scan. Now only 409/404 clear the job, errors carry HTTP status, and the cancel request timeout (45s) outlasts the ~33s server-side kill path.

## Correctness / plumbing

- `ci review --time-limit 0` (documented as unlimited) was swallowed by an `or 300` fallback, same falsy-drop bug as the dashboard's unlimited runs (#899).
- Report writes are atomic (tmp + rename). Readers poll `evaluation/<dim>.json` and treat a parse failure as a missing dimension, so a mid-write read silently dropped the dimension; a corrupt file also put the dashboard cache into a permanent re-read loop.
- `JobManager.delete` now exists; `EvaluationsIndex.delete` called it behind `hasattr` and it never did, so discarded runs kept resurfacing in `/api/evaluations` for 24h.
- Run budget (`time_limit_s`) is plumbed end to end: JobSnapshot/Job, status.json (0 = unlimited preserved), index snapshots, and the progress route, which previously read a nonexistent `snapshot.options` so the per-dim budget bar could never render.
- Progress endpoint no longer 500s on naive timestamps in legacy status.json.
- Live findings polling stops when the job turns terminal (was fetching every per-dim payload every 2s forever), with one final fetch on the running→terminal edge.

## Known issues documented for follow-up (docs/NOTES.md)

Server-restart handling (running jobs flip to failed while the subprocess lives on; the UI's 'lost' status is unreachable), consolidated-run progress (always 0%), SSE frame shape vs job cache, settings-vs-payload default mismatches (cloud provider defaults, per-dimension toggle, wizard time limit), severity-bucket logic duplicated in 7 places, visible-standards filter hiding custom-only runs, and clock unification. Several of these need product decisions before code.