### PR TITLE
feat(ui): live feed shows only this scan's findings; fix copy hit-area

### DIFF
--- a/src/quodeq/analysis/_report_constants.py
+++ b/src/quodeq/analysis/_report_constants.py
@@ -14,6 +14,14 @@ _FIELD_CONFIDENCE_INTERVAL_SNAKE = "confidence_interval"
 # intentionally NOT here (#640): it is a UI/triage signal (it drives the
 # dashboard's "Low confidence" grouping), not a grade input. Keeping it out
 # keeps the grade objective and non-gameable. See tests/core/test_confidence_not_scored.py.
+#
+# "Reads" here means two different things, and they don't have to agree:
+# a key just needs to be copied into the report JSON to reach the UI (that's
+# how `carried_forward` survives from the cache-replay walk to the API and
+# the live feed), while scoring itself never reads this JSON at all — it
+# reads findings via the SQLite projection and tallies purely on `vt`
+# (verdict). So a UI-only signal can live in this tuple without touching a
+# grade.
 _VIOLATION_FIELDS = (
     "file", "line", "end_line", "title", "reason",
     "snippet", "context", "scope", "severity", "req", "req_refs",

--- a/src/quodeq/analysis/_report_constants.py
+++ b/src/quodeq/analysis/_report_constants.py
@@ -17,6 +17,10 @@ _FIELD_CONFIDENCE_INTERVAL_SNAKE = "confidence_interval"
 _VIOLATION_FIELDS = (
     "file", "line", "end_line", "title", "reason",
     "snippet", "context", "scope", "severity", "req", "req_refs",
+    # _flatten_findings copies ONLY these keys into evaluation/<dim>.json.
+    # Without this entry the cache-replay marker is dropped the moment a
+    # dimension finishes and its report is written.
+    "carried_forward",
 )
 _COMPLIANCE_FIELDS = (
     "file", "line", "end_line", "title", "reason",

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -206,13 +206,22 @@ def _write_findings(
     # safe to apply unconditionally to every cached finding.
     for finding in findings:
         apply_provenance_gate(finding)
+    # Every caller of this function is a cache replay -- the dispatcher
+    # writes its own fresh findings and never comes through here. Stamp the
+    # origin so the live evaluation feed can show only what this scan is
+    # actually producing.
+    #
+    # Copy, do not mutate: these dicts are owned by the cache entries, and
+    # the periodic-persist watcher could otherwise write the flag back into
+    # the cache, making a later fresh scan of the same file look carried.
+    stamped = [{**finding, "carried_forward": True} for finding in findings]
     jsonl.parent.mkdir(parents=True, exist_ok=True)
     mode = "a" if append else "w"
     with jsonl.open(mode, encoding="utf-8") as out:
-        for finding in findings:
+        for finding in stamped:
             out.write(json.dumps(finding) + "\n")
     if emit_events:
-        _emit_cached_findings(_events_log_path(jsonl), findings)
+        _emit_cached_findings(_events_log_path(jsonl), stamped)
 
 
 def process_dimension_with_cache(

--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -161,6 +161,7 @@ def _payload_as_sse_finding(payload: Any, finding_id: int) -> dict[str, Any]:
         "snippet": payload.snippet,
         "confidence": payload.confidence,
         "provenance_downgrade": getattr(payload, "provenance_downgrade", False),
+        "carried_forward": getattr(payload, "carried_forward", False),
     }
 
 

--- a/src/quodeq/core/events/models.py
+++ b/src/quodeq/core/events/models.py
@@ -69,6 +69,11 @@ class Judgment(BaseModel):
     # finding from critical to major. UI/DB-visible audit marker (#656); the
     # severity flip already drives the grade, this just makes it auditable.
     provenance_downgrade: bool = False
+    # True when this finding was replayed from the content-addressed cache
+    # rather than produced by the running scan. Lets the live evaluation
+    # feed show only what this scan is actually finding (the rest of the
+    # app still shows every finding in the run).
+    carried_forward: bool = False
 
     @field_validator("req_refs", mode="before")
     @classmethod

--- a/src/quodeq/core/evidence/_jsonl.py
+++ b/src/quodeq/core/evidence/_jsonl.py
@@ -63,6 +63,7 @@ def parse_jsonl_line(line: str) -> tuple[Judgment, list[str] | None] | None:
         confidence=_jsonl_confidence(obj.get("confidence")),
         req_refs=req_refs,
         provenance_downgrade=bool(obj.get("provenance_downgrade")),
+        carried_forward=bool(obj.get("carried_forward")),
     )
     return j, obj.get("refs")
 
@@ -97,6 +98,10 @@ def judgment_to_dict(j: Judgment) -> dict:
     # confidence -- keeps the common (un-downgraded) finding dict compact.
     if j.provenance_downgrade:
         d["provenance_downgrade"] = True
+    # Emit only when set, mirroring confidence / provenance_downgrade, so
+    # the common (freshly-scanned) finding dict stays compact.
+    if j.carried_forward:
+        d["carried_forward"] = True
     return d
 
 

--- a/src/quodeq/core/finding_builder.py
+++ b/src/quodeq/core/finding_builder.py
@@ -33,6 +33,7 @@ class FindingSpec:
     include_severity: bool = True
     confidence: int = 100
     provenance_downgrade: bool = False
+    carried_forward: bool = False
 
 
 def build_finding_base(spec: FindingSpec) -> Finding:
@@ -63,6 +64,7 @@ def build_finding_base(spec: FindingSpec) -> Finding:
         scope=spec.scope if spec.scope else None,
         confidence=spec.confidence,
         provenance_downgrade=spec.provenance_downgrade,
+        carried_forward=spec.carried_forward,
     )
 
 

--- a/src/quodeq/core/finding_mappings.py
+++ b/src/quodeq/core/finding_mappings.py
@@ -62,6 +62,7 @@ def wire_dict_to_judgment(d: dict[str, Any]) -> Judgment:
         req_refs=_coerce_req_refs(d.get("req_refs")),
         cwe=d.get("cwe"),
         provenance_downgrade=bool(d.get("provenance_downgrade")),
+        carried_forward=bool(d.get("carried_forward")),
     )
 
 

--- a/src/quodeq/core/types/finding.py
+++ b/src/quodeq/core/types/finding.py
@@ -45,3 +45,6 @@ class Finding:
     # True when the deterministic provenance gate (#639) de-escalated this
     # finding from critical to major. Audit marker surfaced in the DB/UI (#656).
     provenance_downgrade: bool = False
+    # True when this finding was replayed from the content-addressed cache
+    # rather than produced by the running scan (see Judgment.carried_forward).
+    carried_forward: bool = False

--- a/src/quodeq/data/fs/report_parser/_report_parsing.py
+++ b/src/quodeq/data/fs/report_parser/_report_parsing.py
@@ -39,6 +39,7 @@ def build_finding(item: dict, *, include_severity: bool) -> Finding:
         context=item.get("context"),
         scope=item.get("scope"),
         include_severity=include_severity,
+        carried_forward=bool(item.get("carried_forward")),
     ))
 
 

--- a/src/quodeq/services/violations_parsing.py
+++ b/src/quodeq/services/violations_parsing.py
@@ -83,6 +83,7 @@ def _build_finding_entry(obj: dict, dimension: str, req_refs_lookup: dict[str, l
         scope=obj.get("scope"),
         confidence=_coerce_confidence(obj.get("confidence")),
         provenance_downgrade=bool(obj.get("provenance_downgrade")),
+        carried_forward=bool(obj.get("carried_forward")),
     ))
     return replace(entry, dimension=obj.get("d", dimension), violation_type=obj.get("vt"))
 

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -94,7 +94,11 @@ export default function EvaluationStatus({ job, jobProjectInfo, startedProjectIn
     const next = {};
     let hidden = 0;
     for (const [dim, vs] of Object.entries(liveViolations || {})) {
-      const fresh = (vs || []).filter((v) => !v.carriedForward);
+      // The SSE stream (VITE_USE_SSE_EVENTS) writes raw wire payloads
+      // straight into the findings cache with no violation-model mapping,
+      // so those entries carry snake_case `carried_forward` instead of
+      // `carriedForward`. Accept both spellings here.
+      const fresh = (vs || []).filter((v) => !(v.carriedForward ?? v.carried_forward));
       hidden += (vs || []).length - fresh.length;
       if (fresh.length) next[dim] = fresh;
     }
@@ -116,7 +120,7 @@ export default function EvaluationStatus({ job, jobProjectInfo, startedProjectIn
     <div className="panel evaluate-panel--terminal">
       <JobHeader job={job} onDismiss={onDismiss} onCancel={onCancel} />
       <JobIdentityStrip job={job} projectLabel={projectLabel} />
-      <JobStatStrip job={job} liveViolations={shown} />
+      <JobStatStrip job={job} liveViolations={shown} hiddenCarriedCount={hiddenCarriedCount} />
       <ScanProgress job={job} hasEvaluations={hasEvaluations} />
       <LiveViolationsFeed job={job} liveViolations={shown} hiddenCarriedCount={hiddenCarriedCount} />
     </div>

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import LiveViolationsFeed from './LiveViolationsFeed.jsx';
 import ScanProgress from './ScanProgress.jsx';
 import CopyButton from '../../../components/CopyButton.jsx';
@@ -7,6 +8,7 @@ import JobStatStrip from './JobStatStrip.jsx';
 import { IdentityStrip, IdentityCell } from './IdentityStrip.jsx';
 import { deriveScanMode } from './buildJobStatCells.js';
 import { useEvaluationProgress } from '../hooks/useEvaluationProgress.js';
+import useLiveFeedSettings from '../../settings/hooks/useLiveFeedSettings.js';
 
 const STATUS = { RUNNING: 'running', DONE: 'done', FAILED: 'failed', LOST: 'lost' };
 const TERMINAL_STATES = new Set(['done', 'completed', 'failed', 'cancelled', 'lost']);
@@ -83,6 +85,22 @@ function JobIdentityStrip({ job, projectLabel }) {
 }
 
 export default function EvaluationStatus({ job, jobProjectInfo, startedProjectInfo, liveViolations = {}, onDismiss, onCancel, hasEvaluations }) {
+  const { newOnly } = useLiveFeedSettings();
+  // Filter ONCE, above both consumers. JobStatStrip derives its violations
+  // cell from the same object the feed lists, so filtering in each child
+  // separately is how the counter and the list drift apart (see #878).
+  const { shown, hiddenCarriedCount } = useMemo(() => {
+    if (!newOnly) return { shown: liveViolations, hiddenCarriedCount: 0 };
+    const next = {};
+    let hidden = 0;
+    for (const [dim, vs] of Object.entries(liveViolations || {})) {
+      const fresh = (vs || []).filter((v) => !v.carriedForward);
+      hidden += (vs || []).length - fresh.length;
+      if (fresh.length) next[dim] = fresh;
+    }
+    return { shown: next, hiddenCarriedCount: hidden };
+  }, [liveViolations, newOnly]);
+
   if (!job) return null;
   // Prefer the running job's own project so the card stays accurate when the
   // UI's global selection points at a different project than the job is
@@ -98,9 +116,9 @@ export default function EvaluationStatus({ job, jobProjectInfo, startedProjectIn
     <div className="panel evaluate-panel--terminal">
       <JobHeader job={job} onDismiss={onDismiss} onCancel={onCancel} />
       <JobIdentityStrip job={job} projectLabel={projectLabel} />
-      <JobStatStrip job={job} liveViolations={liveViolations} />
+      <JobStatStrip job={job} liveViolations={shown} />
       <ScanProgress job={job} hasEvaluations={hasEvaluations} />
-      <LiveViolationsFeed job={job} liveViolations={liveViolations} />
+      <LiveViolationsFeed job={job} liveViolations={shown} hiddenCarriedCount={hiddenCarriedCount} />
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
@@ -1,14 +1,19 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import EvaluationStatus from './EvaluationStatus.jsx';
+import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+import { NEW_FINDINGS_ONLY_KEY } from '../../settings/hooks/useLiveFeedSettings.js';
 
-vi.mock('./LiveViolationsFeed.jsx', () => ({ default: () => null }));
+// ScanProgress reads EvalLogContext directly (no provider here), so it stays
+// mocked like JobStatStrip. LiveViolationsFeed is left real below: the
+// live-findings-filter tests assert on what it renders.
 vi.mock('./ScanProgress.jsx', () => ({ default: () => null }));
 vi.mock('./JobStatStrip.jsx', () => ({ default: () => null }));
-// The identity strip reads the shared progress query for its "mode" cell.
+// The identity strip reads the shared progress query for its "mode" cell;
+// LiveViolationsFeed reads the same query for its streaming footer/header.
 vi.mock('../../../api/index.js', () => ({
-  getEvaluationProgress: vi.fn().mockResolvedValue(null),
+  getEvaluationProgress: vi.fn().mockResolvedValue({ dimensions: [] }),
 }));
 
 function renderWithClient(ui) {
@@ -111,5 +116,57 @@ describe('project label', () => {
     // The repository cell shows a dash instead — unknown beats wrong.
     const strip = document.querySelector('.eval-identity');
     expect(strip.textContent).toMatch(/repository—/);
+  });
+});
+
+const filterJob = { jobId: 'j1', status: 'running', dimensions: ['security'] };
+
+const filterLiveViolations = {
+  security: [
+    { severity: 'major', principle: 'P1', file: 'new.py', line: 1, carriedForward: false },
+    { severity: 'major', principle: 'P2', file: 'old-a.py', line: 2, carriedForward: true },
+    { severity: 'minor', principle: 'P3', file: 'old-b.py', line: 3, carriedForward: true },
+  ],
+};
+
+function renderStatus(props = {}) {
+  const QC = withQueryClient();
+  return render(
+    <QC><EvaluationStatus job={filterJob} liveViolations={filterLiveViolations} {...props} /></QC>
+  );
+}
+
+describe('EvaluationStatus live-findings filter', () => {
+  beforeEach(() => { localStorage.clear(); });
+
+  it('hides carried-forward findings by default', () => {
+    renderStatus();
+    expect(screen.getByText('new.py:1')).toBeInTheDocument();
+    expect(screen.queryByText('old-a.py:2')).not.toBeInTheDocument();
+  });
+
+  it('discloses how many are hidden rather than hiding them silently', () => {
+    renderStatus();
+    expect(screen.getByText(/2 carried forward hidden/)).toBeInTheDocument();
+  });
+
+  it('shows everything when the preference is off', () => {
+    localStorage.setItem(NEW_FINDINGS_ONLY_KEY, 'false');
+    renderStatus();
+    expect(screen.getByText('old-a.py:2')).toBeInTheDocument();
+    expect(screen.queryByText(/carried forward hidden/)).not.toBeInTheDocument();
+  });
+
+  it('says nothing about carries when the run has none', () => {
+    const QC = withQueryClient();
+    render(
+      <QC>
+        <EvaluationStatus
+          job={filterJob}
+          liveViolations={{ security: [{ severity: 'major', principle: 'P1', file: 'a.py', line: 1 }] }}
+        />
+      </QC>
+    );
+    expect(screen.queryByText(/carried forward hidden/)).not.toBeInTheDocument();
   });
 });

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
@@ -168,6 +168,28 @@ describe('EvaluationStatus live-findings filter', () => {
     expect(screen.getByTestId('strip-sum')).toHaveTextContent('3');
   });
 
+  it('hides snake_case carried_forward findings too (SSE payloads with no violation-model mapping)', () => {
+    // Under VITE_USE_SSE_EVENTS, findings land in the cache as raw wire
+    // payloads, so they carry `carried_forward` instead of `carriedForward`.
+    const QC = withQueryClient();
+    render(
+      <QC>
+        <EvaluationStatus
+          job={filterJob}
+          liveViolations={{
+            security: [
+              { severity: 'major', principle: 'P1', file: 'new.py', line: 1, carried_forward: false },
+              { severity: 'major', principle: 'P2', file: 'old-a.py', line: 2, carried_forward: true },
+            ],
+          }}
+        />
+      </QC>
+    );
+    expect(screen.getByText('new.py:1')).toBeInTheDocument();
+    expect(screen.queryByText('old-a.py:2')).not.toBeInTheDocument();
+    expect(screen.getByText(/1 carried forward hidden/)).toBeInTheDocument();
+  });
+
   it('says nothing about carries when the run has none', () => {
     const QC = withQueryClient();
     render(

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
@@ -9,7 +9,15 @@ import { NEW_FINDINGS_ONLY_KEY } from '../../settings/hooks/useLiveFeedSettings.
 // mocked like JobStatStrip. LiveViolationsFeed is left real below: the
 // live-findings-filter tests assert on what it renders.
 vi.mock('./ScanProgress.jsx', () => ({ default: () => null }));
-vi.mock('./JobStatStrip.jsx', () => ({ default: () => null }));
+// Probe instead of a null stub: renders the total violation count the strip
+// actually received, so a regression that reverts EvaluationStatus to pass
+// the unfiltered liveViolations to the strip (while the feed stays filtered)
+// shows up here instead of leaving every test green.
+vi.mock('./JobStatStrip.jsx', () => ({
+  default: ({ liveViolations }) => <i data-testid="strip-sum">{
+    Object.values(liveViolations || {}).reduce((n, vs) => n + (vs?.length || 0), 0)
+  }</i>,
+}));
 // The identity strip reads the shared progress query for its "mode" cell;
 // LiveViolationsFeed reads the same query for its streaming footer/header.
 vi.mock('../../../api/index.js', () => ({
@@ -143,6 +151,8 @@ describe('EvaluationStatus live-findings filter', () => {
     renderStatus();
     expect(screen.getByText('new.py:1')).toBeInTheDocument();
     expect(screen.queryByText('old-a.py:2')).not.toBeInTheDocument();
+    // The strip must see the same filtered set as the feed (1 fresh of 3).
+    expect(screen.getByTestId('strip-sum')).toHaveTextContent('1');
   });
 
   it('discloses how many are hidden rather than hiding them silently', () => {
@@ -155,6 +165,7 @@ describe('EvaluationStatus live-findings filter', () => {
     renderStatus();
     expect(screen.getByText('old-a.py:2')).toBeInTheDocument();
     expect(screen.queryByText(/carried forward hidden/)).not.toBeInTheDocument();
+    expect(screen.getByTestId('strip-sum')).toHaveTextContent('3');
   });
 
   it('says nothing about carries when the run has none', () => {

--- a/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
@@ -40,7 +40,7 @@ function deriveElapsedS(startedAt, endedAt, isTerminal, fallbackElapsed) {
   return null;
 }
 
-export default function JobStatStrip({ job, liveViolations }) {
+export default function JobStatStrip({ job, liveViolations, hiddenCarriedCount = 0 }) {
   const jobId = job?.jobId;
   const isTerminal = TERMINAL_STATES.has(job?.status);
 
@@ -91,12 +91,13 @@ export default function JobStatStrip({ job, liveViolations }) {
     const suppressedCount = sumSuppressed(progress);
     return buildJobStatCells(job.status, {
       overallPct, takenFiles, totalFiles, elapsedS, liveCount, etaHint, suppressedCount,
+      carriedCount: hiddenCarriedCount,
       dimCycle: buildDimensionCycle(progress),
       sevCounts: sumSeverities(liveViolations),
       scanMode: deriveScanMode(progress),
     });
     // `tick` drives the per-second recompute; the sample store is read (not a dep).
-  }, [jobId, job?.status, job?.startedAt, job?.endedAt, isTerminal, progress, liveViolations, tick]);
+  }, [jobId, job?.status, job?.startedAt, job?.endedAt, isTerminal, progress, liveViolations, hiddenCarriedCount, tick]);
 
   if (!jobId) return null;
 

--- a/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
@@ -18,6 +18,9 @@ function sumLiveViolations(liveViolations) {
 // The live feed already excludes dismissed/deleted findings (it reads the same
 // filtered dimension evals the report does), so FOUND is a net number. The
 // progress payload carries what was netted out, so the strip can say so.
+// The parent (EvaluationStatus) may also have filtered out carried-forward
+// findings before this component ever sees liveViolations, per the
+// live-findings-only setting, so FOUND can be net of those too.
 function sumSuppressed(progress) {
   return (progress?.dimensions || []).reduce((n, d) => n + (d?.suppressed || 0), 0);
 }

--- a/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.jsx
@@ -124,7 +124,7 @@ function DimensionGroup({ dim, violations, open, onToggle }) {
   );
 }
 
-export default function LiveViolationsFeed({ liveViolations, job = null }) {
+export default function LiveViolationsFeed({ liveViolations, job = null, hiddenCarriedCount = 0 }) {
   // Per-dim activity timestamps power "latest active dimension on top".
   const lastActivity = useDimensionActivity(liveViolations);
 
@@ -164,7 +164,10 @@ export default function LiveViolationsFeed({ liveViolations, job = null }) {
   }, [topDim]);
 
   const totalCount = orderedDims.reduce((sum, d) => sum + d.violations.length, 0);
-  if (!totalCount) return null;
+  // A fully-cached dimension yields zero NEW findings. Bailing out here
+  // would make the feed disappear and read as "nothing found", so keep the
+  // header whenever the filter is what emptied the list.
+  if (!totalCount && !hiddenCarriedCount) return null;
 
   return (
     <div className="vlive-feed">
@@ -173,6 +176,9 @@ export default function LiveViolationsFeed({ liveViolations, job = null }) {
           <SectionLabel>live violations</SectionLabel>
           <span className="vlive-counter">
             {totalCount} across {orderedDims.length} dimension{orderedDims.length !== 1 ? 's' : ''}
+            {hiddenCarriedCount > 0 && (
+              <span className="vlive-counter-hidden"> · {hiddenCarriedCount} carried forward hidden</span>
+            )}
             {isRunning && ' · streaming'}
           </span>
         </span>

--- a/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.jsx
@@ -175,7 +175,9 @@ export default function LiveViolationsFeed({ liveViolations, job = null, hiddenC
         <span className="vlive-head-left">
           <SectionLabel>live violations</SectionLabel>
           <span className="vlive-counter">
-            {totalCount} across {orderedDims.length} dimension{orderedDims.length !== 1 ? 's' : ''}
+            {totalCount > 0
+              ? <>{totalCount} across {orderedDims.length} dimension{orderedDims.length !== 1 ? 's' : ''}</>
+              : 'no new findings'}
             {hiddenCarriedCount > 0 && (
               <span className="vlive-counter-hidden"> · {hiddenCarriedCount} carried forward hidden</span>
             )}

--- a/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.jsx
@@ -186,23 +186,25 @@ export default function LiveViolationsFeed({ liveViolations, job = null, hiddenC
           <span className="vlive-head-dim">{progress.currentDimension}</span>
         )}
       </div>
-      <div className="vlive-card">
-        {orderedDims.map(({ dim, violations }) => (
-          <DimensionGroup
-            key={dim}
-            dim={dim}
-            violations={violations}
-            open={openDim === dim}
-            onToggle={() => setOpenDim((cur) => (cur === dim ? null : dim))}
-          />
-        ))}
-        {isRunning && (
-          <div className="vlive-footer">
-            <span className="vlive-footer__dot" aria-hidden="true" />
-            scanning for more{queued != null ? <> · {queued} files queued</> : null}
-          </div>
-        )}
-      </div>
+      {(totalCount > 0 || isRunning) && (
+        <div className="vlive-card">
+          {orderedDims.map(({ dim, violations }) => (
+            <DimensionGroup
+              key={dim}
+              dim={dim}
+              violations={violations}
+              open={openDim === dim}
+              onToggle={() => setOpenDim((cur) => (cur === dim ? null : dim))}
+            />
+          ))}
+          {isRunning && (
+            <div className="vlive-footer">
+              <span className="vlive-footer__dot" aria-hidden="true" />
+              scanning for more{queued != null ? <> · {queued} files queued</> : null}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.test.jsx
@@ -79,4 +79,14 @@ describe('LiveViolationsFeed', () => {
     const { container } = renderFeed({ liveViolations: {}, hiddenCarriedCount: 0 });
     expect(container.firstChild).toBeNull();
   });
+
+  it('omits the bordered card when the filter emptied a terminal job, keeping only the disclosure', () => {
+    const { container } = renderFeed({
+      job: { jobId: 'j1', status: 'done' },
+      liveViolations: {},
+      hiddenCarriedCount: 12,
+    });
+    expect(screen.getByText(/12 carried forward hidden/)).toBeInTheDocument();
+    expect(container.querySelector('.vlive-card')).toBeNull();
+  });
 });

--- a/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.test.jsx
@@ -70,9 +70,13 @@ describe('LiveViolationsFeed', () => {
 
   it('keeps the header when the filter empties the list', () => {
     // A fully-cached dimension produces zero new findings. Returning null
-    // here would make the feed vanish and read as "nothing found".
+    // here would make the feed vanish and read as "nothing found". The
+    // "0 across 0 dimensions" phrasing would be confusing, so a wholly
+    // filtered-out run says "no new findings" instead.
     renderFeed({ liveViolations: {}, hiddenCarriedCount: 12 });
+    expect(screen.getByText(/no new findings/)).toBeInTheDocument();
     expect(screen.getByText(/12 carried forward hidden/)).toBeInTheDocument();
+    expect(screen.queryByText(/across 0 dimension/)).toBeNull();
   });
 
   it('still renders nothing when there is genuinely nothing', () => {

--- a/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.test.jsx
@@ -62,4 +62,21 @@ describe('LiveViolationsFeed', () => {
     fireEvent.click(row);
     expect(row).toHaveAttribute('aria-expanded', 'true');
   });
+
+  it('counts only what it renders', () => {
+    renderFeed({ liveViolations: violations, hiddenCarriedCount: 5 });
+    expect(screen.getByText('2 across 1 dimension')).toBeInTheDocument();
+  });
+
+  it('keeps the header when the filter empties the list', () => {
+    // A fully-cached dimension produces zero new findings. Returning null
+    // here would make the feed vanish and read as "nothing found".
+    renderFeed({ liveViolations: {}, hiddenCarriedCount: 12 });
+    expect(screen.getByText(/12 carried forward hidden/)).toBeInTheDocument();
+  });
+
+  it('still renders nothing when there is genuinely nothing', () => {
+    const { container } = renderFeed({ liveViolations: {}, hiddenCarriedCount: 0 });
+    expect(container.firstChild).toBeNull();
+  });
 });

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
@@ -201,11 +201,22 @@ export function suppressedSuffix(suppressedCount) {
   return ` · ${suppressedCount} suppressed`;
 }
 
-function foundCell(liveCount, label = 'FOUND', hint = 'live violations', suppressedCount = 0) {
+/**
+ * The count of findings this run re-discovered that the live-findings-only
+ * preference filtered out before FOUND ever saw them, as a hint suffix.
+ * Without it the cell silently drops a number the feed already discloses
+ * next to the list, so the strip and the feed can look like they disagree.
+ */
+export function carriedSuffix(carriedCount) {
+  if (!(carriedCount > 0)) return '';
+  return ` · ${carriedCount} carried forward`;
+}
+
+function foundCell(liveCount, label = 'FOUND', hint = 'live violations', suppressedCount = 0, carriedCount = 0) {
   return {
     label,
     value: liveCount,
-    hint: `${hint}${suppressedSuffix(suppressedCount)}`,
+    hint: `${hint}${suppressedSuffix(suppressedCount)}${carriedSuffix(carriedCount)}`,
     tone: liveCount > 0 ? 'critical' : 'default',
   };
 }
@@ -219,6 +230,7 @@ function foundCell(liveCount, label = 'FOUND', hint = 'live violations', suppres
  * @param {number|null|undefined} inputs.elapsedS
  * @param {number} inputs.liveCount
  * @param {number} [inputs.suppressedCount] — re-found findings already dismissed/deleted
+ * @param {number} [inputs.carriedCount] — carried-forward findings the live-feed preference hid
  * @param {object|null} [inputs.dimCycle] — from buildDimensionCycle (running only)
  * @param {object} [inputs.sevCounts] — from sumSeverities (running only)
  * @param {string|null} [inputs.scanMode] — from deriveScanMode (running only)
@@ -232,7 +244,7 @@ export function buildJobStatCells(status, inputs) {
     return [
       statusCell,
       { label: 'SCANNED', value: inputs.totalFiles > 0 ? inputs.totalFiles : '—', hint: 'files', tone: 'default' },
-      foundCell(inputs.liveCount, 'VIOLATIONS', severityHint(inputs.liveCount), inputs.suppressedCount),
+      foundCell(inputs.liveCount, 'VIOLATIONS', severityHint(inputs.liveCount), inputs.suppressedCount, inputs.carriedCount),
       elapsedCell(inputs.elapsedS, 'DURATION', 'total'),
     ];
   }
@@ -258,7 +270,7 @@ export function buildJobStatCells(status, inputs) {
         hint: runKnown ? `${inputs.overallPct}%${modeHint}` : 'preparing…',
         tone: 'default',
       },
-      foundCell(inputs.liveCount, 'violations', formatSevHint(inputs.sevCounts), inputs.suppressedCount),
+      foundCell(inputs.liveCount, 'violations', formatSevHint(inputs.sevCounts), inputs.suppressedCount, inputs.carriedCount),
       elapsedCell(inputs.elapsedS, 'elapsed', inputs.etaHint ?? null),
     ];
   }
@@ -267,7 +279,7 @@ export function buildJobStatCells(status, inputs) {
   return [
     statusCell,
     progressCell(inputs),
-    foundCell(inputs.liveCount, 'FOUND', 'live violations', inputs.suppressedCount),
+    foundCell(inputs.liveCount, 'FOUND', 'live violations', inputs.suppressedCount, inputs.carriedCount),
     elapsedCell(inputs.elapsedS, 'ELAPSED', inputs.etaHint ?? null),
   ];
 }

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
@@ -10,6 +10,7 @@ import {
   buildEtaHint,
   msUntilNextSecond,
   suppressedSuffix,
+  carriedSuffix,
   buildDimensionCycle,
   sumSeverities,
   formatSevHint,
@@ -301,6 +302,46 @@ test('suppressedSuffix: ignores negative and non-numeric counts', () => {
   assert.equal(suppressedSuffix(-5), '');
   assert.equal(suppressedSuffix(undefined), '');
   assert.equal(suppressedSuffix('lots'), '');
+});
+
+// ---------------------------------------------------------------------------
+// carried-forward hint — the live-findings-only preference filters FOUND
+// before the strip ever sees it, so say what was filtered out
+// ---------------------------------------------------------------------------
+
+test('buildJobStatCells: violations hint reports the carried-forward count while running', () => {
+  const cells = buildJobStatCells('running', {
+    ...baseInputs, liveCount: 1, carriedCount: 12,
+    sevCounts: { critical: 0, major: 1, minor: 0 },
+  });
+  assert.equal(cells[2].label, 'violations');
+  assert.equal(cells[2].hint, '1 major · 12 carried forward');
+});
+
+test('buildJobStatCells: VIOLATIONS hint reports the carried-forward count on a finished job too', () => {
+  const cells = buildJobStatCells('done', { ...baseInputs, liveCount: 1, carriedCount: 12 });
+  assert.equal(cells[2].label, 'VIOLATIONS');
+  assert.ok(cells[2].hint.endsWith('12 carried forward'), `got: ${cells[2].hint}`);
+});
+
+test('buildJobStatCells: no carried-forward hint when nothing was filtered', () => {
+  const running = buildJobStatCells('running', { ...baseInputs, carriedCount: 0 });
+  const missing = buildJobStatCells('running', baseInputs);
+  assert.equal(running[2].hint, 'none yet');
+  assert.equal(missing[2].hint, 'none yet');
+});
+
+test('buildJobStatCells: suppressed and carried-forward suffixes combine', () => {
+  const cells = buildJobStatCells('done', {
+    ...baseInputs, liveCount: 1, suppressedCount: 5, carriedCount: 12,
+  });
+  assert.equal(cells[2].hint, '1 total · 5 suppressed · 12 carried forward');
+});
+
+test('carriedSuffix: ignores negative and non-numeric counts', () => {
+  assert.equal(carriedSuffix(-5), '');
+  assert.equal(carriedSuffix(undefined), '');
+  assert.equal(carriedSuffix('lots'), '');
 });
 
 // ---------------------------------------------------------------------------

--- a/src/quodeq/ui/src/features/settings/components/EvaluationSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/EvaluationSection.jsx
@@ -1,0 +1,27 @@
+import useLiveFeedSettings from '../hooks/useLiveFeedSettings.js';
+import SectionLabel from '../../../components/terminal/SectionLabel.jsx';
+
+export default function EvaluationSection() {
+  const { newOnly, setNewOnly } = useLiveFeedSettings();
+  return (
+    <section className="panel settings-section">
+      <div className="panel-header"><SectionLabel marker="▶">Evaluation</SectionLabel></div>
+      <div className="settings-row settings-row--last">
+        <div className="settings-row-label">
+          <span className="settings-label">Live findings</span>
+          <span className="settings-description">
+            While a scan is running, show only the findings it produces. Findings reused
+            from unchanged files stay in the final report either way.
+          </span>
+        </div>
+        <div className="settings-pill-group" role="tablist">
+          {[{ v: true, l: 'New only' }, { v: false, l: 'All' }].map(({ v, l }) => (
+            <button key={l} type="button" role="tab" aria-selected={newOnly === v}
+              className={`settings-pill${newOnly === v ? ' settings-pill--active' : ''}`}
+              onClick={() => setNewOnly(v)}>{l}</button>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/quodeq/ui/src/features/settings/components/EvaluationSection.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/EvaluationSection.test.jsx
@@ -1,0 +1,19 @@
+import { it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import EvaluationSection from './EvaluationSection.jsx';
+import { NEW_FINDINGS_ONLY_KEY } from '../hooks/useLiveFeedSettings.js';
+
+beforeEach(() => { localStorage.clear(); });
+
+it('defaults to New only', () => {
+  render(<EvaluationSection />);
+  expect(screen.getByRole('tab', { name: 'New only' })).toHaveAttribute('aria-selected', 'true');
+});
+
+it('switching to All persists the opt-out', () => {
+  render(<EvaluationSection />);
+  fireEvent.click(screen.getByRole('tab', { name: 'All' }));
+  expect(localStorage.getItem(NEW_FINDINGS_ONLY_KEY)).toBe('false');
+  expect(screen.getByRole('tab', { name: 'All' })).toHaveAttribute('aria-selected', 'true');
+});

--- a/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
+++ b/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
@@ -5,6 +5,7 @@ import AppearanceSection from './AppearanceSection.jsx';
 import UpdatesSection from './UpdatesSection.jsx';
 import ProviderTabs from './ProviderTabs.jsx';
 import AssistantProviderTabs from './AssistantProviderTabs.jsx';
+import EvaluationSection from './EvaluationSection.jsx';
 import TerminalSection from './TerminalSection.jsx';
 import ServerSection from './ServerSection.jsx';
 import SharedRepoSection from './SharedRepoSection.jsx';
@@ -40,6 +41,7 @@ export default function SettingsPage({ theme, onOpenGradeFormula, onSharedDiscon
       <div className="settings-grid">
         <ProviderTabs providerConfigs={providerConfigs} />
         <AssistantProviderTabs providerConfigs={providerConfigs} />
+        <EvaluationSection />
         <TerminalSection />
         <ServerSection />
         <SharedRepoSection onDisconnected={onSharedDisconnected} />

--- a/src/quodeq/ui/src/features/settings/hooks/useLiveFeedSettings.js
+++ b/src/quodeq/ui/src/features/settings/hooks/useLiveFeedSettings.js
@@ -1,0 +1,40 @@
+import { useState, useCallback, useEffect } from 'react';
+
+export const NEW_FINDINGS_ONLY_KEY = 'cc-eval-new-findings-only';
+const CHANGE_EVENT = 'live-feed-settings-changed';
+
+function loadNewOnly(storage) {
+  // On by default: only an explicit opt-out ('false') shows findings
+  // carried forward from the incremental cache.
+  return storage.getItem(NEW_FINDINGS_ONLY_KEY) !== 'false';
+}
+
+export default function useLiveFeedSettings({ storage = localStorage } = {}) {
+  const [newOnly, setNewOnlyState] = useState(() => loadNewOnly(storage));
+
+  const setNewOnly = useCallback((value) => {
+    try {
+      storage.setItem(NEW_FINDINGS_ONLY_KEY, value ? 'true' : 'false');
+    } catch (err) {
+      console.warn('[useLiveFeedSettings] could not persist:', err);
+    }
+    setNewOnlyState(value);
+    // A 'storage' event does not fire in the tab that wrote the value, so
+    // the Settings page and the evaluation screen need this to stay in
+    // sync within one window.
+    if (typeof window !== 'undefined') window.dispatchEvent(new Event(CHANGE_EVENT));
+  }, [storage]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const onChange = () => setNewOnlyState(loadNewOnly(storage));
+    window.addEventListener(CHANGE_EVENT, onChange);
+    window.addEventListener('storage', onChange);
+    return () => {
+      window.removeEventListener(CHANGE_EVENT, onChange);
+      window.removeEventListener('storage', onChange);
+    };
+  }, [storage]);
+
+  return { newOnly, setNewOnly };
+}

--- a/src/quodeq/ui/src/features/settings/hooks/useLiveFeedSettings.test.jsx
+++ b/src/quodeq/ui/src/features/settings/hooks/useLiveFeedSettings.test.jsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import useLiveFeedSettings, { NEW_FINDINGS_ONLY_KEY } from './useLiveFeedSettings.js';
+
+function Probe() {
+  const { newOnly, setNewOnly } = useLiveFeedSettings();
+  return (
+    <button onClick={() => setNewOnly(!newOnly)}>
+      {newOnly ? 'new-only' : 'all'}
+    </button>
+  );
+}
+
+describe('useLiveFeedSettings', () => {
+  beforeEach(() => { localStorage.clear(); });
+
+  it('defaults to new-only', () => {
+    render(<Probe />);
+    expect(screen.getByRole('button')).toHaveTextContent('new-only');
+  });
+
+  it('treats only the literal "false" as opt-out', () => {
+    localStorage.setItem(NEW_FINDINGS_ONLY_KEY, 'false');
+    render(<Probe />);
+    expect(screen.getByRole('button')).toHaveTextContent('all');
+  });
+
+  it('persists the choice', () => {
+    render(<Probe />);
+    act(() => { screen.getByRole('button').click(); });
+    expect(localStorage.getItem(NEW_FINDINGS_ONLY_KEY)).toBe('false');
+    expect(screen.getByRole('button')).toHaveTextContent('all');
+  });
+
+  it('syncs a second consumer in the same tab', () => {
+    // A storage event does not fire in the tab that wrote the value, so the
+    // hook dispatches its own. Without it the Settings page and the
+    // evaluation screen disagree until a reload.
+    render(<><Probe /><Probe /></>);
+    const [first, second] = screen.getAllByRole('button');
+    act(() => { first.click(); });
+    expect(second).toHaveTextContent('all');
+  });
+});

--- a/src/quodeq/ui/src/models/violation.js
+++ b/src/quodeq/ui/src/models/violation.js
@@ -27,6 +27,7 @@
  * @property {string|null}   dimension
  * @property {string|null}   violationType
  * @property {boolean}       provenanceDowngrade  true when the provenance gate (#639) de-escalated this from critical to major
+ * @property {boolean}       carriedForward  true when replayed from the incremental cache rather than produced by the running scan
  */
 
 /**
@@ -57,6 +58,7 @@ export function createViolation(raw) {
     dimension:     raw.dimension ?? null,
     violationType: raw.violationType ?? raw.violation_type ?? null,
     provenanceDowngrade: raw.provenanceDowngrade ?? raw.provenance_downgrade ?? false,
+    carriedForward: raw.carriedForward ?? raw.carried_forward ?? false,
   };
 }
 

--- a/src/quodeq/ui/src/models/violation.test.js
+++ b/src/quodeq/ui/src/models/violation.test.js
@@ -20,3 +20,18 @@ test('createViolation defaults provenanceDowngrade to false when absent', () => 
   const v = createViolation({ severity: 'minor' });
   assert.equal(v.provenanceDowngrade, false);
 });
+
+test('createViolation maps carriedForward (camelCase from API)', () => {
+  const v = createViolation({ severity: 'major', carriedForward: true });
+  assert.equal(v.carriedForward, true);
+});
+
+test('createViolation maps carried_forward (snake_case from raw JSON)', () => {
+  const v = createViolation({ severity: 'major', carried_forward: true });
+  assert.equal(v.carriedForward, true);
+});
+
+test('createViolation defaults carriedForward to false when absent', () => {
+  const v = createViolation({ severity: 'major' });
+  assert.equal(v.carriedForward, false);
+});

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -3820,6 +3820,14 @@ button.eval-provider-badge--clickable:focus-visible {
 .vdetail-row--major    .vlive-rail { background: color-mix(in srgb, var(--color-sev-major-text) 55%, transparent); }
 .vdetail-row--minor    .vlive-rail { background: color-mix(in srgb, var(--color-sev-minor-text) 55%, transparent); }
 .vlive-card .term-sev-badge { justify-self: stretch; text-align: center; }
+/* The file button is a grid item in the 1fr column, so it stretches to the
+   full column width by default and swallows clicks meant for the row
+   (FileCopyBtn stopPropagation's, so the row never toggles). Shrink it to
+   its label; the leftover column space is bare grid area owned by
+   .vdetail-row-main, which already carries the expand/collapse handler. */
+.vlive-card .vdetail-row-main.vlive-collapsible .vlive-detail-file-btn {
+  justify-self: start;
+}
 .vrow-rule {
   font-family: var(--term-font-mono, ui-monospace, Menlo, monospace);
   font-size: 11px;

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -1923,6 +1923,10 @@ button.eval-provider-badge--clickable:focus-visible {
   padding: 0 4px;
 }
 
+.vlive-counter-hidden {
+  color: var(--color-text-subtle);
+}
+
 .vlive-dimension-group {
 }
 

--- a/tests/analysis/cache/test_dimension_runner_carried_forward.py
+++ b/tests/analysis/cache/test_dimension_runner_carried_forward.py
@@ -1,0 +1,81 @@
+"""Cache replays must be distinguishable from this scan's own findings.
+
+The live evaluation feed filters on carried_forward. It is stamped here,
+at the only place that knows a finding came from the cache rather than
+from the running scan.
+"""
+import json
+from pathlib import Path
+
+from quodeq.analysis.cache.dimension_runner import _write_findings
+
+
+def _finding(title: str) -> dict:
+    return {
+        "file": "a.py", "line": 1, "t": "violation", "w": title,
+        "p": "P1", "d": "security", "req": "X-1", "severity": "minor",
+        "snippet": "x", "reason": "r",
+    }
+
+
+def test_write_findings_stamps_carried_forward(tmp_path: Path):
+    jsonl = tmp_path / "security_evidence.jsonl"
+    _write_findings(jsonl, [_finding("carry-a")], append=False, emit_events=False)
+    written = [json.loads(ln) for ln in jsonl.read_text().splitlines() if ln.strip()]
+    assert written[0]["carried_forward"] is True
+
+
+def test_write_findings_does_not_mutate_the_source_dicts(tmp_path: Path):
+    """The dicts belong to the cache entry. Stamping in place risks the
+    persist watcher writing the flag back into the cache, which would make
+    a later fresh scan of the same file look carried."""
+    jsonl = tmp_path / "security_evidence.jsonl"
+    source = [_finding("carry-a")]
+    _write_findings(jsonl, source, append=False, emit_events=False)
+    assert "carried_forward" not in source[0]
+
+
+from unittest.mock import patch
+
+from quodeq.analysis.cache.entry import CacheEntry
+from tests.analysis.cache.test_dimension_runner import (
+    _make_callbacks, _make_ctx, _make_dummy_evidence, _setup, cache,
+)
+
+
+def test_only_cache_replays_are_flagged(tmp_path: Path, cache):
+    """a.py is a cache hit, b.py is dispatched. Exactly one is flagged."""
+    from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
+    from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+
+    config, _src = _setup(tmp_path, {"a.py": "x", "b.py": "y"})
+
+    key = build_cache_key_for_file(config, "a.py", "security")
+    cache.put(key, CacheEntry(
+        key=key, schema_version=1,
+        findings=[dict(_finding("carry-a"), file="a.py")],
+        files_read=1, file_path="a.py", dimension="security",
+        model_id="test-model",
+    ))
+
+    def fake_dispatch(cfg, dim_id, idx, ctx, callbacks):
+        jsonl = (cfg.work_dir or cfg.src) / f"{dim_id}_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        with jsonl.open("a") as out:
+            out.write(json.dumps(dict(_finding("fresh-b"), file="b.py", p="P2")) + "\n")
+            out.write(json.dumps({"_marker": "file_done", "file": "b.py", "status": "ok"}) + "\n")
+        return _make_dummy_evidence(files_read=1)
+
+    with patch(
+        "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+        new=fake_dispatch,
+    ):
+        process_dimension_with_cache(
+            config, "security", 1, _make_ctx(), _make_callbacks(), cache=cache,
+        )
+
+    jsonl_path = (config.work_dir or config.src) / "security_evidence.jsonl"
+    lines = [json.loads(ln) for ln in jsonl_path.read_text().splitlines() if ln.strip()]
+    by_title = {ln["w"]: ln for ln in lines if "_marker" not in ln}
+    assert by_title["carry-a"].get("carried_forward") is True
+    assert by_title["fresh-b"].get("carried_forward", False) is False

--- a/tests/api/test_run_event_stream.py
+++ b/tests/api/test_run_event_stream.py
@@ -83,6 +83,33 @@ def test_payload_as_sse_finding_includes_provenance_downgrade():
     assert payload["provenance_downgrade"] is True
 
 
+def test_payload_as_sse_finding_includes_carried_forward():
+    # The live feed's carried-forward filter needs this flag on the SSE
+    # path too, or every finding reads as new under VITE_USE_SSE_EVENTS.
+    from quodeq.api._run_event_stream import _payload_as_sse_finding
+    from quodeq.core.events.models import Judgment
+
+    j = Judgment(
+        practice_id="R-FT-2", verdict="violation", dimension="security",
+        file="f.py", line=1, reason="r", severity="major",
+        carried_forward=True,
+    )
+    payload = _payload_as_sse_finding(j, finding_id=1)
+    assert payload["carried_forward"] is True
+
+
+def test_payload_as_sse_finding_defaults_carried_forward_false():
+    from quodeq.api._run_event_stream import _payload_as_sse_finding
+    from quodeq.core.events.models import Judgment
+
+    j = Judgment(
+        practice_id="R-FT-2", verdict="violation", dimension="security",
+        file="f.py", line=1, reason="r", severity="major",
+    )
+    payload = _payload_as_sse_finding(j, finding_id=1)
+    assert payload["carried_forward"] is False
+
+
 # ---------------------------------------------------------------------------
 # WatcherState tests
 # ---------------------------------------------------------------------------

--- a/tests/core/test_evidence_jsonl_carried_forward.py
+++ b/tests/core/test_evidence_jsonl_carried_forward.py
@@ -1,0 +1,47 @@
+"""carried_forward must survive the JSONL <-> Judgment round trip.
+
+The live evaluation feed hides findings replayed from the incremental
+cache. The marker is stamped at replay time and read back here; if this
+seam drops it, every carried finding reads as new and the filter is inert.
+"""
+import json
+
+from quodeq.core.evidence._jsonl import judgment_to_dict, parse_jsonl_line
+from quodeq.core.finding_mappings import wire_dict_to_judgment
+
+
+def _line(**extra) -> str:
+    base = {
+        "p": "M-MOD-12", "t": "violation", "d": "maintainability",
+        "file": "a.py", "line": 19, "severity": "minor",
+        "w": "title", "reason": "why",
+    }
+    base.update(extra)
+    return json.dumps(base)
+
+
+def test_parse_reads_carried_forward():
+    judgment, _refs = parse_jsonl_line(_line(carried_forward=True))
+    assert judgment.carried_forward is True
+
+
+def test_parse_defaults_carried_forward_to_false():
+    judgment, _refs = parse_jsonl_line(_line())
+    assert judgment.carried_forward is False
+
+
+def test_judgment_to_dict_emits_flag_only_when_set():
+    carried, _ = parse_jsonl_line(_line(carried_forward=True))
+    fresh, _ = parse_jsonl_line(_line())
+    assert judgment_to_dict(carried)["carried_forward"] is True
+    # Absent, not False: keeps the common-case dict compact, mirroring
+    # how confidence and provenance_downgrade are handled.
+    assert "carried_forward" not in judgment_to_dict(fresh)
+
+
+def test_wire_dict_to_judgment_reads_carried_forward():
+    # Used by _emit_cached_findings to mirror cache replays into
+    # events.jsonl, which feeds the SSE path.
+    assert wire_dict_to_judgment(
+        json.loads(_line(carried_forward=True))
+    ).carried_forward is True

--- a/tests/services/test_carried_forward_read_paths.py
+++ b/tests/services/test_carried_forward_read_paths.py
@@ -1,0 +1,45 @@
+"""carried_forward must reach the API on BOTH dimension-eval read paths.
+
+resolve_dimension_eval prefers evaluation/<dim>.json and falls back to the
+evidence JSONL. A running dimension has only the JSONL; a finished one has
+the JSON. The live feed crosses that boundary mid-run, so a gap in either
+parser makes carried findings reappear as each dimension completes.
+"""
+import json
+from pathlib import Path
+
+from quodeq.analysis._report_constants import _VIOLATION_FIELDS
+from quodeq.data.fs.report_parser._report_parsing import build_finding
+from quodeq.services.violation_context import ViolationContext
+from quodeq.services.violations_parsing import _build_finding_entry
+
+
+def test_live_jsonl_path_carries_the_flag():
+    obj = {
+        "p": "P1", "t": "violation", "d": "security", "file": "a.py",
+        "line": 1, "severity": "minor", "w": "t", "reason": "r",
+        "carried_forward": True,
+    }
+    assert _build_finding_entry(obj, "security").carried_forward is True
+
+
+def test_live_jsonl_path_defaults_to_false():
+    obj = {
+        "p": "P1", "t": "violation", "d": "security", "file": "a.py",
+        "line": 1, "severity": "minor", "w": "t", "reason": "r",
+    }
+    assert _build_finding_entry(obj, "security").carried_forward is False
+
+
+def test_report_json_path_carries_the_flag():
+    item = {
+        "principle": "P1", "file": "a.py", "line": 1, "severity": "minor",
+        "title": "t", "reason": "r", "carried_forward": True,
+    }
+    assert build_finding(item, include_severity=True).carried_forward is True
+
+
+def test_report_write_whitelist_includes_the_flag():
+    """_flatten_findings keeps ONLY these keys when writing
+    evaluation/<dim>.json. Omission here drops the flag silently."""
+    assert "carried_forward" in _VIOLATION_FIELDS

--- a/tests/services/test_carried_forward_read_paths.py
+++ b/tests/services/test_carried_forward_read_paths.py
@@ -5,12 +5,9 @@ evidence JSONL. A running dimension has only the JSONL; a finished one has
 the JSON. The live feed crosses that boundary mid-run, so a gap in either
 parser makes carried findings reappear as each dimension completes.
 """
-import json
-from pathlib import Path
-
 from quodeq.analysis._report_constants import _VIOLATION_FIELDS
+from quodeq.analysis._report_findings import _flatten_findings
 from quodeq.data.fs.report_parser._report_parsing import build_finding
-from quodeq.services.violation_context import ViolationContext
 from quodeq.services.violations_parsing import _build_finding_entry
 
 
@@ -39,7 +36,22 @@ def test_report_json_path_carries_the_flag():
     assert build_finding(item, include_severity=True).carried_forward is True
 
 
-def test_report_write_whitelist_includes_the_flag():
-    """_flatten_findings keeps ONLY these keys when writing
-    evaluation/<dim>.json. Omission here drops the flag silently."""
-    assert "carried_forward" in _VIOLATION_FIELDS
+def test_report_write_whitelist_carries_the_flag_through_flatten():
+    """_flatten_findings keeps ONLY the keys listed in _VIOLATION_FIELDS when
+    writing evaluation/<dim>.json. Omission here drops the flag silently."""
+    items = [
+        {
+            "file": "a.py", "line": 1, "severity": "minor",
+            "title": "t", "reason": "r", "carried_forward": True,
+        },
+        {
+            "file": "b.py", "line": 2, "severity": "minor",
+            "title": "t", "reason": "r",
+        },
+    ]
+
+    flattened = _flatten_findings(items, "P1", _VIOLATION_FIELDS)
+
+    carried, not_carried = flattened
+    assert carried["carried_forward"] is True
+    assert "carried_forward" not in not_carried


### PR DESCRIPTION
## What

Two changes to the live evaluation feed:

1. **Copy hit-area fix.** The `file.py:68` copy button was a grid item in the row's 1fr column, so it stretched to the full column width and (because it stops propagation) swallowed clicks meant to expand the row. One scoped `justify-self: start` rule shrinks it to its label; the freed area belongs to the row again. Verified live: button 99px in a 1063px row, dead-zone click expands.

2. **New-findings-only live feed.** On incremental runs the cache replays prior runs' findings into the run's evidence, so the feed showed hundreds of findings the running scan never produced. A `carried_forward` marker is now stamped at the single cache-replay write (`_write_findings`, on copies so cache-owned dicts are never mutated) and threaded end to end: Judgment -> evidence JSONL -> both dimension-eval read paths (live JSONL parser and `evaluation/<dim>.json` via the `_VIOLATION_FIELDS` whitelist) -> SSE event stream -> UI violation model. `EvaluationStatus` filters once, above both the stat strip and the feed, so their counts cannot diverge (the #878 class). The feed header discloses `N carried forward hidden`; the stat cell hint appends `· N carried forward`; a filter-emptied feed reads `no new findings · N carried forward hidden` instead of vanishing.

Preference: Settings > Evaluation > Live findings (`New only` / `All`), default New only, localStorage-backed (`cc-eval-new-findings-only`), applies without reload via the same event mechanism as the terminal setting.

## Backward compatibility

Absent flag parses as false everywhere, emitted only when true: old runs, old caches, and old reports are byte-identical. Clean scans never carry, so nothing changes there.

## Deliberately not threaded

The flag intentionally does NOT flow into the SQLite projection (`row_to_finding`), `judgment_to_finding`, or `parse_finding` — the live feed reads only the FS parsers and the SSE stream. A future consumer of those paths should not assume the field is universal.

## Known follow-up

Findings kept from a cancelled run replay as carried on the next evaluation even though they never reached the Overview. Making them count as new until a completed run consolidates them needs the cache to track producing-run status — agreed as a separate PR.

## Verification

- Python: 1996 passed (`tests/api tests/core tests/services -m "not integration"`), plus `tests/analysis` green earlier in the branch (2381 with services/data).
- JS: `npm run test:all` — 381 node + 1459 vitest, all green.
- Live, against a fake running run through the real stack: strip + feed both show the filtered count (3 shown / 5 hidden across 2 dims) with the disclosure label; the JSONL -> report-JSON mid-run switchover keeps carried findings hidden as each dimension completes; Settings `All` restores all 8 with no label and no reload; `New only` reapplies via the change event.
- Invariant tests carry proofs: the `_flatten_findings` whitelist test fails if the field is removed from `_VIOLATION_FIELDS`; the strip probe test fails if `JobStatStrip` is handed the unfiltered object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)