### PR TITLE
fix: evaluation audit batch 2 — restart handling, consolidated progress, settings truthfulness, severity

### DIFF
--- a/src/quodeq/services/_evaluations_index.py
+++ b/src/quodeq/services/_evaluations_index.py
@@ -80,14 +80,29 @@ class EvaluationsIndex:
             internal_jobs = self._jobs.list_jobs(reports_root=None)
         except (AttributeError, TypeError):
             internal_jobs = []
+        # 'lost' internal jobs are restart placeholders whose subprocess may
+        # still be alive: they must not shadow the truthful ext- row derived
+        # from the run's own status.json, and when such a row exists the
+        # placeholder itself is dropped in its favor.
         covered = {
             (j.output_project, j.output_run_id) for j in internal_jobs
-            if j.output_project and j.output_run_id
+            if j.output_project and j.output_run_id and j.status != "lost"
         }
+        row_keys = {
+            (s.output_project, s.output_run_id) for s in snapshots
+            if s.output_project and s.output_run_id
+        }
+        visible_internal = [
+            j for j in internal_jobs
+            if not (
+                j.status == "lost"
+                and (j.output_project, j.output_run_id) in row_keys
+            )
+        ]
         merged = [
             s for s in snapshots
             if (s.output_project, s.output_run_id) not in covered
-        ] + list(internal_jobs)
+        ] + visible_internal
         if states:
             merged = [s for s in merged if s.status in states]
         merged.sort(key=lambda s: s.started_at or "", reverse=True)

--- a/src/quodeq/services/_job_model.py
+++ b/src/quodeq/services/_job_model.py
@@ -285,10 +285,16 @@ class FileJobStore:
             try:
                 data = json.loads(path.read_text(encoding="utf-8"))
                 job = _job_from_json(data)
-                # Jobs that were 'running' when we crashed are effectively failed.
+                # Jobs that were 'running' when the server went down lose
+                # their monitor thread, but the subprocess itself was
+                # spawned start_new_session=True and usually survives — the
+                # run may well still be alive and writing status.json. Mark
+                # the job 'lost' (tracking gone), NOT 'failed': the merged
+                # evaluations list then yields to the truthful ext- index
+                # row for the same run, which can still track and cancel it.
                 if job.status == "running":
-                    job.status = "failed"
-                    job.exit_code = -1
+                    job.status = "lost"
+                    job.exit_code = None
                     # Stamp an end time or _cleanup_stale (which only prunes
                     # jobs with ended_at) keeps the flipped job forever.
                     if not job.ended_at:

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -24,6 +24,7 @@ from quodeq.data.fs.repo_validation import validate_remote_url
 from quodeq.services._fs_clone import run_git_clone
 from quodeq.services._fs_scan import scan_project
 from quodeq.shared._env import get_clones_dir
+from quodeq.shared.provider_env import provider_env_exports
 from quodeq.shared.utils import get_ai_cmd, get_ai_model, is_repo_url, project_name_from_repo
 
 if TYPE_CHECKING:
@@ -340,6 +341,13 @@ class FsEvaluationMixin:
             built_env["QUODEQ_NO_CONSOLIDATE"] = "1"
         if options.context_size > 0:
             built_env["QUODEQ_CONTEXT_SIZE"] = str(options.context_size)
+        # Export user-entered API credentials under the env names the scan
+        # subprocess resolves them from (provider's api_key_env). Without
+        # this, a key typed in Settings for e.g. OpenRouter never reached
+        # the run and it failed with a missing-key error.
+        built_env.update(provider_env_exports(
+            options.ai_cmd, options.provider_api_key, options.provider_api_base,
+        ))
         if options.ai_cmd == "omlx":
             if options.provider_api_key:
                 built_env["OMLX_API_KEY"] = options.provider_api_key

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -200,6 +200,37 @@ def _dim_elapsed_s(dim_id: str, run_dir: Path, state: str) -> float | None:
     return max(0.0, end - start)
 
 
+def _consolidated_dim_progress(run_dir: Path, time_limit_s: int | None) -> _DimProgress:
+    """Progress row for a live consolidated (grouped) pass.
+
+    Evidence counters are the raw cross-dimension tally: suppression
+    netting is per-dimension and cannot be applied to the combined stream,
+    so the live numbers may slightly over-read what the finished reports
+    will show.
+    """
+    evidence_dir = run_dir / "evidence"
+    queue = _read_json(evidence_dir / "consolidated_queue.json") or {}
+    taken = 0
+    for entry in queue.get("taken") or []:
+        fs = entry.get("files") if isinstance(entry, dict) else None
+        if isinstance(fs, list):
+            taken += len(fs)
+    pending = len(queue.get("pending") or [])
+    tally = tally_unique_findings(evidence_dir / "consolidated_evidence.jsonl")
+    budget = time_limit_s if (time_limit_s and time_limit_s > 0) else None
+    return _DimProgress(
+        id="consolidated",
+        state="running",
+        files={"taken": taken, "total": taken + pending},
+        violations=tally.violations,
+        compliance=tally.compliance,
+        duplicates=tally.duplicates,
+        elapsed_s=_dim_elapsed_s("consolidated", run_dir, "running"),
+        budget_s=budget,
+        active_agents=_active_agents(evidence_dir, "consolidated"),
+    )
+
+
 def build_scan_progress(
     job_id: str,
     run_dir: Path,
@@ -263,6 +294,29 @@ def build_scan_progress(
         dim_ids = list(recovered)
     evidence_dir = run_dir / "evidence"
     evaluators_dir = default_paths().evaluators_dir
+
+    # Consolidated (grouped) runs dispatch every dimension in one pass and
+    # write consolidated_* files — there are no per-dim queues, so the
+    # per-dim reader below would report 0% / "estimating…" for the whole
+    # run. While such a run is live, report the consolidated pass as one
+    # row with the real file counts. Once the run is terminal the per-dim
+    # evaluation files exist and normal per-dim classification applies.
+    consolidated_queue = evidence_dir / "consolidated_queue.json"
+    if (
+        not is_terminal
+        and consolidated_queue.is_file()
+        and not any((evidence_dir / f"{d}_queue.json").is_file() for d in dim_ids)
+    ):
+        return _ScanProgress(
+            job_id=job_id,
+            state=state,
+            phase=status.get("phase"),
+            current_dimension=status.get("current_dimension"),
+            project_files=project_files,
+            total_elapsed_s=total_elapsed_s,
+            dimensions=[_consolidated_dim_progress(run_dir, time_limit_s)],
+        )
+
     # The scanner re-finds everything the user has dismissed or deleted, so a
     # raw evidence tally can run several times the number the finished report
     # shows. Read the suppression stores once per tick and net them out here,

--- a/src/quodeq/services/violations.py
+++ b/src/quodeq/services/violations.py
@@ -222,7 +222,9 @@ def aggregate_violations(dashboard: dict[str, Any]) -> ViolationSummary:
         severity = dim.get("totals", {}).get("severity", {})
         critical += severity.get("critical", 0)
         major += severity.get("major", 0)
-        minor += severity.get("minor", 0)
+        # The summary exposes three buckets; fold build_totals' 'unknown'
+        # into minor so critical+major+minor always equals the total.
+        minor += severity.get("minor", 0) + severity.get("unknown", 0)
         for violation in dim.get("violations", []) or []:
             file_path = violation.get("file")
             if not file_path:
@@ -231,9 +233,8 @@ def aggregate_violations(dashboard: dict[str, Any]) -> ViolationSummary:
                 file_path, {"path": file_path, "count": 0, "critical": 0, "major": 0, "minor": 0}
             )
             entry["count"] += 1
-            sev = violation.get("severity", "minor")
-            if sev in entry:
-                entry[sev] += 1
+            sev = violation.get("severity") or "minor"
+            entry[sev if sev in ("critical", "major") else "minor"] += 1
     # _max_violation_files() reads from env at call time; the env injection
     # parameter exists for unit-testing _max_violation_files directly.
     top_files = sorted(

--- a/src/quodeq/shared/provider_env.py
+++ b/src/quodeq/shared/provider_env.py
@@ -1,0 +1,55 @@
+"""Resolve provider API-credential env exports from ai_providers.json.
+
+The scan subprocess reads a cloud provider's API key from the env var named
+by the provider's ``api_key_env`` (see analysis/subprocess). This helper
+maps user-entered credentials (Settings -> EvaluationOptions) onto those
+env names so the service layer can export them without importing from the
+analysis layer.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+_DEFAULT_PATH = Path(__file__).resolve().parent.parent / "data" / "config" / "ai_providers.json"
+
+
+def _providers_path() -> Path:
+    return Path(os.environ.get("QUODEQ_AI_PROVIDERS_PATH", str(_DEFAULT_PATH)))
+
+
+def provider_env_exports(
+    provider_id: str | None,
+    api_key: str | None,
+    api_base: str | None,
+) -> dict[str, str]:
+    """Return env vars carrying user-entered credentials for *provider_id*.
+
+    The API key is exported under the provider's ``api_key_env``. A base URL
+    is only exported when the provider's configured ``api_base`` is an env
+    template (``${VAR}``, e.g. the ``custom`` provider) — fixed endpoints
+    are not overridable per-run.
+    """
+    if not provider_id:
+        return {}
+    try:
+        configs = json.loads(_providers_path().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return {}
+    cfg = configs.get(provider_id)
+    if not isinstance(cfg, dict):
+        return {}
+    exports: dict[str, str] = {}
+    key_env = cfg.get("api_key_env")
+    if api_key and isinstance(key_env, str) and key_env:
+        exports[key_env] = api_key
+    base_template = cfg.get("api_base", "")
+    if (
+        api_base
+        and isinstance(base_template, str)
+        and base_template.startswith("${")
+        and base_template.endswith("}")
+    ):
+        exports[base_template[2:-1]] = api_base
+    return exports

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -360,7 +360,8 @@ export function buildWizardHandlers({ state, setWizardEntry, navTab }) {
       if (branch) payload.branch = branch;
       if (provider?.id) payload.aiCmd = provider.id;
       if (provider?.model) payload.aiModel = provider.model;
-      if (totalTimeLimitS) payload.timeLimit = totalTimeLimitS;
+      // != null keeps an explicit 0 ("Unlimited") — 0 is falsy but meaningful.
+      if (totalTimeLimitS != null) payload.timeLimit = totalTimeLimitS;
       state.evalLifecycle.handleStartEvaluation(payload);
       navTab('evaluate');
     },

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -2,7 +2,8 @@ import { useState, useEffect } from 'react';
 import EvaluationStatus from './EvaluationStatus.jsx';
 import ReEvaluateCard from './ReEvaluateCard.jsx';
 import CountdownTimer from './CountdownTimer.jsx';
-import { ACTIVE_PROVIDER_KEY, DEFAULT_TIME_LIMIT_S, LOCAL_API_PROVIDERS, providerKey } from '../../../constants.js';
+import { ACTIVE_PROVIDER_KEY, providerKey } from '../../../constants.js';
+import { resolveProviderSettings } from '../../../utils/effectiveProviderSettings.js';
 import { TermHeader } from '../../../components/terminal/index.js';
 
 const TOAST_DISMISS_TIMEOUT_MS = 5000;
@@ -36,14 +37,9 @@ function ActiveProviderBadge({ storage = localStorage, onClick }) {
 export function readBudgetSeconds(storage = localStorage) {
   const provider = storage.getItem(ACTIVE_PROVIDER_KEY) || '';
   if (!provider) return 0;
-  // Read new key first; fall back to legacy 'pool-budget' for back-compat.
-  const raw = storage.getItem(providerKey(provider, 'time-limit'))
-    ?? storage.getItem(providerKey(provider, 'pool-budget'));
-  // Same unset-key defaults the start payload uses (see preparePayload in
-  // useEvaluation.js) so the header can never claim a limit the run won't get.
-  if (raw === null || raw === undefined) return LOCAL_API_PROVIDERS.has(provider) ? 0 : DEFAULT_TIME_LIMIT_S;
-  const parsed = parseInt(raw, 10);
-  return Number.isFinite(parsed) ? parsed : 0;
+  // Same resolution the start payload and the Settings screen use, so the
+  // header can never claim a limit the run won't get.
+  return resolveProviderSettings(provider, storage).timeLimitS;
 }
 
 const TERMINAL_STATUSES = new Set(['done', 'failed', 'cancelled', 'lost', 'completed']);

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.test.jsx
@@ -11,6 +11,7 @@ vi.mock('../../../components/terminal/index.js', () => ({
 vi.mock('../../../constants.js', () => ({
   ACTIVE_PROVIDER_KEY: 'active-provider',
   DEFAULT_TIME_LIMIT_S: 3600,
+  DEFAULT_MAX_SUBAGENTS: 5,
   LOCAL_API_PROVIDERS: new Set(['ollama', 'llamacpp', 'omlx']),
   providerKey: (p, k) => `${p}-${k}`,
 }));

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreenCountdown.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreenCountdown.test.jsx
@@ -15,6 +15,7 @@ vi.mock('../../../components/terminal/index.js', () => ({ TermHeader: () => null
 vi.mock('../../../constants.js', () => ({
   ACTIVE_PROVIDER_KEY: 'active-provider',
   DEFAULT_TIME_LIMIT_S: 3600,
+  DEFAULT_MAX_SUBAGENTS: 5,
   LOCAL_API_PROVIDERS: new Set(['ollama', 'llamacpp', 'omlx']),
   providerKey: (p, k) => `${p}-${k}`,
 }));

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -30,10 +30,9 @@ import { evaluationKeys, projectKeys } from "../../../api/queryKeys.js";
 import {
   ACTIVE_PROVIDER_KEY,
   providerKey,
-  DEFAULT_MAX_SUBAGENTS,
-  DEFAULT_TIME_LIMIT_S,
   LOCAL_API_PROVIDERS,
 } from "../../../constants.js";
+import { resolveProviderSettings } from "../../../utils/effectiveProviderSettings.js";
 
 const SSE_ENABLED = import.meta.env?.VITE_USE_SSE_EVENTS === "true";
 const JOB_POLL_MS = 1500;
@@ -51,42 +50,39 @@ export function findingsRefetchInterval(job, sseEnabled = SSE_ENABLED) {
   if (job?.status && job.status !== "running") return false;
   return DIM_POLL_MS;
 }
-const DEFAULT_OLLAMA_SUBAGENTS = "1";
-const DEFAULT_CLI_SUBAGENTS = String(DEFAULT_MAX_SUBAGENTS);
-const DEFAULT_OLLAMA_BUDGET = "0";
-const DEFAULT_CLI_BUDGET = String(DEFAULT_TIME_LIMIT_S);
 // Re-exported for the existing importers; the set itself lives in constants.js
 // so the Evaluate header resolves unset limits exactly like the start payload.
 export { LOCAL_API_PROVIDERS };
 
 /**
  * Merge per-provider Settings (provider, model, subagents, budget, etc.)
- * from localStorage into the start-evaluation payload. Mirrors the legacy
- * useEvaluation behavior; throws a user-facing error if no provider/model
- * is configured.
+ * from localStorage into the start-evaluation payload.
+ *
+ * Caller-provided values win: a wizard launch names its provider/model and
+ * time limit explicitly, and those must not be silently overwritten by the
+ * active tab's Settings (the wizard's TIME LIMIT field used to be dead
+ * code because of exactly that). Per-provider settings are read from the
+ * payload's provider when one is named. Unset keys resolve through
+ * resolveProviderSettings — the same source of truth the Settings screen
+ * and the Evaluate header display. Throws a user-facing error if no
+ * provider/model is configured.
  */
 function preparePayload(payload, storage = localStorage) {
-  const activeProvider = storage.getItem(ACTIVE_PROVIDER_KEY) || "";
-  if (!activeProvider) throw new Error("No provider selected. Go to Settings to configure one.");
-  const get = (key) => storage.getItem(providerKey(activeProvider, key));
-  const model = get("model");
+  const provider = payload.aiCmd || storage.getItem(ACTIVE_PROVIDER_KEY) || "";
+  if (!provider) throw new Error("No provider selected. Go to Settings to configure one.");
+  const get = (key) => storage.getItem(providerKey(provider, key));
+  const model = payload.aiModel || get("model");
   if (!model) throw new Error("No model selected. Go to Settings and select one.");
-  const isLocalApi = LOCAL_API_PROVIDERS.has(activeProvider);
-  const subagents = parseInt(get("subagents") || (isLocalApi ? DEFAULT_OLLAMA_SUBAGENTS : DEFAULT_CLI_SUBAGENTS), 10);
-  // Read new key first; fall back to legacy 'pool-budget' for back-compat.
-  const timeLimit = parseInt(
-    get("time-limit") || get("pool-budget") || (isLocalApi ? DEFAULT_OLLAMA_BUDGET : DEFAULT_CLI_BUDGET),
-    10,
-  );
+  const settings = resolveProviderSettings(provider, storage);
   const result = {
     ...payload,
-    aiCmd: activeProvider,
+    aiCmd: provider,
     aiModel: model,
-    maxSubagents: subagents,
-    timeLimit,
+    maxSubagents: settings.subagents,
+    timeLimit: payload.timeLimit ?? settings.timeLimitS,
   };
-  if (get("per-dimension") === "true") result.perDimension = true;
-  if (get("verify") === "false") result.verifyFindings = false;
+  if (settings.perDimension) result.perDimension = true;
+  if (!settings.verify) result.verifyFindings = false;
   const apiKey = get("api-key");
   if (apiKey) result.apiKey = apiKey;
   const apiBase = get("api-base");

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
@@ -383,3 +383,34 @@ describe("cancel failure handling", () => {
     await waitFor(() => expect(result.current.job).toBeNull());
   });
 });
+
+describe("preparePayload honors caller-provided values", () => {
+  it("keeps an explicit timeLimit (including 0) instead of overwriting from Settings", async () => {
+    // The wizard shows a TIME LIMIT field; its value used to be dead code
+    // because the payload merge unconditionally re-read localStorage.
+    localStorage.setItem("cc-ollama-time-limit", "600");
+    fakeApi.startEvaluation.mockResolvedValue({ jobId: "j-w", status: "pending", dimensions: [] });
+    const { result } = renderHook(() => useEvaluation(), { wrapper: makeWrapper() });
+    await act(async () => {
+      await result.current.startEvaluation({ repo: "x", dimensions: [], timeLimit: 0 });
+    });
+    expect(fakeApi.startEvaluation).toHaveBeenCalledWith(
+      expect.objectContaining({ timeLimit: 0 }),
+    );
+  });
+
+  it("uses the caller's provider and reads that provider's settings", async () => {
+    // Wizard-launched runs name their provider; per-provider settings must
+    // come from that provider's keys, not the active tab's.
+    localStorage.setItem("cc-claude-model", "sonnet");
+    localStorage.setItem("cc-claude-time-limit", "1200");
+    fakeApi.startEvaluation.mockResolvedValue({ jobId: "j-w2", status: "pending", dimensions: [] });
+    const { result } = renderHook(() => useEvaluation(), { wrapper: makeWrapper() });
+    await act(async () => {
+      await result.current.startEvaluation({ repo: "x", dimensions: [], aiCmd: "claude" });
+    });
+    expect(fakeApi.startEvaluation).toHaveBeenCalledWith(
+      expect.objectContaining({ aiCmd: "claude", aiModel: "sonnet", timeLimit: 1200 }),
+    );
+  });
+});

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -17,6 +17,7 @@ import PrinciplesRadial from './PrinciplesRadial.jsx';
 import PrinciplesCardsRow from './PrinciplesCardsRow.jsx';
 import DimensionScoreHistoryPanel from './DimensionScoreHistoryPanel.jsx';
 import StatGrid2x2 from './StatGrid2x2.jsx';
+import { countBySeverity } from '../../../utils/severity.js';
 
 function buildRadialPrinciples(principleGrades) {
   return (principleGrades || []).map((pg) => {
@@ -43,11 +44,7 @@ function buildEnrichedPrinciples(principleGrades, allViolations, complianceByPri
   }
   return (principleGrades || []).map((pg) => {
     const vs = violationsByPrinciple.get(pg.principle) || [];
-    const severity = { critical: 0, major: 0, minor: 0 };
-    for (const v of vs) {
-      const s = (v.severity || 'minor').toLowerCase();
-      if (severity[s] !== undefined) severity[s]++;
-    }
+    const severity = countBySeverity(vs);
     const compliance = complianceByPrinciple?.get?.(pg.principle) || [];
     return {
       ...pg,

--- a/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.js
+++ b/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useApi } from '../../../api/ApiContext.jsx';
 import { buildTopOffendingFiles } from '../../../utils/explorerUtils.js';
+import { countBySeverity } from '../../../utils/severity.js';
 
 export function computeAllViolations(evalData) {
   if (!evalData) return [];
@@ -17,12 +18,7 @@ export function computeAllViolations(evalData) {
 }
 
 export function computeSeverityCounts(allViolations) {
-  const counts = { critical: 0, major: 0, minor: 0 };
-  allViolations.forEach((v) => {
-    const s = (v.severity || 'minor').toLowerCase();
-    if (counts[s] !== undefined) counts[s]++;
-  });
-  return counts;
+  return countBySeverity(allViolations);
 }
 
 function computeComplianceByPrinciple(evalData) {

--- a/src/quodeq/ui/src/features/settings/components/LlamaCppTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/LlamaCppTab.jsx
@@ -16,6 +16,16 @@ const LLAMACPP_MODEL_HINT = (
   </>
 );
 
+
+// Local-API tabs default to a single subagent; clamp commits to [MIN, MAX]
+// so an empty/garbage entry can't persist to storage.
+const LOCAL_DEFAULT_SUBAGENTS = '1';
+function clampSubagents(raw) {
+  const n = parseInt(raw, 10);
+  if (Number.isNaN(n)) return LOCAL_DEFAULT_SUBAGENTS;
+  return String(Math.max(MIN_SUBAGENTS, Math.min(MAX_SUBAGENTS, n)));
+}
+
 function LoadedModel({ models }) {
   if (!models.length) {
     return <span className="settings-model-hint">No model loaded yet. Start llama-server with a GGUF file.</span>;
@@ -118,7 +128,7 @@ export default function LlamaCppTab({ state, update }) {
               <span className="settings-description">Estimated from your VRAM. Run a quick test for a more accurate number.</span>
             </div>
             <div className="settings-budget-control">
-              <input type="number" aria-label="Max parallel agents" className="settings-model-input" min={MIN_SUBAGENTS} max={MAX_SUBAGENTS} value={state.subagents} onChange={(e) => update('subagents', e.target.value)} />
+              <input type="number" aria-label="Max parallel agents" className="settings-model-input" min={MIN_SUBAGENTS} max={MAX_SUBAGENTS} value={state.subagents} onChange={(e) => update('subagents', e.target.value)} onBlur={(e) => { if (e.target.value !== '') update('subagents', clampSubagents(e.target.value)); }} />
               <button type="button" className="settings-action-btn" onClick={runTest} disabled={testing || !models.length}>
                 {testing ? 'Testing...' : 'Auto-detect'}
               </button>

--- a/src/quodeq/ui/src/features/settings/components/OllamaTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/OllamaTab.jsx
@@ -15,6 +15,16 @@ const OLLAMA_MODEL_HINT = (
   </>
 );
 
+
+// Local-API tabs default to a single subagent; clamp commits to [MIN, MAX]
+// so an empty/garbage entry can't persist to storage.
+const LOCAL_DEFAULT_SUBAGENTS = '1';
+function clampSubagents(raw) {
+  const n = parseInt(raw, 10);
+  if (Number.isNaN(n)) return LOCAL_DEFAULT_SUBAGENTS;
+  return String(Math.max(MIN_SUBAGENTS, Math.min(MAX_SUBAGENTS, n)));
+}
+
 function ModelSelector({ value, models, onChange }) {
   const needsModel = !value;
   return (
@@ -106,7 +116,7 @@ export default function OllamaTab({ state, update }) {
               <span className="settings-description">We make a guess based on your VRAM. Run a quick test for a more accurate number.</span>
             </div>
             <div className="settings-budget-control">
-              <input type="number" className="settings-model-input" min={MIN_SUBAGENTS} max={MAX_SUBAGENTS} value={state.subagents} onChange={(e) => update('subagents', e.target.value)} />
+              <input type="number" className="settings-model-input" min={MIN_SUBAGENTS} max={MAX_SUBAGENTS} value={state.subagents} onChange={(e) => update('subagents', e.target.value)} onBlur={(e) => { if (e.target.value !== '') update('subagents', clampSubagents(e.target.value)); }} />
               <button type="button" className="settings-action-btn" onClick={runTest} disabled={testing || !state.model}>
                 {testing ? 'Testing...' : 'Auto-detect'}
               </button>

--- a/src/quodeq/ui/src/features/settings/components/OmlxTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/OmlxTab.jsx
@@ -14,6 +14,16 @@ const OMLX_MODEL_HINT = (
   </>
 );
 
+
+// Local-API tabs default to a single subagent; clamp commits to [MIN, MAX]
+// so an empty/garbage entry can't persist to storage.
+const LOCAL_DEFAULT_SUBAGENTS = '1';
+function clampSubagents(raw) {
+  const n = parseInt(raw, 10);
+  if (Number.isNaN(n)) return LOCAL_DEFAULT_SUBAGENTS;
+  return String(Math.max(MIN_SUBAGENTS, Math.min(MAX_SUBAGENTS, n)));
+}
+
 function ModelSelector({ value, models, onChange }) {
   const needsModel = !value;
   const hasModels = models.length > 0;
@@ -164,6 +174,7 @@ export default function OmlxTab({ state, update }) {
                 max={MAX_SUBAGENTS}
                 value={state.subagents}
                 onChange={(e) => update('subagents', e.target.value)}
+                onBlur={(e) => { if (e.target.value !== '') update('subagents', clampSubagents(e.target.value)); }}
               />
               <button
                 type="button"

--- a/src/quodeq/ui/src/features/settings/components/ProviderTabs.defaults.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ProviderTabs.defaults.test.jsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { defaultsForProvider } from './ProviderTabs.jsx';
+
+// Truth-in-display: the Settings tab must show the values a run would
+// actually use. Cloud providers without a bespoke entry used to fall back
+// to the generic hook defaults (1 subagent / Unlimited) while the start
+// payload ran them with 5 / 600s.
+describe('defaultsForProvider', () => {
+  it('cli providers: concurrent subagents with the 10-minute cap', () => {
+    expect(defaultsForProvider('cli', 'claude')).toMatchObject({
+      subagents: '5',
+      'time-limit': '600',
+    });
+  });
+
+  it('generic cloud providers get the same effective defaults as the payload', () => {
+    expect(defaultsForProvider('cloud-api', 'some-new-cloud')).toMatchObject({
+      subagents: '5',
+      'time-limit': '600',
+    });
+  });
+
+  it('openrouter keeps its bespoke model default on top of the cloud fallback', () => {
+    const d = defaultsForProvider('cloud-api', 'openrouter');
+    expect(d).toMatchObject({ subagents: '5', 'time-limit': '600' });
+    expect(d.model).toBeTruthy();
+  });
+
+  it('local-api providers stay at unlimited', () => {
+    for (const id of ['ollama', 'llamacpp', 'omlx']) {
+      expect(defaultsForProvider('local-api', id)).toMatchObject({ 'time-limit': '0' });
+    }
+  });
+});

--- a/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
@@ -41,10 +41,28 @@ const CLI_DEFAULTS = { 'subagents': String(DEFAULT_MAX_SUBAGENTS), 'time-limit':
 const OLLAMA_DEFAULTS = { 'time-limit': '0' };
 const LLAMACPP_DEFAULTS = { 'time-limit': '0' };
 const OMLX_DEFAULTS = { 'time-limit': '0' };
+// Every cloud provider runs with the CLI-style effective defaults
+// (5 subagents / 600s — see resolveProviderSettings); the tab must display
+// them for unset keys or Settings claims values the run won't use.
+const CLOUD_FALLBACK_DEFAULTS = { 'subagents': String(DEFAULT_MAX_SUBAGENTS), 'time-limit': String(DEFAULT_TIME_LIMIT_S) };
 const CLOUD_DEFAULTS_BY_ID = {
-  openrouter: { 'time-limit': String(DEFAULT_TIME_LIMIT_S), 'model': 'baidu/cobuddy:free' },
+  openrouter: { 'model': 'baidu/cobuddy:free' },
 };
 const DEFAULT_PROVIDER_ORDER = 50;
+
+/**
+ * Display defaults for a provider tab: what an unset key effectively runs
+ * with. Exported so tests can pin display == payload.
+ */
+export function defaultsForProvider(classification, providerId) {
+  if (classification === 'cli') return CLI_DEFAULTS;
+  if (classification === 'local-api') {
+    if (providerId === 'llamacpp') return LLAMACPP_DEFAULTS;
+    if (providerId === 'omlx') return OMLX_DEFAULTS;
+    return OLLAMA_DEFAULTS;
+  }
+  return { ...CLOUD_FALLBACK_DEFAULTS, ...(CLOUD_DEFAULTS_BY_ID[providerId] || {}) };
+}
 
 const MIGRATION_DONE_KEY = 'cc-provider-tabs-migrated';
 const LEGACY_AI_CMD_KEY = 'cc-ai-cmd';
@@ -59,16 +77,7 @@ const LEGACY_SETTING_MIGRATIONS = {
 
 function TabContent({ provider, providerConfig }) {
   const classification = classifyProvider(provider.id, provider.type, providerConfig);
-  const localApiDefaults = provider.id === 'llamacpp'
-    ? LLAMACPP_DEFAULTS
-    : provider.id === 'omlx'
-      ? OMLX_DEFAULTS
-      : OLLAMA_DEFAULTS;
-  const defaults = classification === 'cli'
-    ? CLI_DEFAULTS
-    : classification === 'local-api'
-      ? localApiDefaults
-      : CLOUD_DEFAULTS_BY_ID[provider.id];
+  const defaults = defaultsForProvider(classification, provider.id);
   const { state, update } = useProviderSettings(provider.id, defaults);
 
   if (classification === 'local-api') {

--- a/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.js
+++ b/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.js
@@ -10,7 +10,9 @@ const DEFAULTS = {
   'model-thorough': '',
   'subagents': '1',
   'time-limit': '0',
-  'per-dimension': 'true',
+  // Grouped is the engine's actual default; the pill must not claim
+  // per-dimension for an untouched toggle.
+  'per-dimension': 'false',
   'verify': 'true',
   'api-key': '',
   'api-base': '',

--- a/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.test.jsx
+++ b/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.test.jsx
@@ -84,3 +84,19 @@ describe('useProviderSettings', () => {
     warnSpy.mockRestore();
   });
 });
+
+describe('useProviderSettings effective defaults', () => {
+  it('unset per-dimension displays Grouped (the mode a run actually uses)', () => {
+    const mockStorage = {
+      getItem: vi.fn().mockReturnValue(null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+    const { result } = renderHook(() =>
+      useProviderSettings('claude', {}, { storage: mockStorage })
+    );
+    // The engine defaults to one grouped/consolidated pass; a highlighted
+    // "Per-dimension" pill for an untouched toggle was a lie.
+    expect(result.current.state['per-dimension']).toBe('false');
+  });
+});

--- a/src/quodeq/ui/src/utils/effectiveProviderSettings.js
+++ b/src/quodeq/ui/src/utils/effectiveProviderSettings.js
@@ -1,0 +1,67 @@
+/**
+ * Single source of truth for a provider's *effective* evaluation settings.
+ *
+ * Settings only persists a key once the user edits it, so every reader of an
+ * unset key must resolve the same default — otherwise the Settings screen,
+ * the Evaluate header, and the start payload each tell a different story
+ * (e.g. Settings showed "1 subagent / Unlimited" for a cloud provider while
+ * the run used 5 / 600s). Both the display and the payload resolve through
+ * this module.
+ */
+import {
+  DEFAULT_MAX_SUBAGENTS,
+  DEFAULT_TIME_LIMIT_S,
+  LOCAL_API_PROVIDERS,
+  providerKey,
+} from '../constants.js';
+
+/**
+ * Effective defaults for a provider when no key was ever written.
+ * Local-API providers run one model on the user's own hardware: a single
+ * subagent and no time limit. Everything else (CLI + cloud) gets the
+ * concurrent default with the 10-minute cap.
+ */
+export function effectiveProviderDefaults(providerId) {
+  const isLocalApi = LOCAL_API_PROVIDERS.has(providerId);
+  return {
+    subagents: isLocalApi ? 1 : DEFAULT_MAX_SUBAGENTS,
+    timeLimitS: isLocalApi ? 0 : DEFAULT_TIME_LIMIT_S,
+    // The scan engine defaults to one grouped (consolidated) pass; the
+    // display must say so instead of claiming per-dimension.
+    perDimension: false,
+    verify: true,
+  };
+}
+
+function readInt(storage, providerId, key) {
+  const raw = storage.getItem(providerKey(providerId, key));
+  if (raw === null || raw === undefined) return null;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Resolve the settings an evaluation for *providerId* would actually run
+ * with: stored values (including an explicit 0 = unlimited) win, anything
+ * unset or corrupt falls back to the effective defaults.
+ */
+export function resolveProviderSettings(providerId, storage = localStorage) {
+  const defaults = effectiveProviderDefaults(providerId);
+  const get = (key) => storage.getItem(providerKey(providerId, key));
+  const subagents = readInt(storage, providerId, 'subagents');
+  // Read the new key first; fall back to the legacy 'pool-budget' key.
+  const timeLimitS = readInt(storage, providerId, 'time-limit')
+    ?? readInt(storage, providerId, 'pool-budget');
+  const perDimensionRaw = get('per-dimension');
+  const verifyRaw = get('verify');
+  return {
+    subagents: subagents ?? defaults.subagents,
+    timeLimitS: timeLimitS ?? defaults.timeLimitS,
+    perDimension: perDimensionRaw === null || perDimensionRaw === undefined
+      ? defaults.perDimension
+      : perDimensionRaw === 'true',
+    verify: verifyRaw === null || verifyRaw === undefined
+      ? defaults.verify
+      : verifyRaw !== 'false',
+  };
+}

--- a/src/quodeq/ui/src/utils/effectiveProviderSettings.test.js
+++ b/src/quodeq/ui/src/utils/effectiveProviderSettings.test.js
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveProviderSettings, effectiveProviderDefaults } from './effectiveProviderSettings.js';
+
+const storage = (entries) => ({ getItem: (key) => (key in entries ? entries[key] : null) });
+
+test('defaults: local-API providers get 1 subagent / unlimited, others 5 / 600', () => {
+  for (const p of ['ollama', 'llamacpp', 'omlx']) {
+    assert.deepEqual(
+      effectiveProviderDefaults(p),
+      { subagents: 1, timeLimitS: 0, perDimension: false, verify: true },
+    );
+  }
+  for (const p of ['claude', 'codex', 'gemini', 'openrouter', 'some-new-cloud']) {
+    assert.deepEqual(
+      effectiveProviderDefaults(p),
+      { subagents: 5, timeLimitS: 600, perDimension: false, verify: true },
+    );
+  }
+});
+
+test('stored values win, including explicit unlimited (0)', () => {
+  const s = storage({
+    'cc-claude-subagents': '3',
+    'cc-claude-time-limit': '0',
+    'cc-claude-per-dimension': 'true',
+    'cc-claude-verify': 'false',
+  });
+  assert.deepEqual(
+    resolveProviderSettings('claude', s),
+    { subagents: 3, timeLimitS: 0, perDimension: true, verify: false },
+  );
+});
+
+test('unset keys resolve to the effective defaults', () => {
+  assert.deepEqual(
+    resolveProviderSettings('claude', storage({})),
+    { subagents: 5, timeLimitS: 600, perDimension: false, verify: true },
+  );
+  assert.deepEqual(
+    resolveProviderSettings('ollama', storage({})),
+    { subagents: 1, timeLimitS: 0, perDimension: false, verify: true },
+  );
+});
+
+test('corrupt numeric values fall back to defaults instead of NaN', () => {
+  const s = storage({ 'cc-claude-subagents': 'abc', 'cc-claude-time-limit': '' });
+  assert.deepEqual(
+    resolveProviderSettings('claude', s),
+    { subagents: 5, timeLimitS: 600, perDimension: false, verify: true },
+  );
+});
+
+test('legacy pool-budget key is honored when time-limit is unset', () => {
+  const s = storage({ 'cc-claude-pool-budget': '1200' });
+  assert.equal(resolveProviderSettings('claude', s).timeLimitS, 1200);
+});

--- a/src/quodeq/ui/src/utils/planBuilder.js
+++ b/src/quodeq/ui/src/utils/planBuilder.js
@@ -7,6 +7,7 @@ import {
   FIX_HINTS,
 } from './planConstants.js';
 import { KNOWN_SEVERITIES } from './constants.js';
+import { normalizeSeverity } from './severity.js';
 
 const PLAN_SNIPPET_MAX_LINES = 5;
 
@@ -62,10 +63,7 @@ export function getFixHint(req) {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function normalizeSeverity(value) {
-  const normalized = String(value || 'unknown').toLowerCase();
-  return KNOWN_SEVERITIES.includes(normalized) ? normalized : 'unknown';
-}
+
 
 /** Collect unique files touched by violations. */
 function collectAffectedFiles(violations) {

--- a/src/quodeq/ui/src/utils/scoreFiltering.js
+++ b/src/quodeq/ui/src/utils/scoreFiltering.js
@@ -6,6 +6,7 @@
  */
 
 import { bucketKey, isBucketEligible } from './dailyGrouping.js';
+import { countBySeverity } from './severity.js';
 
 const roundOneDecimal = (n) => Math.round(n * 10) / 10;
 
@@ -166,17 +167,17 @@ export function computeSummaryFromFilteredDimensions(dimensions) {
       const sev = totals.severity || {};
       severity.critical += sev.critical || 0;
       severity.major += sev.major || 0;
-      severity.minor += sev.minor || 0;
+      // Fold the backend's 'unknown' bucket into minor so
+      // critical+major+minor always equals violationCount.
+      severity.minor += (sev.minor || 0) + (sev.unknown || 0);
     } else {
       const violations = d.violations || [];
       totalViolations += violations.length;
       totalCompliance += d.compliance?.length || 0;
-      for (const v of violations) {
-        const s = (v.severity || '').toLowerCase();
-        if (s === 'critical') severity.critical++;
-        else if (s === 'major') severity.major++;
-        else if (s === 'minor') severity.minor++;
-      }
+      const counts = countBySeverity(violations);
+      severity.critical += counts.critical;
+      severity.major += counts.major;
+      severity.minor += counts.minor;
     }
   }
   return { totalViolations, totalCompliance, severity };

--- a/src/quodeq/ui/src/utils/severity.js
+++ b/src/quodeq/ui/src/utils/severity.js
@@ -1,0 +1,31 @@
+/**
+ * Single source of truth for severity handling.
+ *
+ * Two vocabularies exist on purpose:
+ * - Display/filtering uses the full set (critical/major/minor/unknown):
+ *   normalizeSeverity.
+ * - Summary counters (the chips next to a total) use three buckets, with
+ *   unknown folded into minor so critical+major+minor always equals the
+ *   violation total: summaryBucket / countBySeverity. Before this module
+ *   seven independent implementations disagreed on the fold and chip sums
+ *   drifted from totals whenever a finding lacked a severity.
+ */
+import { KNOWN_SEVERITIES } from './constants.js';
+
+export function normalizeSeverity(value) {
+  const normalized = String(value || 'unknown').toLowerCase();
+  return KNOWN_SEVERITIES.includes(normalized) ? normalized : 'unknown';
+}
+
+export function summaryBucket(value) {
+  const normalized = normalizeSeverity(value);
+  return normalized === 'unknown' ? 'minor' : normalized;
+}
+
+export function countBySeverity(violations) {
+  const counts = { critical: 0, major: 0, minor: 0 };
+  for (const v of violations || []) {
+    counts[summaryBucket(v?.severity)]++;
+  }
+  return counts;
+}

--- a/src/quodeq/ui/src/utils/severity.test.js
+++ b/src/quodeq/ui/src/utils/severity.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeSeverity, summaryBucket, countBySeverity } from './severity.js';
+
+test('normalizeSeverity maps missing/invalid to unknown, known pass through', () => {
+  assert.equal(normalizeSeverity('critical'), 'critical');
+  assert.equal(normalizeSeverity('MAJOR'), 'major');
+  assert.equal(normalizeSeverity(''), 'unknown');
+  assert.equal(normalizeSeverity(null), 'unknown');
+  assert.equal(normalizeSeverity('bogus'), 'unknown');
+});
+
+test('summaryBucket folds unknown into minor so chips sum to the total', () => {
+  assert.equal(summaryBucket('critical'), 'critical');
+  assert.equal(summaryBucket(null), 'minor');
+  assert.equal(summaryBucket('bogus'), 'minor');
+});
+
+test('countBySeverity counts every violation exactly once', () => {
+  const counts = countBySeverity([
+    { severity: 'critical' },
+    { severity: 'major' },
+    { severity: 'minor' },
+    { severity: null },
+    { severity: 'weird' },
+    {},
+  ]);
+  assert.deepEqual(counts, { critical: 1, major: 1, minor: 4 });
+  assert.equal(counts.critical + counts.major + counts.minor, 6);
+});

--- a/src/quodeq/ui/src/utils/visibleStandards.js
+++ b/src/quodeq/ui/src/utils/visibleStandards.js
@@ -1,5 +1,6 @@
 import { VISIBLE_STANDARDS_STORAGE_KEY, DEFAULT_VISIBLE_STANDARDS } from '../constants.js';
 import { getStandardsVisibility, putStandardsVisibility } from '../api/standards.js';
+import { countBySeverity } from './severity.js';
 
 // Marks that the (per-browser, not per-project) cache has been reconciled
 // with SOME project's own real file -- either because that project already
@@ -150,12 +151,10 @@ export function computeSummaryFromDimensions(dimensions) {
     const violations = d.violations || [];
     totalViolations += violations.length;
     totalCompliance += d.compliance?.length || 0;
-    for (const v of violations) {
-      const s = (v.severity || '').toLowerCase();
-      if (s === 'critical') severity.critical++;
-      else if (s === 'major') severity.major++;
-      else if (s === 'minor') severity.minor++;
-    }
+    const counts = countBySeverity(violations);
+    severity.critical += counts.critical;
+    severity.major += counts.major;
+    severity.minor += counts.minor;
   }
   return { totalViolations, totalCompliance, severity };
 }

--- a/tests/services/test_evaluation_mixin.py
+++ b/tests/services/test_evaluation_mixin.py
@@ -177,6 +177,24 @@ class TestBuildEvalEnv:
         env = m._build_eval_env("/repo", opts, env={})
         assert env["QUODEQ_CONTEXT_SIZE"] == "128000"
 
+    def test_cloud_provider_api_key_exported(self):
+        # The subprocess resolves cloud keys from the env var named by the
+        # provider's api_key_env. Only omlx used to get its key exported, so
+        # an OpenRouter key typed in Settings was silently discarded.
+        m = self._mixin()
+        opts = EvaluationOptions(ai_cmd="openrouter", provider_api_key="sk-or-1")
+        env = m._build_eval_env("/repo", opts, env={})
+        assert env["OPENROUTER_API_KEY"] == "sk-or-1"
+
+    def test_omlx_key_and_base_still_exported(self):
+        m = self._mixin()
+        opts = EvaluationOptions(
+            ai_cmd="omlx", provider_api_key="k1", provider_api_base="http://h:1/v1",
+        )
+        env = m._build_eval_env("/repo", opts, env={})
+        assert env["OMLX_API_KEY"] == "k1"
+        assert env["OMLX_BASE_URL"] == "http://h:1/v1"
+
     def test_zero_context_size_not_set(self):
         m = self._mixin()
         opts = EvaluationOptions(context_size=0)

--- a/tests/services/test_evaluations_index_dedup.py
+++ b/tests/services/test_evaluations_index_dedup.py
@@ -183,3 +183,85 @@ def test_list_prefers_internal_over_indexed_external(tmp_path: Path) -> None:
         f"expected internal entry to win, got job_id={matching[0].job_id!r} "
         f"(source={matching[0].source!r})"
     )
+
+
+def test_lost_internal_job_yields_to_the_live_indexed_row(tmp_path: Path) -> None:
+    """After a server restart the internal job flips to 'lost' while the
+    subprocess keeps running and writing status.json. The truthful ext- row
+    must win the merge: before this fix the internal placeholder covered it,
+    the live scan disappeared from /api/evaluations, and cancel 409ed.
+    """
+    import os
+
+    reports_root = tmp_path / "reports"
+    project = "proj-uuid-2"
+    run_id = "run-uuid-2"
+    # Live PID: the surviving subprocess. A dead PID gets promoted to
+    # cancelled(stale_detected) by sync_index — correct, but not the
+    # scenario under test.
+    run_dir = reports_root / project / run_id
+    run_dir.mkdir(parents=True)
+    write_status(
+        run_dir,
+        state=RunState.RUNNING,
+        job_id=f"ext-{run_id}",
+        started_at="2026-05-22T19:00:00+00:00",
+        dimensions=["security"],
+        phase="analyzing",
+        pid=os.getpid(),
+    )
+
+    store = InMemoryJobStore()
+    store.put(
+        Job(
+            job_id="internal-uuid-2",
+            status="lost",
+            command=["python", "-m", "quodeq.cli", "evaluate"],
+            started_at="2026-05-22T19:00:00+00:00",
+            ended_at="2026-05-22T19:05:00+00:00",
+            exit_code=None,
+            output_project=project,
+            output_run_id=run_id,
+        ),
+    )
+    jobs = JobManager(job_store=store, reports_root=reports_root)
+    index = EvaluationsIndex(
+        jobs=jobs, index_db_path=tmp_path / "index.db", reports_root=reports_root,
+    )
+
+    entries = index.list(reports_dir=reports_root)
+    matching = [
+        e for e in entries
+        if e.output_project == project and e.output_run_id == run_id
+    ]
+    assert len(matching) == 1, [(e.job_id, e.status) for e in matching]
+    assert matching[0].job_id == f"ext-{run_id}"
+    assert matching[0].status == "running"
+
+
+def test_lost_internal_job_without_indexed_row_stays_visible(tmp_path: Path) -> None:
+    """A lost job whose run never produced a status.json has no truthful
+    replacement — keep the 'lost' placeholder so the user sees what happened."""
+    reports_root = tmp_path / "reports"
+    reports_root.mkdir(parents=True)
+
+    store = InMemoryJobStore()
+    store.put(
+        Job(
+            job_id="internal-uuid-3",
+            status="lost",
+            command=["python"],
+            started_at="2026-05-22T19:00:00+00:00",
+            ended_at="2026-05-22T19:05:00+00:00",
+            exit_code=None,
+            output_project="proj-x",
+            output_run_id="run-x",
+        ),
+    )
+    jobs = JobManager(job_store=store, reports_root=reports_root)
+    index = EvaluationsIndex(
+        jobs=jobs, index_db_path=tmp_path / "index.db", reports_root=reports_root,
+    )
+
+    entries = index.list(reports_dir=reports_root)
+    assert [e.status for e in entries] == ["lost"]

--- a/tests/services/test_job_model.py
+++ b/tests/services/test_job_model.py
@@ -293,7 +293,12 @@ class TestFileJobStore:
         assert job is not None
         assert job.status == "completed"
 
-    def test_running_jobs_marked_failed_on_load(self, tmp_path: Path):
+    def test_running_jobs_marked_lost_on_load(self, tmp_path: Path):
+        # The subprocess is spawned start_new_session=True and survives a
+        # server restart — the run is usually still alive and writing. It
+        # is "lost" (tracking gone), not "failed": marking it failed showed
+        # a live scan as dead and (via list dedup) hid the truthful ext-
+        # index row that could still track and cancel it.
         data = {
             "job_id": "j1",
             "status": "running",
@@ -304,8 +309,8 @@ class TestFileJobStore:
         store = FileJobStore(persist_dir=tmp_path)
         job = store.get("j1")
         assert job is not None
-        assert job.status == "failed"
-        assert job.exit_code == -1
+        assert job.status == "lost"
+        assert job.exit_code is None
 
     def test_corrupt_file_skipped(self, tmp_path: Path):
         (tmp_path / "bad.json").write_text("not json{{{")
@@ -370,7 +375,7 @@ class TestFileJobStore:
         }
         (tmp_path / "j1.json").write_text(json.dumps(data))
         store = FileJobStore(persist_dir=tmp_path)
-        # Running -> failed on load, but should still exist
+        # Running -> lost on load, but should still exist
         assert store.get("j1") is not None
 
     def test_stale_cleanup_skips_no_ended_at(self, tmp_path: Path):
@@ -386,7 +391,7 @@ class TestFileJobStore:
         assert store.get("j1") is not None
 
     def test_flipped_running_job_gets_ended_at(self, tmp_path: Path):
-        """A crashed 'running' job flipped to failed must get an ended_at.
+        """A 'running' job flipped to lost must get an ended_at.
 
         Without it, _cleanup_stale skips the job forever (it only prunes
         jobs with ended_at), so crash/test leftovers accumulate until they
@@ -402,7 +407,7 @@ class TestFileJobStore:
         store = FileJobStore(persist_dir=tmp_path)
         job = store.get("j1")
         assert job is not None
-        assert job.status == "failed"
+        assert job.status == "lost"
         assert job.ended_at, "flipped jobs must be prunable by _cleanup_stale"
         on_disk = json.loads((tmp_path / "j1.json").read_text())
         assert on_disk["ended_at"], "the flip must be persisted with ended_at"

--- a/tests/services/test_scan_progress.py
+++ b/tests/services/test_scan_progress.py
@@ -409,3 +409,54 @@ class TestDimElapsed:
         dim = progress.dimensions[0]
         assert dim.elapsed_s is not None
         assert 115 <= dim.elapsed_s <= 130
+
+
+class TestConsolidatedProgress:
+    """Consolidated (grouped) runs write consolidated_* files, not per-dim
+    queues, so the per-dim reader showed 0% / "estimating…" for the whole
+    run. While such a run is live, progress reports one consolidated row
+    with the real file counts."""
+
+    def test_live_consolidated_run_reports_one_real_row(self, tmp_path: Path) -> None:
+        import time as _t
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security", "reliability"])
+        (run_dir / "evidence" / "consolidated_queue.json").write_text(
+            json.dumps({
+                "created_at": _t.time() - 60,
+                "taken": [{"files": ["a.py", "b.py"], "agent": "a1", "ts": _t.time() - 5}],
+                "pending": [f"f{i}.py" for i in range(8)],
+            }),
+            encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        assert [d.id for d in progress.dimensions] == ["consolidated"]
+        dim = progress.dimensions[0]
+        assert dim.state == "running"
+        assert dim.files == {"taken": 2, "total": 10}
+        assert dim.elapsed_s is not None and dim.elapsed_s >= 55
+
+    def test_per_dimension_run_unaffected(self, tmp_path: Path) -> None:
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"])
+        (run_dir / "evidence" / "security_queue.json").write_text(
+            json.dumps({"taken": [], "pending": ["a.py"]}), encoding="utf-8",
+        )
+        progress = build_scan_progress("j1", run_dir)
+        assert [d.id for d in progress.dimensions] == ["security"]
+
+    def test_terminal_consolidated_run_keeps_per_dim_rows(self, tmp_path: Path) -> None:
+        # After the run, per-dim evaluation files exist and the normal
+        # per-dim classification applies.
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"], state="done")
+        (run_dir / "evidence" / "consolidated_queue.json").write_text(
+            json.dumps({"taken": [], "pending": []}), encoding="utf-8",
+        )
+        (run_dir / "evaluation").mkdir()
+        (run_dir / "evaluation" / "security.json").write_text("{}", encoding="utf-8")
+        progress = build_scan_progress("j1", run_dir)
+        assert [d.id for d in progress.dimensions] == ["security"]
+        assert progress.dimensions[0].state == "done"

--- a/tests/services/test_violations.py
+++ b/tests/services/test_violations.py
@@ -103,3 +103,34 @@ class TestResolveDimensionEval:
         (eval_dir / "security.json").write_text(json.dumps(eval_data))
         result = resolve_dimension_eval(base, "proj", "run-1", "security")
         assert result is not None
+
+
+class TestAggregateUnknownSeverity:
+    def test_unknown_bucket_folds_into_minor_so_chips_sum_to_total(self):
+        # build_totals puts missing/invalid severities in an 'unknown'
+        # bucket. The summary only exposes critical/major/minor, so unknown
+        # findings made critical+major+minor drift below the total.
+        from quodeq.services.violations import aggregate_violations
+
+        dashboard = {
+            "dimensions": [
+                {
+                    "totals": {
+                        "violationCount": 4,
+                        "severity": {"critical": 1, "major": 1, "minor": 1, "unknown": 1},
+                    },
+                    "violations": [
+                        {"file": "a.py", "severity": "critical"},
+                        {"file": "a.py", "severity": "major"},
+                        {"file": "a.py", "severity": "minor"},
+                        {"file": "a.py"},
+                    ],
+                },
+            ],
+        }
+        summary = aggregate_violations(dashboard)
+        assert summary.total == 4
+        assert summary.critical + summary.major + summary.minor == summary.total
+        assert summary.minor == 2
+        f = summary.files[0]
+        assert f.critical + f.major + f.minor == f.count

--- a/tests/shared/test_provider_env.py
+++ b/tests/shared/test_provider_env.py
@@ -1,0 +1,64 @@
+"""Tests for shared.provider_env — exporting user-entered API credentials.
+
+The scan subprocess resolves cloud API keys from the env var named by the
+provider's ``api_key_env`` (analysis/subprocess._resolve_provider_config).
+The dashboard collected the key in Settings but only ever exported it for
+omlx, so an OpenRouter key typed in the UI was silently discarded and the
+run failed with a missing-key error.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.shared.provider_env import provider_env_exports
+
+
+@pytest.fixture()
+def providers_file(tmp_path: Path, monkeypatch):
+    path = tmp_path / "ai_providers.json"
+    path.write_text(json.dumps({
+        "openrouter": {
+            "type": "api",
+            "api_base": "https://openrouter.ai/api/v1",
+            "api_key_env": "OPENROUTER_API_KEY",
+            "api_key_required": True,
+        },
+        "custom": {
+            "type": "api",
+            "api_base": "${AI_API_BASE}",
+            "api_key_env": "AI_API_KEY",
+        },
+        "claude": {"type": "cli"},
+    }), encoding="utf-8")
+    monkeypatch.setenv("QUODEQ_AI_PROVIDERS_PATH", str(path))
+    return path
+
+
+def test_exports_key_under_provider_env_name(providers_file):
+    assert provider_env_exports("openrouter", "sk-or-123", None) == {
+        "OPENROUTER_API_KEY": "sk-or-123",
+    }
+
+
+def test_custom_provider_exports_key_and_templated_base(providers_file):
+    assert provider_env_exports("custom", "k", "http://myhost:9/v1") == {
+        "AI_API_KEY": "k",
+        "AI_API_BASE": "http://myhost:9/v1",
+    }
+
+
+def test_fixed_base_is_not_exported(providers_file):
+    assert provider_env_exports("openrouter", None, "http://elsewhere") == {}
+
+
+def test_provider_without_key_env_exports_nothing(providers_file):
+    assert provider_env_exports("claude", "key", None) == {}
+
+
+def test_unknown_provider_and_missing_file_are_safe(providers_file, monkeypatch):
+    assert provider_env_exports("nope", "key", None) == {}
+    monkeypatch.setenv("QUODEQ_AI_PROVIDERS_PATH", "/nonexistent.json")
+    assert provider_env_exports("openrouter", "key", None) == {}

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -20,7 +20,7 @@ src/quodeq/services/_violations_jsonl.py:12:analysis
 src/quodeq/services/_violations_stream.py:10:analysis
 src/quodeq/services/_violations_stream.py:11:analysis
 src/quodeq/services/evaluation_mixin.py:22:analysis
-src/quodeq/services/evaluation_mixin.py:529:analysis
+src/quodeq/services/evaluation_mixin.py:537:analysis
 src/quodeq/services/jobs.py:20:analysis
 src/quodeq/services/scan_progress.py:23:analysis
 src/quodeq/services/tooling_mixin.py:17:analysis


### PR DESCRIPTION
Stacked on #900 (base is `fix/evaluation-audit-batch-1`; retarget to `develop` after #900 merges). Backend 5051 tests green, UI 1335 green, all fixes test-driven.

## Server restart no longer kills or hides a live scan

Evaluation subprocesses survive an API restart (`start_new_session=True`), but the persisted job store flipped their jobs to `failed`, and the internal job then shadowed the truthful `ext-` index row in the merged list: the live scan vanished from `/api/evaluations` and cancel 409ed. Restart now flips jobs to `lost` (the status the UI already renders as "Server restarted, job tracking lost" but nothing ever wrote), lost placeholders yield to the ext- row, and the live run resurfaces, trackable and cancellable.

## Consolidated (grouped) runs show real progress

Grouped runs write `consolidated_*` files, so the per-dim progress reader showed 0% and "estimating…" for the entire run. Live consolidated runs now report one consolidated row with real file counts, evidence tallies, elapsed time, and active agents.

## Settings, Evaluate header, and start payload agree (display tells the truth)

One resolver (`resolveProviderSettings`) is the single source for what a run actually uses. No run behavior changes:
- Cloud provider tabs showed "1 subagent / Unlimited" for unset keys while the run used 5 / 600s. Tabs now display the effective values.
- The per-dimension pill was highlighted for an untouched toggle while the engine ran grouped; unset now displays Grouped.
- The wizard's TIME LIMIT / provider / model actually reach the server (they were dead code, unconditionally overwritten from the active tab's localStorage). An explicit 0 (Unlimited) survives.
- Corrupt stored numbers fall back to defaults instead of NaN. Local-API tabs clamp the subagents input.

## Cloud API keys reach the scan

Only omlx ever had its key exported; an OpenRouter key typed in Settings was silently discarded and the run died with a missing-key error. A new `shared/provider_env.py` maps user-entered credentials onto the provider's `api_key_env` (and the `custom` provider's templated base URL).

## Severity chips always sum to the total

Seven independent severity counters disagreed on missing/unknown severities (Python has an `unknown` bucket; JS coerced to minor or dropped). One shared vocabulary now: display keeps the four-value set, summaries fold unknown into minor, and `aggregate_violations` applies the same fold, so critical+major+minor always equals the violation total everywhere.