### PR TITLE
fix(tests): deflake the TerminalPane focus test

### DIFF
--- a/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
@@ -83,7 +83,10 @@ it('focuses xterm when it is the active tab so the user can type without clickin
   fakeTerm.focus.mockClear();
   render(<TerminalPane active />);
   await screen.findByTestId('tty-root');
-  expect(fakeTerm.focus).toHaveBeenCalled();
+  // waitFor, not a plain assert: focus() runs in a post-commit effect, so it
+  // can land a beat after tty-root appears under CI load (flaked on develop,
+  // same race the mount test above was hardened against).
+  await waitFor(() => expect(fakeTerm.focus).toHaveBeenCalled());
 });
 
 it('does not focus xterm while backgrounded (active=false)', async () => {


### PR DESCRIPTION
## Why

The develop Tests run for the #916 merge (run 30403930907) failed on exactly one UI test:

`TerminalPane.test.jsx > focuses xterm when it is the active tab so the user can type without clicking in`
`AssertionError: expected "vi.fn()" to be called at least once`

The same tree passed on the PR branch CI, and the test passes locally, so this is a timing flake, not a regression. It currently blocks cutting v1.8.0 on a green develop.

## Root cause

`tty-root` appears on the render commit, but `focus()` runs in a post-commit effect (`TerminalSessionView.jsx:210`). The test asserted synchronously the moment `findByTestId('tty-root')` resolved, so under CI load the effect flush can land after the assertion. This is the same race class the mount test in this file was already hardened against (its comment: "the Terminal constructor runs in the view's mount EFFECT, which can land a beat later under CI load").

## Fix

Wrap the assertion in `waitFor`, mirroring the established pattern in the neighboring test. No production code changes.

## Verification

- Ran the file 15 consecutive times locally: 21/21 tests pass every run.
- Full vitest suite: 1467/1467 across 178 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)