### PR TITLE
fix(manifest): keep source outside detected subprojects instead of dropping it

### DIFF
--- a/src/quodeq/analysis/manifest_build.py
+++ b/src/quodeq/analysis/manifest_build.py
@@ -185,8 +185,9 @@ def _walk_and_partition_by_scope(
     """Walk *src* once, bucketing files by their owning subproject scope.
 
     Each file is assigned to the deepest scope path that contains it. Files outside
-    every scope are silently dropped — they don't belong to any classified
-    subproject and shouldn't appear in any target.
+    every scope are dropped — they don't belong to any classified subproject and
+    shouldn't appear in any target. Callers that must not lose unclassified source
+    pass ``"."`` among *scope_paths* as a catch-all (see _build_multi_scope_manifest).
     """
     ignore_patterns = ignore_patterns or []
     files_by_scope_lang: dict[str, dict[str, list[str]]] = {s: {} for s in scope_paths}
@@ -230,6 +231,17 @@ def _build_multi_scope_manifest(
     """Produce a manifest with one target group per detected subproject scope."""
     scope_paths = [rel for rel, _ in sub_results]
     matches_by_scope = {rel: matches for rel, matches in sub_results}
+    if "." not in matches_by_scope:
+        # No rule classified the repo root, but source can still live outside every
+        # detected subproject — e.g. a Kotlin Multiplatform repo where only
+        # ``iosApp/`` matches (via *.xcodeproj) while the Gradle/Kotlin root does
+        # not. Without a catch-all root scope those files are dropped and the
+        # manifest comes back with no targets, which downstream reads as "no
+        # source files". "." is depth 0 in _deepest_scope, so it only claims files
+        # no more specific scope owns, and _MIN_FILES_PER_TARGET still keeps a
+        # handful of stray root files from becoming a target.
+        scope_paths.append(".")
+        matches_by_scope["."] = []
     files_by_scope, ext_counts_overall, ext_counts_by_scope_lang = _walk_and_partition_by_scope(
         src, ext_map, skip_dirs, skip_patterns, scope_paths,
         ignore_patterns=ignore_patterns,

--- a/tests/engine/test_manifest.py
+++ b/tests/engine/test_manifest.py
@@ -282,6 +282,53 @@ def test_build_monorepo_partitions_files_by_subproject(
     assert all(f.startswith("apps/web/") for f in web.source_files)
 
 
+def test_monorepo_keeps_source_outside_detected_subprojects(tmp_path: Path) -> None:
+    """A repo whose only *detected* subproject is a nested one must not lose the
+    source tree living outside it.
+
+    Kotlin Multiplatform is the real-world case: ``iosApp/`` is recognised via
+    ``*.xcodeproj``, but the Gradle/Kotlin root is not (its plugins come from a
+    version catalog, so no ``com.android`` literal appears in build.gradle.kts).
+    Without a catch-all root scope every ``.kt`` file is dropped and the manifest
+    comes back empty, which downstream reads as "no source files".
+    """
+    from quodeq.config.paths import default_paths
+
+    kmp_detection = {
+        "extensions": {".kt": "kotlin", ".swift": "swift"},
+        "skip_dirs": ["build", ".gradle"],
+        "skip_patterns": [],
+    }
+
+    _write(tmp_path / "settings.gradle.kts", 'rootProject.name = "app"\n')
+    _write(
+        tmp_path / "build.gradle.kts",
+        "plugins {\n    alias(libs.plugins.androidApplication) apply false\n}\n",
+    )
+    for name in ("App", "Main", "Repo", "Model"):
+        _write(tmp_path / f"composeApp/src/commonMain/kotlin/{name}.kt", "class X\n")
+
+    _write(tmp_path / "iosApp/iosApp.xcodeproj/project.pbxproj", "// pbxproj\n")
+    for name in ("ContentView", "iosAppApp", "Theme"):
+        _write(tmp_path / f"iosApp/iosApp/{name}.swift", "import SwiftUI\n")
+
+    disciplines_conf = default_paths().disciplines_conf
+    if not disciplines_conf.exists():
+        pytest.skip("disciplines.conf not installed")
+
+    manifest = build_manifest(tmp_path, kmp_detection, disciplines_conf=disciplines_conf)
+
+    kotlin_files = [
+        f for t in manifest.targets if t.language == "kotlin" for f in t.source_files
+    ]
+    assert len(kotlin_files) == 4
+    assert manifest.total_files == 7
+    assert manifest.language_stats == {".kt": 4, ".swift": 3}
+
+    swift = next(t for t in manifest.targets if t.language == "swift")
+    assert swift.scope_path == "iosApp"
+
+
 def test_monorepo_walk_applies_skip_patterns(tmp_path: Path, detection: dict) -> None:
     """The multi-scope (monorepo) walk honours skip_patterns too."""
     from quodeq.config.paths import default_paths


### PR DESCRIPTION
Fixes the file-loss half of #921.

## Problem

When recursive subproject discovery returns any scope other than the repo root, `build_manifest` takes the multi-scope path and `_walk_and_partition_by_scope` assigns each file to the deepest enclosing scope. Files that no scope owns get `continue`d away.

If nothing classified the repo root, that means **the entire source tree is discarded**. Kotlin Multiplatform is the case I hit: `iosApp/` matches via `*.xcodeproj`, the Gradle/Kotlin root matches nothing, so all 752 `.kt`/`.kts` files are dropped. The 8 `.swift` files then split 2-per-scope across four `iosApp` roots, each below `_MIN_FILES_PER_TARGET`, so zero targets survive:

```json
{"language": "unknown", "total_files": 0, "source_files_count": 0,
 "language_stats": {".swift": 8}, "targets": []}
```

`_list_source_files` returns `[]`, the subagent pool is skipped, the single-agent fallback reads 3 files, and the run exits `0` with `[SUCCESS]` and `performance: 0.0/10`.

It is not only the total-loss case. With 3+ Swift files under `iosApp/`, that repo would have produced a confident Swift-only evaluation of a Kotlin codebase.

## Change

Add `"."` as a catch-all scope in `_build_multi_scope_manifest` when no rule classified the root.

`_deepest_scope` already treats `"."` as depth 0, so it only claims files no more specific scope owns — per-subproject routing is untouched. `_MIN_FILES_PER_TARGET` still keeps a couple of stray root files from becoming a target, which is why the existing `test_build_monorepo_partitions_files_by_subproject` ("files outside any subproject are dropped", one orphan `.py`) passes unchanged.

Also refreshed the now-inaccurate "silently dropped" note in `_walk_and_partition_by_scope`'s docstring.

## Verification

- New regression test `test_monorepo_keeps_source_outside_detected_subprojects` builds a KMP-shaped repo (alias-only `build.gradle.kts`, 4 `.kt` under `composeApp/`, `iosApp.xcodeproj` + 3 `.swift`). Fails on `develop` with `assert 0 == 4`; passes here.
- Against the real repo from #921, `build_manifest` goes from `total_files: 0` to `total_files: 752` (`.kt` 728, `.kts` 24), with the Swift scopes untouched.
- `uv run pytest tests/ -q -m "not integration"` → **5248 passed, 1 skipped**.

Detection of catalog-declared AGP is the other half of #921 and is a separate PR, since either fix alone leaves the repo partly misread.
