### PR TITLE
fix(detection): match Android projects that declare AGP in a version catalog

### DIFF
--- a/src/quodeq/data/config/disciplines.conf
+++ b/src/quodeq/data/config/disciplines.conf
@@ -120,7 +120,7 @@ detect_contains=com.android
 detect_file_alt=build.gradle.kts
 detect_contains_alt=com.android
 detect_file_alt2=gradle/libs.versions.toml
-detect_contains_alt2=com.android.tools.build
+detect_contains_alt2=com.android
 detect_priority=2
 suggested_topics=Kotlin Code Standards,Clean Architecture,SOLID Principles,DDD Principles,Android Engineering Standards,Modern Android Development Standards
 

--- a/tests/fixtures/discipline_corpus/mobile_android_version_catalog/expected.json
+++ b/tests/fixtures/discipline_corpus/mobile_android_version_catalog/expected.json
@@ -1,0 +1,7 @@
+{
+  "matches": [
+    "mobile_android"
+  ],
+  "primary": "mobile_android",
+  "language": "kotlin"
+}

--- a/tests/fixtures/discipline_corpus/mobile_android_version_catalog/repo/build.gradle.kts
+++ b/tests/fixtures/discipline_corpus/mobile_android_version_catalog/repo/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    alias(libs.plugins.kotlinMultiplatform) apply false
+    alias(libs.plugins.androidApplication) apply false
+}

--- a/tests/fixtures/discipline_corpus/mobile_android_version_catalog/repo/composeApp/src/commonMain/kotlin/App.kt
+++ b/tests/fixtures/discipline_corpus/mobile_android_version_catalog/repo/composeApp/src/commonMain/kotlin/App.kt
@@ -1,0 +1,1 @@
+class App

--- a/tests/fixtures/discipline_corpus/mobile_android_version_catalog/repo/gradle/libs.versions.toml
+++ b/tests/fixtures/discipline_corpus/mobile_android_version_catalog/repo/gradle/libs.versions.toml
@@ -1,0 +1,7 @@
+[versions]
+agp = "8.7.3"
+kotlin = "2.1.0"
+
+[plugins]
+androidApplication = { id = "com.android.application", version.ref = "agp" }
+kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }


### PR DESCRIPTION
Fixes the detection half of #921.

## Problem

`mobile_android`'s version-catalog trigger looks for the literal `com.android.tools.build` in `gradle/libs.versions.toml`. Catalogs written the modern way declare the plugin id instead:

```toml
# gradle/libs.versions.toml
androidApplication = { id = "com.android.application", version.ref = "agp" }
```

and the root build file only references it through the alias:

```kotlin
// build.gradle.kts
plugins { alias(libs.plugins.androidApplication) apply false }
```

So none of the three triggers fire — `detect_file` / `detect_file_alt` want a literal `com.android` in the build files, `detect_file_alt2` wants a needle the catalog never contains:

```python
>>> reg.detect_matches(src)                 # KMP wizard output
[]
```

A Kotlin Multiplatform / Compose Multiplatform repo from the KMP wizard is therefore classified as nothing at all, and the evaluation runs without the Android and Kotlin standards it should have loaded.

## Change

Widen `detect_contains_alt2` from `com.android.tools.build` to `com.android`. That still covers the classpath coordinate (`com.android.tools.build:gradle`) and now also the plugin ids (`com.android.application`, `com.android.library`). `libs.versions.toml` has no structured matcher, so this is a plain substring check — `com.android` in a Gradle version catalog is Android by construction.

## Verification

- New corpus fixture `mobile_android_version_catalog` (alias-only `build.gradle.kts`, catalog with `id = "com.android.application"`, one `.kt` file) expecting `mobile_android` / `kotlin`. Fails on `develop`, passes here — confirmed by stashing just the conf change and re-running.
- Existing `mobile_android` fixture (`id 'com.android.application'` in `build.gradle`) and the rest of the 71-fixture corpus unchanged.
- `uv run pytest tests/ -q -m "not integration"` → **5248 passed, 1 skipped**.

Separately worth noting: there is no Kotlin Multiplatform discipline, so a KMP repo lands on `mobile_android` and its shared/iOS source is judged by Android topics. Happy to follow up with a `mobile_kmp` rule if you want one.
