### PR TITLE
fix(ui): keep long stat values inside their tiles

### DIFF
--- a/src/quodeq/ui/src/components/terminal/StatStrip.jsx
+++ b/src/quodeq/ui/src/components/terminal/StatStrip.jsx
@@ -31,11 +31,18 @@ export function StatStrip({ children, cards = false }) {
  */
 export function Stat({ label, value, hint, trailing, tone = 'default', onClick, ariaLabel }) {
   const className = `term-stat term-stat--${tone}${onClick ? ' term-stat--clickable' : ''}`;
+  // Character count of the plain-text value, published to CSS so the value can
+  // size itself down to fit its card (see `.term-stat__value`). Numbers are
+  // short and stay at the max size; a long word like a dimension name shrinks
+  // instead of overflowing the card and widening the whole strip. Rich values
+  // (nodes) carry no measurable length — they keep the default.
+  const plain = typeof value === 'string' || typeof value === 'number' ? String(value) : null;
+  const valueStyle = plain ? { '--stat-value-len': plain.length } : undefined;
   const labelValue = (
     <>
-      <div className="term-stat__label">{label}</div>
+      <div className="term-stat__label" title={typeof label === 'string' ? label : undefined}>{label}</div>
       <div className="term-stat__value-row">
-        <span className="term-stat__value">{value}</span>
+        <span className="term-stat__value" style={valueStyle} title={plain ?? undefined}>{value}</span>
         {trailing != null && <span className="term-stat__trailing">{trailing}</span>}
       </div>
     </>

--- a/src/quodeq/ui/src/components/terminal/StatStrip.test.jsx
+++ b/src/quodeq/ui/src/components/terminal/StatStrip.test.jsx
@@ -47,6 +47,24 @@ describe('Stat with interactive hint', () => {
     expect(onStat).not.toHaveBeenCalled();
   });
 
+  it('publishes the value length so CSS can fit it to the card', () => {
+    // The fit-to-card font size in terminal.css divides the card width by this
+    // count. Without it a long word (a dimension name) overflows its card and
+    // widens the whole strip.
+    const { container } = render(
+      <StatStrip cards>
+        <Stat label="analyzing" value="maintainability" hint="next: performance" />
+        <Stat label="files this run" value={285} trailing="/ 1037" />
+        <Stat label="score" value={<em>9.0</em>} />
+      </StatStrip>,
+    );
+    const values = [...container.querySelectorAll('.term-stat__value')];
+    expect(values[0].style.getPropertyValue('--stat-value-len')).toBe('15');
+    expect(values[1].style.getPropertyValue('--stat-value-len')).toBe('3');
+    // Rich values carry no measurable length — no property, CSS default applies.
+    expect(values[2].style.getPropertyValue('--stat-value-len')).toBe('');
+  });
+
   it('renders a plain (non-button) card when not clickable', () => {
     const { container } = render(
       <StatStrip cards>

--- a/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.test.jsx
@@ -27,8 +27,12 @@ describe('JobStatStrip', () => {
       totalElapsedS: 134,
     });
     renderWithClient(<JobStatStrip job={runningJob} liveViolations={{ security: [{ severity: 'major' }, { severity: 'critical' }] }} />);
-    expect(await screen.findByText('analyzing · dimension 1 / 1')).toBeInTheDocument();
-    expect(screen.getByText('security')).toBeInTheDocument();
+    // Wait on the dimension name, not the "analyzing" label: the label is the
+    // same before and after the progress query lands, so it resolves against
+    // the pre-data render and asserts nothing.
+    expect(await screen.findByText('security')).toBeInTheDocument();
+    expect(screen.getByText('analyzing')).toBeInTheDocument();
+    expect(screen.getByText('dim 1/1')).toBeInTheDocument();
     expect(screen.getByText('files this run')).toBeInTheDocument();
     expect(screen.getByText('violations')).toBeInTheDocument();
     expect(screen.getByText('elapsed')).toBeInTheDocument();

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
@@ -246,9 +246,15 @@ export function buildJobStatCells(status, inputs) {
       : inputs.scanMode === 'clean scan' ? ' · full rescan' : '';
     return [
       {
-        label: dc ? `analyzing · dimension ${dc.index} / ${dc.count}` : 'analyzing',
+        // The counter lives in the hint, not the label. Tile labels are a
+        // single ellipsized line, and "analyzing · dimension 3 / 4" doesn't fit
+        // a quarter-width card — it truncated to "analyzing · dimen…", hiding
+        // the only part that carries information. The hint wraps, so it can.
+        label: 'analyzing',
         value: dc?.current ?? '—',
-        hint: dc ? (dc.next ? `next: ${dc.next}` : (dc.count > 1 ? 'last dimension' : null)) : 'preparing…',
+        hint: dc
+          ? `dim ${dc.index}/${dc.count}${dc.next ? ` · next: ${dc.next}` : ''}`
+          : 'preparing…',
         tone: 'accent',
       },
       {

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
@@ -54,9 +54,9 @@ test('buildJobStatCells: builds 4 cells for a running job with progress data', (
     scanMode: 'incremental',
   });
   assert.equal(cells.length, 4);
-  assert.equal(cells[0].label, 'analyzing · dimension 1 / 3');
+  assert.equal(cells[0].label, 'analyzing');
   assert.equal(cells[0].value, 'reliability');
-  assert.equal(cells[0].hint, 'next: usability');
+  assert.equal(cells[0].hint, 'dim 1/3 · next: usability');
   assert.equal(cells[0].tone, 'accent');
   assert.equal(cells[1].label, 'files this run');
   assert.equal(cells[1].value, 138);
@@ -76,13 +76,13 @@ test('buildJobStatCells: running analyzing tile falls back while dims are unknow
   assert.equal(cells[0].hint, 'preparing…');
 });
 
-test('buildJobStatCells: running last dimension says so instead of a next hint', () => {
+test('buildJobStatCells: running last dimension keeps the counter and drops the next hint', () => {
   const cells = buildJobStatCells('running', {
     ...baseInputs,
     dimCycle: { current: 'usability', index: 3, count: 3, next: null },
   });
-  assert.equal(cells[0].label, 'analyzing · dimension 3 / 3');
-  assert.equal(cells[0].hint, 'last dimension');
+  assert.equal(cells[0].label, 'analyzing');
+  assert.equal(cells[0].hint, 'dim 3/3');
 });
 
 test('buildJobStatCells: running files hint omits mode copy when mode is unknown', () => {

--- a/src/quodeq/ui/src/styles/onboarding.css
+++ b/src/quodeq/ui/src/styles/onboarding.css
@@ -311,6 +311,10 @@
   font-weight: 500;
   line-height: 1.4;
   word-break: break-all;
+  /* This strip wants prose that WRAPS (UUIDs, provider names), not the
+     single-line ellipsis the dashboard tiles use. */
+  white-space: normal;
+  overflow: visible;
 }
 .onboarding-step--standard-launch .term-stat__hint {
   font-size: 11px;

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -84,6 +84,16 @@
   flex-direction: column;
   gap: var(--term-space-1);
 }
+/* Grid items default to `min-width: auto`, so a long unbreakable value (a
+   dimension name like "maintainability" at 28px) grows its track past 1fr and
+   pushes the whole strip — and the page — wider than the pane. Pinning the
+   min to 0 keeps the track honest; the value shrinks to fit instead (see
+   `.term-stat__value`). `container-type` makes each card a query container so
+   the value can size itself against the card's own content box. */
+.term-stat {
+  min-width: 0;
+  container-type: inline-size;
+}
 
 /* Tablet/mobile — drop card padding and shrink the value font so the stat
    strip stays readable when it wraps to two columns or stacks. */
@@ -95,7 +105,7 @@
   .term-stat-strip--cards .term-stat {
     padding: var(--term-space-2);
   }
-  .term-stat__value { font-size: 22px; }
+  .term-stat__value { --stat-value-max: 22px; }
   .term-stat__label { margin-bottom: 0; }
 }
 
@@ -117,22 +127,43 @@
   display: flex;
   align-items: baseline;
   gap: var(--term-space-2);
+  min-width: 0;
 }
+/* Fit-to-card sizing. `--stat-value-len` is the character count, set inline by
+   <Stat>; 0.62em is the advance width of the mono face, so the division is the
+   largest size at which the value still fits the card's content box (100cqw).
+   Numbers stay at --stat-value-max — only long words (dimension names) shrink,
+   and only on cards too narrow to hold them. The floor keeps them legible; the
+   ellipsis is the backstop below it, and where container queries are
+   unsupported the whole clamp is dropped and --stat-value-max applies. */
 .term-stat__value {
-  font-size: 28px;
+  --stat-value-max: 28px;
+  font-size: clamp(13px, calc(100cqw / (var(--stat-value-len, 4) * 0.62)), var(--stat-value-max));
   font-weight: 500;
   color: var(--color-text);
   font-variant-numeric: tabular-nums;
   line-height: 1.1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  /* `overflow: hidden` clips against the line box, and at line-height 1.1 that
+     shaves the descenders off "reliability" / "usability". Pad the box out and
+     pull the same amount back off the flow so nothing else moves. */
+  padding-bottom: 0.12em;
+  margin-bottom: -0.12em;
 }
 .term-stat__trailing {
   font-size: 12px;
   color: var(--color-text-muted);
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 .term-stat__hint {
   margin-top: var(--term-space-1);
   font-size: 11px;
   color: var(--color-text-muted);
+  overflow-wrap: anywhere;
 }
 .term-stat--success .term-stat__value { color: var(--color-success); }
 .term-stat--warning .term-stat__value { color: var(--color-warning); }
@@ -2466,7 +2497,7 @@ button.term-sev-badge--clickable:focus-visible {
 @media (max-width: 480px) {
   .dashboard { padding: var(--term-space-2); }
   .term-header__name { font-size: 17px; }
-  .term-stat__value { font-size: 22px; }
+  .term-stat__value { --stat-value-max: 22px; }
 }
 
 /* ------------------------------------------------------------
@@ -2589,7 +2620,7 @@ button.term-sev-badge--clickable:focus-visible {
   text-overflow: ellipsis;
 }
 .eval-job-stat-strip .term-stat__value {
-  font-size: 24px;
+  --stat-value-max: 24px;
 }
 .eval-job-stat-strip .term-stat__trailing {
   font-size: 15px;


### PR DESCRIPTION
## Problem

On the evaluating panel, a long dimension name overflowed its stat tile: `maintainability` at 24px is wider than a quarter-width card, and grid items default to `min-width: auto`, so the track grew past `1fr` and pushed the strip (and the page) wider than the pane. The value spilled across the neighbouring tile and the identity row got clipped at the window edge.

Two smaller format issues in the same strip:
- the tile label `analyzing · dimension 3 / 4` never fit a quarter-width card and truncated to `analyzing · dimen…`, hiding the counter, which is the only part of the label carrying information;
- `overflow: hidden` at `line-height: 1.1` shaved the descenders off values like `reliability`.

## Fix

- `.term-stat` pins `min-width: 0` (track stays honest) and gets `container-type: inline-size` so the value can size against the card's own content box.
- `.term-stat__value` fits itself to the card: `100cqw / (len * 0.62)`, capped at the tile's `--stat-value-max` (so numbers are untouched), floored at 13px with an ellipsis + `title` backstop below that. `<Stat>` publishes the character count as `--stat-value-len`; the existing fixed-size overrides now set `--stat-value-max` instead of `font-size`.
- The dimension counter moves from the label to the hint (`dim 3/4 · next: performance`) — the hint wraps, the label does not.
- Padding/negative-margin pair on the value so the clipping box clears descenders without moving anything.

## Verification

- `npm run test` (373) and `npx vitest run` (1445) pass; `npm run build` clean.
- Measured in a browser against the real stylesheet, at pane widths 340–1500px: no page overflow at any width, no clipped labels, value renders at the 24px cap on wide windows and scales down to fit narrow ones. Overview stat cards render unchanged.
- New unit test asserts `<Stat>` publishes `--stat-value-len` (and omits it for rich values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)