### PR TITLE
feat(ui): overview loading skeleton on project switch

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -3,6 +3,7 @@ import DimensionCard from './DimensionCard.jsx';
 import AccumulatedOverviewPanel from './AccumulatedOverviewPanel.jsx';
 import RunOverviewPanel from './RunOverviewPanel.jsx';
 import IncompleteSetupCard from './IncompleteSetupCard.jsx';
+import OverviewSkeleton from './OverviewSkeleton.jsx';
 import LoadingScreen from '../../../components/LoadingScreen.jsx';
 import EmptyState from '../../../components/EmptyState.jsx';
 
@@ -403,6 +404,18 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   // The page dims itself slightly so the user sees "still working" without
   // the jarring full-screen LoadingScreen.
   const isRefreshing = isFetching && !!dashboard && !isLoading;
+  // Overview only: both loader windows (isLoading, and the grace fallback
+  // below) become one continuous OverviewSkeleton instead of a LoadingScreen
+  // -- from the user's perspective there's no handoff between the two, only
+  // the underlying reason it's still showing changes. runMode keeps the
+  // LoadingScreen ladder untouched (RunOverviewPanel has its own inline gate
+  // this skeleton was never meant to cover).
+  const showOverviewSkeleton = !runMode && (isLoading || (dashboard && !isLoading && !contentReady));
+  // The `dashboard-loading` 40% dim exists to fade *stale* content sitting
+  // under the loader overlay. For the Overview the skeleton IS the content
+  // (nothing stale is underneath it), so it never dims -- only a runMode
+  // load, which still uses the sibling LoadingScreen below, does.
+  const isDimmed = isLoading && runMode;
   return (
     <>
       {/* Sibling to .dashboard-page, not a child of it: that div carries the
@@ -412,18 +425,22 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
           a project switch now clears the old payload (placeholderData is
           project-scoped -- see samePlaceholderScope), so this spinner is what
           the user sees right after picking a project; saying which one makes
-          the wait legible instead of looking like the page hung. */}
-      {isLoading && <LoadingScreen variant="inline" message={projectName ? `Loading ${projectName}…` : undefined} />}
-      <div className={`dashboard-page dashboard-fade ${isLoading ? 'dashboard-loading' : `dashboard-ready${dashboardAppearClass}`}${isRefreshing ? ' dashboard-refreshing' : ''}`}>
+          the wait legible instead of looking like the page hung. runMode only
+          -- the Overview shows the OverviewSkeleton (inside .dashboard-page,
+          see showOverviewSkeleton) instead. */}
+      {isLoading && runMode && <LoadingScreen variant="inline" message={projectName ? `Loading ${projectName}…` : undefined} />}
+      <div className={`dashboard-page dashboard-fade ${isDimmed ? 'dashboard-loading' : `dashboard-ready${dashboardAppearClass}`}${isRefreshing ? ' dashboard-refreshing' : ''}`}>
         <IncompleteSetupCard projectInfo={projectInfo} onComplete={handleSetupComplete} />
         {error && <p className="inline-error">Failed to load dashboard data. Please try again.</p>}
+        {showOverviewSkeleton && <OverviewSkeleton projectName={projectName} />}
         {/* Grace elapsed but content still isn't ready (dashboard is in, accumulated
             isn't yet): the page has already stopped showing its own full loader
             above, but there's nothing ready to mount below either. This is the ONE
             other place, at this same top level, that a loader can render from --
             DashboardContent itself never makes this decision, so the two can't
-            drift out of sync the way they did in the original bug. */}
-        {dashboard && !isLoading && !contentReady && <LoadingScreen variant="inline" message={projectName ? `Loading ${projectName}…` : undefined} />}
+            drift out of sync the way they did in the original bug. runMode only --
+            the Overview's showOverviewSkeleton above already covers this window. */}
+        {runMode && dashboard && !isLoading && !contentReady && <LoadingScreen variant="inline" message={projectName ? `Loading ${projectName}…` : undefined} />}
         {dashboard && contentReady && (
           <DashboardContent
             runMode={runMode}

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -213,7 +213,7 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   // where it's consumed: the latch below needs to know a skeleton (not real
   // content) is what's showing, for every branch, not just the main one --
   // same reason `isLoading` itself is hoisted above the early returns.
-  const showOverviewSkeleton = !runMode && (isLoading || (dashboard && !isLoading && !contentReady));
+  const showOverviewSkeleton = !runMode && !!(isLoading || (dashboard && !isLoading && !contentReady));
 
   // Fade-once latch: `dashboard-fadein` should play when the page's content
   // first appears for this project/source/run context, not on every
@@ -461,14 +461,11 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
         <IncompleteSetupCard projectInfo={projectInfo} onComplete={handleSetupComplete} />
         {error && <p className="inline-error">Failed to load dashboard data. Please try again.</p>}
         {showOverviewSkeleton && <OverviewSkeleton projectName={projectName} />}
-        {/* Grace elapsed but content still isn't ready (dashboard is in, accumulated
-            isn't yet): the page has already stopped showing its own full loader
-            above, but there's nothing ready to mount below either. This is the ONE
-            other place, at this same top level, that a loader can render from --
-            DashboardContent itself never makes this decision, so the two can't
-            drift out of sync the way they did in the original bug. runMode only --
-            the Overview's showOverviewSkeleton above already covers this window. */}
-        {runMode && dashboard && !isLoading && !contentReady && <LoadingScreen variant="inline" message={projectName ? `Loading ${projectName}…` : undefined} />}
+        {/* No runMode equivalent of the Overview's grace-fallback loader: in
+            runMode contentReady is `!!dashboard`, so the instant dashboard lands
+            contentReady is already true -- there's no window where dashboard is
+            in but content isn't ready yet. The `isLoading && runMode`
+            LoadingScreen above is the only loader runMode needs. */}
         {dashboard && contentReady && (
           <DashboardContent
             runMode={runMode}

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -174,8 +174,20 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   const contentReady = runMode ? !!dashboard : (!!dashboard && !!accumulated);
   // Grace state for the slow/cold-load fallback (consumed by isLoading below).
   const [graceElapsed, setGraceElapsed] = useState(false);
+  // Reset synchronously during render, not from the effect below: contentReady
+  // flipping true (or dashboard disappearing) and graceElapsed resetting are
+  // the same logical transition. Doing it from an effect meant a stale
+  // intermediate commit (graceElapsed still true) landed first and ran ITS
+  // OWN effects -- including the appear-fade latch's ref write further down
+  // -- before this effect got a chance to correct it; a second, cascading
+  // commit then found the latch already spent and dropped the fade it had
+  // just armed. Resetting here settles the transition in a single commit,
+  // before any effects run at all -- same "adjust state during render"
+  // pattern as noRunsEmptySticky below, safe under StrictMode's double-
+  // render for the same reason: idempotent once the condition clears.
+  if (graceElapsed && (contentReady || !dashboard)) setGraceElapsed(false);
   useEffect(() => {
-    if (contentReady || !dashboard) { setGraceElapsed(false); return undefined; }
+    if (contentReady || !dashboard) return undefined;
     const timer = setTimeout(() => setGraceElapsed(true), 700);
     return () => clearTimeout(timer);
   }, [contentReady, dashboard]);
@@ -193,6 +205,15 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   // it's consumed) because the fade-once latch below needs it for every branch,
   // not just the main one.
   const isLoading = loading && !contentReady && !(dashboard && graceElapsed);
+
+  // Overview only (!runMode): both loader windows below (isLoading itself,
+  // and the grace-fallback window once dashboard has landed but accumulated
+  // hasn't) render one continuous OverviewSkeleton instead of a LoadingScreen.
+  // Computed here, above the appear latch, rather than beside the return
+  // where it's consumed: the latch below needs to know a skeleton (not real
+  // content) is what's showing, for every branch, not just the main one --
+  // same reason `isLoading` itself is hoisted above the early returns.
+  const showOverviewSkeleton = !runMode && (isLoading || (dashboard && !isLoading && !contentReady));
 
   // Fade-once latch: `dashboard-fadein` should play when the page's content
   // first appears for this project/source/run context, not on every
@@ -217,19 +238,30 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   // the error/runMode-empty branches gate on `!loading` outright -- so the
   // latch is never consumed before real first-appearance content is on
   // screen; isLoading being true only ever suppresses a repeat.
+  // `!showOverviewSkeleton` gates both the read and the write: without it,
+  // the grace-elapsed flip (isLoading true -> false while the Overview's
+  // skeleton keeps showing, accumulated still pending) would (a) play the
+  // 400ms fade over a skeleton that was already fully visible and unchanged
+  // -- a flash the skeleton is supposed to avoid -- and (b) spend the latch
+  // early, so the *real* content that mounts once accumulated lands would
+  // get no fade at all. showOverviewSkeleton is false for every other branch
+  // (runMode, error, empty states, sticky no-runs), so this is a no-op there.
   const dashboardAppearKey = `${selectedProject}::${selectedSource}::${runMode ? selectedRunId : 'overview'}`;
   const dashboardAppearedKeyRef = useRef(null);
-  const dashboardAppearNow = !isLoading && dashboardAppearedKeyRef.current !== dashboardAppearKey;
+  const dashboardAppearNow = !isLoading && !showOverviewSkeleton && dashboardAppearedKeyRef.current !== dashboardAppearKey;
   useEffect(() => {
-    if (!isLoading) dashboardAppearedKeyRef.current = dashboardAppearKey;
-  }, [isLoading, dashboardAppearKey]);
+    if (!isLoading && !showOverviewSkeleton) dashboardAppearedKeyRef.current = dashboardAppearKey;
+  }, [isLoading, showOverviewSkeleton, dashboardAppearKey]);
   const dashboardAppearClass = dashboardAppearNow ? ' dashboard-appear' : '';
   // Trade-off: the appear class only lives for the one render where it's computed
   // above -- it doesn't stay latched until dashboardAppearKey next changes -- so any
-  // re-render inside the animation window (e.g. grace-fallback partial page then
-  // contentReady flipping true) drops it and snaps opacity to 1, cutting the fade
-  // short. Latching it across renders was rejected: it would fail to re-arm on a
-  // run switch without reintroducing a loading gap.
+  // *unrelated* re-render inside the animation window (e.g. isFetching flipping a
+  // moment after content first appears) drops it and snaps opacity to 1, cutting
+  // the fade short. Latching it across renders was rejected: it would fail to
+  // re-arm on a run switch without reintroducing a loading gap. (The
+  // grace-fallback -> content-ready flip used to be an example of this too, until
+  // the graceElapsed reset above moved to render-phase specifically to stop that
+  // one from self-inflicting a same-tick drop -- see the comment on graceElapsed.)
 
   // Sticky "no evaluations yet" latch: once that empty state is showing for
   // this project+source, stay on it through a subsequent load (the post-eval
@@ -404,13 +436,9 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   // The page dims itself slightly so the user sees "still working" without
   // the jarring full-screen LoadingScreen.
   const isRefreshing = isFetching && !!dashboard && !isLoading;
-  // Overview only: both loader windows (isLoading, and the grace fallback
-  // below) become one continuous OverviewSkeleton instead of a LoadingScreen
-  // -- from the user's perspective there's no handoff between the two, only
-  // the underlying reason it's still showing changes. runMode keeps the
-  // LoadingScreen ladder untouched (RunOverviewPanel has its own inline gate
-  // this skeleton was never meant to cover).
-  const showOverviewSkeleton = !runMode && (isLoading || (dashboard && !isLoading && !contentReady));
+  // showOverviewSkeleton is computed above (beside the appear latch, which
+  // needs it too) -- from the user's perspective this covers both loader
+  // windows as one continuous OverviewSkeleton, no handoff between them.
   // The `dashboard-loading` 40% dim exists to fade *stale* content sitting
   // under the loader overlay. For the Overview the skeleton IS the content
   // (nothing stale is underneath it), so it never dims -- only a runMode

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -674,7 +674,13 @@ describe('DashboardPage frame stability and fade-once across branch transitions 
     expect(page.className).not.toContain('dashboard-appear');
   });
 
-  it('does not replay dashboard-appear across the grace-fallback -> content-ready double flip', () => {
+  // P6 fix: the appear latch's read AND write are gated on `!showOverviewSkeleton`
+  // (DashboardPage.jsx, beside `dashboardAppearKey`). Before that gate, the
+  // grace-elapsed flip replayed a 400ms fade over the already-visible,
+  // unchanged skeleton (a flash) and spent the latch early, so real content
+  // got no fade at all. Now: no fade while the skeleton continues across the
+  // flip, and the fade is reserved for when DashboardContent actually mounts.
+  it('does not fade the skeleton at the grace-elapsed flip, and fires dashboard-appear once real content mounts', () => {
     vi.useFakeTimers();
     try {
       const { container, rerender } = render(
@@ -683,9 +689,54 @@ describe('DashboardPage frame stability and fade-once across branch transitions 
         </SidePaneProvider>,
       );
       act(() => { vi.advanceTimersByTime(800); });
+      // Grace elapsed, accumulated still not in: the skeleton continues
+      // (same as before the flip) -- must not fade, that would flash it.
       let page = container.querySelector('.dashboard-page');
       expect(page.className).toContain('dashboard-ready');
+      expect(page.className).not.toContain('dashboard-appear');
+      expect(page.querySelector('.overview-skeleton')).toBeTruthy();
+
+      rerender(
+        <SidePaneProvider>
+          <DashboardPage data={readyOverview} callbacks={{}} runMode={false} />
+        </SidePaneProvider>,
+      );
+      // Real content mounts for the first time in this context: this is what
+      // gets the fade, not the earlier grace-elapsed flip.
+      page = container.querySelector('.dashboard-page');
+      expect(page.className).toContain('dashboard-ready');
       expect(page.className).toContain('dashboard-appear');
+      expect(page.querySelector('.overview-skeleton')).toBeNull();
+
+      rerender(
+        <SidePaneProvider>
+          <DashboardPage data={{ ...readyOverview, isFetching: true }} callbacks={{}} runMode={false} />
+        </SidePaneProvider>,
+      );
+      // Repeat render over the same context: no replay.
+      page = container.querySelector('.dashboard-page');
+      expect(page.className).not.toContain('dashboard-appear');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Fast path: content lands well before the grace timer would fire (the
+  // common case). isLoading and contentReady flip in the same render, so the
+  // showOverviewSkeleton gate never engages and the fade plays exactly as it
+  // did before this fix.
+  it('plays dashboard-appear normally when content arrives before the grace timer fires', () => {
+    vi.useFakeTimers();
+    try {
+      const { container, rerender } = render(
+        <SidePaneProvider>
+          <DashboardPage data={{ ...readyOverview, accumulated: null, loading: true }} callbacks={{}} runMode={false} />
+        </SidePaneProvider>,
+      );
+      // Partway through the grace window -- timer still pending, not fired.
+      act(() => { vi.advanceTimersByTime(300); });
+      let page = container.querySelector('.dashboard-page');
+      expect(page.className).not.toContain('dashboard-appear');
 
       rerender(
         <SidePaneProvider>
@@ -694,7 +745,7 @@ describe('DashboardPage frame stability and fade-once across branch transitions 
       );
       page = container.querySelector('.dashboard-page');
       expect(page.className).toContain('dashboard-ready');
-      expect(page.className).not.toContain('dashboard-appear');
+      expect(page.className).toContain('dashboard-appear');
     } finally {
       vi.useRealTimers();
     }

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -31,13 +31,16 @@ const overviewLoading = {
 };
 
 describe('DashboardPage first-load loading gate', () => {
-  it('keeps the Overview in the loading state until accumulated (scores) is ready', () => {
+  // P6: the Overview no longer dims .dashboard-page while isLoading -- the
+  // OverviewSkeleton rendered inside it IS the content (the dim existed to
+  // fade *stale* content under the loader overlay, and there is none here).
+  it('keeps the Overview showing the skeleton (not real content) until accumulated (scores) is ready, undimmed', () => {
     const { container } = render(<DashboardPage data={overviewLoading} callbacks={{}} runMode={false} />);
     const page = container.querySelector('.dashboard-page');
     expect(page).toBeTruthy();
-    // Must NOT flip to the ready fade before the data needed to render is present.
-    expect(page.className).toContain('dashboard-loading');
-    expect(page.className).not.toContain('dashboard-ready');
+    expect(page.className).not.toContain('dashboard-loading');
+    expect(page.className).toContain('dashboard-ready');
+    expect(page.querySelector('.overview-skeleton')).toBeTruthy();
   });
 
   // Scenario 1 (collision): dashboard has resolved but accumulated hasn't, so
@@ -46,29 +49,32 @@ describe('DashboardPage first-load loading gate', () => {
   // variant) and DashboardContent's own LoadingScreen mounted at once, two
   // overlapping pulsing logos. DashboardContent must not render a loader of
   // its own; readiness is a single decision made by the page.
-  it('renders exactly one LoadingScreen while dashboard is resolved but accumulated is not', () => {
+  // P6: the Overview's loader ladder is the OverviewSkeleton now, not
+  // LoadingScreen -- still exactly one, never both.
+  it('renders exactly one overview skeleton and no LoadingScreen while dashboard is resolved but accumulated is not', () => {
     const { container } = render(<DashboardPage data={overviewLoading} callbacks={{}} runMode={false} />);
-    expect(container.querySelectorAll('.loading-screen').length).toBe(1);
+    expect(container.querySelectorAll('.loading-screen').length).toBe(0);
+    expect(container.querySelectorAll('.overview-skeleton').length).toBe(1);
   });
 
-  // P2 containment: the page's own loader must use the contained variant
-  // (absolutely positioned within .dashboard via .loading-screen--inline in
-  // base.css, not fixed to the viewport) so a project switch never covers
-  // Sidebar/TopBar. Only the app-level cold-start loader stays fullscreen.
-  it('renders the inline (contained) loader variant, not the fullscreen one', () => {
+  // P2 containment, carried over to the skeleton: it renders inside
+  // .dashboard-page (never a fixed/fullscreen overlay), so a project switch
+  // never covers Sidebar/TopBar. Only the app-level cold-start loader stays
+  // fullscreen.
+  it('renders the skeleton contained within .dashboard-page, not a fullscreen loader', () => {
     const { container } = render(<DashboardPage data={overviewLoading} callbacks={{}} runMode={false} />);
-    expect(container.querySelector('.loading-screen').className).toContain('loading-screen--inline');
+    const page = container.querySelector('.dashboard-page');
+    expect(page.querySelector('.overview-skeleton')).toBeTruthy();
+    expect(container.querySelector('.loading-screen')).toBeNull();
   });
 
-  // Scenario 8: the page-level loader must never be a descendant of the
-  // `.dashboard-loading` (opacity .4) container -- otherwise the logo renders
-  // at an effective 6% opacity while loading, then jumps to full opacity once
-  // the container flips to `.dashboard-ready`.
-  it('does not nest the loader inside the dimmed .dashboard-loading container', () => {
+  // Scenario 8, carried over: the skeleton must never sit inside a dimmed
+  // `.dashboard-loading` (opacity .4) container -- there is none for the
+  // Overview any more, since the skeleton is the content, not an overlay.
+  it('does not dim the container the skeleton lives in', () => {
     const { container } = render(<DashboardPage data={overviewLoading} callbacks={{}} runMode={false} />);
-    const dimmed = container.querySelector('.dashboard-loading');
-    expect(dimmed).toBeTruthy();
-    expect(dimmed.querySelector('.loading-screen')).toBeNull();
+    expect(container.querySelector('.dashboard-loading')).toBeNull();
+    expect(container.querySelector('.overview-skeleton')).toBeTruthy();
   });
 
   // The flip side: a cold score cache can take several seconds to rebuild. We
@@ -89,26 +95,26 @@ describe('DashboardPage first-load loading gate', () => {
     }).not.toThrow();
   });
 
-  it('falls back to the partial page after a grace period if scores stays slow', () => {
+  // P6: the grace fallback no longer hands off from a skeleton to a
+  // LoadingScreen -- the same OverviewSkeleton continues across the flip, so
+  // there's no loader/skeleton swap for the user to notice.
+  it('continues the same overview skeleton across the grace period if scores stays slow (no loader handoff)', () => {
     vi.useFakeTimers();
     try {
       const { container } = render(<DashboardPage data={overviewLoading} callbacks={{}} runMode={false} />);
-      // Before the grace: still the full loading screen.
-      expect(container.querySelector('.dashboard-page').className).toContain('dashboard-loading');
-      // After the grace elapses with scores still pending: drop to the partial page.
+      // Before the grace: skeleton already showing, undimmed.
+      expect(container.querySelector('.dashboard-page').className).not.toContain('dashboard-loading');
+      expect(container.querySelectorAll('.overview-skeleton').length).toBe(1);
+      // After the grace elapses with scores still pending: same skeleton, still
+      // exactly one, no LoadingScreen ever mounts, no dim.
       act(() => { vi.advanceTimersByTime(800); });
       expect(container.querySelector('.dashboard-page').className).toContain('dashboard-ready');
-      // Reachable state: dashboard is in, accumulated still isn't, and the page
-      // has already stopped showing its own full loader. Exactly one loader must
-      // still be on screen (the page's own content-area fallback), not zero and
-      // not two, and it must not be sitting inside a dimmed container.
-      expect(container.querySelectorAll('.loading-screen').length).toBe(1);
+      expect(container.querySelectorAll('.overview-skeleton').length).toBe(1);
+      expect(container.querySelectorAll('.loading-screen').length).toBe(0);
       expect(container.querySelector('.dashboard-loading')).toBeNull();
-      // Same message as the pre-grace loader it replaced: otherwise the
-      // message-bearing loader unmounts and a message-less one takes its
-      // place in the same frame, and the logo visibly shifts up by the
-      // message line's height on the handoff.
-      expect(container.querySelector('.loading-message')?.textContent).toBe('Loading p1…');
+      // Same project-name signal the loader it replaced used to carry, now in
+      // the skeleton's TermHeader sub.
+      expect(container.querySelector('.term-header__sub')?.textContent).toBe('loading p1…');
     } finally {
       vi.useRealTimers();
     }
@@ -307,7 +313,7 @@ describe('DashboardPage no-runs -> first-run transition (P5-T2)', () => {
     expect(container.querySelector('.loading-screen')).toBeNull();
   });
 
-  it('resets the stickiness on a project switch: the loader shows, not the previous project\'s empty state', () => {
+  it('resets the stickiness on a project switch: the skeleton shows, not the previous project\'s empty state', () => {
     const { container, getByText, queryByText, rerender } = render(
       <SidePaneProvider>
         <DashboardPage data={baseNoRuns} callbacks={{}} runMode={false} />
@@ -331,7 +337,8 @@ describe('DashboardPage no-runs -> first-run transition (P5-T2)', () => {
       </SidePaneProvider>,
     );
     expect(queryByText('No evaluations yet')).toBeNull();
-    expect(container.querySelector('.loading-screen')).toBeTruthy();
+    expect(container.querySelector('.overview-skeleton')).toBeTruthy();
+    expect(container.querySelector('.loading-screen')).toBeNull();
   });
 
   it('runMode is excluded from the no-runs empty state, and instead renders a run-appropriate empty state (not a blank frame)', () => {
@@ -640,8 +647,12 @@ describe('DashboardPage frame stability and fade-once across branch transitions 
       </SidePaneProvider>,
     );
     let page = container.querySelector('.dashboard-page');
-    expect(page.className).toContain('dashboard-loading');
+    // P6: the Overview never dims -- the skeleton is showing here, undimmed --
+    // but it's still "still loading" for the appear latch's purposes.
+    expect(page.className).not.toContain('dashboard-loading');
+    expect(page.className).toContain('dashboard-ready');
     expect(page.className).not.toContain('dashboard-appear');
+    expect(page.querySelector('.overview-skeleton')).toBeTruthy();
 
     rerender(
       <SidePaneProvider>

--- a/src/quodeq/ui/src/features/dashboard/components/OverviewSkeleton.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/OverviewSkeleton.jsx
@@ -1,0 +1,93 @@
+import { TermHeader, StatStrip, SectionLabel } from '../../../components/terminal/index.js';
+
+// Skeleton frame for the Overview's guaranteed content: the stat-strip hero
+// and the quality-dimensions grid. Rides the same classes the real
+// AccumulatedHeroSection / AccumulatedDimensionsSection / DimensionGaugeCard
+// render (dashboard.css / terminal.css / dim-gauge-card.css) so the footprint
+// (card sizes, grid gaps, min-heights) matches exactly -- only the label/
+// value/gauge content areas are swapped for static dimmed blocks (house
+// idiom: SidePane's body-skeleton spans, SidePane.css:186-201 -- no shimmer,
+// no animation). Shown for the Overview only, in place of the inline
+// LoadingScreen, for both windows DashboardPage can be waiting in (before the
+// dashboard payload lands, and again if scoring is still catching up after it
+// does), so it reads as one continuous skeleton rather than a loader-to-
+// skeleton handoff.
+//
+// Real `<Stat>`/`<DimensionGaugeCard>` render actual numbers/labels as text;
+// this component hand-rolls the same class names instead of reusing those
+// components so every content slot can be a dimmed block rather than real
+// text with nothing to show yet.
+
+const STAT_SLOTS = ['score', 'violations', 'compliance', 'ratio'];
+
+// Representative placeholder count -- the real grid's card count varies per
+// project (server-filtered by visible standards, see readVisibleStandardIds),
+// there is no fixed list to mirror here.
+const DIMENSION_CARD_COUNT = 6;
+
+function SkeletonStat({ slot }) {
+  return (
+    <div className="term-stat term-stat--default" aria-hidden="true" data-slot={slot}>
+      <div className="term-stat__label">
+        <span className="overview-skeleton__bar overview-skeleton__bar--label" />
+      </div>
+      <div className="term-stat__value-row">
+        <span className="overview-skeleton__bar overview-skeleton__bar--value" />
+      </div>
+      <div className="term-stat__hint">
+        <span className="overview-skeleton__bar overview-skeleton__bar--hint" />
+      </div>
+    </div>
+  );
+}
+
+function SkeletonDimensionCard({ index }) {
+  return (
+    <article className="dim-gauge-card" aria-hidden="true" data-skeleton-index={index}>
+      <div className="dim-gauge-card__head">
+        <span className="overview-skeleton__bar overview-skeleton__bar--name" />
+      </div>
+      <div className="dim-gauge-card__gauge">
+        <span className="overview-skeleton__bar overview-skeleton__bar--gauge" />
+      </div>
+      <div className="dim-gauge-card__meta">
+        <span className="overview-skeleton__bar overview-skeleton__bar--meta" />
+      </div>
+      <div className="dim-gauge-card__sev-row">
+        <span className="overview-skeleton__bar overview-skeleton__bar--sev" />
+      </div>
+    </article>
+  );
+}
+
+/**
+ * @param {object} props
+ * @param {string} [props.projectName] The project being loaded, carried in
+ *   the header sub line so the wait still names what it's waiting on.
+ */
+export default function OverviewSkeleton({ projectName }) {
+  return (
+    <div className="overview-skeleton" aria-busy="true">
+      <section className="acc-eval-panel acc-eval-panel--terminal">
+        <div className="acc-eval-panel__top">
+          <TermHeader name="overview" sub={projectName ? `loading ${projectName}…` : 'loading…'} />
+        </div>
+        <StatStrip cards>
+          {STAT_SLOTS.map((slot) => <SkeletonStat key={slot} slot={slot} />)}
+        </StatStrip>
+      </section>
+      <section className="quality-dimensions" aria-label="Quality dimensions">
+        <div className="quality-dimensions__head">
+          <SectionLabel>quality_dimensions</SectionLabel>
+        </div>
+        <div className="dimensions-panel">
+          <div className="dimensions-grid">
+            {Array.from({ length: DIMENSION_CARD_COUNT }, (_, index) => (
+              <SkeletonDimensionCard key={index} index={index} />
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/dashboard/components/OverviewSkeleton.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/OverviewSkeleton.jsx
@@ -76,7 +76,7 @@ export default function OverviewSkeleton({ projectName }) {
           {STAT_SLOTS.map((slot) => <SkeletonStat key={slot} slot={slot} />)}
         </StatStrip>
       </section>
-      <section className="quality-dimensions" aria-label="Quality dimensions">
+      <section className="quality-dimensions" aria-hidden="true">
         <div className="quality-dimensions__head">
           <SectionLabel>quality_dimensions</SectionLabel>
         </div>

--- a/src/quodeq/ui/src/features/dashboard/components/OverviewSkeleton.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/OverviewSkeleton.test.jsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import OverviewSkeleton from './OverviewSkeleton.jsx';
+
+describe('OverviewSkeleton', () => {
+  it('rides the real overview shell classes', () => {
+    const { container } = render(<OverviewSkeleton projectName="acme" />);
+    expect(container.querySelector('.acc-eval-panel.acc-eval-panel--terminal')).toBeTruthy();
+    expect(container.querySelector('.acc-eval-panel__top')).toBeTruthy();
+    expect(container.querySelector('.term-stat-strip.term-stat-strip--cards')).toBeTruthy();
+    expect(container.querySelector('.quality-dimensions')).toBeTruthy();
+    expect(container.querySelector('.quality-dimensions__head')).toBeTruthy();
+    expect(container.querySelector('.dimensions-panel > .dimensions-grid')).toBeTruthy();
+  });
+
+  it('carries the "which project" loading signal in the TermHeader sub', () => {
+    const { getByText } = render(<OverviewSkeleton projectName="acme" />);
+    expect(getByText('loading acme…')).toBeTruthy();
+  });
+
+  it('renders a real TermHeader named overview', () => {
+    const { container } = render(<OverviewSkeleton projectName="acme" />);
+    const header = container.querySelector('.term-header');
+    expect(header).toBeTruthy();
+    expect(header.querySelector('.term-header__name').textContent).toBe('overview');
+  });
+
+  it('renders exactly 4 stat tiles', () => {
+    const { container } = render(<OverviewSkeleton projectName="acme" />);
+    expect(container.querySelectorAll('.term-stat').length).toBe(4);
+  });
+
+  it('renders exactly 6 dimension placeholder cards shaped like dim-gauge-card', () => {
+    const { container } = render(<OverviewSkeleton projectName="acme" />);
+    const cards = container.querySelectorAll('.dimensions-grid > .dim-gauge-card');
+    expect(cards.length).toBe(6);
+    const first = cards[0];
+    expect(first.querySelector('.dim-gauge-card__head')).toBeTruthy();
+    expect(first.querySelector('.dim-gauge-card__gauge')).toBeTruthy();
+    expect(first.querySelector('.dim-gauge-card__meta')).toBeTruthy();
+    expect(first.querySelector('.dim-gauge-card__sev-row')).toBeTruthy();
+  });
+
+  it('the quality_dimensions section label carries no count (the real count is unknown)', () => {
+    const { getByText } = render(<OverviewSkeleton projectName="acme" />);
+    expect(getByText('quality_dimensions')).toBeTruthy();
+  });
+
+  it('marks skeleton visuals aria-hidden and the container aria-busy', () => {
+    const { container } = render(<OverviewSkeleton projectName="acme" />);
+    expect(container.querySelector('.overview-skeleton')).toHaveAttribute('aria-busy', 'true');
+    container.querySelectorAll('.term-stat').forEach((el) => {
+      expect(el).toHaveAttribute('aria-hidden', 'true');
+    });
+    container.querySelectorAll('.dim-gauge-card').forEach((el) => {
+      expect(el).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  it('falls back to a generic "loading…" sub when no project name is available yet', () => {
+    const { getByText } = render(<OverviewSkeleton />);
+    expect(getByText('loading…')).toBeTruthy();
+  });
+});

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -1915,7 +1915,9 @@
   opacity: 0.6;
 }
 .overview-skeleton__bar--label { width: 45%; height: 8px; }
-.overview-skeleton__bar--value { width: 55%; height: 22px; }
+/* 31px matches the real .term-stat__value box (font-size 28px, line-height
+   1.1, terminal.css:119-124) so the stat card's footprint doesn't shrink. */
+.overview-skeleton__bar--value { width: 55%; height: 31px; }
 .overview-skeleton__bar--hint { width: 70%; height: 8px; }
 .overview-skeleton__bar--name { width: 60%; height: 14px; }
 /* 100px matches DimensionGaugeCard's RING_SIZE (DimensionGaugeCard.jsx) so the
@@ -1924,6 +1926,14 @@
 .overview-skeleton__bar--gauge { width: 100px; height: 100px; border-radius: 50%; }
 .overview-skeleton__bar--meta { width: 50%; height: 8px; }
 .overview-skeleton__bar--sev { width: 40%; height: 12px; }
+
+/* The real .dim-gauge-card is cursor:pointer + hover/focus affordances
+   (dim-gauge-card.css) -- this card isn't clickable, so neutralize both
+   rather than let a placeholder look interactive. */
+.overview-skeleton .dim-gauge-card {
+  cursor: default;
+  pointer-events: none;
+}
 
 /* ── Project selector (in main content area) ──────────── */
 

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -1902,6 +1902,29 @@
   flex-direction: column;
 }
 
+/* ── Overview loading skeleton ──────────────────────────
+   Static dimmed blocks (no shimmer/animation -- house idiom, see
+   SidePane.css:186-201) standing in for the stat-strip and dimension-card
+   content areas while the Overview is loading. OverviewSkeleton.jsx rides
+   the real .term-stat / .dim-gauge-card classes for layout; only these bar
+   elements are skeleton-specific. */
+.overview-skeleton__bar {
+  display: inline-block;
+  border-radius: 4px;
+  background: var(--color-surface-alt);
+  opacity: 0.6;
+}
+.overview-skeleton__bar--label { width: 45%; height: 8px; }
+.overview-skeleton__bar--value { width: 55%; height: 22px; }
+.overview-skeleton__bar--hint { width: 70%; height: 8px; }
+.overview-skeleton__bar--name { width: 60%; height: 14px; }
+/* 100px matches DimensionGaugeCard's RING_SIZE (DimensionGaugeCard.jsx) so the
+   card's overall height footprint lines up with the real gauge, not just the
+   head/sev-row min-heights. */
+.overview-skeleton__bar--gauge { width: 100px; height: 100px; border-radius: 50%; }
+.overview-skeleton__bar--meta { width: 50%; height: 8px; }
+.overview-skeleton__bar--sev { width: 40%; height: 12px; }
+
 /* ── Project selector (in main content area) ──────────── */
 
 .project-selector {


### PR DESCRIPTION
P6, the last phase of the loading/transition rework (#902-#905). Replaces the logo loader on Overview project switches with a content-shaped skeleton.

## What changed

- New OverviewSkeleton: the overview's real frame (acc-eval-panel shell, TermHeader reading "loading <project>…", 4 stat tiles, quality-dimensions section with 6 card-shaped placeholders), built from static dimmed bars riding the real CSS classes. No shimmer, matching the existing skeleton idiom. Hidden from the accessibility tree except the loading header line.
- On Overview, both loading windows (initial load and the post-grace scores wait) render one continuous skeleton inside the page frame, undimmed, until content is ready. No handoff between two loaders, no logo.
- The logo LoadingScreen stays for app cold start, and run-detail pages keep their current spinner.
- The appear-fade latch is gated while the skeleton shows, so the page fade plays exactly once, when real content mounts (review caught it flashing over the skeleton at the 700ms grace mark on slow loads; the grace-timer reset moved to render phase to make the transition settle in one commit).
- Dropped a loader branch the runMode gate made unreachable.

## Tests

1434 passing (baseline 1425 + 9 new: skeleton structure, both-window continuity, grace-flip no-flash, appear-fade on content mount, runMode/cold-start exclusions).