### PR TITLE
fix(ui): transition dedupe — one fade per content appearance, no chart pop-in

### DIFF
--- a/src/quodeq/ui/src/components/scoreChartHelpers.js
+++ b/src/quodeq/ui/src/components/scoreChartHelpers.js
@@ -55,3 +55,7 @@ export const CHART_MARGIN = { top: 8, right: 0, bottom: 0, left: 0 };
 /** Opacity for the selected vs deselected bars across all score charts. */
 export const SELECTED_BAR_OPACITY = 0.85;
 export const DESELECTED_BAR_OPACITY = 0.4;
+
+/** Fixed chart height for the History tab's score chart (HistoryChartPanel),
+ * shared with its Suspense placeholder so the two never drift apart. */
+export const HISTORY_CHART_HEIGHT = 220;

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -4,6 +4,7 @@ import DimensionCardsGrid from './DimensionCardsGrid.jsx';
 import { formatRunId, gradeLetter, complianceRatio, extDisplayName } from '../../../utils/formatters.js';
 import { collapseByPeriod, collectPeriodDimensions, bucketKey, extractDimensionPeriodSeries, sliceTrendAtRun } from '../../../utils/dailyGrouping.js';
 const RunHistoryPanel = lazy(() => import('./RunHistoryPanel.jsx'));
+import RunHistoryPanelPlaceholder from './RunHistoryPanelPlaceholder.jsx';
 import DimensionScorePanel from './DimensionScorePanel.jsx';
 import TopOffendingFilesTable from './TopOffendingFilesTable.jsx';
 import { buildTopOffendingFiles, buildProjectRootFile } from '../../../utils/explorerUtils.js';
@@ -289,7 +290,7 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
       />
 
       <div className="history-panels-row">
-        <Suspense fallback={null}>
+        <Suspense fallback={<RunHistoryPanelPlaceholder />}>
           {chartMountable && (
             <RunHistoryPanel
               trend={filteredPeriodTrend}

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.suspense.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.suspense.test.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import AccumulatedOverviewPanel from './AccumulatedOverviewPanel.jsx';
+import { SidePaneProvider } from '../../side-pane/SidePaneProvider.jsx';
+
+// Never resolves, so the lazy RunHistoryPanel stays suspended and the
+// Suspense fallback (RunHistoryPanelPlaceholder) is what ends up on screen.
+vi.mock('./RunHistoryPanel.jsx', () => new Promise(() => {}));
+
+// Two days of trend data — enough for chartMountable (>= 2) to be true.
+const TREND = [
+  { runId: 't1', dateISO: '2026-07-03T10:00:00', dateLabel: 'Jul 3', numericAverage: 9, overallGrade: 'A', dimensions: ['maintainability'], dimensionDetails: [{ dimension: 'maintainability', score: 9 }] },
+  { runId: 't2', dateISO: '2026-06-15T10:00:00', dateLabel: 'Jun 15', numericAverage: 7, overallGrade: 'B', dimensions: ['maintainability'], dimensionDetails: [{ dimension: 'maintainability', score: 7 }] },
+];
+const DIMS = [{ dimension: 'maintainability', overallScore: '7.0/10' }];
+
+function baseData(trend) {
+  return {
+    accumulated: { summary: { numericAverage: 7 }, dimensions: DIMS },
+    accumulatedDimensions: DIMS,
+    availableRuns: [],
+    dailyRuns: null,
+    overviewRunIndex: 0,
+    trend,
+    selectedRunId: 't1',
+    granularity: 'day',
+    projectInfo: null,
+    selectedProject: 'proj1',
+    selectedSource: 'local',
+  };
+}
+
+const callbacks = {
+  onRunClick: vi.fn(),
+  onDimensionClick: vi.fn(),
+  onNavigate: vi.fn(),
+};
+
+describe('AccumulatedOverviewPanel — chart Suspense fallback', () => {
+  it('renders the panel-shell placeholder while the chart chunk is unresolved (chartMountable)', async () => {
+    render(
+      <SidePaneProvider>
+        <AccumulatedOverviewPanel data={baseData(TREND)} callbacks={callbacks} />
+      </SidePaneProvider>,
+    );
+    expect(await screen.findByTestId('run-history-panel-placeholder')).toBeInTheDocument();
+  });
+
+  it('keeps the chartMountable gate: renders nothing (not even the placeholder) with < 2 days of trend', () => {
+    render(
+      <SidePaneProvider>
+        <AccumulatedOverviewPanel data={baseData([TREND[0]])} callbacks={callbacks} />
+      </SidePaneProvider>,
+    );
+    expect(screen.queryByTestId('run-history-panel-placeholder')).toBeNull();
+  });
+});

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -223,6 +223,12 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
     if (!isLoading) dashboardAppearedKeyRef.current = dashboardAppearKey;
   }, [isLoading, dashboardAppearKey]);
   const dashboardAppearClass = dashboardAppearNow ? ' dashboard-appear' : '';
+  // Trade-off: the appear class only lives for the one render where it's computed
+  // above -- it doesn't stay latched until dashboardAppearKey next changes -- so any
+  // re-render inside the animation window (e.g. grace-fallback partial page then
+  // contentReady flipping true) drops it and snaps opacity to 1, cutting the fade
+  // short. Latching it across renders was rejected: it would fail to re-arm on a
+  // run switch without reintroducing a loading gap.
 
   // Sticky "no evaluations yet" latch: once that empty state is showing for
   // this project+source, stay on it through a subsequent load (the post-eval
@@ -261,6 +267,11 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
     if (sharedHasContent) {
       return (
         <>
+          {/* This `{null}` pins .dashboard-page to Fragment child index 1 in every
+              early-return branch, matching the main return's two-child Fragment
+              (loader + div) below -- so switching between branches reconciles
+              against the same slot instead of remounting the subtree and
+              replaying the fade-in. Don't remove it. */}
           {null}
           <div className={`dashboard-page dashboard-fade dashboard-ready${dashboardAppearClass}`}>
             <EmptyState

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -179,6 +179,40 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
     return () => clearTimeout(timer);
   }, [contentReady, dashboard]);
 
+  // Hold the full LoadingScreen until the content is ready, so we don't fade in
+  // a half-drawn page and then pop the real content in a beat later (the
+  // first-load flicker). BUT a cold score cache can take several seconds to
+  // rebuild (e.g. right after a dismiss/restore/formula change invalidates it);
+  // sitting on a blank spinner that whole time reads as "not opening". So once
+  // the dashboard payload is in and the grace has elapsed (graceElapsed, set
+  // above), fall back to the partial page (frame + a content spinner) so a slow
+  // load shows progress instead of a hang. The grace comfortably exceeds a warm
+  // load, so the fast path still gets one clean transition.
+  // Hoisted above the early returns (rather than kept by the main return where
+  // it's consumed) because the fade-once latch below needs it for every branch,
+  // not just the main one.
+  const isLoading = loading && !contentReady && !(dashboard && graceElapsed);
+
+  // Fade-once latch: `dashboard-fadein` should play when the page's content
+  // first appears for this project/source/run context, not on every
+  // loading<->ready flip within it (grace-fallback then content-ready, an
+  // error settling, the no-runs sticky state handing off to real content).
+  // Keyed like noRunsScopeKey below, but the run is folded in too so a run
+  // switch on run-detail gets its own fade. The animation itself lives on a
+  // separate `dashboard-appear` class (kept apart from the `dashboard-ready`
+  // state class) so re-adding `dashboard-ready` alone -- e.g. dropping
+  // `dashboard-refreshing` -- never replays it. The ref is only written from
+  // an effect (post-commit), never during render: mutating it inline would
+  // make the appear decision depend on how many times React happens to
+  // invoke this render (StrictMode double-invokes it in dev).
+  const dashboardAppearKey = `${selectedProject}::${selectedSource}::${runMode ? selectedRunId : 'overview'}`;
+  const dashboardAppearedKeyRef = useRef(null);
+  const dashboardAppearNow = !isLoading && dashboardAppearedKeyRef.current !== dashboardAppearKey;
+  useEffect(() => {
+    if (!isLoading) dashboardAppearedKeyRef.current = dashboardAppearKey;
+  }, [isLoading, dashboardAppearKey]);
+  const dashboardAppearClass = dashboardAppearNow ? ' dashboard-appear' : '';
+
   // Sticky "no evaluations yet" latch: once that empty state is showing for
   // this project+source, stay on it through a subsequent load (the post-eval
   // selectedRun flip -- new dashboard key, loading true, dashboard still
@@ -215,37 +249,46 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
     // repositories tab; the copy is what differs.
     if (sharedHasContent) {
       return (
-        <div className="dashboard-page dashboard-fade dashboard-ready">
-          <EmptyState
-            title="No local projects yet"
-            description="Your team’s online repository has published projects you can browse without scanning anything locally."
-            actionLabel="Browse remote repositories"
-            onAction={() => onNavigate?.('projects')}
-          />
-        </div>
+        <>
+          {null}
+          <div className={`dashboard-page dashboard-fade dashboard-ready${dashboardAppearClass}`}>
+            <EmptyState
+              title="No local projects yet"
+              description="Your team’s online repository has published projects you can browse without scanning anything locally."
+              actionLabel="Browse remote repositories"
+              onAction={() => onNavigate?.('projects')}
+            />
+          </div>
+        </>
       );
     }
     return (
-      <div className="dashboard-page dashboard-fade dashboard-ready">
-        <EmptyState
-          title="No projects yet"
-          description="Add a project to start analyzing code quality."
-          actionLabel="Add a project"
-          onAction={() => onNavigate?.('projects')}
-        />
-      </div>
+      <>
+        {null}
+        <div className={`dashboard-page dashboard-fade dashboard-ready${dashboardAppearClass}`}>
+          <EmptyState
+            title="No projects yet"
+            description="Add a project to start analyzing code quality."
+            actionLabel="Add a project"
+            onAction={() => onNavigate?.('projects')}
+          />
+        </div>
+      </>
     );
   }
   if (!selectedProject) {
     return (
-      <div className="dashboard-page dashboard-fade dashboard-ready">
-        <EmptyState
-          title="No project selected"
-          description="Pick a project to view its overview."
-          actionLabel="Choose project"
-          onAction={() => onNavigate?.('projects')}
-        />
-      </div>
+      <>
+        {null}
+        <div className={`dashboard-page dashboard-fade dashboard-ready${dashboardAppearClass}`}>
+          <EmptyState
+            title="No project selected"
+            description="Pick a project to view its overview."
+            actionLabel="Choose project"
+            onAction={() => onNavigate?.('projects')}
+          />
+        </div>
+      </>
     );
   }
   const projectName = projectInfo?.displayName || projectInfo?.name || selectedProject;
@@ -257,20 +300,26 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
     // the loader instead so clicking Retry visibly does something.
     if (isFetching) {
       return (
-        <div className="dashboard-page dashboard-fade dashboard-ready">
-          <LoadingScreen variant="inline" message={projectName ? `Loading ${projectName}…` : undefined} />
-        </div>
+        <>
+          {null}
+          <div className={`dashboard-page dashboard-fade dashboard-ready${dashboardAppearClass}`}>
+            <LoadingScreen variant="inline" message={projectName ? `Loading ${projectName}…` : undefined} />
+          </div>
+        </>
       );
     }
     return (
-      <div className="dashboard-page dashboard-fade dashboard-ready">
-        <EmptyState
-          title="Couldn't load this project"
-          description={error}
-          actionLabel="Retry"
-          onAction={() => callbacks.onRetry?.()}
-        />
-      </div>
+      <>
+        {null}
+        <div className={`dashboard-page dashboard-fade dashboard-ready${dashboardAppearClass}`}>
+          <EmptyState
+            title="Couldn't load this project"
+            description={error}
+            actionLabel="Retry"
+            onAction={() => callbacks.onRetry?.()}
+          />
+        </div>
+      </>
     );
   }
   if (showNoRunsEmpty) {
@@ -281,15 +330,18 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
     // true, dashboard still null): stay here, dimmed, until the payload
     // lands rather than swapping to the full inline loader and back.
     return (
-      <div className={`dashboard-page dashboard-fade dashboard-ready${isFetching ? ' dashboard-refreshing' : ''}`}>
-        <IncompleteSetupCard projectInfo={projectInfo} onComplete={handleSetupComplete} />
-        <EmptyState
-          title="No evaluations yet"
-          description={`Run an evaluation for ${projectName} to populate this page.`}
-          actionLabel="Start evaluation"
-          onAction={() => onNavigate?.('evaluate')}
-        />
-      </div>
+      <>
+        {null}
+        <div className={`dashboard-page dashboard-fade dashboard-ready${dashboardAppearClass}${isFetching ? ' dashboard-refreshing' : ''}`}>
+          <IncompleteSetupCard projectInfo={projectInfo} onComplete={handleSetupComplete} />
+          <EmptyState
+            title="No evaluations yet"
+            description={`Run an evaluation for ${projectName} to populate this page.`}
+            actionLabel="Start evaluation"
+            onAction={() => onNavigate?.('evaluate')}
+          />
+        </div>
+      </>
     );
   }
   if (runMode && !loading && !dashboard && !error) {
@@ -301,33 +353,29 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
     // being truthy) to a genuinely blank .dashboard-page.
     if (isFetching) {
       return (
-        <div className="dashboard-page dashboard-fade dashboard-ready">
-          <LoadingScreen variant="inline" message={projectName ? `Loading ${projectName}…` : undefined} />
-        </div>
+        <>
+          {null}
+          <div className={`dashboard-page dashboard-fade dashboard-ready${dashboardAppearClass}`}>
+            <LoadingScreen variant="inline" message={projectName ? `Loading ${projectName}…` : undefined} />
+          </div>
+        </>
       );
     }
     return (
-      <div className="dashboard-page dashboard-fade dashboard-ready">
-        <EmptyState
-          title="Couldn't load this run"
-          description="This run's data didn't come back. Try refreshing."
-          actionLabel="Retry"
-          onAction={() => callbacks.onRetry?.()}
-        />
-      </div>
+      <>
+        {null}
+        <div className={`dashboard-page dashboard-fade dashboard-ready${dashboardAppearClass}`}>
+          <EmptyState
+            title="Couldn't load this run"
+            description="This run's data didn't come back. Try refreshing."
+            actionLabel="Retry"
+            onAction={() => callbacks.onRetry?.()}
+          />
+        </div>
+      </>
     );
   }
 
-  // Hold the full LoadingScreen until the content is ready, so we don't fade in
-  // a half-drawn page and then pop the real content in a beat later (the
-  // first-load flicker). BUT a cold score cache can take several seconds to
-  // rebuild (e.g. right after a dismiss/restore/formula change invalidates it);
-  // sitting on a blank spinner that whole time reads as "not opening". So once
-  // the dashboard payload is in and the grace has elapsed (graceElapsed, set
-  // above), fall back to the partial page (frame + a content spinner) so a slow
-  // load shows progress instead of a hang. The grace comfortably exceeds a warm
-  // load, so the fast path still gets one clean transition.
-  const isLoading = loading && !contentReady && !(dashboard && graceElapsed);
   // True while a *background* fetch is running but we're already showing
   // data (placeholderData kept the previous run on screen during a switch).
   // The page dims itself slightly so the user sees "still working" without
@@ -344,7 +392,7 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
           the user sees right after picking a project; saying which one makes
           the wait legible instead of looking like the page hung. */}
       {isLoading && <LoadingScreen variant="inline" message={projectName ? `Loading ${projectName}…` : undefined} />}
-      <div className={`dashboard-page dashboard-fade ${isLoading ? 'dashboard-loading' : 'dashboard-ready'}${isRefreshing ? ' dashboard-refreshing' : ''}`}>
+      <div className={`dashboard-page dashboard-fade ${isLoading ? 'dashboard-loading' : `dashboard-ready${dashboardAppearClass}`}${isRefreshing ? ' dashboard-refreshing' : ''}`}>
         <IncompleteSetupCard projectInfo={projectInfo} onComplete={handleSetupComplete} />
         {error && <p className="inline-error">Failed to load dashboard data. Please try again.</p>}
         {/* Grace elapsed but content still isn't ready (dashboard is in, accumulated

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -205,6 +205,17 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   // an effect (post-commit), never during render: mutating it inline would
   // make the appear decision depend on how many times React happens to
   // invoke this render (StrictMode double-invokes it in dev).
+  // isLoading, reused below as "was this render ready", isn't guaranteed
+  // false on every render of every early-return branch -- e.g. the no-runs
+  // sticky branch below CAN be reached with isLoading true, once
+  // wasNoRunsEmpty is already latched (a repeat render of an already-shown
+  // context, gated by showNoRunsEmpty's `!loading || wasNoRunsEmpty` below).
+  // What matters is narrower and does hold: on the render where a context's
+  // empty/error state genuinely first appears, `loading` is false --
+  // showNoRunsEmpty requires `!loading` until wasNoRunsEmpty is latched, and
+  // the error/runMode-empty branches gate on `!loading` outright -- so the
+  // latch is never consumed before real first-appearance content is on
+  // screen; isLoading being true only ever suppresses a repeat.
   const dashboardAppearKey = `${selectedProject}::${selectedSource}::${runMode ? selectedRunId : 'overview'}`;
   const dashboardAppearedKeyRef = useRef(null);
   const dashboardAppearNow = !isLoading && dashboardAppearedKeyRef.current !== dashboardAppearKey;

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -753,6 +753,52 @@ describe('DashboardPage frame stability and fade-once across branch transitions 
     page = container.querySelector('.dashboard-page');
     expect(page.className).toContain('dashboard-appear');
   });
+
+  it('re-arms dashboard-appear on a run switch in run-detail, but not on a repeat render of the same run', () => {
+    const readyRun = (runId) => ({
+      projectsLoaded: true,
+      projects: [{ id: 'p1', name: 'p1' }],
+      selectedProject: 'p1',
+      selectedSource: 'local',
+      selectedRun: runId,
+      dashboard: {
+        dimensions: [{ dimension: 'Security', overallScore: '7.0/10', violations: [], compliance: [], principles: [] }],
+        trend: [],
+        selectedRun: { runId, dateLabel: '2026-05-01' },
+      },
+      accumulated: null,
+      loading: false,
+      isFetching: false,
+      error: null,
+      availableRuns: [{ runId, status: 'complete' }],
+    });
+
+    const { container, rerender } = render(
+      <SidePaneProvider>
+        <DashboardPage data={readyRun('r1')} callbacks={{}} runMode={true} />
+      </SidePaneProvider>,
+    );
+    let page = container.querySelector('.dashboard-page');
+    expect(page.className).toContain('dashboard-appear');
+
+    // Same run re-rendered (e.g. an unrelated prop changing): must not replay.
+    rerender(
+      <SidePaneProvider>
+        <DashboardPage data={{ ...readyRun('r1'), isFetching: true }} callbacks={{}} runMode={true} />
+      </SidePaneProvider>,
+    );
+    page = container.querySelector('.dashboard-page');
+    expect(page.className).not.toContain('dashboard-appear');
+
+    // Switching to a different run in run-detail is a legitimate new context.
+    rerender(
+      <SidePaneProvider>
+        <DashboardPage data={readyRun('r2')} callbacks={{}} runMode={true} />
+      </SidePaneProvider>,
+    );
+    page = container.querySelector('.dashboard-page');
+    expect(page.className).toContain('dashboard-appear');
+  });
 });
 
 // Finding 5 (final whole-branch review): projectInfo for a shared selection

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -570,6 +570,191 @@ describe('DashboardPage frame stability in empty branches', () => {
   });
 });
 
+// P3-T2: the page-level frame must survive every branch transition (no
+// div<->Fragment root-type flip), and `dashboard-fadein` must play once per
+// project/source/run context instead of replaying on every loading<->ready
+// flip or branch swap over unchanged content.
+describe('DashboardPage frame stability and fade-once across branch transitions (P3-T2)', () => {
+  const readyOverview = {
+    projectsLoaded: true,
+    projects: [{ id: 'p1', name: 'p1' }],
+    selectedProject: 'p1',
+    selectedSource: 'local',
+    dashboard: {
+      dimensions: [{ dimension: 'Security', overallScore: '7.0/10', violations: [], compliance: [], principles: [] }],
+      trend: [],
+      selectedRun: { runId: 'r1', dateLabel: '2026-05-01' },
+    },
+    accumulated: { dimensions: [{ dimension: 'Security', overallScore: '7.0/10' }] },
+    loading: false,
+    isFetching: false,
+    error: null,
+    availableRuns: [{ runId: 'r1', status: 'complete' }],
+  };
+
+  it('keeps the same .dashboard-page DOM node across a transition from an early-return branch to the main content branch', () => {
+    const { container, rerender } = render(
+      <SidePaneProvider>
+        <DashboardPage data={{ projectsLoaded: true, projects: [{ id: 'p1', name: 'p1' }], selectedProject: '', loading: false, isFetching: false, error: null, availableRuns: [] }} callbacks={{}} runMode={false} />
+      </SidePaneProvider>,
+    );
+    const nodeBefore = container.querySelector('.dashboard-page');
+    expect(nodeBefore).toBeTruthy();
+
+    rerender(
+      <SidePaneProvider>
+        <DashboardPage data={readyOverview} callbacks={{}} runMode={false} />
+      </SidePaneProvider>,
+    );
+    const nodeAfter = container.querySelector('.dashboard-page');
+    expect(nodeAfter).toBeTruthy();
+    expect(nodeAfter).toBe(nodeBefore);
+  });
+
+  it('keeps the same .dashboard-page DOM node across a transition from the error branch to the main content branch', () => {
+    const { container, rerender } = render(
+      <SidePaneProvider>
+        <DashboardPage
+          data={{ projectsLoaded: true, projects: [{ id: 'p1', name: 'p1' }], selectedProject: 'p1', dashboard: null, accumulated: null, loading: false, isFetching: false, error: 'boom', availableRuns: [] }}
+          callbacks={{}}
+          runMode={false}
+        />
+      </SidePaneProvider>,
+    );
+    const nodeBefore = container.querySelector('.dashboard-page');
+    expect(nodeBefore).toBeTruthy();
+
+    rerender(
+      <SidePaneProvider>
+        <DashboardPage data={readyOverview} callbacks={{}} runMode={false} />
+      </SidePaneProvider>,
+    );
+    const nodeAfter = container.querySelector('.dashboard-page');
+    expect(nodeAfter).toBe(nodeBefore);
+  });
+
+  it('carries dashboard-appear on first content appearance, not while still loading, and not on a second ready render over the same context', () => {
+    const { container, rerender } = render(
+      <SidePaneProvider>
+        <DashboardPage data={{ ...readyOverview, accumulated: null, loading: true }} callbacks={{}} runMode={false} />
+      </SidePaneProvider>,
+    );
+    let page = container.querySelector('.dashboard-page');
+    expect(page.className).toContain('dashboard-loading');
+    expect(page.className).not.toContain('dashboard-appear');
+
+    rerender(
+      <SidePaneProvider>
+        <DashboardPage data={readyOverview} callbacks={{}} runMode={false} />
+      </SidePaneProvider>,
+    );
+    page = container.querySelector('.dashboard-page');
+    expect(page.className).toContain('dashboard-ready');
+    expect(page.className).toContain('dashboard-appear');
+
+    rerender(
+      <SidePaneProvider>
+        <DashboardPage data={{ ...readyOverview, isFetching: true }} callbacks={{}} runMode={false} />
+      </SidePaneProvider>,
+    );
+    page = container.querySelector('.dashboard-page');
+    expect(page.className).toContain('dashboard-ready');
+    expect(page.className).toContain('dashboard-refreshing');
+    expect(page.className).not.toContain('dashboard-appear');
+  });
+
+  it('does not replay dashboard-appear across the grace-fallback -> content-ready double flip', () => {
+    vi.useFakeTimers();
+    try {
+      const { container, rerender } = render(
+        <SidePaneProvider>
+          <DashboardPage data={{ ...readyOverview, accumulated: null, loading: true }} callbacks={{}} runMode={false} />
+        </SidePaneProvider>,
+      );
+      act(() => { vi.advanceTimersByTime(800); });
+      let page = container.querySelector('.dashboard-page');
+      expect(page.className).toContain('dashboard-ready');
+      expect(page.className).toContain('dashboard-appear');
+
+      rerender(
+        <SidePaneProvider>
+          <DashboardPage data={readyOverview} callbacks={{}} runMode={false} />
+        </SidePaneProvider>,
+      );
+      page = container.querySelector('.dashboard-page');
+      expect(page.className).toContain('dashboard-ready');
+      expect(page.className).not.toContain('dashboard-appear');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not replay dashboard-appear when the sticky no-runs empty state hands off to real content', () => {
+    const baseNoRuns = {
+      projectsLoaded: true,
+      projects: [{ id: 'p1', name: 'p1' }],
+      selectedProject: 'p1',
+      selectedSource: 'local',
+      dashboard: null,
+      accumulated: null,
+      loading: false,
+      isFetching: false,
+      error: null,
+      availableRuns: [],
+    };
+    const { container, rerender, getByText, queryByText } = render(
+      <SidePaneProvider>
+        <DashboardPage data={baseNoRuns} callbacks={{}} runMode={false} />
+      </SidePaneProvider>,
+    );
+    expect(getByText('No evaluations yet')).toBeTruthy();
+    let page = container.querySelector('.dashboard-page');
+    expect(page.className).toContain('dashboard-appear');
+
+    rerender(
+      <SidePaneProvider>
+        <DashboardPage data={{ ...readyOverview, selectedProject: 'p1', selectedSource: 'local' }} callbacks={{}} runMode={false} />
+      </SidePaneProvider>,
+    );
+    expect(queryByText('No evaluations yet')).toBeNull();
+    page = container.querySelector('.dashboard-page');
+    expect(page.className).toContain('dashboard-ready');
+    expect(page.className).not.toContain('dashboard-appear');
+  });
+
+  it('re-arms dashboard-appear on a project switch (a new context gets its own fade)', () => {
+    const { container, rerender } = render(
+      <SidePaneProvider>
+        <DashboardPage data={readyOverview} callbacks={{}} runMode={false} />
+      </SidePaneProvider>,
+    );
+    let page = container.querySelector('.dashboard-page');
+    expect(page.className).toContain('dashboard-appear');
+
+    rerender(
+      <SidePaneProvider>
+        <DashboardPage data={{ ...readyOverview, isFetching: true }} callbacks={{}} runMode={false} />
+      </SidePaneProvider>,
+    );
+    page = container.querySelector('.dashboard-page');
+    expect(page.className).not.toContain('dashboard-appear');
+
+    const project2 = {
+      ...readyOverview,
+      selectedProject: 'p2',
+      projects: [{ id: 'p2', name: 'p2' }],
+      dashboard: { ...readyOverview.dashboard, selectedRun: { runId: 'r2', dateLabel: '2026-06-01' } },
+    };
+    rerender(
+      <SidePaneProvider>
+        <DashboardPage data={project2} callbacks={{}} runMode={false} />
+      </SidePaneProvider>,
+    );
+    page = container.querySelector('.dashboard-page');
+    expect(page.className).toContain('dashboard-appear');
+  });
+});
+
 // Finding 5 (final whole-branch review): projectInfo for a shared selection
 // must come from the shared-repo fetch (sharedProjectInfo, see useDashboard),
 // never the LOCAL projects list -- a shared selection's id can collide with

--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanelPlaceholder.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanelPlaceholder.jsx
@@ -1,0 +1,20 @@
+import { SectionLabel } from '../../../components/terminal/index.js';
+
+// Suspense fallback for the lazy-loaded RunHistoryPanel. Rides the same
+// `.run-history-panel` / `.recharts-responsive-container` selectors the real
+// panel does (dashboard.css / terminal.css) so the flex row's height math is
+// identical before and after the chunk lands — no new dimensions here.
+export default function RunHistoryPanelPlaceholder() {
+  return (
+    <section
+      className="run-history-panel run-history-panel--terminal panel"
+      aria-hidden="true"
+      data-testid="run-history-panel-placeholder"
+    >
+      <div className="run-history-panel__header">
+        <SectionLabel>score_history</SectionLabel>
+      </div>
+      <div className="recharts-responsive-container" />
+    </section>
+  );
+}

--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanelPlaceholder.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanelPlaceholder.jsx
@@ -1,9 +1,12 @@
 import { SectionLabel } from '../../../components/terminal/index.js';
 
 // Suspense fallback for the lazy-loaded RunHistoryPanel. Rides the same
-// `.run-history-panel` / `.recharts-responsive-container` selectors the real
-// panel does (dashboard.css / terminal.css) so the flex row's height math is
-// identical before and after the chunk lands — no new dimensions here.
+// `.run-history-panel` selectors the real panel does (dashboard.css /
+// terminal.css) so the flex row's height math is identical before and after
+// the chunk lands — no new dimensions here. `run-history-panel__chart-slot`
+// is a local class added alongside `.recharts-responsive-container` in the
+// dashboard.css flex:1/min-height:160px rule, so this div doesn't have to
+// impersonate a recharts-internal class name to pick up the sizing.
 export default function RunHistoryPanelPlaceholder() {
   return (
     <section
@@ -12,9 +15,11 @@ export default function RunHistoryPanelPlaceholder() {
       data-testid="run-history-panel-placeholder"
     >
       <div className="run-history-panel__header">
+        {/* Deliberately omits the real header's controls/stats — both are
+            single-line flex rows, so leaving them out doesn't change height. */}
         <SectionLabel>score_history</SectionLabel>
       </div>
-      <div className="recharts-responsive-container" />
+      <div className="run-history-panel__chart-slot" />
     </section>
   );
 }

--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanelPlaceholder.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanelPlaceholder.test.jsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import RunHistoryPanelPlaceholder from './RunHistoryPanelPlaceholder.jsx';
+
+describe('RunHistoryPanelPlaceholder', () => {
+  it('rides the real panel shell classes so the flex row footprint matches', () => {
+    render(<RunHistoryPanelPlaceholder />);
+    const el = screen.getByTestId('run-history-panel-placeholder');
+    expect(el.className).toContain('run-history-panel');
+    expect(el.className).toContain('run-history-panel--terminal');
+    expect(el.className).toContain('panel');
+  });
+
+  it('reproduces the header structure', () => {
+    render(<RunHistoryPanelPlaceholder />);
+    const el = screen.getByTestId('run-history-panel-placeholder');
+    expect(el.querySelector('.run-history-panel__header')).not.toBeNull();
+  });
+
+  it('gives the body the recharts-responsive-container class that carries flex:1/min-height:160px', () => {
+    render(<RunHistoryPanelPlaceholder />);
+    const el = screen.getByTestId('run-history-panel-placeholder');
+    expect(el.querySelector('.recharts-responsive-container')).not.toBeNull();
+  });
+
+  it('is quiet: no spinner or pulsing indicator, hidden from assistive tech', () => {
+    render(<RunHistoryPanelPlaceholder />);
+    const el = screen.getByTestId('run-history-panel-placeholder');
+    expect(el).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanelPlaceholder.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanelPlaceholder.test.jsx
@@ -18,10 +18,10 @@ describe('RunHistoryPanelPlaceholder', () => {
     expect(el.querySelector('.run-history-panel__header')).not.toBeNull();
   });
 
-  it('gives the body the recharts-responsive-container class that carries flex:1/min-height:160px', () => {
+  it('gives the body the run-history-panel__chart-slot class that carries flex:1/min-height:160px', () => {
     render(<RunHistoryPanelPlaceholder />);
     const el = screen.getByTestId('run-history-panel-placeholder');
-    expect(el.querySelector('.recharts-responsive-container')).not.toBeNull();
+    expect(el.querySelector('.run-history-panel__chart-slot')).not.toBeNull();
   });
 
   it('is quiet: no spinner or pulsing indicator, hidden from assistive tech', () => {

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -4,6 +4,8 @@ import { useApi } from "../../../api/ApiContext.jsx";
 import { useProjectScores } from "../../../hooks/useProjectScores.js";
 import { projectKeys, samePlaceholderScope } from "../../../api/queryKeys.js";
 
+const EMPTY_TREND = [];
+
 /**
  * @param {{
  *   selectedProject: string,
@@ -86,6 +88,18 @@ export function useDashboard({ selectedProject, selectedRun, selectedSource = "l
     placeholderData: keepPlaceholder ? keepInScope : undefined,
   });
 
+  // Trend to use for payloads that lack their own (older cached payloads /
+  // the grade-formula early-return path). Memoized on its own: scores and
+  // latestScores get new object identities on every refetch/resolution even
+  // when the trend array they carry hasn't changed, and dashboardWithTrend
+  // below needs a stable reference here to avoid busting its own memo.
+  // EMPTY_TREND is a module-level constant so the `|| []` default doesn't
+  // itself mint a fresh identity every render.
+  const fallbackTrend = useMemo(
+    () => scores?.trend || latestScores?.trend || EMPTY_TREND,
+    [scores, latestScores],
+  );
+
   const dashboardWithTrend = useMemo(() => {
     if (!dashboardQuery.data) return null;
     // The dashboard payload carries its OWN cache-backed, dismiss-adjusted
@@ -100,9 +114,8 @@ export function useDashboard({ selectedProject, selectedRun, selectedSource = "l
     // the payload lacks one (older cached payloads / the grade-formula
     // early-return path).
     if (dashboardQuery.data.trend?.length) return dashboardQuery.data;
-    const trend = scores?.trend || latestScores?.trend || [];
-    return { ...dashboardQuery.data, trend };
-  }, [dashboardQuery.data, scores, latestScores]);
+    return { ...dashboardQuery.data, trend: fallbackTrend };
+  }, [dashboardQuery.data, fallbackTrend]);
 
   const refreshDashboard = useCallback(() => {
     if (!selectedProject) return;

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
@@ -470,6 +470,86 @@ describe("useDashboard frozen historical runs", () => {
     expect(result.current.dashboard.trend).toBe(dashTrend);
   });
 
+  // Fallback path: older cached payloads / the grade-formula early-return path
+  // carry no trend of their own, so the hook folds in scores.trend. That must
+  // not reintroduce the flicker: a new (but equivalent) scores object whose
+  // trend array is the SAME reference must not mint a new dashboard identity.
+  it("keeps a stable dashboard identity in the fallback path when the trend reference is unchanged", async () => {
+    const fakeApi = makeFakeApi();
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 60_000 }, mutations: { retry: false } },
+    });
+    const sharedTrend = [
+      { runId: "r1", dimensionDetails: [{ dimension: "security", delta: 0.2, score: 7 }] },
+    ];
+    // No trend on the payload itself => fallback path.
+    client.setQueryData(
+      projectKeys.dashboard("p1", "r1"),
+      {
+        marker: "dash",
+        trend: [],
+        dimensions: [{ dimension: "Security", overallScore: "7.0/10", violations: [], compliance: [] }],
+        selectedRun: { runId: "r1", dateLabel: "2026-05-01" },
+      },
+      { updatedAt: Date.now() },
+    );
+    client.setQueryData(
+      projectKeys.scores("p1", null),
+      {
+        accumulated: { score: 90 },
+        trend: sharedTrend,
+        availableRuns: [{ runId: "r1", status: "complete" }],
+      },
+      { updatedAt: Date.now() },
+    );
+    // Pre-seed the scoped query too (same reference), so the initial mount
+    // is already resolved and doesn't race the fakeApi mock's own fetch.
+    client.setQueryData(
+      projectKeys.scores("p1", "r1"),
+      { accumulated: { score: 90 }, trend: sharedTrend },
+      { updatedAt: Date.now() },
+    );
+
+    const { result } = renderHook(
+      () => useDashboard({ selectedProject: "p1", selectedRun: "r1", keepPlaceholder: false }),
+      { wrapper: wrapWith(client, fakeApi) },
+    );
+
+    await waitFor(() => expect(result.current.dashboard?.marker).toBe("dash"));
+    const before = result.current.dashboard;
+    expect(before.trend).toBe(sharedTrend);
+
+    // The scoped scores query resolves a beat later with a DIFFERENT scores
+    // object, but the SAME trend array reference. Must not mint a new dashboard.
+    await act(async () => {
+      client.setQueryData(
+        projectKeys.scores("p1", "r1"),
+        { accumulated: { score: 90 }, trend: sharedTrend },
+        { updatedAt: Date.now() },
+      );
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(result.current.dashboard).toBe(before);
+    expect(result.current.dashboard.trend).toBe(sharedTrend);
+
+    // Now the trend reference genuinely changes: the data must flow.
+    const newTrend = [
+      { runId: "r1", dimensionDetails: [{ dimension: "security", delta: 0.5, score: 8 }] },
+    ];
+    await act(async () => {
+      client.setQueryData(
+        projectKeys.scores("p1", "r1"),
+        { accumulated: { score: 90 }, trend: newTrend },
+        { updatedAt: Date.now() },
+      );
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(result.current.dashboard).not.toBe(before);
+    expect(result.current.dashboard.trend[0].dimensionDetails[0].delta).toBe(0.5);
+  });
+
   // placeholderData is observer-scoped, not key-scoped — an unguarded
   // (prev) => prev parks the PREVIOUS project's overview on screen (with
   // loading false, so no loading state either) until the new project's fetch

--- a/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
@@ -21,10 +21,11 @@ import {
   CHART_MARGIN,
   SELECTED_BAR_OPACITY,
   DESELECTED_BAR_OPACITY,
+  HISTORY_CHART_HEIGHT,
 } from '../../../components/scoreChartHelpers.js';
 
 const MAX_CHART_RUNS = 40;
-const CHART_HEIGHT = 220;
+const CHART_HEIGHT = HISTORY_CHART_HEIGHT;
 const REF_LINE_FLOOR = 0;
 const REF_LINE_CEIL = 10;
 const HOVER_STROKE_WIDTH = 1.5;

--- a/src/quodeq/ui/src/features/history/components/HistoryChartPanelPlaceholder.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryChartPanelPlaceholder.jsx
@@ -1,0 +1,22 @@
+import { HISTORY_CHART_HEIGHT } from '../../../components/scoreChartHelpers.js';
+
+// Suspense fallback for the lazy-loaded HistoryChartPanel. Reproduces the
+// panel shell (same classes as the real `.run-history-panel`) with a
+// 220px-high chart area — the real panel's height comes from the
+// ResponsiveContainer's `height={HISTORY_CHART_HEIGHT}` prop rather than
+// CSS, so the placeholder pulls the same shared constant instead of
+// hardcoding the number again.
+export default function HistoryChartPanelPlaceholder() {
+  return (
+    <section
+      className="run-history-panel run-history-panel--terminal panel"
+      aria-hidden="true"
+      data-testid="history-chart-panel-placeholder"
+    >
+      <div className="run-history-panel__header">
+        <span className="term-section-label__text">SCORE_HISTORY</span>
+      </div>
+      <div className="chart-with-kbd" style={{ height: HISTORY_CHART_HEIGHT }} />
+    </section>
+  );
+}

--- a/src/quodeq/ui/src/features/history/components/HistoryChartPanelPlaceholder.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryChartPanelPlaceholder.jsx
@@ -14,6 +14,8 @@ export default function HistoryChartPanelPlaceholder() {
       data-testid="history-chart-panel-placeholder"
     >
       <div className="run-history-panel__header">
+        {/* Deliberately omits the real header's LATEST/AVG/MIN/MAX stats —
+            both are single-line flex rows, so leaving them out doesn't change height. */}
         <span className="term-section-label__text">SCORE_HISTORY</span>
       </div>
       <div className="chart-with-kbd" style={{ height: HISTORY_CHART_HEIGHT }} />

--- a/src/quodeq/ui/src/features/history/components/HistoryChartPanelPlaceholder.test.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryChartPanelPlaceholder.test.jsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import HistoryChartPanelPlaceholder from './HistoryChartPanelPlaceholder.jsx';
+import { HISTORY_CHART_HEIGHT } from '../../../components/scoreChartHelpers.js';
+
+describe('HistoryChartPanelPlaceholder', () => {
+  it('rides the real panel shell classes', () => {
+    render(<HistoryChartPanelPlaceholder />);
+    const el = screen.getByTestId('history-chart-panel-placeholder');
+    expect(el.className).toContain('run-history-panel');
+    expect(el.className).toContain('run-history-panel--terminal');
+    expect(el.className).toContain('panel');
+  });
+
+  it('reproduces the header structure', () => {
+    render(<HistoryChartPanelPlaceholder />);
+    const el = screen.getByTestId('history-chart-panel-placeholder');
+    expect(el.querySelector('.run-history-panel__header')).not.toBeNull();
+  });
+
+  it('reserves the real panel chart height (220px) via the shared constant', () => {
+    render(<HistoryChartPanelPlaceholder />);
+    const el = screen.getByTestId('history-chart-panel-placeholder');
+    const body = el.querySelector('.chart-with-kbd');
+    expect(body).not.toBeNull();
+    expect(body).toHaveStyle({ height: `${HISTORY_CHART_HEIGHT}px` });
+  });
+
+  it('is quiet: no spinner or pulsing indicator, hidden from assistive tech', () => {
+    render(<HistoryChartPanelPlaceholder />);
+    const el = screen.getByTestId('history-chart-panel-placeholder');
+    expect(el).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -6,6 +6,7 @@ import { useRunningRunsRefresh } from '../../../hooks/useRunningRunsRefresh.js';
 import { useHistoryRunLive } from '../hooks/useHistoryRunLive.js';
 import { formatLiveDimSummary } from '../utils/formatLiveDimSummary.js';
 const HistoryChartPanel = lazy(() => import('./HistoryChartPanel.jsx'));
+import HistoryChartPanelPlaceholder from './HistoryChartPanelPlaceholder.jsx';
 
 import RunNavigator from '../../dashboard/components/RunNavigator.jsx';
 import { useRunNavigator } from '../../../hooks/useRunNavigator.js';
@@ -382,7 +383,7 @@ function HistoryContent({ data, callbacks, runNav, languageSub, selectedSource, 
         )}
       </div>
 
-      <Suspense fallback={null}>
+      <Suspense fallback={<HistoryChartPanelPlaceholder />}>
         <HistoryChartPanel trend={trend} selectedRunId={selectedRunId} onBarClick={(runId) => onRunChange(runId)} />
       </Suspense>
 

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.suspense.test.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.suspense.test.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import HistoryPage from './HistoryPage.jsx';
+import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+import { ApiProvider } from '../../../api/ApiContext.jsx';
+
+// Never resolves, so the lazy HistoryChartPanel stays suspended and the
+// Suspense fallback (HistoryChartPanelPlaceholder) is what ends up on screen.
+vi.mock('./HistoryChartPanel.jsx', () => new Promise(() => {}));
+
+const trend = [
+  {
+    runId: 'r1',
+    status: 'complete',
+    dateISO: '2026-07-01T10:00:00Z',
+    dateLabel: '1 Jul 2026',
+    numericAverage: 8.2,
+    overallGrade: 'B',
+    dimensionDetails: [{ dimension: 'security', score: 8.2 }],
+  },
+];
+const availableRuns = [
+  { runId: 'r1', status: 'complete', dateISO: '2026-07-01T10:00:00Z', dateLabel: '1 Jul 2026' },
+];
+
+function makeFakeApi() {
+  return {
+    deleteEvaluation: vi.fn(async () => ({ ok: true })),
+    getDashboard: vi.fn(async () => ({})),
+    sharedGetDashboard: vi.fn(async () => ({})),
+    getProjectScores: vi.fn(async () => ({})),
+    sharedGetProjectScores: vi.fn(async () => ({})),
+  };
+}
+
+describe('HistoryPage — chart Suspense fallback', () => {
+  it('renders the fixed-height placeholder while the chart chunk is unresolved', async () => {
+    const QC = withQueryClient();
+    render(
+      <QC>
+        <ApiProvider value={makeFakeApi()}>
+          <HistoryPage
+            trend={trend}
+            selection={{ selectedRunId: 'r1' }}
+            availableRuns={availableRuns}
+            dimensions={{}}
+            callbacks={{
+              onRunClick: vi.fn(),
+              onDimensionClick: vi.fn(),
+              onNavigate: vi.fn(),
+              onRunChange: vi.fn(),
+              onRunDeleted: vi.fn(),
+            }}
+            projectInfo={{ displayName: 'Test Project' }}
+            projects={[{ id: 'proj1', name: 'proj1' }]}
+            projectsLoaded
+            selectedProject="proj1"
+            selectedSource="local"
+            loading={false}
+            isFetching={false}
+          />
+        </ApiProvider>
+      </QC>,
+    );
+
+    expect(await screen.findByTestId('history-chart-panel-placeholder')).toBeInTheDocument();
+  });
+});

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -2179,7 +2179,8 @@
   flex-direction: column;
 }
 
-.run-history-panel .recharts-responsive-container {
+.run-history-panel .recharts-responsive-container,
+.run-history-panel .run-history-panel__chart-slot {
   flex: 1;
   min-height: 160px;
 }

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -19,7 +19,7 @@
   opacity: 0.4;
 }
 
-.dashboard-ready {
+.dashboard-appear {
   animation: dashboard-fadein 400ms ease;
 }
 


### PR DESCRIPTION
P3 of the loading/transition rework (follows #902, #903, #904). Kills the replayed and nested fades and the chart layout shift.

## What changed

- DashboardPage's 400ms fade-in now plays once per content appearance (per project/source, and per run on run detail) via a dedicated dashboard-appear class. It no longer replays on loading-to-ready flips, the grace-period double flip, error-to-content settles, or the sticky empty-to-content handoff. Project, source, and run-detail run switches still get their fade.
- All DashboardPage branches share one root shape, so switching between loading/empty/error/content states reuses the same .dashboard-page DOM node instead of remounting the subtree (which is what replayed the fade before). Pinned by DOM-node identity tests.
- useDashboard's no-trend fallback path no longer mints a new dashboard object on every scores refetch. This was the remaining identity churn that re-ran RunOverviewPanel's memos (replaying its fade) and re-rendered Sidebar/TopBar. The main path was already fixed in 4b893dbd, this closes the fallback.
- The two lazy chart panels (Overview run history, History score chart) reserve their real footprint while their chunk loads instead of fallback={null}, so charts no longer pop in and shift layout after the page has faded in. Placeholders are quiet shells riding the panels' existing CSS.

Note: the plan's original tab-key item stays dropped (wrong premise, documented in the plan file).

## Tests

1425 passing (baseline 1406 + 19 new: fallback identity, cross-branch DOM-node identity, fade once-per-context incl. runMode run switch, grace and sticky handoffs, placeholder footprint and chartMountable gating).