### PR TITLE
fix(ui): remember the selected terminal tab across drawer close/reopen

### DIFF
--- a/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
@@ -57,6 +57,7 @@ vi.mock('../assistant/AssistantDrawerProvider.jsx', () => ({
 import TerminalPane from './TerminalPane.jsx';
 
 beforeEach(() => {
+  window.localStorage.clear();
   fakeSessions = [{ id: 's1', name: 'zsh · 1', alive: true, cwd: '~/proj' }];
   nextSession = 2;
   listTerminalSessions.mockClear();
@@ -248,6 +249,35 @@ it('only the active session view is visible; the other stays mounted but hidden'
   const hidden = wraps.filter((w) => w.style.display === 'none');
   expect(wraps).toHaveLength(2);   // both mounted (PTYs survive the switch)
   expect(hidden).toHaveLength(1);  // exactly one hidden
+});
+
+it('restores the previously selected tab when the pane remounts (drawer closed and reopened)', async () => {
+  const { userEvent } = await import('@testing-library/user-event').then((m) => ({ userEvent: m.default }));
+  fakeSessions = [
+    { id: 's1', name: 'zsh · 1', alive: true, cwd: '~/proj' },
+    { id: 's5', name: 'zsh · 5', alive: true, cwd: '~/mid' },
+    { id: 's9', name: 'zsh · 9', alive: true, cwd: '~/other' },
+  ];
+  const first = render(<TerminalPane active />);
+  await screen.findByRole('tab', { name: /zsh · 5/ });
+  await userEvent.click(screen.getByRole('tab', { name: /zsh · 5/ }));
+  expect(screen.getByRole('tab', { name: /zsh · 5/ })).toHaveAttribute('aria-selected', 'true');
+  // Closing the drawer unmounts the whole pane; reopening mounts it fresh.
+  first.unmount();
+  render(<TerminalPane active />);
+  const tab = await screen.findByRole('tab', { name: /zsh · 5/ });
+  await waitFor(() => expect(tab).toHaveAttribute('aria-selected', 'true'));
+});
+
+it('falls back to the newest session when the stored selection no longer exists', async () => {
+  window.localStorage.setItem('quodeq.terminal.activeSession', 'dead-id');
+  fakeSessions = [
+    { id: 's1', name: 'zsh · 1', alive: true, cwd: '~/proj' },
+    { id: 's9', name: 'zsh · 9', alive: true, cwd: '~/other' },
+  ];
+  render(<TerminalPane active />);
+  const tab = await screen.findByRole('tab', { name: /zsh · 9/ });
+  await waitFor(() => expect(tab).toHaveAttribute('aria-selected', 'true'));
 });
 
 it('copy button copies the active session selection to the clipboard', async () => {

--- a/src/quodeq/ui/src/features/terminal/useTerminalSessions.js
+++ b/src/quodeq/ui/src/features/terminal/useTerminalSessions.js
@@ -1,6 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { listTerminalSessions, createTerminalSession, killTerminalSession } from '../../api/terminal.js';
 
+// Closing the drawer unmounts the pane (and this hook), so the selected tab
+// must survive outside React state or reopening always lands on the newest
+// session. localStorage (not sessionStorage): the desktop shell can recreate
+// the webview page, and a stale id is harmless — reconcile validates it
+// against the server list and falls back.
+const ACTIVE_SESSION_KEY = 'quodeq.terminal.activeSession';
+
+function readStoredActive() {
+  try { return window.localStorage.getItem(ACTIVE_SESSION_KEY); } catch { return null; }
+}
+
 /**
  * Client side of the session tab strip. The SERVER owns the canonical session
  * list (sessions survive page reloads and drawer closes); this hook reconciles
@@ -34,7 +45,14 @@ export function useTerminalSessions({ enabled }) {
           const list = r.sessions || [];
           setSessions(list);
           if (r.max) setMax(r.max);
-          setActiveId((prev) => (list.some((s) => s.id === prev) ? prev : (list[list.length - 1]?.id ?? null)));
+          setActiveId((prev) => {
+            if (list.some((s) => s.id === prev)) return prev;
+            // Fresh mount (drawer reopened): restore the last selected tab if
+            // that session still exists, else fall back to the newest one.
+            const stored = readStoredActive();
+            if (list.some((s) => s.id === stored)) return stored;
+            return list[list.length - 1]?.id ?? null;
+          });
         } catch { /* server unreachable: keep current tabs; sockets surface it */ }
         finally { reconcilingRef.current = null; }
       })();
@@ -45,6 +63,13 @@ export function useTerminalSessions({ enabled }) {
   useEffect(() => {
     if (enabled) reconcile();
   }, [enabled, reconcile]);
+
+  // Persist every selection change (click, create, close-neighbor, restore)
+  // so the next mount of this hook starts from the same tab.
+  useEffect(() => {
+    if (!activeId) return;
+    try { window.localStorage.setItem(ACTIVE_SESSION_KEY, activeId); } catch { /* noop */ }
+  }, [activeId]);
 
   const openSession = useCallback(async () => {
     try {


### PR DESCRIPTION
## Problem
Select terminal tab 3, hide the drawer, reopen it: the newest tab (e.g. the 6th) is selected instead of the one you were on.

## Root cause
Closing the drawer unmounts `TerminalPane` entirely (BottomDrawer renders nothing for closed panels), so `useTerminalSessions`' `activeId` state is lost. On remount, reconcile falls back to `list[list.length - 1]` — always the newest session.

## Fix
Persist the active session id in `localStorage` (`quodeq.terminal.activeSession`) on every selection change, and restore it during reconcile when that session still exists on the server. A stale stored id (killed session, server restart) falls back to the newest session as before.

## Verification
- 2 new tests: remount restores the previously selected tab; stale stored id falls back to newest. Red before the fix, green after; full terminal + drawer suites pass (57).
- Verified live against a real server: 3 sessions with Claude Code running in tab 1, selected tab 1, hid the drawer, reopened — tab 1 selected and the running TUI intact.