### PR TITLE
fix(breadcrumb): current sibling menu item navigates back to its level

### DIFF
--- a/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.jsx
@@ -154,7 +154,11 @@ export default function NavBreadcrumb({ stack = [], onGoTo, projectName, onSelec
                           type="button"
                           role="menuitemradio"
                           aria-checked={!!item.current}
-                          onClick={() => { setOpenKey(null); if (!item.current) item.onSelect(); }}
+                          // Picking the current sibling means "back to this
+                          // level" — from a deeper page it's the only way up
+                          // to it, since the segment itself opens the menu.
+                          // onGoTo no-ops when this is already the last entry.
+                          onClick={() => { setOpenKey(null); if (item.current) onGoTo(seg.index); else item.onSelect(); }}
                         >
                           <span className="nav-breadcrumb__menu-dot" aria-hidden="true" />
                           {item.label}

--- a/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.test.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.test.jsx
@@ -127,6 +127,35 @@ describe('NavBreadcrumb collapse and jump bar', () => {
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
 
+  it('navigates back to the level when the current sibling is picked from a deeper page', () => {
+    // Regression: from a detail page, the ancestor dimension crumb only opened
+    // the sibling menu and its current item was a no-op, so there was no way
+    // back up to that level.
+    const onGoTo = vi.fn();
+    const siblingsFor = (entry) => (entry.page === 'explorer'
+      ? [
+          { key: 'Security', label: 'security', current: true, onSelect: () => {} },
+          { key: 'Maintainability', label: 'maintainability', current: false, onSelect: () => {} },
+        ]
+      : null);
+    render(
+      <NavBreadcrumb
+        stack={[
+          { page: 'violations' },
+          { page: 'explorer', dimension: 'Security' },
+          { page: 'file', label: 'HomeVC.swift' },
+        ]}
+        onGoTo={onGoTo}
+        projectName="repo"
+        onSelectProject={() => {}}
+        siblingsFor={siblingsFor}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'security' }));
+    fireEvent.click(screen.getByRole('menuitemradio', { name: 'security' }));
+    expect(onGoTo).toHaveBeenCalledWith(1);
+  });
+
   it('stays a plain link when siblingsFor returns null for the level', () => {
     const onGoTo = vi.fn();
     render(


### PR DESCRIPTION
From a detail page there was no way back to a breadcrumb level that has a sibling menu (root tab, explorer dimension). Clicking the segment only toggles the dropdown, and the current item in the dropdown was a no-op, so the level itself was unreachable.

Picking the current sibling now navigates to that level via `onGoTo`. When you are already on that level it stays a no-op (`navGoTo` ignores zero steps), so nothing changes for lateral moves.

Test: regression case in NavBreadcrumb.test.jsx (deep stack, current sibling click calls `onGoTo` with the segment index). Full UI suite passes (1467 tests).