### PR TITLE
fix(ui): one loader per route, contained to the content area

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -248,6 +248,22 @@ export function shouldShowProjectTabs({ selectedSource, hasCurrentProjectRuns, s
 }
 
 /**
+ * Sidebar violations/history badge counts. `accumulated` and `dashboard`
+ * reset to null the instant the selected project changes (placeholderData is
+ * scoped to project+source -- see samePlaceholderScope in api/queryKeys.js),
+ * so reading straight off them here is what clears the badges immediately on
+ * a project switch instead of leaving the outgoing project's numbers on
+ * screen until the new project's fetch lands. Exported so this contract is
+ * unit-testable without mounting the whole App.
+ */
+export function selectSidebarCounts({ filteredAccumulated, accumulated, filteredTrend, dashboard }) {
+  return {
+    violationsCount: filteredAccumulated?.summary?.totalViolations ?? accumulated?.summary?.totalViolations ?? null,
+    historyCount: (filteredTrend || []).length || dashboard?.trend?.length || null,
+  };
+}
+
+/**
  * Build the `navigation` prop bundle ROUTE_RENDERERS consume. Every
  * navigation key a route renderer reads MUST be forwarded here -- a route
  * consuming a key the bundle lacks fails silently at click time (the
@@ -1146,6 +1162,10 @@ export default function App() {
     selectedProject: state.selectedProject,
   });
 
+  const sidebarCounts = selectSidebarCounts({
+    filteredAccumulated, accumulated: state.accumulated, filteredTrend, dashboard: state.dashboard,
+  });
+
   return (
     <>
       <EvalLogProvider>
@@ -1172,8 +1192,8 @@ export default function App() {
                 meta: state.headerMeta,
               }}
               version={APP_VERSION}
-              violationsCount={filteredAccumulated?.summary?.totalViolations ?? state.accumulated?.summary?.totalViolations ?? null}
-              historyCount={filteredTrend.length || state.dashboard?.trend?.length || null}
+              violationsCount={sidebarCounts.violationsCount}
+              historyCount={sidebarCounts.historyCount}
               lastEvalAt={state.accumulated?.summary?.lastEvaluatedAt || state.accumulated?.summary?.createdAt || null}
               isPinned={sidebarPinned}
               onPinChange={setSidebarPinned}

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -5,7 +5,7 @@ import {
   buildEvalPrincipal, ROUTE_RENDERERS, isSharedSource, shouldBounceToEvaluate, shouldShowEvaluateButton,
   resolveSelectionAfterSharedDisconnect, shouldAutoOpenOnboardingWizard, shouldRedirectToRemoteRepositories, shouldShowProjectTabs,
   buildNavigationBundle, buildDashboardDataBundle, shouldWallEmptyProjects, buildWizardHandlers, buildAssistantSessionPayload,
-  buildAssistantActionAppliedHandler, resolveProjectDisplayName,
+  buildAssistantActionAppliedHandler, resolveProjectDisplayName, selectSidebarCounts,
 } from './App.jsx';
 import Sidebar from './components/Sidebar.jsx';
 
@@ -489,6 +489,47 @@ describe('shouldShowProjectTabs', () => {
     expect(shouldShowProjectTabs({
       selectedSource: 'local', hasCurrentProjectRuns: false, sharedProjectInfo: { id: 'team-proj' },
     })).toBe(false);
+  });
+});
+
+// Scenario 7 (collision): the sidebar's violations/history badges must not
+// keep showing the OUTGOING project's numbers once a project switch is in
+// flight. `accumulated`/`dashboard` already reset to null the instant
+// `selectedProject` changes (samePlaceholderScope, api/queryKeys.js), so
+// reading straight off them here is what clears the badges immediately
+// instead of holding onto stale numbers until the new project's fetch lands.
+describe('selectSidebarCounts', () => {
+  it('reads violations/history counts off the filtered view when present', () => {
+    const result = selectSidebarCounts({
+      filteredAccumulated: { summary: { totalViolations: 12 } },
+      accumulated: { summary: { totalViolations: 99 } },
+      filteredTrend: [{ runId: 'r1' }, { runId: 'r2' }],
+      dashboard: { trend: [{ runId: 'r1' }] },
+    });
+    expect(result.violationsCount).toBe(12);
+    expect(result.historyCount).toBe(2);
+  });
+
+  it('falls back to the unfiltered accumulated/dashboard when the filtered view has nothing', () => {
+    const result = selectSidebarCounts({
+      filteredAccumulated: null,
+      accumulated: { summary: { totalViolations: 7 } },
+      filteredTrend: [],
+      dashboard: { trend: [{ runId: 'r1' }, { runId: 'r2' }] },
+    });
+    expect(result.violationsCount).toBe(7);
+    expect(result.historyCount).toBe(2);
+  });
+
+  it('clears both counts on a project switch, before the new project data lands', () => {
+    const result = selectSidebarCounts({
+      filteredAccumulated: null,
+      accumulated: null,
+      filteredTrend: [],
+      dashboard: null,
+    });
+    expect(result.violationsCount).toBeNull();
+    expect(result.historyCount).toBeNull();
   });
 });
 

--- a/src/quodeq/ui/src/components/LoadingScreen.jsx
+++ b/src/quodeq/ui/src/components/LoadingScreen.jsx
@@ -1,16 +1,23 @@
 import { QMarkIcon } from './QMarkIcon.jsx';
 
 /**
- * @param {{ message?: string }} props
+ * @param {{ message?: string, variant?: 'fullscreen'|'inline' }} props
  *
  * `message` labels what is being waited on. Worth passing whenever the wait
  * follows a user action that swapped the whole page's subject (e.g. switching
  * projects on the Overview), so the pulsing logo reads as "loading THAT" rather
  * than an unexplained blank.
+ *
+ * `variant` (default 'fullscreen'): 'fullscreen' is for cold start only (the
+ * app-level Suspense fallback and any true first-load, before there's a page
+ * frame to contain a loader). 'inline' is for everything mounted within an
+ * already-rendered page -- it must not compete with, or hide behind, other
+ * loaders or dimmed containers on the same route.
  */
-export default function LoadingScreen({ message }) {
+export default function LoadingScreen({ message, variant = 'fullscreen' }) {
+  const className = variant === 'inline' ? 'loading-screen loading-screen--inline' : 'loading-screen';
   return (
-    <div className="loading-screen" role="status" aria-live="polite">
+    <div className={className} role="status" aria-live="polite">
       <QMarkIcon className="loading-logo" />
       {message && <p className="loading-message">{message}</p>}
     </div>

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -280,7 +280,7 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
             other place, at this same top level, that a loader can render from --
             DashboardContent itself never makes this decision, so the two can't
             drift out of sync the way they did in the original bug. */}
-        {dashboard && !isLoading && !contentReady && <LoadingScreen variant="inline" />}
+        {dashboard && !isLoading && !contentReady && <LoadingScreen variant="inline" message={projectName ? `Loading ${projectName}…` : undefined} />}
         {dashboard && contentReady && (
           <DashboardContent
             runMode={runMode}

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -44,16 +44,14 @@ function NoCompletedEvalPanel({ availableRuns = [], onNavigate, selectedSource }
   );
 }
 
-function DashboardContent({ runMode, ready, data, focus, callbacks }) {
+function DashboardContent({ runMode, data, focus, callbacks }) {
   const { dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo, granularity, selectedSource, scoresPending } = data;
   const { dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData } = focus;
   const { onRunSelect, onDimensionCardClick, onAccumulatedDimensionClick, onFileClick, onNavigate, onGranularityChange } = callbacks;
-  // Readiness is decided once, by the page (DashboardPage's isLoading/contentReady
-  // rule) -- this never re-derives it from `accumulated` on its own, so there is
-  // exactly one place a loader can be mounted from.
-  if (!ready) {
-    return <LoadingScreen variant="inline" />;
-  }
+  // No readiness check here on purpose: the page only mounts this component
+  // once contentReady is true (see DashboardPage's return), so there is
+  // exactly one place in the whole page that decides whether a loader is
+  // shown -- never a render decision split between here and the parent.
   if (runMode) {
     return (
       <RunOverviewPanel
@@ -276,10 +274,16 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
       <div className={`dashboard-page dashboard-fade ${isLoading ? 'dashboard-loading' : 'dashboard-ready'}${isRefreshing ? ' dashboard-refreshing' : ''}`}>
         <IncompleteSetupCard projectInfo={projectInfo} onComplete={handleSetupComplete} />
         {error && <p className="inline-error">Failed to load dashboard data. Please try again.</p>}
-        {dashboard && !isLoading && (
+        {/* Grace elapsed but content still isn't ready (dashboard is in, accumulated
+            isn't yet): the page has already stopped showing its own full loader
+            above, but there's nothing ready to mount below either. This is the ONE
+            other place, at this same top level, that a loader can render from --
+            DashboardContent itself never makes this decision, so the two can't
+            drift out of sync the way they did in the original bug. */}
+        {dashboard && !isLoading && !contentReady && <LoadingScreen variant="inline" />}
+        {dashboard && contentReady && (
           <DashboardContent
             runMode={runMode}
-            ready={contentReady}
             data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo, granularity, selectedSource, scoresPending }}
             focus={{ dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData }}
             callbacks={{ onRunSelect, onDimensionCardClick: handlers.handleDimensionCardClick, onAccumulatedDimensionClick: handlers.handleAccumulatedDimensionClick, onFileClick: handlers.handleFileClick, onNavigate, onGranularityChange }}

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -44,10 +44,16 @@ function NoCompletedEvalPanel({ availableRuns = [], onNavigate, selectedSource }
   );
 }
 
-function DashboardContent({ runMode, data, focus, callbacks }) {
+function DashboardContent({ runMode, ready, data, focus, callbacks }) {
   const { dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo, granularity, selectedSource, scoresPending } = data;
   const { dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData } = focus;
   const { onRunSelect, onDimensionCardClick, onAccumulatedDimensionClick, onFileClick, onNavigate, onGranularityChange } = callbacks;
+  // Readiness is decided once, by the page (DashboardPage's isLoading/contentReady
+  // rule) -- this never re-derives it from `accumulated` on its own, so there is
+  // exactly one place a loader can be mounted from.
+  if (!ready) {
+    return <LoadingScreen variant="inline" />;
+  }
   if (runMode) {
     return (
       <RunOverviewPanel
@@ -59,9 +65,6 @@ function DashboardContent({ runMode, data, focus, callbacks }) {
         onNavigate={onNavigate}
       />
     );
-  }
-  if (!accumulated) {
-    return <LoadingScreen />;
   }
   if (accumulatedDimensions.length === 0) {
     // Project has runs (otherwise the upstream `!dashboard` empty
@@ -162,7 +165,10 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
 
   // What each view needs before it can render real content: run detail only
   // needs the dashboard payload; the Overview also needs the scores-derived
-  // `accumulated` block (DashboardContent returns a LoadingScreen without it).
+  // `accumulated` block. This is the single readiness rule for the whole page
+  // -- DashboardContent is only mounted once it holds, and never re-derives
+  // its own readiness from `accumulated`, so there is exactly one loader
+  // decision instead of two that can disagree.
   // These hooks MUST stay above the early returns below — calling them after a
   // conditional return changes the hook count between renders (React error
   // #310, a blank-crash on load).
@@ -257,23 +263,29 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   // the jarring full-screen LoadingScreen.
   const isRefreshing = isFetching && !!dashboard && !isLoading;
   return (
-    <div className={`dashboard-page dashboard-fade ${isLoading ? 'dashboard-loading' : 'dashboard-ready'}${isRefreshing ? ' dashboard-refreshing' : ''}`}>
-      <IncompleteSetupCard projectInfo={projectInfo} onComplete={handleSetupComplete} />
-      {error && <p className="inline-error">Failed to load dashboard data. Please try again.</p>}
-      {/* Name the project being loaded. A project switch now clears the old
-          payload (placeholderData is project-scoped -- see
-          samePlaceholderScope), so this spinner is what the user sees right
-          after picking a project; saying which one makes the wait legible
-          instead of looking like the page hung. */}
-      {isLoading && <LoadingScreen message={projectName ? `Loading ${projectName}…` : undefined} />}
-      {dashboard && (
-        <DashboardContent
-          runMode={runMode}
-          data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo, granularity, selectedSource, scoresPending }}
-          focus={{ dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData }}
-          callbacks={{ onRunSelect, onDimensionCardClick: handlers.handleDimensionCardClick, onAccumulatedDimensionClick: handlers.handleAccumulatedDimensionClick, onFileClick: handlers.handleFileClick, onNavigate, onGranularityChange }}
-        />
-      )}
-    </div>
+    <>
+      {/* Sibling to .dashboard-page, not a child of it: that div carries the
+          `dashboard-loading` opacity-.4 class for exactly as long as this loader
+          is shown, and a loader dimmed by its own "still loading" state renders
+          its logo at an unreadable 6% opacity. Names the project being loaded --
+          a project switch now clears the old payload (placeholderData is
+          project-scoped -- see samePlaceholderScope), so this spinner is what
+          the user sees right after picking a project; saying which one makes
+          the wait legible instead of looking like the page hung. */}
+      {isLoading && <LoadingScreen variant="inline" message={projectName ? `Loading ${projectName}…` : undefined} />}
+      <div className={`dashboard-page dashboard-fade ${isLoading ? 'dashboard-loading' : 'dashboard-ready'}${isRefreshing ? ' dashboard-refreshing' : ''}`}>
+        <IncompleteSetupCard projectInfo={projectInfo} onComplete={handleSetupComplete} />
+        {error && <p className="inline-error">Failed to load dashboard data. Please try again.</p>}
+        {dashboard && !isLoading && (
+          <DashboardContent
+            runMode={runMode}
+            ready={contentReady}
+            data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo, granularity, selectedSource, scoresPending }}
+            focus={{ dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData }}
+            callbacks={{ onRunSelect, onDimensionCardClick: handlers.handleDimensionCardClick, onAccumulatedDimensionClick: handlers.handleAccumulatedDimensionClick, onFileClick: handlers.handleFileClick, onNavigate, onGranularityChange }}
+          />
+        )}
+      </div>
+    </>
   );
 }

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -1,15 +1,16 @@
 import { render, act, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import DashboardPage, { selectDashboardProjectInfo } from './DashboardPage.jsx';
+import { SidePaneProvider } from '../../side-pane/index.js';
 
 // First-load flicker guard. On a fresh (uncached) load the dashboard query
-// resolves a beat before the scores query. The Overview renders nothing until
-// `accumulated` (derived from scores) arrives — DashboardContent returns a
-// LoadingScreen without it. If the page drops its loading state the moment the
-// dashboard payload lands, it fades to `dashboard-ready` (a 400ms fade-in)
-// while still showing a spinner, then the real content pops in a beat later:
-// the "it refreshes again" flicker. So the Overview must stay in the loading
-// state until BOTH the dashboard and the accumulated block are present.
+// resolves a beat before the scores query. The Overview isn't ready to render
+// until `accumulated` (derived from scores) arrives too. If the page drops its
+// loading state the moment the dashboard payload lands, it fades to
+// `dashboard-ready` (a 400ms fade-in) while still showing a spinner, then the
+// real content pops in a beat later: the "it refreshes again" flicker. So the
+// Overview must stay in the loading state until BOTH the dashboard and the
+// accumulated block are present.
 const overviewLoading = {
   projectsLoaded: true,
   projects: [{ id: 'p1', name: 'p1' }],
@@ -37,6 +38,28 @@ describe('DashboardPage first-load loading gate', () => {
     // Must NOT flip to the ready fade before the data needed to render is present.
     expect(page.className).toContain('dashboard-loading');
     expect(page.className).not.toContain('dashboard-ready');
+  });
+
+  // Scenario 1 (collision): dashboard has resolved but accumulated hasn't, so
+  // DashboardContent used to gate its own `!accumulated` check independently
+  // of the page's isLoading -- both the page-level grace loader (message
+  // variant) and DashboardContent's own LoadingScreen mounted at once, two
+  // overlapping pulsing logos. DashboardContent must not render a loader of
+  // its own; readiness is a single decision made by the page.
+  it('renders exactly one LoadingScreen while dashboard is resolved but accumulated is not', () => {
+    const { container } = render(<DashboardPage data={overviewLoading} callbacks={{}} runMode={false} />);
+    expect(container.querySelectorAll('.loading-screen').length).toBe(1);
+  });
+
+  // Scenario 8: the page-level loader must never be a descendant of the
+  // `.dashboard-loading` (opacity .4) container -- otherwise the logo renders
+  // at an effective 6% opacity while loading, then jumps to full opacity once
+  // the container flips to `.dashboard-ready`.
+  it('does not nest the loader inside the dimmed .dashboard-loading container', () => {
+    const { container } = render(<DashboardPage data={overviewLoading} callbacks={{}} runMode={false} />);
+    const dimmed = container.querySelector('.dashboard-loading');
+    expect(dimmed).toBeTruthy();
+    expect(dimmed.querySelector('.loading-screen')).toBeNull();
   });
 
   // The flip side: a cold score cache can take several seconds to rebuild. We
@@ -150,6 +173,50 @@ describe('DashboardPage fetch-failure state', () => {
       <DashboardPage data={{ ...errorData, error: null }} callbacks={{}} runMode={false} />,
     );
     expect(getByText('No evaluations yet')).toBeTruthy();
+  });
+});
+
+// Scenario 2 (collision): runMode renders RunOverviewPanel, which has its own
+// inline loading state (`!dashboard.dimensions`). Before the page's own
+// isLoading/DashboardContent-mount decision accounted for that, the page-level
+// grace loader and RunOverviewPanel's inline spinner could both mount at once.
+describe('DashboardPage runMode loading gate', () => {
+  const runModeLoading = {
+    projectsLoaded: true,
+    projects: [{ id: 'p1', name: 'p1' }],
+    selectedProject: 'p1',
+    selectedRun: 'r1',
+    dashboard: null,
+    accumulated: null,
+    loading: true,
+    isFetching: false,
+    error: null,
+    availableRuns: [{ runId: 'r1', status: 'complete' }],
+  };
+
+  it('renders exactly one LoadingScreen before the run payload has resolved', () => {
+    const { container } = render(
+      <SidePaneProvider>
+        <DashboardPage data={runModeLoading} callbacks={{}} runMode={true} />
+      </SidePaneProvider>,
+    );
+    expect(container.querySelectorAll('.loading-screen').length).toBe(1);
+  });
+
+  it('renders exactly one LoadingScreen once the run payload resolves without dimensions yet', () => {
+    const { container } = render(
+      <SidePaneProvider>
+        <DashboardPage
+          data={{
+            ...runModeLoading,
+            dashboard: { selectedRun: { runId: 'r1', dateLabel: '2026-05-01' }, trend: [] },
+          }}
+          callbacks={{}}
+          runMode={true}
+        />
+      </SidePaneProvider>,
+    );
+    expect(container.querySelectorAll('.loading-screen').length).toBe(1);
   });
 });
 

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -104,6 +104,11 @@ describe('DashboardPage first-load loading gate', () => {
       // not two, and it must not be sitting inside a dimmed container.
       expect(container.querySelectorAll('.loading-screen').length).toBe(1);
       expect(container.querySelector('.dashboard-loading')).toBeNull();
+      // Same message as the pre-grace loader it replaced: otherwise the
+      // message-bearing loader unmounts and a message-less one takes its
+      // place in the same frame, and the logo visibly shifts up by the
+      // message line's height on the handoff.
+      expect(container.querySelector('.loading-message')?.textContent).toBe('Loading p1…');
     } finally {
       vi.useRealTimers();
     }

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -89,6 +89,12 @@ describe('DashboardPage first-load loading gate', () => {
       // After the grace elapses with scores still pending: drop to the partial page.
       act(() => { vi.advanceTimersByTime(800); });
       expect(container.querySelector('.dashboard-page').className).toContain('dashboard-ready');
+      // Reachable state: dashboard is in, accumulated still isn't, and the page
+      // has already stopped showing its own full loader. Exactly one loader must
+      // still be on screen (the page's own content-area fallback), not zero and
+      // not two, and it must not be sitting inside a dimmed container.
+      expect(container.querySelectorAll('.loading-screen').length).toBe(1);
+      expect(container.querySelector('.dashboard-loading')).toBeNull();
     } finally {
       vi.useRealTimers();
     }

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -51,6 +51,15 @@ describe('DashboardPage first-load loading gate', () => {
     expect(container.querySelectorAll('.loading-screen').length).toBe(1);
   });
 
+  // P2 containment: the page's own loader must use the contained variant
+  // (absolutely positioned within .dashboard via .loading-screen--inline in
+  // base.css, not fixed to the viewport) so a project switch never covers
+  // Sidebar/TopBar. Only the app-level cold-start loader stays fullscreen.
+  it('renders the inline (contained) loader variant, not the fullscreen one', () => {
+    const { container } = render(<DashboardPage data={overviewLoading} callbacks={{}} runMode={false} />);
+    expect(container.querySelector('.loading-screen').className).toContain('loading-screen--inline');
+  });
+
   // Scenario 8: the page-level loader must never be a descendant of the
   // `.dashboard-loading` (opacity .4) container -- otherwise the logo renders
   // at an effective 6% opacity while loading, then jumps to full opacity once
@@ -207,6 +216,7 @@ describe('DashboardPage runMode loading gate', () => {
       </SidePaneProvider>,
     );
     expect(container.querySelectorAll('.loading-screen').length).toBe(1);
+    expect(container.querySelector('.loading-screen').className).toContain('loading-screen--inline');
   });
 
   it('renders exactly one LoadingScreen once the run payload resolves without dimensions yet', () => {

--- a/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
@@ -193,7 +193,7 @@ export default function RunOverviewPanel({ dashboard, selectedRunId, projectName
   if (isLoading) {
     return (
       <div className="run-overview-fade run-overview-loading">
-        <div className="run-overview-spinner"><LoadingScreen /></div>
+        <div className="run-overview-spinner"><LoadingScreen variant="inline" /></div>
       </div>
     );
   }

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1869,6 +1869,15 @@ textarea:focus {
   animation: loading-fadein 500ms ease;
 }
 
+/* Contained variant for loaders mounted within an already-rendered page (see
+   LoadingScreen.jsx's `variant` prop). Scoped to the nearest positioned
+   ancestor -- `main.dashboard` -- instead of the viewport, so it never covers
+   Sidebar/TopBar and both stay interactive while it's up. */
+.loading-screen--inline {
+  position: absolute;
+  z-index: 2;
+}
+
 .loading-message {
   margin: 0;
   font-size: var(--text-sm);


### PR DESCRIPTION
Fixes the double LoadingScreen collision on project switch and stops in-page loaders from covering the whole viewport.

## What changed

- LoadingScreen takes a variant prop: fullscreen (default, cold start) or inline.
- DashboardPage has a single readiness rule covering dashboard and accumulated. It renders at most one loader, at the top level of its return. DashboardContent no longer renders any loader.
- The inline variant is absolutely positioned inside main.dashboard instead of fixed inset-0 z-50, so TopBar and Sidebar stay visible and interactive during a project switch.
- Sidebar counts formula extracted to a tested selectSidebarCounts. Counts already clear on project switch via query placeholder scoping, the tests now pin that.
- The grace-expiry loader handoff keeps the same "Loading <project>" message, so the logo no longer jumps.

This kills collision scenarios 1, 2, 7 (on the dashboard route) and 8 from docs/plans/ux-loading-transitions.md. The plan's P3 tab-key item was dropped: its premise was wrong, the tab fade is keyed by the stable page name and never replays on same-tab re-click, and the _tabKey bump only drives the intentional reset-on-reclick in Violations/Map (plan doc corrected).

## Tests

1363 passing (baseline 1355 + 8 new: loader count/nesting invariants, runMode states, grace-elapsed state, message handoff, sidebar counts).