### PR TITLE
fix(evaluate): describe the time budget as one total for the run

### DIFF
--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -198,9 +198,9 @@ def register_evaluation_item_routes(app: Flask, provider: ActionProvider) -> Non
         if run_dir is None:
             body, status = error_response("Job not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
             return jsonify(body), status
-        # Time limit for the running dim's bar. The snapshot carries the
+        # Total time limit for the whole run. The snapshot carries the
         # budget for both internal jobs (JobManager) and index-served runs
-        # (read from status.json). 0 = unlimited -> no bar.
+        # (read from status.json). 0 = unlimited -> no budget shown.
         time_limit_s: int | None = None
         snapshot = provider.get_evaluation_status(job_id, reports_dir=_reports_dir())
         if snapshot is not None:

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -41,7 +41,6 @@ class _DimProgress:
     suppressed: int = 0  # re-found findings already dismissed/deleted in the dashboard
     quarantined: int = 0  # findings whose principle is not in the dimension's standard
     elapsed_s: float | None = None
-    budget_s: int | None = None
     active_agents: int = 0
     estimate_reason: str | None = None  # see _dim_estimates module docstring
     exit_reason: str | None = None
@@ -58,6 +57,9 @@ class _ScanProgress:
     current_dimension: str | None
     project_files: int
     total_elapsed_s: float | None
+    # The time limit is one deadline for the whole run, shared across all
+    # selected dimensions — never a per-dimension allowance.
+    budget_s: int | None = None
     dimensions: list[_DimProgress] = field(default_factory=list)
 
 
@@ -200,7 +202,7 @@ def _dim_elapsed_s(dim_id: str, run_dir: Path, state: str) -> float | None:
     return max(0.0, end - start)
 
 
-def _consolidated_dim_progress(run_dir: Path, time_limit_s: int | None) -> _DimProgress:
+def _consolidated_dim_progress(run_dir: Path) -> _DimProgress:
     """Progress row for a live consolidated (grouped) pass.
 
     Evidence counters are the raw cross-dimension tally: suppression
@@ -217,7 +219,6 @@ def _consolidated_dim_progress(run_dir: Path, time_limit_s: int | None) -> _DimP
             taken += len(fs)
     pending = len(queue.get("pending") or [])
     tally = tally_unique_findings(evidence_dir / "consolidated_evidence.jsonl")
-    budget = time_limit_s if (time_limit_s and time_limit_s > 0) else None
     return _DimProgress(
         id="consolidated",
         state="running",
@@ -226,7 +227,6 @@ def _consolidated_dim_progress(run_dir: Path, time_limit_s: int | None) -> _DimP
         compliance=tally.compliance,
         duplicates=tally.duplicates,
         elapsed_s=_dim_elapsed_s("consolidated", run_dir, "running"),
-        budget_s=budget,
         active_agents=_active_agents(evidence_dir, "consolidated"),
     )
 
@@ -275,6 +275,7 @@ def build_scan_progress(
     else:
         total_elapsed_s = None
 
+    run_budget_s = time_limit_s if (time_limit_s and time_limit_s > 0) else None
     project_files = _project_total_files(run_dir)
     dim_estimates = read_dim_estimates(run_dir)
     dim_records = read_dimensions(run_dir).get("dimensions") or {}
@@ -314,7 +315,8 @@ def build_scan_progress(
             current_dimension=status.get("current_dimension"),
             project_files=project_files,
             total_elapsed_s=total_elapsed_s,
-            dimensions=[_consolidated_dim_progress(run_dir, time_limit_s)],
+            budget_s=run_budget_s,
+            dimensions=[_consolidated_dim_progress(run_dir)],
         )
 
     # The scanner re-finds everything the user has dismissed or deleted, so a
@@ -372,7 +374,6 @@ def build_scan_progress(
             resolver=build_principle_resolver(dim_id, evaluators_dir, compiled_dir),
         )
         elapsed = _dim_elapsed_s(dim_id, run_dir, d_state)
-        budget = time_limit_s if (d_state == "running" and time_limit_s and time_limit_s > 0) else None
         active = _active_agents(evidence_dir, dim_id) if d_state == "running" else 0
 
         dim_results.append(_DimProgress(
@@ -385,7 +386,6 @@ def build_scan_progress(
             suppressed=tally.suppressed,
             quarantined=tally.quarantined,
             elapsed_s=elapsed,
-            budget_s=budget,
             active_agents=active,
             estimate_reason=estimate_reason,
             exit_reason=exit_reason,
@@ -401,6 +401,7 @@ def build_scan_progress(
         current_dimension=status.get("current_dimension"),
         project_files=project_files,
         total_elapsed_s=total_elapsed_s,
+        budget_s=run_budget_s,
         dimensions=dim_results,
     )
 

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -21,7 +21,7 @@ const EVAL_OPTIONS_HINT = (
     <div><strong>Scope</strong>: click the scope cell to restrict the evaluation to a subfolder. Default is the whole project.</div>
     <div><strong>Model</strong>: click the model cell to pick the provider/model in Settings.</div>
     <div><strong>Scan mode</strong>: incremental re-analyzes only files changed since the last run; clean scan re-evaluates everything from scratch.</div>
-    <div><strong>Time budget</strong>: per-dimension limit for this run. It auto-scales up for large file sets.</div>
+    <div><strong>Time budget</strong>: total limit for the whole run, shared across the selected dimensions. Whatever doesn't finish in time is picked up by the next run.</div>
   </>
 );
 
@@ -238,7 +238,7 @@ function BudgetChips({ valueS, onChange, disabled }) {
     <div className="eval-budget">
       <div className="eval-budget__head">
         <span className="eval-budget__label">time budget</span>
-        <span className="eval-budget__sub">per dimension · auto-scales for large file sets</span>
+        <span className="eval-budget__sub">total for the run · shared across dimensions</span>
       </div>
       <div className="eval-budget-chips">
         {BUDGET_CHOICES_S.map((s) => (
@@ -281,7 +281,7 @@ function RunBar({ disabled, canStart, handleScan, selectedDims, estimates, clean
       }, null)
     : null;
 
-  const budgetPart = timeLimitS > 0 ? `${formatBudgetLabel(timeLimitS)} budget each` : 'no time limit';
+  const budgetPart = timeLimitS > 0 ? `${formatBudgetLabel(timeLimitS)} total budget` : 'no time limit';
   const line1 = picked > 0
     ? [
         `${picked} dimension${picked === 1 ? '' : 's'}`,

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.test.jsx
@@ -267,6 +267,37 @@ describe('ReEvaluateCard error state', () => {
   });
 });
 
+describe('ReEvaluateCard time budget copy', () => {
+  beforeEach(() => { invalidateDimensionCache(); });
+
+  const localInfo = { name: 'demo', path: '/repos/myproj', location: 'local', ephemeral: false, evaluable: true };
+  const apiWithDims = () => makeFakeApi({
+    getProjectInfo: vi.fn().mockResolvedValue(localInfo),
+    listPlugins: vi.fn().mockResolvedValue([{ dimensions: [
+      { id: 'security', label: 'Security' },
+    ] }]),
+  });
+
+  it('describes the budget as a total for the run, not per dimension', async () => {
+    renderCard({ project: 'p-budget', projectInfo: localInfo, api: apiWithDims() });
+    await waitFor(() => expect(screen.getByText('time budget')).toBeInTheDocument());
+    expect(screen.getByText(/total for the run/i)).toBeInTheDocument();
+    expect(screen.queryByText(/per dimension/i)).not.toBeInTheDocument();
+  });
+
+  it('summarizes a picked budget as the run total, never "each"', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event');
+    const user = userEvent.setup();
+    renderCard({ project: 'p-budget2', projectInfo: localInfo, api: apiWithDims(), preselectDims: ['security'] });
+    await waitFor(() => expect(screen.getByRole('button', { name: /security/i })).toHaveAttribute('aria-pressed', 'true'));
+
+    await user.click(screen.getByRole('button', { name: '10:00' }));
+
+    expect(screen.getByText(/10:00 total budget/)).toBeInTheDocument();
+    expect(screen.queryByText(/budget each/)).not.toBeInTheDocument();
+  });
+});
+
 describe('ReEvaluateCard preselection seeding', () => {
   beforeEach(() => { invalidateDimensionCache(); });
 

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -94,26 +94,18 @@ function DimRow({ dim }) {
   } else {
     // Only show a clock segment when we actually have a number to print.
     // Without this guard, a running dim with no elapsed time yields a
-    // dangling "· —" tail.
-    let budgetPart = null;
-    if (dim.budgetS) {
-      const overrun = dim.elapsedS != null && dim.elapsedS > dim.budgetS;
-      const cls = overrun ? 'scan-progress__budget scan-progress__budget--overrun' : 'scan-progress__budget';
-      budgetPart = (
-        <span className={cls}>
-          {formatClock(dim.elapsedS)} / {formatClock(dim.budgetS)} budget
-        </span>
-      );
-    } else if (dim.elapsedS != null) {
-      budgetPart = <span className="scan-progress__budget">{formatClock(dim.elapsedS)}</span>;
-    }
+    // dangling "· —" tail. The time budget is run-level (shared across
+    // dimensions, shown in the footer), so rows only get their elapsed.
+    const clockPart = dim.elapsedS != null
+      ? <span className="scan-progress__budget">{formatClock(dim.elapsedS)}</span>
+      : null;
     meta = (
       <>
         {dim.activeAgents > 0 && <>{dim.activeAgents} agents</>}
         {reasonBadge}
         {dim.violations > 0 && <> · <span className="scan-progress__v">{dim.violations}v</span></>}
         {dim.compliance > 0 && <> · <span className="scan-progress__c">{dim.compliance}c</span></>}
-        {budgetPart && <> · {budgetPart}</>}
+        {clockPart && <> · {clockPart}</>}
       </>
     );
   }
@@ -198,11 +190,18 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
       ? <div className="scan-progress__error">Server restarted, job tracking lost</div>
       : null;
 
-  // The old header countdown moved here: while a dimension runs, its elapsed
-  // vs its own budget (the limit is per-dimension); otherwise total elapsed.
-  const runningDim = dims.find((d) => d?.state === 'running');
-  const clockPart = isRunning && runningDim?.budgetS > 0
-    ? <> · {formatClock(runningDim.elapsedS)} of {formatClock(runningDim.budgetS)} budget</>
+  // The time limit is one deadline for the whole run, shared across all
+  // selected dimensions — so the countdown pairs total elapsed with the
+  // run-level budget. Overrun can show briefly: the watchdog allows a
+  // short grace past the deadline before killing the job.
+  const runBudgetS = progress?.budgetS;
+  const overrun = runBudgetS > 0 && progress?.totalElapsedS > runBudgetS;
+  const clockPart = isRunning && runBudgetS > 0
+    ? (
+      <> · <span className={overrun ? 'scan-progress__budget scan-progress__budget--overrun' : 'scan-progress__budget'}>
+        {formatClock(progress.totalElapsedS)} of {formatClock(runBudgetS)} budget
+      </span></>
+    )
     : progress?.totalElapsedS != null
       ? <> · {formatClock(progress.totalElapsedS)} total</>
       : null;

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.test.jsx
@@ -225,12 +225,37 @@ describe('ScanProgress total coverage (incremental runs)', () => {
     expect(screen.queryByText('preparing…')).toBeNull();
   });
 
-  it('shows the running dimension budget in the footer', async () => {
+  it('shows run elapsed against the total run budget in the footer', async () => {
     const payload = coveragePayload();
+    payload.budgetS = 600;
+    payload.totalElapsedS = 78;
+    getEvaluationProgress.mockResolvedValue(payload);
+    withEvalLog(<ScanProgress job={baseJob} />, ctx);
+    expect(await screen.findByText(/1:18 of 10:00 budget/)).toBeInTheDocument();
+  });
+
+  it('marks the footer budget as overrun once elapsed passes it', async () => {
+    const payload = coveragePayload();
+    payload.budgetS = 600;
+    payload.totalElapsedS = 640;
+    getEvaluationProgress.mockResolvedValue(payload);
+    const { container } = withEvalLog(<ScanProgress job={baseJob} />, ctx);
+    await screen.findByText(/10:40 of 10:00 budget/);
+    expect(container.querySelector('.scan-progress__budget--overrun')).not.toBeNull();
+  });
+
+  it('never shows a per-dimension budget in the detail rows', async () => {
+    const payload = coveragePayload();
+    payload.budgetS = 600;
+    // Legacy payloads carried the run budget on the running dim; it must
+    // not render as if the dimension had its own allowance.
     payload.dimensions[0].budgetS = 600;
     payload.dimensions[0].elapsedS = 78;
     getEvaluationProgress.mockResolvedValue(payload);
     withEvalLog(<ScanProgress job={baseJob} />, ctx);
-    expect(await screen.findByText(/1:18 of 10:00 budget/)).toBeInTheDocument();
+    fireEvent.click(await screen.findByTitle('Show per-dimension detail'));
+    const row = (await screen.findByText('security')).closest('.scan-progress__dim');
+    expect(row.textContent).toContain('1:18');
+    expect(row.textContent).not.toContain('budget');
   });
 });

--- a/src/quodeq/ui/src/features/evaluation/components/scanSummary.js
+++ b/src/quodeq/ui/src/features/evaluation/components/scanSummary.js
@@ -53,7 +53,7 @@ export function detectedLanguages(languages, limit = 4) {
     .slice(0, limit);
 }
 
-/** Preset per-dimension time budgets, in seconds. 0 = no limit. */
+/** Preset total run time budgets, in seconds. 0 = no limit. */
 export const BUDGET_CHOICES_S = [300, 600, 1200, 1800, 0];
 
 /** "10:00" for seconds, "no limit" for 0/negative. */

--- a/tests/api/test_evaluation_progress_budget.py
+++ b/tests/api/test_evaluation_progress_budget.py
@@ -112,8 +112,11 @@ def test_budget_resolved_from_snapshot(reports_root: Path):
     client = create_app(_make_provider(run_dir, 600)).test_client()
     response = client.get("/api/evaluations/job-1/progress")
     assert response.status_code == 200
-    dims = response.get_json()["dimensions"]
-    assert dims[0]["budgetS"] == 600
+    body = response.get_json()
+    # The time limit is one deadline for the whole run, so the budget is
+    # reported at run level, never per dimension.
+    assert body["budgetS"] == 600
+    assert body["dimensions"][0].get("budgetS") is None
 
 
 def test_unlimited_budget_stays_absent(reports_root: Path):
@@ -121,5 +124,6 @@ def test_unlimited_budget_stays_absent(reports_root: Path):
     client = create_app(_make_provider(run_dir, 0)).test_client()
     response = client.get("/api/evaluations/job-1/progress")
     assert response.status_code == 200
-    dims = response.get_json()["dimensions"]
-    assert dims[0].get("budgetS") is None
+    body = response.get_json()
+    assert body.get("budgetS") is None
+    assert body["dimensions"][0].get("budgetS") is None


### PR DESCRIPTION
The time limit is a single run-level deadline shared across all selected dimensions (`_pipeline.py` sets `deadline_at` once before the dim loop, `_loops.py` skips remaining dims when it passes). The Evaluate UI claimed it was per dimension: "10:00 budget each", "per-dimension limit", and an in-progress footer that paired each dimension's elapsed with the whole-run limit. With 3 dimensions and 10 minutes selected, the copy promised 30 minutes while the run stopped at 10.

Changes:
- Setup card copy (hint, chip sub-label, run bar) now says the budget is a total for the run, shared across dimensions.
- `budgetS` in the progress payload moves from the running dimension to the run level. The footer countdown shows total elapsed against the run budget, with the overrun style when the watchdog grace kicks in. Before, dim 3/3 could show "0:12 / 10:00 budget" seconds before the deadline killed the job.
- Per-dimension detail rows show elapsed only.
- Dropped "auto-scales for large file sets": the pool's scaled per-dim soft limit is always clamped back to the run deadline, so it never buys extra wall clock.

Tests: full pytest suite (5230 passed) and full UI suite (1466 passed). The progress-budget route tests now pin the run-level contract, and new ScanProgress/ReEvaluateCard tests pin the footer countdown, the overrun style, legacy per-dim `budgetS` being ignored, and the new copy.