### PR TITLE
Redesign the toolbar: jump-bar address, tiered actions, run-aware chrome

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useMemo, useState, useEffect, useRef } from 'react';
+import { lazy, Suspense, useCallback, useMemo, useState, useEffect, useRef } from 'react';
 import NavBreadcrumb, { labelFor as navLabelFor } from './features/explorer/components/NavBreadcrumb.jsx';
 import UpdateBanner from './features/updates/UpdateBanner.jsx';
 import { useSharedContentSignal } from './features/dashboard/hooks/useSharedProjects.js';
@@ -26,6 +26,8 @@ import { applyMutationDelta } from './api/applyMutationDelta.js';
 import { getGradeFormula } from './api/index.js';
 import { setGradeThresholds } from './utils/gradeThresholds.js';
 import { deriveEvaluatePreselect } from './utils/evaluatePreselect.js';
+import { useEvaluationProgress } from './features/evaluation/hooks/useEvaluationProgress.js';
+import { computeOverallProgress } from './features/evaluation/components/scanProgressTotals.js';
 import LoadingScreen from './components/LoadingScreen.jsx';
 import Sidebar from './components/Sidebar.jsx';
 import TopBar from './components/TopBar.jsx';
@@ -1042,7 +1044,7 @@ export default function App() {
   const sidebarModel = sidebarProvider && typeof localStorage !== 'undefined'
     ? localStorage.getItem(providerKey(sidebarProvider, 'model'))
     : null;
-  const { activePage, navStack, navPop, navGoTo, navTab, activeTab } = state;
+  const { activePage, navStack, navPop, navGoTo, navSwapAt, navTab, activeTab } = state;
   // Initial landing: decided exactly once, the first render after both the
   // local projects list and the shared signal have settled (whatever the
   // outcome). Mid-session changes never re-trigger it.
@@ -1125,6 +1127,57 @@ export default function App() {
     () => filterAccumulatedByVisibleStandards(state.accumulated, visibleSet, filteredTrend, null),
     [state.accumulated, visibleSet, filteredTrend]
   );
+
+  // Breadcrumb jump-bar data: which siblings a given path segment can swap
+  // to. Two levels have a known sibling set — the root tab (the sidebar's
+  // main destinations) and the explorer dimension. Levels without one return
+  // null and stay plain links.
+  const breadcrumbSiblingsFor = useCallback((entry, index) => {
+    if (index === 0) {
+      if (!state.selectedProject) return null;
+      return ['overview', 'violations', 'map', 'history', 'evaluate'].map((id) => ({
+        key: id,
+        label: navLabelFor({ page: id }),
+        current: entry.page === id,
+        onSelect: () => (id === 'evaluate'
+          ? navTab('evaluate', { preselectDims: deriveEvaluatePreselect(activePage) })
+          : navTab(id)),
+      }));
+    }
+    if (entry.page === 'explorer') {
+      const dims = filteredAccumulated?.dimensions || [];
+      if (dims.length < 2) return null;
+      return dims.map((dim) => ({
+        key: dim.dimension,
+        label: (dim.dimension || '').toLowerCase(),
+        current: dim.dimension === entry.dimension,
+        onSelect: () => navSwapAt(index, {
+          page: 'explorer',
+          dimension: dim.dimension,
+          runId: dim.fromRunId,
+          dateLabel: dim.fromDateLabel,
+          fromProject: dim.fromProject,
+          sourceTab: entry.sourceTab || 'violations',
+        }),
+      }));
+    }
+    return null;
+  }, [state.selectedProject, navTab, navSwapAt, activePage, filteredAccumulated]);
+
+  // Live run progress for the topbar chrome (run chip + bottom hairline).
+  // Shares the JobStatStrip/ScanProgress query cache entry, so this adds no
+  // extra polling.
+  const evalJob = state.evalLifecycle?.job;
+  const { data: evalProgress } = useEvaluationProgress(isEvaluating ? evalJob?.jobId : undefined, !isEvaluating);
+  const topbarRunProgress = useMemo(() => {
+    if (!isEvaluating) return null;
+    const overall = computeOverallProgress(evalProgress);
+    const runningDim = (evalProgress?.dimensions || []).find((d) => d?.state === 'running');
+    return {
+      dimension: runningDim?.id ? String(runningDim.id).toLowerCase() : null,
+      percent: overall.totalFiles > 0 ? overall.overallPct : null,
+    };
+  }, [isEvaluating, evalProgress]);
 
   const contentProps = {
     dashboardData: buildDashboardDataBundle({ state, sharedHasContent: sharedSignal.hasContent }),
@@ -1215,6 +1268,7 @@ export default function App() {
               selectedSource={state.selectedSource}
               onEvaluate={shouldShowEvaluateButton(state.projects?.length, state.selectedSource) ? (() => navTab('evaluate', { preselectDims: deriveEvaluatePreselect(activePage) })) : null}
               evaluating={state.evalLifecycle?.job?.status === 'running'}
+              runProgress={topbarRunProgress}
               onProviderClick={() => navTab('settings')}
               onMenuToggle={() => setSidebarPinned((v) => !v)}
               onSelectProject={() => navTab('projects')}
@@ -1224,6 +1278,7 @@ export default function App() {
                   onGoTo={navGoTo}
                   projectName={resolvedDisplayName}
                   onSelectProject={() => navTab('projects')}
+                  siblingsFor={breadcrumbSiblingsFor}
                 />
               }
               mobileTitle={navStack.length ? navLabelFor(navStack[navStack.length - 1]) : (activeTab || '')}

--- a/src/quodeq/ui/src/components/AssistantLauncherButton.jsx
+++ b/src/quodeq/ui/src/components/AssistantLauncherButton.jsx
@@ -26,6 +26,7 @@ export function AssistantLauncherButton() {
           viewBox edge-to-edge while stroke icons carry built-in padding, so
           equal pixel sizes read visually larger. */}
       <QMarkIcon size={11} />
+      <span className="topbar-btn__label">assistant</span>
     </button>
   );
 }

--- a/src/quodeq/ui/src/components/ServerStatusDot.jsx
+++ b/src/quodeq/ui/src/components/ServerStatusDot.jsx
@@ -21,6 +21,11 @@ export default function ServerStatusDot({ connected, url }) {
         className={`topbar-dot ${connected ? 'topbar-dot--ok' : 'topbar-dot--err'}`}
         aria-hidden="true"
       />
+      {/* Dot at rest; the word slides out under the cursor (5a). The full
+          state already lives in aria-label/title, so this is presentational. */}
+      <span className="topbar-btn__label" aria-hidden="true">
+        {connected ? 'connected' : 'offline'}
+      </span>
     </span>
   );
 }

--- a/src/quodeq/ui/src/components/TerminalLauncherButton.jsx
+++ b/src/quodeq/ui/src/components/TerminalLauncherButton.jsx
@@ -14,6 +14,7 @@ export function TerminalLauncherButton() {
       aria-pressed={on} aria-label="Terminal (Ctrl+Shift+`)" title="Terminal (Ctrl+Shift+`)"
       onClick={() => toggleTopbar('terminal')}>
       <TerminalIcon />
+      <span className="topbar-btn__label">terminal</span>
     </button>
   );
 }

--- a/src/quodeq/ui/src/components/TopBar.jsx
+++ b/src/quodeq/ui/src/components/TopBar.jsx
@@ -2,7 +2,12 @@
  * TopBar — global app header sitting above the page content.
  *
  * Desktop layout (left → right):
- *   [ breadcrumb (projectName / page / …) ]        [ provider pill | Report | + Evaluate ]
+ *   [ address (projectName / … / page) ]
+ *   [ status | fix plan · report | theme · assistant · terminal | model | ▸ evaluate ]
+ * Action buttons show their icon at rest and expand their label on hover;
+ * the cluster is right-anchored so expansion pushes leftward and the primary
+ * never moves. While a run is live a progress chip replaces the (dimmed)
+ * Evaluate button and a hairline progress line runs along the bottom edge.
  *
  * Mobile layout (left → right):
  *   [ ‹ back ]  [ current page title ]                                          [ burger ]
@@ -35,7 +40,7 @@ function SidePaneSpecButton({ type, label, icon, modifier }) {
       }}
     >
       {icon}
-      <span>{label}</span>
+      <span className="topbar-btn__label">{label}</span>
     </button>
   );
 }
@@ -91,6 +96,10 @@ export default function TopBar({
   model,
   onEvaluate,
   evaluating = false,
+  /* {dimension, percent} while a run is live — feeds the run chip and the
+     progress hairline along the bar's bottom edge. Either field may be null
+     before the first progress poll lands. */
+  runProgress = null,
   onProviderClick,
   onMenuToggle,
   onSelectProject,
@@ -151,8 +160,11 @@ export default function TopBar({
 
       <div className="topbar-actions">
         <ServerStatusDot connected={serverConnected} url={serverUrl} />
+        <span className="topbar-divider" aria-hidden="true" />
+
         <FixPlanToolbarButton />
         <ReportToolbarButton />
+        <span className="topbar-divider" aria-hidden="true" />
 
         {onToggleTheme && (
           <button
@@ -163,11 +175,13 @@ export default function TopBar({
             title={effectiveDark ? 'Switch to light theme' : 'Switch to dark theme'}
           >
             {effectiveDark ? <SunIcon /> : <MoonIcon />}
+            <span className="topbar-btn__label">{effectiveDark ? 'light' : 'dark'}</span>
           </button>
         )}
 
         <AssistantLauncherButton />
         <TerminalLauncherButton />
+        <span className="topbar-divider" aria-hidden="true" />
 
         {(provider || model) && (
           onProviderClick ? (
@@ -177,9 +191,22 @@ export default function TopBar({
               onClick={onProviderClick}
               title="Open Settings to change provider or model"
             >
-              {provider && <span>{provider}</span>}
-              {provider && model && <span className="topbar-pill-sep">·</span>}
-              {model && <span className="topbar-pill-muted">{model}</span>}
+              {provider && model
+                ? (
+                  <>
+                    {/* Model at rest; the provider prefix pays for its label
+                        only under the cursor (5a — icon at rest, label on
+                        hover, expanding leftward so the primary never moves) */}
+                    <span className="topbar-btn__label topbar-btn__label--lead">{provider} ·</span>
+                    <span className="topbar-pill-muted">{model}</span>
+                  </>
+                )
+                : (
+                  <>
+                    {provider && <span>{provider}</span>}
+                    {model && <span className="topbar-pill-muted">{model}</span>}
+                  </>
+                )}
             </button>
           ) : (
             <span className="topbar-pill">
@@ -190,24 +217,36 @@ export default function TopBar({
           )
         )}
 
+        {onEvaluate && evaluating && (
+          <button
+            type="button"
+            className="topbar-run-chip"
+            onClick={onEvaluate}
+            title="View running evaluation"
+          >
+            <span className="topbar-run-chip__dot" aria-hidden="true" />
+            <span className="topbar-run-chip__dim">{runProgress?.dimension || 'evaluating…'}</span>
+            {runProgress?.percent != null && (
+              <>
+                <span className="topbar-run-chip__bar" aria-hidden="true">
+                  <span style={{ width: `${runProgress.percent}%` }} />
+                </span>
+                <span className="topbar-run-chip__pct">{runProgress.percent}%</span>
+              </>
+            )}
+          </button>
+        )}
         {onEvaluate && (
           <button
             type="button"
             className={`topbar-btn topbar-btn--evaluate${evaluating ? ' topbar-btn--evaluate--running' : ''}`}
-            onClick={onEvaluate}
+            onClick={evaluating ? undefined : onEvaluate}
+            aria-disabled={evaluating || undefined}
+            title={evaluating ? 'An evaluation is already running' : undefined}
             aria-live="polite"
           >
-            {evaluating ? (
-              <>
-                <span className="topbar-btn__spinner" aria-hidden="true" />
-                <span>Evaluating…</span>
-              </>
-            ) : (
-              <>
-                <span className="topbar-btn__plus" aria-hidden="true">+</span>
-                <span>Evaluate</span>
-              </>
-            )}
+            <span className="topbar-btn__play" aria-hidden="true">▸</span>
+            <span>Evaluate</span>
           </button>
         )}
 
@@ -223,6 +262,14 @@ export default function TopBar({
           </button>
         )}
       </div>
+
+      {/* Run-aware chrome: a 2px hairline along the bar's bottom edge carries
+          overall progress, so a long run stays visible from any page. */}
+      {evaluating && runProgress?.percent != null && (
+        <span className="topbar-progress" aria-hidden="true">
+          <span style={{ width: `${runProgress.percent}%` }} />
+        </span>
+      )}
     </header>
   );
 }

--- a/src/quodeq/ui/src/components/TopBar.test.jsx
+++ b/src/quodeq/ui/src/components/TopBar.test.jsx
@@ -65,3 +65,35 @@ describe('TopBar source gating', () => {
     expect(screen.getByRole('button', { name: /Assistant/i })).toBeInTheDocument();
   });
 });
+
+describe('TopBar evaluate and run state', () => {
+  it('fires onEvaluate from the primary button when idle', () => {
+    const onEvaluate = vi.fn();
+    renderTopBar({ onEvaluate });
+    fireEvent.click(screen.getByRole('button', { name: 'Evaluate' }));
+    expect(onEvaluate).toHaveBeenCalledTimes(1);
+  });
+
+  it('dims Evaluate and moves the click to the run chip while a run is live', () => {
+    const onEvaluate = vi.fn();
+    renderTopBar({
+      onEvaluate,
+      evaluating: true,
+      runProgress: { dimension: 'reliability', percent: 41 },
+    });
+    const evalBtn = screen.getByRole('button', { name: 'Evaluate' });
+    expect(evalBtn).toHaveAttribute('aria-disabled', 'true');
+    fireEvent.click(evalBtn);
+    expect(onEvaluate).not.toHaveBeenCalled();
+
+    const chip = screen.getByRole('button', { name: /reliability/ });
+    expect(chip).toHaveTextContent('41%');
+    fireEvent.click(chip);
+    expect(onEvaluate).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a placeholder on the run chip before the first progress poll lands', () => {
+    renderTopBar({ onEvaluate: () => {}, evaluating: true, runProgress: null });
+    expect(screen.getByRole('button', { name: /evaluating…/ })).toBeInTheDocument();
+  });
+});

--- a/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.jsx
@@ -1,4 +1,5 @@
-import { Fragment } from 'react';
+import { Fragment, useEffect, useRef, useState } from 'react';
+import { collapseCrumbs, isRunDateEntry } from './crumbModel.js';
 
 const PAGE_LABELS = {
   overview: 'overview',
@@ -31,46 +32,152 @@ export function labelFor(entry) {
 }
 
 /**
- * NavBreadcrumb — the app's single breadcrumb bar.
+ * NavBreadcrumb — the app's address bar, in the TopBar on desktop.
  *
- * Renders as a thin strip under the topbar / right of the sidebar (the
- * AppShell places it directly above page content). Always visible while
- * navigating in a project; falls back to showing just the project root +
- * current tab when the user hasn't drilled in yet.
+ * Two navigation ideas at two scales, one rule ("click a segment to move
+ * within that level"):
+ *   - collapse-the-middle: deep paths keep the two ends that matter (project
+ *     root and where you are); hidden ancestors sit one click away behind a
+ *     "…" chip that opens them as a plain list (see crumbModel.js);
+ *   - jump bar: a segment whose siblings are known (`siblingsFor`) opens a
+ *     menu of them with the current one marked, so lateral moves don't
+ *     require walking back up.
+ * Ancestor menus are a path, sibling menus are a choice — they're styled
+ * differently on purpose.
  *
- * Style: slash-separated plain text, monospace, muted. Intermediate
- * segments are clickable to pop the nav stack; the current segment is
- * accent-colored and non-interactive.
+ * Segments never wrap; only the current (last) segment may shrink.
  */
-export default function NavBreadcrumb({ stack = [], onGoTo, projectName, onSelectProject }) {
+export default function NavBreadcrumb({ stack = [], onGoTo, projectName, onSelectProject, siblingsFor }) {
+  const [openKey, setOpenKey] = useState(null);
+  const rootRef = useRef(null);
+
+  useEffect(() => {
+    if (openKey == null) return undefined;
+    const onDown = (e) => { if (!rootRef.current?.contains(e.target)) setOpenKey(null); };
+    const onEsc = (e) => { if (e.key === 'Escape') setOpenKey(null); };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onEsc);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onEsc);
+    };
+  }, [openKey]);
+
   const crumbs = [];
   if (projectName) crumbs.push({ label: projectName, index: -1, isProject: true });
-  stack.forEach((entry, i) => crumbs.push({ label: labelFor(entry), index: i }));
+  stack.forEach((entry, i) => crumbs.push({
+    label: labelFor(entry),
+    index: i,
+    entry,
+    isRunDate: isRunDateEntry(entry),
+  }));
 
   if (crumbs.length === 0) return null;
 
+  const display = collapseCrumbs(crumbs);
+  const lastCrumb = crumbs[crumbs.length - 1];
+
+  const goTo = (seg) => {
+    setOpenKey(null);
+    if (seg.isProject) onSelectProject?.();
+    else onGoTo(seg.index);
+  };
+
   return (
-    <nav className="nav-breadcrumb" aria-label="Breadcrumb">
+    <nav className="nav-breadcrumb" aria-label="Breadcrumb" ref={rootRef}>
       <ol className="nav-breadcrumb__crumbs">
-        {crumbs.map((seg, i) => {
-          const isLast = i === crumbs.length - 1;
+        {display.map((seg, i) => {
+          const sep = i > 0 && <li className="nav-breadcrumb__sep" aria-hidden="true">/</li>;
+
+          if (seg.ellipsis) {
+            const open = openKey === 'ellipsis';
+            return (
+              <Fragment key="ellipsis">
+                {sep}
+                <li className="nav-breadcrumb__crumb nav-breadcrumb__crumb--ellipsis">
+                  <button
+                    type="button"
+                    aria-label="Show hidden path segments"
+                    aria-haspopup="menu"
+                    aria-expanded={open}
+                    onClick={() => setOpenKey(open ? null : 'ellipsis')}
+                  >
+                    …
+                  </button>
+                  {open && (
+                    <div className="nav-breadcrumb__menu" role="menu" aria-label="Hidden path segments">
+                      {seg.hidden.map((h) => (
+                        <button
+                          key={`${h.label}-${h.index}`}
+                          type="button"
+                          role="menuitem"
+                          onClick={() => goTo(h)}
+                        >
+                          {h.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </li>
+              </Fragment>
+            );
+          }
+
+          const isLast = seg === lastCrumb;
+          const siblings = seg.entry && siblingsFor ? siblingsFor(seg.entry, seg.index) : null;
+          const hasMenu = Array.isArray(siblings) && siblings.length > 1;
+          const crumbClass = `nav-breadcrumb__crumb${isLast ? ' is-current' : ''}${
+            seg.isProject ? ' nav-breadcrumb__crumb--project' : ''
+          }${hasMenu ? ' nav-breadcrumb__crumb--menu' : ''}`;
+
+          if (hasMenu) {
+            const key = `seg-${seg.index}`;
+            const open = openKey === key;
+            return (
+              <Fragment key={`${seg.label}-${i}`}>
+                {sep}
+                <li className={crumbClass}>
+                  <button
+                    type="button"
+                    aria-haspopup="menu"
+                    aria-expanded={open}
+                    onClick={() => setOpenKey(open ? null : key)}
+                  >
+                    {seg.label}
+                    <span className="nav-breadcrumb__caret" aria-hidden="true">▾</span>
+                  </button>
+                  {open && (
+                    <div className="nav-breadcrumb__menu nav-breadcrumb__menu--siblings" role="menu" aria-label={`Switch ${seg.label}`}>
+                      {siblings.map((item) => (
+                        <button
+                          key={item.key}
+                          type="button"
+                          role="menuitemradio"
+                          aria-checked={!!item.current}
+                          onClick={() => { setOpenKey(null); if (!item.current) item.onSelect(); }}
+                        >
+                          <span className="nav-breadcrumb__menu-dot" aria-hidden="true" />
+                          {item.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </li>
+              </Fragment>
+            );
+          }
+
           // The project root is the persistent indicator: clickable whenever a
           // handler is wired, regardless of position. Other crumbs only pop the
           // nav stack and only when they aren't the current page.
           const isProjectButton = seg.isProject && typeof onSelectProject === 'function';
           const isClickable = isProjectButton || (!isLast && seg.index >= 0);
-          const crumbClass = `nav-breadcrumb__crumb${isLast ? ' is-current' : ''}${
-            seg.isProject ? ' nav-breadcrumb__crumb--project' : ''
-          }`;
           return (
             <Fragment key={`${seg.label}-${i}`}>
-              {i > 0 && <li className="nav-breadcrumb__sep" aria-hidden="true">/</li>}
+              {sep}
               <li className={crumbClass}>
                 {isClickable ? (
-                  <button
-                    type="button"
-                    onClick={() => (seg.isProject ? onSelectProject() : onGoTo(seg.index))}
-                  >
+                  <button type="button" onClick={() => goTo(seg)}>
                     {seg.label}
                   </button>
                 ) : (

--- a/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.test.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.test.jsx
@@ -60,3 +60,85 @@ describe('NavBreadcrumb project crumb', () => {
     expect(screen.queryByText('my-project')).toBeNull();
   });
 });
+
+describe('NavBreadcrumb collapse and jump bar', () => {
+  it('collapses deep paths behind a "…" chip whose menu lists hidden ancestors', () => {
+    const onGoTo = vi.fn();
+    render(
+      <NavBreadcrumb
+        stack={[
+          { page: 'violations' },
+          { page: 'explorer', dimension: 'Security' },
+          { page: 'principle', label: 'modularity' },
+          { page: 'file', label: 'HomeVC.swift' },
+        ]}
+        onGoTo={onGoTo}
+        projectName="repo"
+        onSelectProject={() => {}}
+      />
+    );
+    // repo / … / modularity / HomeVC.swift — the middle is one click away
+    expect(screen.queryByText('violations')).toBeNull();
+    expect(screen.queryByText('security')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Show hidden path segments' }));
+    expect(screen.getByRole('menuitem', { name: 'security' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('menuitem', { name: 'violations' }));
+    expect(onGoTo).toHaveBeenCalledWith(0);
+  });
+
+  it('drops intermediate run-date segments from the visible path but keeps them reachable', () => {
+    render(
+      <NavBreadcrumb
+        stack={[
+          { page: 'history' },
+          { page: 'history-run', dateLabel: '28 jul 2026' },
+          { page: 'explorer', dimension: 'Security' },
+        ]}
+        onGoTo={() => {}}
+        projectName="repo"
+        onSelectProject={() => {}}
+      />
+    );
+    expect(screen.queryByText('28 jul 2026')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Show hidden path segments' }));
+    expect(screen.getByRole('menuitem', { name: '28 jul 2026' })).toBeInTheDocument();
+  });
+
+  it('opens a sibling menu with the current item marked when siblingsFor supplies one', () => {
+    const onSelect = vi.fn();
+    const siblingsFor = (entry) => (entry.page === 'explorer'
+      ? [
+          { key: 'Security', label: 'security', current: true, onSelect: () => {} },
+          { key: 'Maintainability', label: 'maintainability', current: false, onSelect },
+        ]
+      : null);
+    render(
+      <NavBreadcrumb
+        stack={[{ page: 'violations' }, { page: 'explorer', dimension: 'Security' }]}
+        onGoTo={() => {}}
+        projectName="repo"
+        onSelectProject={() => {}}
+        siblingsFor={siblingsFor}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'security' }));
+    expect(screen.getByRole('menuitemradio', { name: 'security' })).toHaveAttribute('aria-checked', 'true');
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'maintainability' }));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays a plain link when siblingsFor returns null for the level', () => {
+    const onGoTo = vi.fn();
+    render(
+      <NavBreadcrumb
+        stack={[{ page: 'violations' }, { page: 'explorer', dimension: 'Security' }]}
+        onGoTo={onGoTo}
+        projectName="repo"
+        onSelectProject={() => {}}
+        siblingsFor={() => null}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'violations' }));
+    expect(onGoTo).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/quodeq/ui/src/features/explorer/components/crumbModel.js
+++ b/src/quodeq/ui/src/features/explorer/components/crumbModel.js
@@ -1,0 +1,54 @@
+/**
+ * Pure model for the topbar address: decides which crumbs stay visible and
+ * which collapse behind the "…" chip (Finder-style collapse-the-middle).
+ *
+ * Rules, in order:
+ *   - the first crumb (project root) and the last crumb (current page) are
+ *     always visible;
+ *   - run-date segments ("history / 28 jul 2026") never render as visible
+ *     intermediates — the run date belongs under the page title, not in the
+ *     address — but they stay reachable through the "…" ancestor menu;
+ *   - when the path is deeper than `maxVisible` crumbs, everything between
+ *     the root and the last two segments collapses.
+ */
+
+const RUN_DATE_PAGES = new Set(['run', 'history-run']);
+
+export function isRunDateEntry(entry) {
+  return RUN_DATE_PAGES.has(entry?.page);
+}
+
+/**
+ * @param {Array<{label: string, index: number, isProject?: boolean, isRunDate?: boolean}>} crumbs
+ * @param {{maxVisible?: number}} [opts]
+ * @returns {Array} display items in order: the visible crumbs, with a single
+ *   `{ellipsis: true, hidden: [...crumbs]}` marker at the position of the
+ *   first collapsed crumb. `hidden` preserves path order.
+ */
+export function collapseCrumbs(crumbs, { maxVisible = 4 } = {}) {
+  if (crumbs.length <= 1) return crumbs.slice();
+  const last = crumbs.length - 1;
+  const hidden = new Set();
+  if (crumbs.length > maxVisible) {
+    for (let i = 1; i <= last - 2; i++) hidden.add(i);
+  }
+  for (let i = 1; i < last; i++) {
+    if (crumbs[i].isRunDate) hidden.add(i);
+  }
+  if (hidden.size === 0) return crumbs.slice();
+
+  const out = [];
+  let marker = null;
+  for (let i = 0; i < crumbs.length; i++) {
+    if (hidden.has(i)) {
+      if (!marker) {
+        marker = { ellipsis: true, hidden: [] };
+        out.push(marker);
+      }
+      marker.hidden.push(crumbs[i]);
+    } else {
+      out.push(crumbs[i]);
+    }
+  }
+  return out;
+}

--- a/src/quodeq/ui/src/features/explorer/components/crumbModel.test.js
+++ b/src/quodeq/ui/src/features/explorer/components/crumbModel.test.js
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { collapseCrumbs, isRunDateEntry } from './crumbModel.js';
+
+const c = (label, index, extra = {}) => ({ label, index, ...extra });
+
+test('short paths pass through untouched', () => {
+  const crumbs = [c('repo', -1, { isProject: true }), c('overview', 0), c('maintainability', 1)];
+  assert.deepEqual(collapseCrumbs(crumbs), crumbs);
+});
+
+test('deep paths keep root plus last two, collapse the middle', () => {
+  const crumbs = [
+    c('repo', -1, { isProject: true }),
+    c('overview', 0),
+    c('security', 1),
+    c('maintainability', 2),
+    c('modularity', 3),
+  ];
+  const out = collapseCrumbs(crumbs);
+  assert.equal(out.length, 4);
+  assert.equal(out[0].label, 'repo');
+  assert.equal(out[1].ellipsis, true);
+  assert.deepEqual(out[1].hidden.map((h) => h.label), ['overview', 'security']);
+  assert.equal(out[2].label, 'maintainability');
+  assert.equal(out[3].label, 'modularity');
+});
+
+test('intermediate run-date segments collapse even in short paths', () => {
+  const crumbs = [
+    c('repo', -1, { isProject: true }),
+    c('history', 0),
+    c('28 jul 2026', 1, { isRunDate: true }),
+    c('maintainability', 2),
+  ];
+  const out = collapseCrumbs(crumbs);
+  assert.deepEqual(out.map((s) => s.ellipsis ? '…' : s.label), ['repo', 'history', '…', 'maintainability']);
+  assert.deepEqual(out[2].hidden.map((h) => h.label), ['28 jul 2026']);
+});
+
+test('a run-date segment that is the current page stays visible', () => {
+  const crumbs = [
+    c('repo', -1, { isProject: true }),
+    c('history', 0),
+    c('28 jul 2026', 1, { isRunDate: true }),
+  ];
+  assert.deepEqual(collapseCrumbs(crumbs), crumbs);
+});
+
+test('deep path with a run date merges everything into one ellipsis group', () => {
+  const crumbs = [
+    c('repo', -1, { isProject: true }),
+    c('history', 0),
+    c('28 jul 2026', 1, { isRunDate: true }),
+    c('maintainability', 2),
+    c('modularity', 3),
+  ];
+  const out = collapseCrumbs(crumbs);
+  assert.deepEqual(out.map((s) => s.ellipsis ? '…' : s.label), ['repo', '…', 'maintainability', 'modularity']);
+  assert.deepEqual(out[1].hidden.map((h) => h.label), ['history', '28 jul 2026']);
+});
+
+test('single crumb renders as-is', () => {
+  const crumbs = [c('repo', -1, { isProject: true })];
+  assert.deepEqual(collapseCrumbs(crumbs), crumbs);
+});
+
+test('isRunDateEntry matches run and history-run pages only', () => {
+  assert.equal(isRunDateEntry({ page: 'run' }), true);
+  assert.equal(isRunDateEntry({ page: 'history-run' }), true);
+  assert.equal(isRunDateEntry({ page: 'explorer' }), false);
+  assert.equal(isRunDateEntry(null), false);
+});

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -69,7 +69,7 @@ function useProjects({ onNoProjects }) {
 
 function useAppNavigation() {
   const [serverConnected, setServerConnected, serverVersion] = useServerHealth();
-  const { navStack, activePage, navPush, navPop, navReplace, navGoTo, navReset, navTab } = useNavStack();
+  const { navStack, activePage, navPush, navPop, navReplace, navGoTo, navSwapAt, navReset, navTab } = useNavStack();
   const projectBundle = useProjects({ onNoProjects: () => { /* wizard handles fresh-user UX in App.jsx */ } });
   const { selectedRun, setSelectedRun, handleRunChange } = projectBundle;
   const [historySelectedRun, setHistorySelectedRun] = useState('latest');
@@ -83,7 +83,7 @@ function useAppNavigation() {
     // repositories local/online tabs): history must not grow per flip.
     navReplace({ page, ...params });
   }
-  return { serverConnected, setServerConnected, serverVersion, navStack, activePage, navPush, navPop, navGoTo, navReset, navTab, projectBundle, handleNavigate, handleNavigateReplace, handleRunChange, historySelectedRun, setHistorySelectedRun };
+  return { serverConnected, setServerConnected, serverVersion, navStack, activePage, navPush, navPop, navGoTo, navSwapAt, navReset, navTab, projectBundle, handleNavigate, handleNavigateReplace, handleRunChange, historySelectedRun, setHistorySelectedRun };
 }
 
 export function formatDayLabel(trend, currentOverviewRun, dailyRuns, overviewRunIndex) {
@@ -135,7 +135,7 @@ export function useOverviewReturnReconcile({ rootTab, selectedProject, selectedS
 
 export function useAppState() {
   const nav = useAppNavigation();
-  const { serverConnected, setServerConnected, serverVersion, navStack, activePage, navPop, navGoTo, navReset, navTab, projectBundle, handleNavigate, handleNavigateReplace, handleRunChange, historySelectedRun, setHistorySelectedRun } = nav;
+  const { serverConnected, setServerConnected, serverVersion, navStack, activePage, navPop, navGoTo, navSwapAt, navReset, navTab, projectBundle, handleNavigate, handleNavigateReplace, handleRunChange, historySelectedRun, setHistorySelectedRun } = nav;
   const {
     projects, projectsLoaded, setProjects, selectedProject, selectedSource,
     selectedRun, setSelectedRun, loadProjects, handleProjectChange,
@@ -182,7 +182,7 @@ export function useAppState() {
   useOverviewReturnReconcile({ rootTab: navStack[0]?.page, selectedProject, selectedSource });
 
   return {
-    serverConnected, setServerConnected, serverVersion, navStack, activePage, navPop, navGoTo, navTab,
+    serverConnected, setServerConnected, serverVersion, navStack, activePage, navPop, navGoTo, navSwapAt, navTab,
     projects, projectsLoaded, selectedProject, selectedSource, selectedRun, loadProjects, handleProjectChange, handleNavigate, handleNavigateReplace,
     handleDeleteProject, handleExportProject, handleRelocateProject, handleImportProject,
     dashboard, accumulated, latestAccumulated, rescoreLookup, loading, isFetching, scoresPending, error, availableRuns, dailyRuns: visibleDailyRuns, overviewRunIndex, sharedProjectInfo,

--- a/src/quodeq/ui/src/hooks/useNavStack.js
+++ b/src/quodeq/ui/src/hooks/useNavStack.js
@@ -13,7 +13,7 @@ const defaultHistoryAdapter = {
 /**
  * Manages a browser-history-backed navigation stack.
  *
- * Returns { navStack, activePage, navPush, navPop, navReplace, navGoTo, navReset, navTab }.
+ * Returns { navStack, activePage, navPush, navPop, navReplace, navGoTo, navSwapAt, navReset, navTab }.
  */
 function handlePopState(e, setNavStack) {
   const targetIndex = e.state?.navIndex ?? 0;
@@ -55,6 +55,22 @@ function createNavActions(setNavStack, navStackRef, history) {
     if (steps > 0) history.go(-steps);
   }
 
+  function navSwapAt(index, entry) {
+    // Lateral move within one level of the path (the breadcrumb's sibling
+    // menus): replace the entry at `index` and drop everything deeper.
+    // Same shape as navTab: truncate state synchronously, then walk browser
+    // history back — the resulting popstate finds the stack already cut and
+    // no-ops (see handlePopState).
+    const prev = navStackRef.current;
+    const stepsBack = prev.length - 1 - index;
+    if (stepsBack <= 0) {
+      navReplace(entry);
+      return;
+    }
+    setNavStack([...prev.slice(0, index), entry]);
+    history.go(-stepsBack);
+  }
+
   function navReset() {
     const stepsBack = navStackRef.current.length - 1;
     setNavStack([{ page: DEFAULT_PAGE }]);
@@ -72,7 +88,7 @@ function createNavActions(setNavStack, navStackRef, history) {
     if (stepsBack > 0) history.go(-stepsBack);
   }
 
-  return { navPush, navPop, navReplace, navGoTo, navReset, navTab };
+  return { navPush, navPop, navReplace, navGoTo, navSwapAt, navReset, navTab };
 }
 
 export function useNavStack({ historyAdapter } = {}) {
@@ -91,7 +107,7 @@ export function useNavStack({ historyAdapter } = {}) {
     return () => window.removeEventListener('popstate', handler);
   }, []);
 
-  const { navPush, navPop, navReplace, navGoTo, navReset, navTab } = createNavActions(setNavStack, navStackRef, history);
+  const { navPush, navPop, navReplace, navGoTo, navSwapAt, navReset, navTab } = createNavActions(setNavStack, navStackRef, history);
   const activePage = navStack[navStack.length - 1];
 
   useEffect(() => {
@@ -103,5 +119,5 @@ export function useNavStack({ historyAdapter } = {}) {
     else window.scrollTo({ top: 0 });
   }, [activePage]);
 
-  return { navStack, activePage, navPush, navPop, navReplace, navGoTo, navReset, navTab };
+  return { navStack, activePage, navPush, navPop, navReplace, navGoTo, navSwapAt, navReset, navTab };
 }

--- a/src/quodeq/ui/src/styles/explorer.css
+++ b/src/quodeq/ui/src/styles/explorer.css
@@ -175,47 +175,70 @@
   user-select: none;
 }
 
+/* Segments never wrap — only the current (last) segment is allowed to
+   shrink, so the two ends of the address always stay readable. */
 .nav-breadcrumb__crumbs {
   display: flex;
   align-items: center;
-  gap: 6px;
-  flex-wrap: wrap;
+  gap: 2px;
+  flex-wrap: nowrap;
   list-style: none;
   margin: 0;
   padding: 0;
   min-width: 0;
-  overflow: hidden;
+  /* visible, not hidden: the jump-bar menus hang below this list; each
+     segment clips its own text instead. */
+  overflow: visible;
 }
 
 .nav-breadcrumb__sep {
+  flex: 0 0 auto;
   color: var(--color-text-subtle);
   opacity: 0.55;
   font-weight: 400;
+  margin: 0 3px;
 }
 
 .nav-breadcrumb__crumb {
+  position: relative;
   display: inline-flex;
   align-items: center;
+  flex: 0 0 auto;
   min-width: 0;
+}
+.nav-breadcrumb__crumb.is-current {
+  flex: 0 1 auto;
 }
 .nav-breadcrumb__crumb > button,
 .nav-breadcrumb__crumb > span {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
   background: transparent;
   border: 0;
-  padding: 0;
+  padding: 3px 6px;
+  border-radius: 5px;
   font: inherit;
   color: inherit;
   white-space: nowrap;
+}
+.nav-breadcrumb__crumb > span,
+.nav-breadcrumb__crumb > button {
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .nav-breadcrumb__crumb > button {
   cursor: pointer;
-  transition: color 120ms ease;
+  transition: color 120ms ease, background 120ms ease;
 }
-.nav-breadcrumb__crumb > button:hover {
+.nav-breadcrumb__crumb > button:hover,
+.nav-breadcrumb__crumb > button[aria-expanded='true'] {
   color: var(--color-text);
-  text-decoration: underline;
+  background: var(--color-surface-alt);
+}
+.nav-breadcrumb__crumb > button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
 }
 .nav-breadcrumb__crumb.is-current > span,
 .nav-breadcrumb__crumb.is-current > button {
@@ -224,8 +247,7 @@
 }
 
 /* Project root — the persistent "which project" indicator. Accent-colored
-   and clickable (opens the Projects tab). Kept as plain text per this
-   breadcrumb's no-chips convention. */
+   and clickable (opens the Projects tab). */
 .nav-breadcrumb__crumb--project > button,
 .nav-breadcrumb__crumb--project > span {
   color: var(--color-accent);
@@ -233,7 +255,90 @@
 }
 .nav-breadcrumb__crumb--project > button:hover {
   color: var(--color-accent-hover);
-  text-decoration: underline;
+}
+
+/* "…" chip — stands in for the collapsed middle of a deep path. Carries a
+   resting surface so it reads as a control, not a typo. */
+.nav-breadcrumb__crumb--ellipsis > button {
+  padding: 3px 8px;
+  background: var(--color-surface-alt);
+  color: var(--color-text-muted);
+}
+.nav-breadcrumb__crumb--ellipsis > button:hover,
+.nav-breadcrumb__crumb--ellipsis > button[aria-expanded='true'] {
+  color: var(--color-text);
+  background: color-mix(in srgb, var(--color-text-muted) 16%, transparent);
+}
+
+/* ▾ affordance on jump-bar segments — invisible at rest (Xcode-style),
+   revealed by hover, keyboard focus, or an open menu. */
+.nav-breadcrumb__caret {
+  flex: 0 0 auto;
+  margin-left: 5px;
+  font-size: 8px;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+.nav-breadcrumb__crumb--menu > button:hover .nav-breadcrumb__caret,
+.nav-breadcrumb__crumb--menu > button:focus-visible .nav-breadcrumb__caret,
+.nav-breadcrumb__crumb--menu > button[aria-expanded='true'] .nav-breadcrumb__caret {
+  opacity: 0.7;
+}
+
+/* Dropdown shared by the ancestor ("…") and sibling menus. */
+.nav-breadcrumb__menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 60;
+  min-width: 176px;
+  padding: 4px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-lg, 0 14px 30px rgba(0, 0, 0, 0.35));
+}
+.nav-breadcrumb__menu > button {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 28px;
+  padding: 3px 9px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  font: inherit;
+  color: var(--color-text-muted);
+  text-align: left;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color 120ms ease, background 120ms ease;
+}
+.nav-breadcrumb__menu > button:hover {
+  color: var(--color-text);
+  background: var(--color-surface-alt);
+}
+.nav-breadcrumb__menu > button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+/* Sibling menus are a choice, not a path: each row carries a state dot and
+   the current sibling is marked. The ancestor menu stays a plain list. */
+.nav-breadcrumb__menu-dot {
+  flex: 0 0 auto;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  margin-right: 8px;
+  background: color-mix(in srgb, var(--color-text-muted) 45%, transparent);
+}
+.nav-breadcrumb__menu--siblings > button[aria-checked='true'] {
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+.nav-breadcrumb__menu--siblings > button[aria-checked='true'] .nav-breadcrumb__menu-dot {
+  background: var(--color-accent);
 }
 
 /* Legacy chip-trail classes — kept inert in case a stray consumer

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -22,7 +22,9 @@
   --term-space-3: 16px;
   --term-space-4: 24px;
   --term-space-5: 48px;
-  --app-header-h: 52px;
+  /* 44px per the toolbar redesign (compact unified bar, VS Code density);
+     the macOS native shell overrides to 40px to center the traffic lights. */
+  --app-header-h: 44px;
   --term-radius: 2px;
   --term-border: 1px solid var(--color-border);
   --term-divider: 1px solid var(--color-border);
@@ -882,7 +884,9 @@ button.term-sev-badge--clickable:focus-visible {
   .topbar-btn--evaluate,
   .topbar-btn--theme,
   .topbar-btn--report,
-  .topbar-btn--fixplan { display: none !important; }
+  .topbar-btn--fixplan,
+  .topbar-divider,
+  .topbar-run-chip { display: none !important; }
   .topbar-actions { gap: var(--term-space-1); }
   /* Compact view: hide all side-pane triggers. The pane itself is too
      narrow to be useful below 900px, and without triggers users can't
@@ -1905,6 +1909,7 @@ button.term-sev-badge--clickable:focus-visible {
    TopBar — replaces ProjectHeader
    ============================================================ */
 .topbar {
+  position: relative; /* anchors the run-progress hairline on its bottom edge */
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -1927,7 +1932,9 @@ button.term-sev-badge--clickable:focus-visible {
   display: inline-flex;
   align-items: center;
   min-width: 0;
-  overflow: hidden;
+  /* visible: the breadcrumb's jump-bar menus drop below the bar; the
+     breadcrumb clips its own segments. */
+  overflow: visible;
 }
 
 .topbar-back-btn {
@@ -2002,21 +2009,71 @@ button.term-sev-badge--clickable:focus-visible {
 .topbar-actions {
   display: inline-flex;
   align-items: center;
-  gap: var(--term-space-2);
-  flex-wrap: wrap;
+  gap: 2px;
+  /* Right-anchored, never wraps, never shrinks: hover label expansion pushes
+     leftward into the breadcrumb's slack, and the primary never moves. */
+  flex-wrap: nowrap;
+  flex-shrink: 0;
   justify-content: flex-end;
+}
+
+/* Hairline between action groups (status | named actions | utilities |
+   model + primary) — reads as tiers without a single button border. */
+.topbar-divider {
+  flex: 0 0 auto;
+  width: 1px;
+  height: 18px;
+  margin: 0 6px;
+  background: var(--color-border);
+}
+/* A group can render empty (specs not yet registered, status unknown):
+   collapse a divider that would lead the row or double up. */
+.topbar-actions > .topbar-divider:first-child,
+.topbar-actions > .topbar-divider + .topbar-divider { display: none; }
+
+/* Icon at rest, label on hover (5a): the label pays for its width only
+   under the cursor or keyboard focus. */
+.topbar-btn__label {
+  display: inline-block;
+  max-width: 0;
+  opacity: 0;
+  margin-left: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  transition: max-width 0.2s ease, opacity 0.16s ease, margin-left 0.2s ease;
+}
+.topbar-btn:hover .topbar-btn__label,
+.topbar-btn:focus-visible .topbar-btn__label,
+.topbar-pill--button:hover .topbar-btn__label,
+.topbar-pill--button:focus-visible .topbar-btn__label,
+.topbar-status-dot:hover .topbar-btn__label {
+  max-width: 110px;
+  opacity: 1;
+  margin-left: 6px;
+}
+/* Leading variant (provider prefix before the model name): expands to the
+   left of its sibling, so the margin sits on the right. */
+.topbar-btn__label--lead { margin-left: 0; margin-right: 0; }
+.topbar-pill--button:hover .topbar-btn__label--lead,
+.topbar-pill--button:focus-visible .topbar-btn__label--lead {
+  margin-left: 0;
+  margin-right: 6px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .topbar-btn__label { transition: none; }
 }
 .topbar-pill {
   /* Matched footprint with .topbar-btn (Evaluate / Report) so the
      provider pill reads as part of the same control row: same height,
-     corner radius, font size, and padding. */
+     corner radius, font size, and padding. Ghost like the rest of the
+     cluster — only hover paints a surface. */
   display: inline-flex;
   align-items: center;
   gap: 6px;
   padding: 4px 10px;
   min-height: 28px;
   box-sizing: border-box;
-  border: 1px solid var(--color-border);
+  border: 1px solid transparent;
   border-radius: var(--term-radius);
   font-size: 12px;
   font-weight: 500;
@@ -2028,11 +2085,11 @@ button.term-sev-badge--clickable:focus-visible {
 }
 /* Clickable provider pill — same visuals as the span variant plus hover */
 .topbar-pill--button {
+  gap: 0; /* the expanding provider prefix carries its own margin */
   cursor: pointer;
-  transition: border-color 0.14s ease, background 0.14s ease, color 0.14s ease;
+  transition: background 0.14s ease, color 0.14s ease;
 }
 .topbar-pill--button:hover {
-  border-color: var(--color-text-muted);
   background: var(--color-surface-alt);
   color: var(--color-text);
 }
@@ -2064,17 +2121,29 @@ button.term-sev-badge--clickable:focus-visible {
 .topbar-dot--err { background: transparent; border: 2px solid var(--color-danger); }
 
 /* Wrapper makes the 8px dot a comfortable hover/tooltip target and keeps it
-   vertically centered as the leading item in the actions row. */
+   vertically centered as the leading item in the actions row. Hovering
+   surfaces the chip and slides out the state word (see ServerStatusDot). */
 .topbar-status-dot {
   display: inline-flex;
   align-items: center;
-  padding: 0 2px;
+  min-height: 28px;
+  padding: 4px 8px;
+  box-sizing: border-box;
+  border-radius: var(--term-radius);
+  font-size: 11.5px;
+  color: var(--color-text-muted);
+  transition: background 0.14s ease;
+}
+.topbar-status-dot:hover {
+  background: var(--color-surface-alt);
 }
 
 .topbar-btn {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  /* No flex gap: the hover-expanding label carries its own margin, so a
+     collapsed label leaves the icon perfectly centered at rest. */
+  gap: 0;
   font-family: inherit;
   font-size: 12px;
   font-weight: 500;
@@ -2088,7 +2157,9 @@ button.term-sev-badge--clickable:focus-visible {
   padding: 4px 10px;
   background: transparent;
   color: var(--color-text);
-  border: 1px solid var(--color-border);
+  /* Ghost at rest — the border stays in the box so nothing shifts, it just
+     doesn't paint until a state needs it. */
+  border: 1px solid transparent;
   border-radius: var(--term-radius);
   cursor: pointer;
   box-sizing: border-box;
@@ -2096,7 +2167,6 @@ button.term-sev-badge--clickable:focus-visible {
 }
 .topbar-btn:hover {
   background: var(--color-surface-alt);
-  border-color: var(--color-text-muted);
 }
 
 /* Icon-only variant — square-ish, same height as .topbar-btn for a
@@ -2122,52 +2192,134 @@ button.term-sev-badge--clickable:focus-visible {
 .topbar-btn--icon svg {
   display: block;
 }
-/* Evaluate button: same footprint as Report, with an accent-tinted
-   border + text so it still reads as the primary action without
-   shouting. */
+/* Evaluate button — the single filled action in the bar. */
 .topbar-btn--evaluate {
-  color: var(--color-accent);
-  border-color: color-mix(in srgb, var(--color-accent) 45%, var(--color-border));
+  gap: 7px;
+  margin-left: 8px;
+  background: var(--color-accent);
+  border-color: transparent;
+  color: var(--color-on-accent);
 }
 .topbar-btn--evaluate:hover {
-  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
-  border-color: var(--color-accent);
-  color: var(--color-accent);
+  background: var(--color-accent-hover);
+  color: var(--color-on-accent);
 }
 .topbar-btn--evaluate:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
 
-/* Leading `+` glyph — subtle accent tint, matches the button color */
-.topbar-btn--evaluate .topbar-btn__plus {
-  font-size: 13px;
+/* Leading ▸ glyph — the product's start mark (▸ overview, ▸ evaluate):
+   same mark, same meaning. */
+.topbar-btn--evaluate .topbar-btn__play {
+  font-size: 9px;
   line-height: 1;
-  opacity: 0.85;
 }
 
-/* Running state: muted surface + spinner. Still clickable so users can
-   navigate back to the Evaluate tab to watch progress. */
-.topbar-btn--evaluate--running {
-  color: var(--color-text-muted);
-  border-color: var(--color-border);
-  background: var(--color-surface-alt);
-  cursor: progress;
-}
+/* While a run is live the button dims and stops accepting clicks — the run
+   chip beside it owns the "watch progress" affordance, and a dimmed primary
+   means you can't double-start. */
+.topbar-btn--evaluate--running,
 .topbar-btn--evaluate--running:hover {
-  color: var(--color-text);
-  background: var(--color-surface-alt);
-  border-color: var(--color-text-muted);
+  color: var(--color-text-subtle);
+  border-color: var(--color-border);
+  background: transparent;
+  cursor: default;
 }
-/* Report and Fix-plan toolbar buttons: neutral by default (same shape as
-   Evaluate, no accent tint), accent treatment only on hover or when the
-   pane is open. */
-.topbar-btn--report:hover,
+
+/* Run chip — while an evaluation runs, the run takes the primary slot:
+   live dimension, mini progress bar, percent. Click-through to the
+   Evaluate tab, so the run is never lost by leaving the page. */
+.topbar-run-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  margin-left: 8px;
+  padding: 4px 10px;
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--color-text);
+  background: var(--color-accent-soft);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 30%, transparent);
+  border-radius: var(--term-radius);
+  cursor: pointer;
+  box-sizing: border-box;
+  transition: border-color 0.14s ease;
+}
+.topbar-run-chip:hover {
+  border-color: color-mix(in srgb, var(--color-accent) 60%, transparent);
+}
+.topbar-run-chip:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+.topbar-run-chip__dot {
+  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  animation: topbar-run-pulse 1.6s ease-in-out infinite;
+}
+.topbar-run-chip__dim { white-space: nowrap; }
+.topbar-run-chip__bar {
+  flex: 0 0 auto;
+  position: relative;
+  width: 56px;
+  height: 3px;
+  border-radius: 2px;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--color-accent) 18%, transparent);
+}
+.topbar-run-chip__bar > span {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  border-radius: 2px;
+  background: var(--color-accent);
+  transition: width 0.6s ease;
+}
+.topbar-run-chip__pct {
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+@keyframes topbar-run-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+/* 2px progress hairline along the bar's bottom edge (run-aware chrome):
+   sits on top of the border so any page shows how far the run is. */
+.topbar-progress {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 2px;
+  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+  pointer-events: none;
+}
+.topbar-progress > span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--color-accent) 55%, transparent), var(--color-accent));
+  transition: width 0.6s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .topbar-run-chip__dot { animation: none; }
+  .topbar-run-chip__bar > span,
+  .topbar-progress > span { transition: none; }
+}
+/* Report and Fix-plan toolbar buttons: ghost like the rest of the cluster
+   (hover = neutral surface + expanded label); the accent treatment is
+   reserved for the open-pane state so "on" stays unambiguous. */
 .topbar-btn--report--open,
-.topbar-btn--fixplan:hover,
 .topbar-btn--fixplan--open {
   background: color-mix(in srgb, var(--color-accent) 10%, transparent);
-  border-color: var(--color-accent);
   color: var(--color-accent);
 }
 .topbar-btn--report:focus-visible,
@@ -2189,19 +2341,6 @@ button.term-sev-badge--clickable:focus-visible {
 .topbar-btn--terminal:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
-}
-
-.topbar-btn__spinner {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  border: 1.5px solid color-mix(in srgb, var(--color-accent) 30%, transparent);
-  border-top-color: var(--color-accent);
-  animation: topbar-spin 0.8s linear infinite;
-}
-@keyframes topbar-spin {
-  to { transform: rotate(360deg); }
 }
 
 /* Burger button in TopBar — hidden on desktop, shown on mobile via the


### PR DESCRIPTION
Implements the toolbar direction picked in the design audit (Toolbar Options: 1a structure, 4b/5a action cluster, 3b evaluate, 3d/2a running state, 7a+6b combined address).

## Address bar
- Deep paths collapse to `repo / … / parent / current`. The `…` chip opens the hidden ancestors as a plain list. Only the last segment is allowed to shrink.
- Segments with a known sibling set (main tab, explorer dimension) open a menu of siblings with the current one marked. Lateral moves go through the new `navSwapAt`, which replaces the level instead of growing the path.
- Run-date segments no longer show in the address (the date sits under the page title). They stay reachable through the `…` menu.

## Action cluster
- Ghost buttons in groups split by hairlines: status | fix plan, report | theme, assistant, terminal | model | evaluate.
- Icon at rest, label expands on hover (CSS only). The cluster is right-anchored, so expansion pushes left and the primary never moves.
- Evaluate is the single filled action, with the ▸ glyph instead of `+`.

## Running state
- A chip with the live dimension, percent and a mini bar takes the primary slot; evaluate dims so a run can't be double-started.
- A 2px progress hairline runs along the bar's bottom edge. Both reuse the existing progress query cache, no extra polling.

## Sizing
- Bar height goes 52px → 44px in the browser. The macOS shell keeps its 40px override (traffic-light centering).

## Tests
- New pure collapse model (`crumbModel.js`) with node tests, new NavBreadcrumb and TopBar suites for the menus and run state. Full run green: 373 node + 1444 vitest. Verified live against a local API.