### PR TITLE
Stub SSE env in tests so CodeQL can parse them

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
@@ -40,7 +40,7 @@ describe("useEvaluation", () => {
     Object.values(fakeApi).forEach((fn) => fn.mockReset?.());
     fakeApi.listEvaluations.mockResolvedValue([]);
     // Default: SSE off — refetchInterval path
-    import.meta.env.VITE_USE_SSE_EVENTS = "false";
+    vi.stubEnv("VITE_USE_SSE_EVENTS", "false");
     // preparePayload reads localStorage; seed a working provider+model.
     localStorage.setItem("cc-active-provider", "ollama");
     localStorage.setItem("cc-ollama-model", "llama3.1");

--- a/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.test.jsx
@@ -41,13 +41,13 @@ describe("useRunEventStream (cache-writer)", () => {
   });
 
   it("opens an EventSource against the events endpoint when SSE is enabled", () => {
-    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    vi.stubEnv("VITE_USE_SSE_EVENTS", "true");
     renderStreamAndQuery("job-123", evaluationKeys.status("job-123"));
     expect(MockEventSource.last.url).toBe("/api/evaluations/job-123/events");
   });
 
   it("writes status events into evaluationKeys.status cache slot", async () => {
-    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    vi.stubEnv("VITE_USE_SSE_EVENTS", "true");
     const { result } = renderStreamAndQuery("job-1", evaluationKeys.status("job-1"));
     act(() => {
       MockEventSource.last.emit("status", { state: "running", phase: "analyzing" });
@@ -58,7 +58,7 @@ describe("useRunEventStream (cache-writer)", () => {
   });
 
   it("appends finding events into evaluationKeys.findings cache slot", async () => {
-    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    vi.stubEnv("VITE_USE_SSE_EVENTS", "true");
     const { result } = renderStreamAndQuery("job-1", evaluationKeys.findings("job-1"));
     act(() => {
       MockEventSource.last.emit("finding", { id: 1, practice_id: "P1" });
@@ -73,7 +73,7 @@ describe("useRunEventStream (cache-writer)", () => {
   });
 
   it("writes dimension-completed events as a map keyed by dimension", async () => {
-    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    vi.stubEnv("VITE_USE_SSE_EVENTS", "true");
     const { result } = renderStreamAndQuery("job-1", evaluationKeys.dimensions("job-1"));
     act(() => {
       MockEventSource.last.emit("dimension-completed", {
@@ -88,7 +88,7 @@ describe("useRunEventStream (cache-writer)", () => {
   });
 
   it("closes the source on done event", async () => {
-    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    vi.stubEnv("VITE_USE_SSE_EVENTS", "true");
     renderStreamAndQuery("job-1", evaluationKeys.status("job-1"));
     act(() => {
       MockEventSource.last.emit("done", { state: "done" });
@@ -97,19 +97,19 @@ describe("useRunEventStream (cache-writer)", () => {
   });
 
   it("does not open EventSource when jobId is empty", () => {
-    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    vi.stubEnv("VITE_USE_SSE_EVENTS", "true");
     renderStreamAndQuery("", evaluationKeys.status(""));
     expect(MockEventSource.last).toBeNull();
   });
 
   it("is a no-op when VITE_USE_SSE_EVENTS is not 'true'", () => {
-    import.meta.env.VITE_USE_SSE_EVENTS = "false";
+    vi.stubEnv("VITE_USE_SSE_EVENTS", "false");
     renderStreamAndQuery("job-1", evaluationKeys.status("job-1"));
     expect(MockEventSource.last).toBeNull();
   });
 
   it("invalidates project trend on terminal status (done)", () => {
-    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    vi.stubEnv("VITE_USE_SSE_EVENTS", "true");
     const { invalidateSpy } = renderStreamWithSpy("job-term-1");
     act(() => {
       MockEventSource.last.emit("status", { state: "done" });
@@ -118,7 +118,7 @@ describe("useRunEventStream (cache-writer)", () => {
   });
 
   it("invalidates project trend on terminal status (failed)", () => {
-    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    vi.stubEnv("VITE_USE_SSE_EVENTS", "true");
     const { invalidateSpy } = renderStreamWithSpy("job-term-2");
     act(() => {
       MockEventSource.last.emit("status", { state: "failed" });
@@ -127,7 +127,7 @@ describe("useRunEventStream (cache-writer)", () => {
   });
 
   it("invalidates project trend on terminal status (cancelled)", () => {
-    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    vi.stubEnv("VITE_USE_SSE_EVENTS", "true");
     const { invalidateSpy } = renderStreamWithSpy("job-term-3");
     act(() => {
       MockEventSource.last.emit("status", { state: "cancelled" });
@@ -136,7 +136,7 @@ describe("useRunEventStream (cache-writer)", () => {
   });
 
   it("does NOT invalidate project trend on non-terminal status", () => {
-    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    vi.stubEnv("VITE_USE_SSE_EVENTS", "true");
     const { invalidateSpy } = renderStreamWithSpy("job-running");
     act(() => {
       MockEventSource.last.emit("status", { state: "running" });

--- a/src/quodeq/ui/src/features/history/hooks/useHistoryRunLive.test.jsx
+++ b/src/quodeq/ui/src/features/history/hooks/useHistoryRunLive.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useHistoryRunLive } from './useHistoryRunLive.js';
 import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
@@ -8,7 +8,7 @@ describe('useHistoryRunLive', () => {
   beforeEach(() => {
     global.EventSource = MockEventSource;
     MockEventSource.last = null;
-    import.meta.env.VITE_USE_SSE_EVENTS = 'true';
+    vi.stubEnv('VITE_USE_SSE_EVENTS', 'true');
   });
 
   it('returns empty defaults when no events have arrived', () => {
@@ -70,7 +70,7 @@ describe('useHistoryRunLive', () => {
   });
 
   it('returns empty defaults and opens no EventSource when SSE is off', () => {
-    import.meta.env.VITE_USE_SSE_EVENTS = 'false';
+    vi.stubEnv('VITE_USE_SSE_EVENTS', 'false');
     const wrapper = withQueryClient();
     const { result } = renderHook(() => useHistoryRunLive('run-sseoff'), { wrapper });
     expect(MockEventSource.last).toBeNull();

--- a/src/quodeq/ui/src/hooks/useRunningRunsRefresh.test.jsx
+++ b/src/quodeq/ui/src/hooks/useRunningRunsRefresh.test.jsx
@@ -32,7 +32,7 @@ function refreshCount(invalidateSpy, project = 'p1') {
 describe('useRunningRunsRefresh', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    import.meta.env.VITE_USE_SSE_EVENTS = 'false';
+    vi.stubEnv('VITE_USE_SSE_EVENTS', 'false');
   });
   afterEach(() => {
     vi.useRealTimers();
@@ -192,7 +192,7 @@ describe('useRunningRunsRefresh', () => {
   });
 
   it('mount-time refresh fires regardless of VITE_USE_SSE_EVENTS', () => {
-    import.meta.env.VITE_USE_SSE_EVENTS = 'true';
+    vi.stubEnv('VITE_USE_SSE_EVENTS', 'true');
     const { Wrapper, invalidateSpy } = makeWrapper();
     renderHook(
       () =>
@@ -206,7 +206,7 @@ describe('useRunningRunsRefresh', () => {
   });
 
   it('suppresses recurring poll when VITE_USE_SSE_EVENTS=true', () => {
-    import.meta.env.VITE_USE_SSE_EVENTS = 'true';
+    vi.stubEnv('VITE_USE_SSE_EVENTS', 'true');
     const { Wrapper, invalidateSpy } = makeWrapper();
     renderHook(
       () =>
@@ -224,7 +224,7 @@ describe('useRunningRunsRefresh', () => {
   });
 
   it('still polls when VITE_USE_SSE_EVENTS is not "true"', () => {
-    import.meta.env.VITE_USE_SSE_EVENTS = 'false';
+    vi.stubEnv('VITE_USE_SSE_EVENTS', 'false');
     const { Wrapper, invalidateSpy } = makeWrapper();
     renderHook(
       () =>

--- a/src/quodeq/ui/vitest.config.js
+++ b/src/quodeq/ui/vitest.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    unstubEnvs: true,
     setupFiles: ['./vitest.setup.js'],
     // Only discover component/JSX tests. Pure-JS utility tests in `.test.js`
     // files use Node's native `node:test` runner (see `npm test`) and must


### PR DESCRIPTION
CodeQL's Security tab showed a warning on the `language:javascript-typescript` configuration: "Could not process some files due to syntax errors" in 4 test files. The extractor parses reads of `import.meta.env` fine but rejects assignments through it (`import.meta.env.VITE_USE_SSE_EVENTS = ...`), so those files were excluded from analysis.

Replaced all 16 assignment sites with `vi.stubEnv('VITE_USE_SSE_EVENTS', ...)`, which also stubs `import.meta.env`, and enabled `unstubEnvs: true` in vitest.config.js so stubs reset between tests instead of leaking. Added the missing `vi` import in useHistoryRunLive.test.jsx.

Full vitest suite passes: 178 files, 1467 tests. The tool-status warning clears on the next develop scan after merge.