### PR TITLE
fix(analysis): run dimensions in the order they were selected

### DIFF
--- a/src/quodeq/analysis/_analysis_context.py
+++ b/src/quodeq/analysis/_analysis_context.py
@@ -72,8 +72,10 @@ def load_analysis_context(config: "RunConfig") -> tuple[list[str], "_AnalysisCon
         if unknown:
             log_warning(f"Unknown dimensions ignored: {', '.join(unknown)}. "
                         f"Available: {', '.join(all_dims_raw)}")
-        dims_set = set(config.options.dimensions)
-        dimensions = [d for d in all_dims_raw if d in dims_set]
+        # Preserve the requested order (deduped) — the UI promises dims run
+        # in selection order and derives its "dim N/M" counter from it.
+        requested = list(dict.fromkeys(config.options.dimensions))
+        dimensions = [d for d in requested if d in all_dims_set]
         if not dimensions:
             raise ValueError(
                 f"No valid dimensions selected. "

--- a/tests/analysis/test_analysis_context_coverage.py
+++ b/tests/analysis/test_analysis_context_coverage.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 import pytest
 
-from quodeq.analysis._analysis_context import _load_custom_dimensions
+from quodeq.analysis._analysis_context import _load_custom_dimensions, load_analysis_context
+from quodeq.analysis._types import AnalysisOptions, RunConfig
 
 
 def _enable_propagation():
@@ -16,6 +17,33 @@ def _enable_propagation():
     original = logger.propagate
     logger.propagate = True
     return logger, original
+
+
+def _config(tmp_path: Path, requested: list[str]) -> RunConfig:
+    return RunConfig(
+        src=tmp_path,
+        language="python",
+        options=AnalysisOptions(dimensions=requested),
+        dimensions_data={
+            "applies": [{"id": "security"}, {"id": "maintainability"}, {"id": "flexibility"}],
+        },
+        evaluators_dir=tmp_path / "no-evaluators",
+    )
+
+
+class TestDimensionResolutionOrder:
+    def test_requested_order_is_preserved(self, tmp_path: Path):
+        """#912 — dims must run in the order the user selected, not config order."""
+        dimensions, _ctx = load_analysis_context(_config(tmp_path, ["flexibility", "maintainability"]))
+        assert dimensions == ["flexibility", "maintainability"]
+
+    def test_unknown_dimensions_are_dropped_without_reordering(self, tmp_path: Path):
+        dimensions, _ctx = load_analysis_context(_config(tmp_path, ["flexibility", "bogus", "security"]))
+        assert dimensions == ["flexibility", "security"]
+
+    def test_duplicate_requests_are_deduped(self, tmp_path: Path):
+        dimensions, _ctx = load_analysis_context(_config(tmp_path, ["flexibility", "flexibility"]))
+        assert dimensions == ["flexibility"]
 
 
 class TestLoadCustomDimensions:


### PR DESCRIPTION
## Problem
Selecting several dimensions could make the run appear to start at the second one or skip one. In run `ed22c593` (flexibility + maintainability selected), the UI showed `dim 2/2` running while flexibility sat queued at 0/440.

## Root cause
`load_analysis_context` re-sorted the requested dimensions to the canonical config order (`_analysis_context.py`), while `status.json` kept the selection order. The UI computes `dim N/M` and the queued/running rows from `status.json`, so counter and rows disagreed with what was actually executing. Nothing was ever skipped, the display lied about the order. Only visible when click order differs from canonical order, hence intermittent.

## Fix
Preserve the requested order (deduped, unknown ids still dropped with a warning). Execution now matches the selection, which is also what the selector UI promises ("run in order").

## Tests
- New: order preservation, unknown-dim filtering without reorder, dedupe.
- Full suite: 5217 passed, 8 skipped.