### PR TITLE
fix(ui): post-eval smoothing — one refetch path, no blank frame, no pop

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -185,12 +185,16 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   // null) instead of popping to the full inline loader for a beat. Keyed off
   // project+source so a project switch never inherits the previous
   // project's stickiness (see the reset check below). runMode never shows
-  // this empty state, so it's excluded outright.
+  // this empty state, so it's excluded outright -- and a runMode render must
+  // never touch the latch at all: App.jsx doesn't always remount DashboardPage
+  // between the Overview and a run detail view for the same project+source,
+  // so writing `active: false` here on a runMode pass would clear a
+  // legitimately-active Overview latch out from under it.
   const noRunsScopeKey = `${selectedProject}::${selectedSource}`;
   const [noRunsEmptySticky, setNoRunsEmptySticky] = useState({ scopeKey: noRunsScopeKey, active: false });
   const wasNoRunsEmpty = noRunsEmptySticky.scopeKey === noRunsScopeKey && noRunsEmptySticky.active;
   const showNoRunsEmpty = !runMode && !dashboard && !error && (!loading || wasNoRunsEmpty);
-  if (noRunsEmptySticky.scopeKey !== noRunsScopeKey || noRunsEmptySticky.active !== showNoRunsEmpty) {
+  if (!runMode && (noRunsEmptySticky.scopeKey !== noRunsScopeKey || noRunsEmptySticky.active !== showNoRunsEmpty)) {
     setNoRunsEmptySticky({ scopeKey: noRunsScopeKey, active: showNoRunsEmpty });
   }
 
@@ -276,6 +280,31 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
           description={`Run an evaluation for ${projectName} to populate this page.`}
           actionLabel="Start evaluation"
           onAction={() => onNavigate?.('evaluate')}
+        />
+      </div>
+    );
+  }
+  if (runMode && !loading && !dashboard && !error) {
+    // createDashboard passes a falsy raw response through unchanged rather
+    // than throwing (models/dashboard.js), so "settled, no error, no
+    // dashboard" is a valid non-error outcome, not just a theoretical one --
+    // this run's data didn't come back. Without this branch it fell through
+    // every other check (all gated on runMode being false, or on dashboard
+    // being truthy) to a genuinely blank .dashboard-page.
+    if (isFetching) {
+      return (
+        <div className="dashboard-page dashboard-fade dashboard-ready">
+          <LoadingScreen variant="inline" message={projectName ? `Loading ${projectName}…` : undefined} />
+        </div>
+      );
+    }
+    return (
+      <div className="dashboard-page dashboard-fade dashboard-ready">
+        <EmptyState
+          title="Couldn't load this run"
+          description="This run's data didn't come back. Try refreshing."
+          actionLabel="Retry"
+          onAction={() => callbacks.onRetry?.()}
         />
       </div>
     );

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -179,6 +179,21 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
     return () => clearTimeout(timer);
   }, [contentReady, dashboard]);
 
+  // Sticky "no evaluations yet" latch: once that empty state is showing for
+  // this project+source, stay on it through a subsequent load (the post-eval
+  // selectedRun flip -- new dashboard key, loading true, dashboard still
+  // null) instead of popping to the full inline loader for a beat. Keyed off
+  // project+source so a project switch never inherits the previous
+  // project's stickiness (see the reset check below). runMode never shows
+  // this empty state, so it's excluded outright.
+  const noRunsScopeKey = `${selectedProject}::${selectedSource}`;
+  const [noRunsEmptySticky, setNoRunsEmptySticky] = useState({ scopeKey: noRunsScopeKey, active: false });
+  const wasNoRunsEmpty = noRunsEmptySticky.scopeKey === noRunsScopeKey && noRunsEmptySticky.active;
+  const showNoRunsEmpty = !runMode && !dashboard && !error && (!loading || wasNoRunsEmpty);
+  if (noRunsEmptySticky.scopeKey !== noRunsScopeKey || noRunsEmptySticky.active !== showNoRunsEmpty) {
+    setNoRunsEmptySticky({ scopeKey: noRunsScopeKey, active: showNoRunsEmpty });
+  }
+
   const { projectsLoaded } = data;
   if (!projectsLoaded) return <LoadingScreen />;
   if (projects.length === 0 && selectedSource !== 'shared') {
@@ -222,33 +237,39 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
     );
   }
   const projectName = projectInfo?.displayName || projectInfo?.name || selectedProject;
-  if (!loading && !dashboard && (error || !isFetching)) {
+  if (!loading && !dashboard && error) {
     // A failed fetch also lands here (dashboard === null, queries settled).
     // It must render as an error: claiming "No evaluations yet" on a
     // 404/500/timeout tells the user their existing evaluations are gone.
     // While a retry is in flight (error still set, isFetching true), show
     // the loader instead so clicking Retry visibly does something.
-    if (error && isFetching) {
+    if (isFetching) {
       return (
         <div className="dashboard-page dashboard-fade dashboard-ready">
           <LoadingScreen variant="inline" message={projectName ? `Loading ${projectName}…` : undefined} />
         </div>
       );
     }
-    if (error) {
-      return (
-        <div className="dashboard-page dashboard-fade dashboard-ready">
-          <EmptyState
-            title="Couldn't load this project"
-            description={error}
-            actionLabel="Retry"
-            onAction={() => callbacks.onRetry?.()}
-          />
-        </div>
-      );
-    }
     return (
       <div className="dashboard-page dashboard-fade dashboard-ready">
+        <EmptyState
+          title="Couldn't load this project"
+          description={error}
+          actionLabel="Retry"
+          onAction={() => callbacks.onRetry?.()}
+        />
+      </div>
+    );
+  }
+  if (showNoRunsEmpty) {
+    // Covers both the settled no-runs state and a background refetch of an
+    // empty project (isFetching true, dashboard still null -- previously a
+    // visually blank .dashboard-page with no dim and no loader), plus the
+    // post-eval selectedRun flip while wasNoRunsEmpty is latched (loading
+    // true, dashboard still null): stay here, dimmed, until the payload
+    // lands rather than swapping to the full inline loader and back.
+    return (
+      <div className={`dashboard-page dashboard-fade dashboard-ready${isFetching ? ' dashboard-refreshing' : ''}`}>
         <IncompleteSetupCard projectInfo={projectInfo} onComplete={handleSetupComplete} />
         <EmptyState
           title="No evaluations yet"

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -193,7 +193,15 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   const noRunsScopeKey = `${selectedProject}::${selectedSource}`;
   const [noRunsEmptySticky, setNoRunsEmptySticky] = useState({ scopeKey: noRunsScopeKey, active: false });
   const wasNoRunsEmpty = noRunsEmptySticky.scopeKey === noRunsScopeKey && noRunsEmptySticky.active;
-  const showNoRunsEmpty = !runMode && !dashboard && !error && (!loading || wasNoRunsEmpty);
+  // Latch on !contentReady, not !dashboard: releasing the latch the moment
+  // the dashboard payload lands (but before accumulated does) reopened the
+  // same pop this latch exists to close, just narrower -- empty(dimmed) ->
+  // inline spinner -> content instead of loader -> content. contentReady
+  // already folds in the accumulated wait for the Overview (runMode is
+  // excluded from this branch outright, so its own dashboard-only readiness
+  // never applies here), so holding the empty state open until BOTH payloads
+  // land closes the gap without a separate flag to keep in sync.
+  const showNoRunsEmpty = !runMode && !contentReady && !error && (!loading || wasNoRunsEmpty);
   if (!runMode && (noRunsEmptySticky.scopeKey !== noRunsScopeKey || noRunsEmptySticky.active !== showNoRunsEmpty)) {
     setNoRunsEmptySticky({ scopeKey: noRunsScopeKey, active: showNoRunsEmpty });
   }

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -208,6 +208,115 @@ describe('DashboardPage fetch-failure state', () => {
   });
 });
 
+// P5-T2: the no-runs -> first-run transition. Task 7 removed the redundant
+// eval-completion refetch, but the sequence "No evaluations yet" -> (dashboard
+// key changes to the new run) -> loader -> content still had two bugs: a
+// window-refocus/background refetch of an empty project used to render a
+// visually blank .dashboard-page (no dim, no loader), and the post-eval
+// selectedRun flip used to swap the empty state for the full inline loader
+// for a beat before content landed (empty -> loader -> content pop).
+describe('DashboardPage no-runs -> first-run transition (P5-T2)', () => {
+  const baseNoRuns = {
+    projectsLoaded: true,
+    projects: [{ id: 'p1', name: 'p1' }],
+    selectedProject: 'p1',
+    selectedSource: 'local',
+    dashboard: null,
+    accumulated: null,
+    loading: false,
+    isFetching: false,
+    error: null,
+    availableRuns: [],
+  };
+
+  it('blank-frame shape (background refetch of an empty project) shows the dimmed empty state, not a blank frame', () => {
+    const { container, getByText } = render(
+      <SidePaneProvider>
+        <DashboardPage data={{ ...baseNoRuns, isFetching: true }} callbacks={{}} runMode={false} />
+      </SidePaneProvider>,
+    );
+    expect(getByText('No evaluations yet')).toBeTruthy();
+    expect(container.querySelector('.loading-screen')).toBeNull();
+    expect(container.querySelector('.dashboard-page').className).toContain('dashboard-refreshing');
+  });
+
+  it('keeps the empty state (dimmed) through the post-eval selectedRun flip, then swaps straight to content', () => {
+    const { container, getByText, queryByText, rerender } = render(
+      <SidePaneProvider>
+        <DashboardPage data={baseNoRuns} callbacks={{}} runMode={false} />
+      </SidePaneProvider>,
+    );
+    expect(getByText('No evaluations yet')).toBeTruthy();
+
+    // selectedRun flips to the new run id: new dashboard query key mounts,
+    // same project/source, loading true, dashboard still null.
+    rerender(
+      <SidePaneProvider>
+        <DashboardPage data={{ ...baseNoRuns, loading: true, isFetching: true }} callbacks={{}} runMode={false} />
+      </SidePaneProvider>,
+    );
+    expect(getByText('No evaluations yet')).toBeTruthy();
+    expect(container.querySelector('.loading-screen')).toBeNull();
+    expect(container.querySelector('.dashboard-page').className).toContain('dashboard-refreshing');
+
+    const dims = [{ dimension: 'maintainability', overallScore: '7.0/10' }];
+    rerender(
+      <SidePaneProvider>
+        <DashboardPage
+          data={{
+            ...baseNoRuns,
+            dashboard: { dimensions: dims, trend: [], selectedRun: { runId: 'r1', dateLabel: '2026-07-01' } },
+            accumulated: { dimensions: dims },
+            loading: false,
+            isFetching: false,
+            availableRuns: [{ runId: 'r1', status: 'complete' }],
+          }}
+          callbacks={{}}
+          runMode={false}
+        />
+      </SidePaneProvider>,
+    );
+    expect(queryByText('No evaluations yet')).toBeNull();
+    expect(container.querySelector('.loading-screen')).toBeNull();
+  });
+
+  it('resets the stickiness on a project switch: the loader shows, not the previous project\'s empty state', () => {
+    const { container, getByText, queryByText, rerender } = render(
+      <SidePaneProvider>
+        <DashboardPage data={baseNoRuns} callbacks={{}} runMode={false} />
+      </SidePaneProvider>,
+    );
+    expect(getByText('No evaluations yet')).toBeTruthy();
+
+    rerender(
+      <SidePaneProvider>
+        <DashboardPage
+          data={{
+            ...baseNoRuns,
+            selectedProject: 'p2',
+            projects: [{ id: 'p2', name: 'p2' }],
+            loading: true,
+            isFetching: true,
+          }}
+          callbacks={{}}
+          runMode={false}
+        />
+      </SidePaneProvider>,
+    );
+    expect(queryByText('No evaluations yet')).toBeNull();
+    expect(container.querySelector('.loading-screen')).toBeTruthy();
+  });
+
+  it('runMode is excluded from the no-runs empty state, sticky or not', () => {
+    const { queryByText } = render(
+      <SidePaneProvider>
+        <DashboardPage data={{ ...baseNoRuns, selectedRun: 'r1' }} callbacks={{}} runMode={true} />
+      </SidePaneProvider>,
+    );
+    expect(queryByText('No evaluations yet')).toBeNull();
+  });
+});
+
 // Scenario 2 (collision): runMode renders RunOverviewPanel, which has its own
 // inline loading state (`!dashboard.dimensions`). Before the page's own
 // isLoading/DashboardContent-mount decision accounted for that, the page-level

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -307,13 +307,59 @@ describe('DashboardPage no-runs -> first-run transition (P5-T2)', () => {
     expect(container.querySelector('.loading-screen')).toBeTruthy();
   });
 
-  it('runMode is excluded from the no-runs empty state, sticky or not', () => {
-    const { queryByText } = render(
+  it('runMode is excluded from the no-runs empty state, and instead renders a run-appropriate empty state (not a blank frame)', () => {
+    const onRetry = vi.fn();
+    const { container, getByText, queryByText } = render(
+      <SidePaneProvider>
+        <DashboardPage data={{ ...baseNoRuns, selectedRun: 'r1' }} callbacks={{ onRetry }} runMode={true} />
+      </SidePaneProvider>,
+    );
+    expect(queryByText('No evaluations yet')).toBeNull();
+    const page = container.querySelector('.dashboard-page');
+    expect(page).toBeTruthy();
+    expect(page.children.length).toBeGreaterThan(0);
+    expect(getByText("Couldn't load this run")).toBeTruthy();
+    fireEvent.click(getByText('Retry'));
+    expect(onRetry).toHaveBeenCalled();
+  });
+
+  it('runMode: shows the inline loader (not the run-appropriate empty state) while a retry of a falsy response is in flight', () => {
+    const { container, queryByText } = render(
+      <SidePaneProvider>
+        <DashboardPage data={{ ...baseNoRuns, selectedRun: 'r1', isFetching: true }} callbacks={{}} runMode={true} />
+      </SidePaneProvider>,
+    );
+    expect(queryByText("Couldn't load this run")).toBeNull();
+    expect(container.querySelector('.loading-screen')).toBeTruthy();
+  });
+
+  it('a runMode round-trip does not clear the overview sticky latch for the same project+source', () => {
+    const { getByText, rerender } = render(
+      <SidePaneProvider>
+        <DashboardPage data={baseNoRuns} callbacks={{}} runMode={false} />
+      </SidePaneProvider>,
+    );
+    expect(getByText('No evaluations yet')).toBeTruthy();
+
+    // User opens a run detail view for the same project+source, then returns
+    // to Overview without DashboardPage ever unmounting (App.jsx's key is the
+    // activeTab, which doesn't change when the run page's sourceTab is
+    // 'overview' -- see useAppState.js).
+    rerender(
       <SidePaneProvider>
         <DashboardPage data={{ ...baseNoRuns, selectedRun: 'r1' }} callbacks={{}} runMode={true} />
       </SidePaneProvider>,
     );
-    expect(queryByText('No evaluations yet')).toBeNull();
+
+    // Back to Overview mid-flip (post-eval selectedRun change): the sticky
+    // latch must still be active from the very first render, not cleared by
+    // the runMode pass in between.
+    rerender(
+      <SidePaneProvider>
+        <DashboardPage data={{ ...baseNoRuns, loading: true, isFetching: true }} callbacks={{}} runMode={false} />
+      </SidePaneProvider>,
+    );
+    expect(getByText('No evaluations yet')).toBeTruthy();
   });
 });
 

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -260,6 +260,33 @@ describe('DashboardPage no-runs -> first-run transition (P5-T2)', () => {
     expect(container.querySelector('.dashboard-page').className).toContain('dashboard-refreshing');
 
     const dims = [{ dimension: 'maintainability', overallScore: '7.0/10' }];
+
+    // Finding 2 (P5 final review): the dashboard query settles before the
+    // scores query does -- dashboard payload is in, accumulated isn't yet.
+    // Releasing the latch here (the pre-fix !dashboard check) swapped the
+    // dimmed empty state for the full inline loader for a beat before
+    // content landed: a narrower version of the pop this latch exists to
+    // close. It must stay on the dimmed empty state instead.
+    rerender(
+      <SidePaneProvider>
+        <DashboardPage
+          data={{
+            ...baseNoRuns,
+            dashboard: { dimensions: dims, trend: [], selectedRun: { runId: 'r1', dateLabel: '2026-07-01' } },
+            accumulated: null,
+            loading: true,
+            isFetching: true,
+            availableRuns: [{ runId: 'r1', status: 'complete' }],
+          }}
+          callbacks={{}}
+          runMode={false}
+        />
+      </SidePaneProvider>,
+    );
+    expect(getByText('No evaluations yet')).toBeTruthy();
+    expect(container.querySelector('.loading-screen')).toBeNull();
+    expect(container.querySelector('.dashboard-page').className).toContain('dashboard-refreshing');
+
     rerender(
       <SidePaneProvider>
         <DashboardPage

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
@@ -111,10 +111,10 @@ describe("useDashboard", () => {
     expect(fakeApi.getDashboard).toHaveBeenCalledTimes(1);
   });
 
-  // The eval-completion path must actively refetch the always-mounted Overview
-  // observer — otherwise a freshly-finished run leaves the Overview showing the
-  // stale (often null) pre-run payload until the user switches projects.
-  it("refreshDashboardActive refetches the mounted observer (eval-completion path)", async () => {
+  // refreshDashboardActive must actively refetch the always-mounted Overview
+  // observer — e.g. the manual retry path (App.jsx's onRetry) — otherwise a
+  // stale (often null) payload lingers until the user switches projects.
+  it("refreshDashboardActive refetches the mounted observer (manual retry path)", async () => {
     const fakeApi = makeFakeApi();
     const { result } = renderHook(
       () => useDashboard({ selectedProject: "p1", selectedRun: null }),
@@ -204,7 +204,7 @@ describe("useDashboard scheduleDashboardReconcile (debounced active reconcile)",
 
   // Regression pin: the debounced reconcile is additive, not a replacement.
   // refreshDashboard must keep its lazy refetchType:'none' contract for its
-  // other callers (evaluation-completion effect, run deletion, etc.).
+  // other callers (wizard project registration, dismiss/restore, etc.).
   it("refreshDashboard keeps mark-stale-only behavior (regression pin)", () => {
     const { result, spy } = renderWithSpy();
     act(() => result.current.refreshDashboard());

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -100,11 +100,11 @@ export function formatDayLabel(trend, currentOverviewRun, dailyRuns, overviewRun
 // a mark-stale-only invalidation left behind (refreshDashboard's
 // refetchType:'none', or ordinary staleTime elapse): the Overview's
 // useDashboard observer is mounted at the app root and never remounts on tab
-// navigation (see the eval-completion effect below), and the desktop
-// pywebview window never fires the focus-refetch a browser tab gets on
-// refocus. `stale: true` keeps this a no-op when nothing is actually stale,
-// so switching tabs doesn't re-download the (potentially 10-20 MB) payload
-// on every visit — only a query already marked stale gets refetched here.
+// navigation, and the desktop pywebview window never fires the focus-refetch
+// a browser tab gets on refocus. `stale: true` keeps this a no-op when
+// nothing is actually stale, so switching tabs doesn't re-download the
+// (potentially 10-20 MB) payload on every visit — only a query already
+// marked stale gets refetched here.
 //
 // Gates on `rootTab` (navStack[0].page), NOT the derived `activeTab`.
 // `activeTab`'s fallback bucket defaults any untagged/unknown page to
@@ -171,23 +171,6 @@ export function useAppState() {
   const { overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect } = useRunNavigator({ selectedRun, availableRuns: visibleDailyRuns, onRunChange: handleRunChange, onNavigate: handleNavigate });
   const prefetchHandlers = usePrefetchAdjacentRuns({ selectedProject, selectedSource, availableRuns: visibleDailyRuns, overviewRunIndex });
   const evalLifecycle = useEvaluationLifecycle({ settings, navigation: { navTab, navReset }, projects: { loadProjects, setProjects, selectProjectAndRun }, selectedProject });
-
-  // Refresh all dashboard data (including latestAccumulated) when an evaluation
-  // finishes. This uses the *active* refetch (not the lazy refreshDashboard the
-  // dismiss path uses): the Overview's useDashboard observer is mounted here at
-  // the app root and never remounts on tab navigation, so a mark-stale-only
-  // invalidation would never actually refetch while the user stays on the same
-  // project — leaving the Overview on the stale pre-run payload until a project
-  // switch. A completed run is exactly when a real refetch is warranted.
-  const evalRefreshedRef = useRef(null);
-  useEffect(() => {
-    const job = evalLifecycle.job;
-    const finished = job && job.status !== 'running' && job.outputRunId;
-    if (finished && evalRefreshedRef.current !== job.outputRunId) {
-      evalRefreshedRef.current = job.outputRunId;
-      refreshDashboardActive();
-    }
-  }, [evalLifecycle.job, refreshDashboardActive]);
 
   const activeTab = KNOWN_TABS.includes(activePage.page) ? activePage.page
     : activePage.sourceTab && KNOWN_TABS.includes(activePage.sourceTab) ? activePage.sourceTab

--- a/src/quodeq/ui/src/hooks/useAppState.test.jsx
+++ b/src/quodeq/ui/src/hooks/useAppState.test.jsx
@@ -1,12 +1,30 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useOverviewReturnReconcile, TAB_OVERVIEW, KNOWN_TABS } from './useAppState.js';
+import { useAppState, useOverviewReturnReconcile, TAB_OVERVIEW, KNOWN_TABS } from './useAppState.js';
 import { useNavStack } from './useNavStack.js';
 import { useDashboard } from '../features/dashboard/hooks/useDashboard.js';
 import { ApiProvider } from '../api/ApiContext.jsx';
 import { projectKeys } from '../api/queryKeys.js';
+
+// useAppState composes useEvaluationLifecycle (-> useEvaluation) and
+// useServerHealth. Mocked the same way useEvaluationLifecycle.test.jsx mocks
+// useEvaluation, so the eval-completion regression below can drive `job`
+// directly without a real evaluation API, and without useServerHealth's
+// real network polling.
+const evaluationState = {
+  job: null, jobError: null, liveViolations: {},
+  startEvaluation: vi.fn(), clearJob: vi.fn(), cancelEvaluation: vi.fn(),
+  startedProject: null,
+};
+vi.mock('../features/evaluation/hooks/useEvaluation.js', () => ({
+  useEvaluation: () => evaluationState,
+  LOCAL_API_PROVIDERS: new Set(['ollama', 'llamacpp', 'omlx']),
+}));
+vi.mock('./useServerHealth.js', () => ({
+  useServerHealth: () => [true, vi.fn(), null],
+}));
 
 // Task 2 (stacked on Task 1's scheduleDashboardReconcile): the Overview's
 // useDashboard observer is mounted at the app root and never remounts on tab
@@ -249,5 +267,92 @@ describe('useOverviewReturnReconcile integration with useDashboard (stale gating
     rerender({ rootTab: TAB_OVERVIEW, selectedProject: 'p1', selectedSource: 'local' });
 
     await waitFor(() => expect(fakeApi.getDashboard).toHaveBeenCalledTimes(2));
+  });
+});
+
+// P5-T1: single refetch path on run completion. Before this task, useAppState
+// ran its OWN eval-completion effect (refreshDashboardActive, keyed off
+// job.outputRunId) in the same effect-flush as useEvaluationLifecycle's
+// selectProjectAndRun. That effect fired before selectedRun's state update
+// had committed, so its active invalidation hit the OLD (pre-run) dashboard
+// key — a redundant refetch. useEvaluationLifecycle is now the only
+// completion path: selectProjectAndRun mints the NEW query key, and that key
+// change is the only refetch a completed run causes.
+function makeAppStateFakeApi() {
+  return {
+    listProjects: vi.fn(async () => [{ id: 'project-a', name: 'Project A' }]),
+    getDashboard: vi.fn(async (project, run) => ({
+      project, run: run || 'latest', trend: [], summary: { score: 75 }, dimensions: [],
+      selectedRun: { runId: run || 'latest', dateLabel: '2026-05-01' },
+    })),
+    sharedGetDashboard: vi.fn(),
+    getProjectScores: vi.fn(async () => ({ accumulated: { score: 90 }, trend: [], availableRuns: [] })),
+    sharedGetProjectScores: vi.fn(),
+    sharedGetProjectInfo: vi.fn(),
+  };
+}
+
+describe('useAppState eval-completion: single refetch path (P5-T1)', () => {
+  beforeEach(() => {
+    evaluationState.job = null;
+    localStorage.setItem('quodeq_selected_project', 'project-a');
+    localStorage.setItem('quodeq_selected_source', 'local');
+  });
+  afterEach(() => {
+    localStorage.removeItem('quodeq_selected_project');
+    localStorage.removeItem('quodeq_selected_source');
+  });
+
+  it('refetches only the new run key on completion -- no redundant active refetch of the pre-run key', async () => {
+    const fakeApi = makeAppStateFakeApi();
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    });
+    const { result, rerender } = renderHook(() => useAppState(), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={client}>
+          <ApiProvider value={fakeApi}>{children}</ApiProvider>
+        </QueryClientProvider>
+      ),
+    });
+
+    await waitFor(() => expect(result.current.selectedProject).toBe('project-a'));
+    await waitFor(() => expect(fakeApi.getDashboard).toHaveBeenCalledTimes(1));
+    expect(fakeApi.getDashboard).toHaveBeenNthCalledWith(1, 'project-a', 'latest');
+
+    evaluationState.job = { jobId: 'j1', status: 'done', outputProject: 'project-a', outputRunId: 'run-2' };
+    rerender();
+
+    await waitFor(() => expect(result.current.selectedRun).toBe('run-2'));
+    await waitFor(() => expect(fakeApi.getDashboard).toHaveBeenCalledTimes(2));
+    expect(fakeApi.getDashboard).toHaveBeenNthCalledWith(2, 'project-a', 'run-2');
+    expect(fakeApi.getDashboard.mock.calls.filter(([p, r]) => p === 'project-a' && r === 'latest')).toHaveLength(1);
+
+    // Settle a beat longer to catch any late-firing redundant refetch.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(fakeApi.getDashboard).toHaveBeenCalledTimes(2);
+  });
+
+  it('still refreshes the project list and moves the selection on completion (selectProjectAndRun/loadProjects remain wired)', async () => {
+    const fakeApi = makeAppStateFakeApi();
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    });
+    const { result, rerender } = renderHook(() => useAppState(), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={client}>
+          <ApiProvider value={fakeApi}>{children}</ApiProvider>
+        </QueryClientProvider>
+      ),
+    });
+
+    await waitFor(() => expect(result.current.selectedProject).toBe('project-a'));
+    const listCallsBefore = fakeApi.listProjects.mock.calls.length;
+
+    evaluationState.job = { jobId: 'j1', status: 'done', outputProject: 'project-a', outputRunId: 'run-2' };
+    rerender();
+
+    await waitFor(() => expect(result.current.selectedRun).toBe('run-2'));
+    await waitFor(() => expect(fakeApi.listProjects.mock.calls.length).toBeGreaterThan(listCallsBefore));
   });
 });

--- a/src/quodeq/ui/src/hooks/useAppState.test.jsx
+++ b/src/quodeq/ui/src/hooks/useAppState.test.jsx
@@ -355,4 +355,60 @@ describe('useAppState eval-completion: single refetch path (P5-T1)', () => {
     await waitFor(() => expect(result.current.selectedRun).toBe('run-2'));
     await waitFor(() => expect(fakeApi.listProjects.mock.calls.length).toBeGreaterThan(listCallsBefore));
   });
+
+  // Finding 1 (P5 final review): P5-T1 above only proved the DASHBOARD key
+  // refetches on completion. It missed that the SCORES key -- the `latest`
+  // query behind `accumulated`/`availableRuns` -- has no dependency on
+  // selectedRun at all, so nothing refetched it once useAppState stopped
+  // calling refreshDashboardActive. This fake, unlike makeAppStateFakeApi
+  // above, is run-aware: getProjectScores returns an empty availableRuns
+  // (and a stale accumulated) until the fake's "backend" is told the new run
+  // exists, mirroring what the real API would return once a run completes.
+  function makeRunAwareFakeApi() {
+    const backend = { newRun: null };
+    return {
+      listProjects: vi.fn(async () => [{ id: 'project-a', name: 'Project A' }]),
+      getDashboard: vi.fn(async (project, run) => ({
+        project, run: run || 'latest', trend: [], summary: { score: 75 }, dimensions: [],
+        selectedRun: { runId: run || 'latest', dateLabel: '2026-05-01' },
+      })),
+      sharedGetDashboard: vi.fn(),
+      getProjectScores: vi.fn(async () => (
+        backend.newRun
+          ? { accumulated: { score: 95 }, trend: [], availableRuns: [{ runId: backend.newRun, dateLabel: '2026-07-01', status: 'complete' }] }
+          : { accumulated: { score: 70 }, trend: [], availableRuns: [] }
+      )),
+      sharedGetProjectScores: vi.fn(),
+      sharedGetProjectInfo: vi.fn(),
+      backend,
+    };
+  }
+
+  it('refetches scores on completion -- accumulated and availableRuns pick up the new run without a tab round-trip', async () => {
+    const fakeApi = makeRunAwareFakeApi();
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    });
+    const { result, rerender } = renderHook(() => useAppState(), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={client}>
+          <ApiProvider value={fakeApi}>{children}</ApiProvider>
+        </QueryClientProvider>
+      ),
+    });
+
+    await waitFor(() => expect(result.current.selectedProject).toBe('project-a'));
+    await waitFor(() => expect(result.current.accumulated).toEqual({ score: 70 }));
+    const scoresCallsBefore = fakeApi.getProjectScores.mock.calls.length;
+
+    // The run completes: the backend now knows about it, and the job
+    // transitions to done in the same tick a real completion would.
+    fakeApi.backend.newRun = 'run-2';
+    evaluationState.job = { jobId: 'j1', status: 'done', outputProject: 'project-a', outputRunId: 'run-2' };
+    rerender();
+
+    await waitFor(() => expect(fakeApi.getProjectScores.mock.calls.length).toBeGreaterThan(scoresCallsBefore));
+    await waitFor(() => expect(result.current.accumulated).toEqual({ score: 95 }));
+    await waitFor(() => expect(result.current.availableRuns.some((r) => r.runId === 'run-2')).toBe(true));
+  });
 });

--- a/src/quodeq/ui/src/hooks/useEvaluationLifecycle.js
+++ b/src/quodeq/ui/src/hooks/useEvaluationLifecycle.js
@@ -1,7 +1,9 @@
 import { useState, useEffect, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useEvaluation, LOCAL_API_PROVIDERS } from '../features/evaluation/hooks/useEvaluation.js';
 import { getLevels, STORAGE_KEY as POWER_KEY } from '../features/evaluation/components/powerLevels.js';
 import { ACTIVE_PROVIDER_KEY, providerKey } from '../constants.js';
+import { projectKeys } from '../api/queryKeys.js';
 
 const TIER_NAMES = ['fast', 'balanced', 'thorough'];
 const DEFAULT_ANALYSIS_POWER = 2;
@@ -17,6 +19,7 @@ export function useEvaluationLifecycle({ settings, navigation, projects, selecte
   const { navTab, navReset } = navigation;
   const { loadProjects, setProjects, selectProjectAndRun } = projects;
   const { job, jobError, liveViolations, startEvaluation, clearJob, cancelEvaluation, startedProject } = useEvaluation();
+  const queryClient = useQueryClient();
   // Set when a start request is refused because another evaluation is
   // already running. Surfaced through jobError so the Evaluate screen's
   // toast shows it; a silent refusal left users believing the visible
@@ -49,6 +52,25 @@ export function useEvaluationLifecycle({ settings, navigation, projects, selecte
       loadProjects()
         .then((list) => setProjects(list))
         .catch((err) => console.error('Failed to refresh projects:', err));
+      // useAppState's dashboard-key effect (removed as redundant: the
+      // selectProjectAndRun call below mints a new dashboard query key on its
+      // own) only ever covered the dashboard side. The scores side has its
+      // own key -- projectKeys.scores(project, null, source), the `latest`
+      // query in useProjectScores -- and it does NOT change when selectedRun
+      // flips, because `asOf` only resolves to the new run once
+      // `availableRuns` (itself sourced from this same query) already lists
+      // it. Left un-invalidated, a user parked on the Overview when a run
+      // completes never gets the refreshed `availableRuns`/`accumulated`:
+      // repeat-run projects show stale grades until a tab round-trip, and a
+      // first-run project never gets `accumulated`, so `contentReady` stays
+      // false and the page sits on the inline loader indefinitely. Evaluations
+      // only ever write to the
+      // local repo, so the 'local' source (the default) is always correct
+      // here regardless of which source tab the user has open elsewhere.
+      // Unconditional on outputProject: invalidating an inactive observer's
+      // query just marks it stale (no fetch), so this is a harmless no-op
+      // when nobody is looking at that project.
+      queryClient.invalidateQueries({ queryKey: projectKeys.scores(job.outputProject, null, 'local') });
       // Only move the selection to the finished run when the user is
       // already on that project (or has none selected, e.g. first-eval
       // onboarding). Unconditional switching yanked a user browsing

--- a/src/quodeq/ui/src/hooks/useEvaluationLifecycle.test.jsx
+++ b/src/quodeq/ui/src/hooks/useEvaluationLifecycle.test.jsx
@@ -1,8 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { projectKeys } from "../api/queryKeys.js";
 
 // The lifecycle hook composes useEvaluation; mock it so tests can control
-// the job state without a QueryClient or API layer.
+// the job state without a real API layer. A real QueryClient is still needed
+// -- the hook now calls useQueryClient() to invalidate the scores key on
+// completion (see the "eval completion: scores refetch" describe below).
 const evaluationState = {
   job: null,
   jobError: null,
@@ -19,19 +24,25 @@ vi.mock("../features/evaluation/hooks/useEvaluation.js", () => ({
 
 import { useEvaluationLifecycle } from "./useEvaluationLifecycle.js";
 
-function renderLifecycle({ selectedProject = null, selectProjectAndRun = vi.fn() } = {}) {
-  return renderHook(() =>
-    useEvaluationLifecycle({
-      settings: {},
-      navigation: { navTab: vi.fn(), navReset: vi.fn() },
-      projects: {
-        loadProjects: vi.fn().mockResolvedValue([]),
-        setProjects: vi.fn(),
-        selectProjectAndRun,
-      },
-      selectedProject,
-    }),
+function renderLifecycle({ selectedProject = null, selectProjectAndRun = vi.fn(), client } = {}) {
+  const queryClient = client || new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+  });
+  const utils = renderHook(
+    () =>
+      useEvaluationLifecycle({
+        settings: {},
+        navigation: { navTab: vi.fn(), navReset: vi.fn() },
+        projects: {
+          loadProjects: vi.fn().mockResolvedValue([]),
+          setProjects: vi.fn(),
+          selectProjectAndRun,
+        },
+        selectedProject,
+      }),
+    { wrapper: ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider> },
   );
+  return { ...utils, queryClient };
 }
 
 describe("useEvaluationLifecycle background completion", () => {
@@ -73,6 +84,57 @@ describe("useEvaluationLifecycle background completion", () => {
     const selectProjectAndRun = vi.fn();
     renderLifecycle({ selectedProject: null, selectProjectAndRun });
     expect(selectProjectAndRun).toHaveBeenCalledWith("project-a", "run-a1");
+  });
+});
+
+// Finding 1 (P5 final review): removing useAppState's dashboard-key refetch
+// (69b67347) orphaned the scores side. projectKeys.scores(project, null,
+// source) -- the `latest` query behind useProjectScores's `accumulated` and
+// `availableRuns` -- never changes key when selectedRun flips to the new
+// run, so nothing refetched it: repeat-run projects showed stale grades
+// until a tab round-trip, and first-run projects never got `accumulated` at
+// all (contentReady stuck false, page stuck on the inline loader).
+describe("useEvaluationLifecycle background completion: scores refetch", () => {
+  beforeEach(() => {
+    evaluationState.job = null;
+    evaluationState.jobError = null;
+    evaluationState.startEvaluation = vi.fn();
+  });
+
+  it("invalidates the completed project's local scores query on completion", () => {
+    evaluationState.job = {
+      jobId: "j-done", status: "done",
+      outputProject: "project-a", outputRunId: "run-a1",
+    };
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    });
+    const spy = vi.spyOn(client, "invalidateQueries");
+    renderLifecycle({ selectedProject: "project-a", client });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: projectKeys.scores("project-a", null, "local") }),
+    );
+  });
+
+  it("invalidates the scores query even when the finished project is not the one currently viewed", () => {
+    // Unconditional on outputProject: a mark-stale/no-op invalidation of an
+    // inactive observer's query is harmless, and this is the only path back
+    // to fresh data for the Overview if the user switches to that project
+    // later without a round-trip through another tab.
+    evaluationState.job = {
+      jobId: "j-done", status: "done",
+      outputProject: "project-a", outputRunId: "run-a1",
+    };
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    });
+    const spy = vi.spyOn(client, "invalidateQueries");
+    renderLifecycle({ selectedProject: "project-b", client });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: projectKeys.scores("project-a", null, "local") }),
+    );
   });
 });
 


### PR DESCRIPTION
P5 of the loading/transition rework (follows #902 and #903). Smooths what happens on the Overview when an evaluation run finishes.

## What changed

- One refetch path on run completion. useAppState's duplicate job-completion effect is gone; useEvaluationLifecycle owns the transition. This removes the wasted refetch of the old dashboard key that also caused a blank-frame flash.
- The completion path now invalidates the latest-scores key explicitly. The old duplicate effect was accidentally the only thing refreshing accumulated/availableRuns for a user parked on the Overview (review catch). Without it, a first-run project would spin forever and repeat runs would show stale grades until a tab switch. The dashboard keys stay untouched, so the redundant heavy refetch does not come back.
- No blank frame: a background refetch over an empty project now keeps the "No evaluations yet" state dimmed (same pattern the other pages got in #903) instead of rendering an empty dashboard frame.
- No pop on first run: the empty state stays, dimmed, through the whole first-run load and releases only when both the dashboard and scores payloads have landed. It resets on project or source switch and doesn't apply to run-detail pages.
- Run detail pages got an explicit branch for a settled-but-empty payload ("Couldn't load this run" with Retry) instead of silently rendering a blank frame.

## Tests

1406 passing (baseline 1395 + 11 new: single-refetch regression with the real hook stack, run-aware scores refetch on completion, blank-frame shape, sticky empty-state sequence and project-switch reset, runMode branches).