### PR TITLE
fix(scores): stop freezing partial dim sets in the run-dimension cache

### DIFF
--- a/src/quodeq/services/_cache.py
+++ b/src/quodeq/services/_cache.py
@@ -5,6 +5,7 @@ duplicate I/O when multiple threads request the same uncached key.
 """
 from __future__ import annotations
 
+import json
 import logging
 import threading
 from collections import OrderedDict
@@ -34,6 +35,61 @@ class _CacheContext:
     def get_reader(self) -> _Reader:
         """Return the configured reader, defaulting to read_run_data."""
         return self.reader if self.reader is not None else read_run_data
+
+
+# Terminal status.json states, mirroring data/fs/report_parser/runs.py. Any
+# other state means the run's evaluation/ set may still be growing.
+_TERMINAL_RUN_STATES = frozenset({"done", "failed", "cancelled"})
+
+
+def _count_eval_files(reports_root: Path, project: str, run_id: str) -> int:
+    """Count ``evaluation/*.json`` files on disk for a run.
+
+    Used to detect a stale cache: if the cached dim list has a different
+    count from what's currently on disk, the cache is wrong and must be
+    evicted. One ``listdir`` per cached lookup -- cheap.
+    """
+    eval_dir = reports_root / project / run_id / "evaluation"
+    if not eval_dir.is_dir():
+        return 0
+    try:
+        return sum(1 for p in eval_dir.iterdir() if p.suffix == ".json")
+    except OSError:
+        return 0
+
+
+def _run_is_in_progress(reports_root: Path, project: str, run_id: str) -> bool:
+    """True when the run's ``status.json`` reports a non-terminal state.
+
+    A missing or unreadable status.json counts as terminal: legacy runs never
+    wrote one and their data is immutable. The PID-liveness refinement in
+    ``data/fs/report_parser/runs.py`` is deliberately not replicated here -- a
+    run that crashed without flipping its state reads fresh forever, which is
+    the safe direction for a cache guard.
+    """
+    status_path = reports_root / project / run_id / "status.json"
+    if not status_path.is_file():
+        return False
+    try:
+        data = json.loads(status_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    state = data.get("state") if isinstance(data, dict) else None
+    return isinstance(state, str) and state not in _TERMINAL_RUN_STATES
+
+
+def _cached_entry_is_stale(
+    reports_root: Path, project: str, run_id: str, cached: list[DimensionResult],
+) -> bool:
+    """True when the cached dim count disagrees with ``evaluation/*.json`` on disk.
+
+    Anchored on the evaluation/ directory existing: without disk state to
+    compare against (unit tests that pre-seed the cache), the entry is trusted.
+    """
+    eval_dir = reports_root / project / run_id / "evaluation"
+    if not eval_dir.is_dir():
+        return False
+    return len(cached) != _count_eval_files(reports_root, project, run_id)
 
 
 def _fetch_dimensions_from_disk(
@@ -119,6 +175,19 @@ def make_lru_dimension_fetcher(
     that at most one thread performs disk I/O for any given cache key.  Other
     threads that request the same key while I/O is in progress wait on the
     event and then read the result from the cache.
+
+    Self-healing guards (every caller inherits them, so a request landing
+    mid-run can never freeze a partial dim list in the cache):
+
+    1. **On-disk count validation.** A cached entry whose dim count disagrees
+       with the run's ``evaluation/*.json`` count is stale (e.g. it was
+       populated while the run was still writing dims) -- evict and re-read.
+       Only applies when an evaluation/ directory exists on disk; entries
+       pre-seeded without disk state (test stubs) are trusted.
+
+    2. **In-progress bypass.** Runs whose ``status.json`` state is non-terminal
+       have a growing evaluation/ set. Read directly from disk and don't
+       cache, so the next request also reads fresh.
     """
     ctx = _CacheContext(cache=cache, lock=lock, max_size=max_size, reader=reader)
 
@@ -127,7 +196,15 @@ def make_lru_dimension_fetcher(
 
         cached = _cache_lookup(key, ctx)
         if cached is not None:
-            return cached
+            if not _cached_entry_is_stale(reports_root, project, run_id, cached):
+                return cached
+            with ctx.lock:
+                ctx.cache.pop(key, None)
+
+        if _run_is_in_progress(reports_root, project, run_id):
+            return _fetch_dimensions_from_disk(
+                reports_root, project, run_id, ctx.get_reader(),
+            )
 
         with ctx.lock:
             if key in ctx.cache:

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -201,22 +201,6 @@ def _rescore_run_dimensions(
     ]
 
 
-def _count_eval_files(reports_root: Path, project: str, run_id: str) -> int:
-    """Count ``evaluation/*.json`` files on disk for a run.
-
-    Used to detect a stale cache: if the cached dim list has a different
-    count from what's currently on disk, the cache is wrong and must be
-    evicted. One ``listdir`` per cached lookup -- cheap.
-    """
-    eval_dir = reports_root / project / run_id / "evaluation"
-    if not eval_dir.is_dir():
-        return 0
-    try:
-        return sum(1 for p in eval_dir.iterdir() if p.suffix == ".json")
-    except OSError:
-        return 0
-
-
 def _make_status_aware_fetcher(
     reports_root: Path,
     project: str,
@@ -226,48 +210,23 @@ def _make_status_aware_fetcher(
     max_size: int | None = None,
     version: str = "",
 ) -> Callable[[str], list[DimensionResult]]:
-    """Return a fetcher with two self-healing properties on top of the LRU cache.
+    """Return a fetcher that reads in-progress runs fresh, never from cache.
 
-    1. **In-progress bypass.** Runs with status=in_progress have a mutable
-       on-disk evaluation/ set as dims finish. We read directly from disk
-       and don't write to cache, so the next request also reads fresh.
-
-    2. **On-disk count validation for terminal runs.** Even after a run
-       completes, the cache may hold a stale partial dim set -- e.g. if
-       it was populated by a request that fired between dims being scored
-       (a window opened by the BrokenPipe-during-success-log regression
-       PR #481 fixed). On lookup, we count evaluation/*.json files and
-       compare against the cached length. Mismatch -> evict, re-read.
-
-    Cost: one extra ``listdir`` per cached lookup. Cheap (eval/ is small).
+    The base LRU fetcher (``make_lru_dimension_fetcher``) already self-heals:
+    on-disk count validation plus a status.json in-progress bypass. This
+    wrapper adds the richer status from *runs* (``list_runs`` folds in a
+    PID-liveness check that status.json alone can't see), so a run whose
+    process is still alive reads fresh even before its state flips.
     """
-    resolved_cache = cache if cache is not None else _SHARED_RUN_DIM_CACHE
-    resolved_lock = lock if lock is not None else _SHARED_RUN_DIM_LOCK
     cached = _make_run_dimension_fetcher(
         reports_root, project,
-        cache=resolved_cache, lock=resolved_lock, max_size=max_size, version=version,
+        cache=cache, lock=lock, max_size=max_size, version=version,
     )
     status_by_id = {r.run_id: r.status for r in runs}
 
     def fetch(run_id: str) -> list[DimensionResult]:
         if status_by_id.get(run_id) == "in_progress":
             return read_run_data(reports_root, project, run_id)
-        # Validate any cached entry against the on-disk count. If they
-        # disagree, the cache is stale -- evict so the cached() call below
-        # re-reads from disk and re-caches with the correct value. We only
-        # validate when an actual evaluation/ directory exists on disk:
-        # without that anchor we'd evict every test stub that pre-seeds
-        # the cache without creating disk state.
-        key = (reports_root, project, run_id, version)
-        with resolved_lock:
-            cached_dims = resolved_cache.get(key)
-        if cached_dims is not None:
-            eval_dir = reports_root / project / run_id / "evaluation"
-            if eval_dir.is_dir():
-                on_disk = _count_eval_files(reports_root, project, run_id)
-                if len(cached_dims) != on_disk:
-                    with resolved_lock:
-                        resolved_cache.pop(key, None)
         return cached(run_id)
 
     return fetch

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -41,7 +41,15 @@ _BUSY_TIMEOUT_MS = 5000
 # formula to the run's own evidence jsonl (services/evidence_rescore), so
 # scores cached by the prior writer differ for the SAME suppression state and
 # params; this bump rebuilds them on the evidence basis once.
-_CACHE_WRITER_EPOCH = "5"
+# "6": three scoring read paths built their run-dimension fetcher without the
+# staleness guards (in-progress bypass + eval-file-count validation), so a
+# request landing mid-run could freeze a partial dim list in the process LRU;
+# later writes built from it persisted half-rescored accumulated payloads and
+# partial scalar sets whose version hash can never self-invalidate. The guards
+# now live in the shared fetcher and the accumulated writer refuses
+# partial-coverage payloads; this bump rebuilds rows the prior writer may have
+# poisoned.
+_CACHE_WRITER_EPOCH = "6"
 
 # Shared-root isolation seam (Phase 2): when serving read endpoints from a
 # second (shared) clone, the score cache must not mix rows with the local
@@ -405,11 +413,18 @@ def per_run_versions(
 
 def cached_accumulated(
     project: str, version: str, compute: Callable[[], dict],
+    cacheable: Callable[[dict], bool] | None = None,
 ) -> dict:
     """Read-through cache for the accumulated payload.
 
     Hit -> return the deserialized cached payload. Miss (or kill switch / cache
     error) -> call *compute*, cache the result best-effort, return it.
+
+    *cacheable*, when given, is called with the computed result before it is
+    persisted; returning False serves the result without caching it. This lets
+    the caller withhold payloads it knows are incomplete (e.g. a rescore that
+    covered only part of the dimensions), which would otherwise freeze under a
+    version hash that cannot self-invalidate.
     """
     if score_cache_disabled():
         return compute()
@@ -421,6 +436,8 @@ def cached_accumulated(
     except sqlite3.Error:
         return compute()
     result = compute()
+    if cacheable is not None and not cacheable(result):
+        return result
     try:
         with open_score_cache() as conn:
             write_cached_accumulated(conn, project, version, result)

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -479,6 +479,15 @@ def _rescore_runs_by_dimension(
     return rescored_by_dim
 
 
+def _dims_expecting_rescore(dims: list[dict]) -> set[str]:
+    """Dimension keys that carry a source run and therefore expect a rescore."""
+    return {
+        (d.get("dimension") or "").lower()
+        for d in dims
+        if (d.get("dimension") or "") and (d.get("fromRunId") or d.get("runId"))
+    }
+
+
 def _merge_rescored_dims(dims: list[dict], rescored_by_dim: dict[str, dict]) -> list[dict]:
     """Merge rescored data into accumulated dimensions."""
     new_dims = []
@@ -500,34 +509,60 @@ def _merge_rescored_dims(dims: list[dict], rescored_by_dim: dict[str, dict]) -> 
     return new_dims
 
 
+def _rescore_accumulated_with_coverage(
+    accumulated: dict[str, Any],
+    reports_root: Path,
+    project: str,
+    params: ScoringParams = DEFAULT_PARAMS,
+) -> tuple[dict[str, Any], bool]:
+    """Apply rescore to an accumulated response dict (in-place compatible shape).
+
+    Filters dismissed violations from each dimension, recalculates scores,
+    and recomputes the summary.
+
+    Returns ``(payload, complete)``. ``complete`` is False when at least one
+    dimension that has a source run got no rescored entry back (e.g. the run
+    read returned a partial dim set), in which case the missing dimensions
+    keep their raw baked scores and the payload MUST NOT be persisted: its
+    version hash cannot tell it apart from a fully rescored one.
+    """
+    project_dir = reports_root / project
+    dismissed = dismissed_keys(project_dir)
+    deleted = deleted_keys(project_dir)
+    if (not dismissed and not deleted) or not accumulated:
+        return accumulated, True
+
+    dims = accumulated.get("dimensions", [])
+    if not dims:
+        return accumulated, True
+
+    rescored_by_dim = _rescore_runs_by_dimension(
+        dims, reports_root, project, dismissed, deleted, params=params,
+    )
+    missing = _dims_expecting_rescore(dims) - set(rescored_by_dim)
+    if missing:
+        _logger.warning(
+            "accumulated rescore for %s covered %d of %d dimensions (missing: %s); "
+            "serving the partial result without caching it",
+            project, len(rescored_by_dim), len(dims), sorted(missing),
+        )
+    new_dims = _merge_rescored_dims(dims, rescored_by_dim)
+
+    new_summary = recompute_summary(new_dims, accumulated.get("summary", {}), params=params)
+    return {**accumulated, "dimensions": new_dims, "summary": new_summary}, not missing
+
+
 def _rescore_accumulated_response(
     accumulated: dict[str, Any],
     reports_root: Path,
     project: str,
     params: ScoringParams = DEFAULT_PARAMS,
 ) -> dict[str, Any]:
-    """Apply rescore to an accumulated response dict (in-place compatible shape).
-
-    Filters dismissed violations from each dimension, recalculates scores,
-    and recomputes the summary.
-    """
-    project_dir = reports_root / project
-    dismissed = dismissed_keys(project_dir)
-    deleted = deleted_keys(project_dir)
-    if (not dismissed and not deleted) or not accumulated:
-        return accumulated
-
-    dims = accumulated.get("dimensions", [])
-    if not dims:
-        return accumulated
-
-    rescored_by_dim = _rescore_runs_by_dimension(
-        dims, reports_root, project, dismissed, deleted, params=params,
+    """`_rescore_accumulated_with_coverage` for callers that don't persist."""
+    payload, _complete = _rescore_accumulated_with_coverage(
+        accumulated, reports_root, project, params=params,
     )
-    new_dims = _merge_rescored_dims(dims, rescored_by_dim)
-
-    new_summary = recompute_summary(new_dims, accumulated.get("summary", {}), params=params)
-    return {**accumulated, "dimensions": new_dims, "summary": new_summary}
+    return payload
 
 
 def rescore_accumulated(
@@ -579,12 +614,21 @@ def get_project_scores(
             "availableRuns": [],
         }
 
-    # Build accumulated using the existing service (returns full data with violations)
+    # Build accumulated using the existing service (returns full data with
+    # violations). The rescore-coverage flag rides in a cell so the cacheable
+    # gate below can see it: a payload whose rescore missed dimensions must be
+    # served but never persisted (its version hash can't self-invalidate).
+    rescore_complete = [True]
+
     def _compute_accumulated_payload() -> dict:
         acc = compute_accumulated(str(reports_root), project, as_of, params=params)
         if acc is None:
             acc = {"dimensions": [], "summary": {}}
-        return _rescore_accumulated_response(acc, reports_root, project, params=params)
+        payload, complete = _rescore_accumulated_with_coverage(
+            acc, reports_root, project, params=params,
+        )
+        rescore_complete[0] = complete
+        return payload
 
     if find_children(reports_root, project):
         # Parent aggregation pulls child projects' dismissals/runs into the
@@ -598,7 +642,10 @@ def get_project_scores(
                              [(r.run_id, r.status) for r in all_runs]),
             as_of,
         )
-        accumulated = cached_accumulated(project, acc_version, _compute_accumulated_payload)
+        accumulated = cached_accumulated(
+            project, acc_version, _compute_accumulated_payload,
+            cacheable=lambda _payload: rescore_complete[0],
+        )
 
     # Build trend using the appropriate fetcher: scalar fast path when there
     # are no active dismissals/deletions, rescoring (findings) path otherwise.

--- a/tests/services/scoring/test_rescore_coverage.py
+++ b/tests/services/scoring/test_rescore_coverage.py
@@ -1,0 +1,89 @@
+"""Rescore coverage: a partial rescore must be flagged so it is never persisted.
+
+Regression: `_rescore_runs_by_dimension` silently treats a dimension missing
+from the run read as "keep the raw score". When the run-dimension fetcher
+served a partial dim list (1 of 6 dims frozen in the process LRU mid-run),
+only that one dimension was rescored, and the half-rescored accumulated
+payload was cached under a version hash identical to the complete payload's,
+so the Overview served raw baked scores forever while the detail pages showed
+the dismiss-adjusted ones.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import quodeq.services.scoring as scoring
+from quodeq.services.scoring import (
+    _dims_expecting_rescore,
+    _rescore_accumulated_with_coverage,
+)
+
+
+def _acc(dims):
+    return {"project": "proj", "dimensions": dims, "summary": {}}
+
+
+def _dim(name, run_id="r1", score="5.0/10"):
+    return {"dimension": name, "runId": run_id, "overallScore": score}
+
+
+def test_dims_expecting_rescore_needs_a_source_run():
+    dims = [
+        _dim("security"),
+        {"dimension": "performance"},  # no runId -> nothing to rescore from
+        {"dimension": "", "runId": "r1"},
+    ]
+    assert _dims_expecting_rescore(dims) == {"security"}
+
+
+def test_no_suppressions_is_complete(monkeypatch):
+    monkeypatch.setattr(scoring, "dismissed_keys", lambda pdir: set())
+    monkeypatch.setattr(scoring, "deleted_keys", lambda pdir: set())
+    payload, complete = _rescore_accumulated_with_coverage(
+        _acc([_dim("security")]), Path("/reports"), "proj",
+    )
+    assert complete is True
+    assert payload["dimensions"] == [_dim("security")]
+
+
+def test_full_coverage_is_complete(monkeypatch):
+    monkeypatch.setattr(scoring, "dismissed_keys", lambda pdir: {("R1", "a.py", 1)})
+    monkeypatch.setattr(scoring, "deleted_keys", lambda pdir: set())
+    monkeypatch.setattr(
+        scoring, "_rescore_runs_by_dimension",
+        lambda dims, root, project, dismissed, deleted=None, params=None: {
+            "security": {"overallScore": "7.5/10", "overallGrade": "Good"},
+            "performance": {"overallScore": "8.2/10", "overallGrade": "Good"},
+        },
+    )
+    monkeypatch.setattr(
+        scoring, "recompute_summary", lambda dims, summary, params=None: summary,
+    )
+    payload, complete = _rescore_accumulated_with_coverage(
+        _acc([_dim("security"), _dim("performance")]), Path("/reports"), "proj",
+    )
+    assert complete is True
+    assert payload["dimensions"][0]["overallScore"] == "7.5/10"
+    assert payload["dimensions"][1]["overallScore"] == "8.2/10"
+
+
+def test_partial_coverage_is_flagged_incomplete(monkeypatch):
+    """Rescore came back for security only: serve it, but flag it uncacheable."""
+    monkeypatch.setattr(scoring, "dismissed_keys", lambda pdir: {("R1", "a.py", 1)})
+    monkeypatch.setattr(scoring, "deleted_keys", lambda pdir: set())
+    monkeypatch.setattr(
+        scoring, "_rescore_runs_by_dimension",
+        lambda dims, root, project, dismissed, deleted=None, params=None: {
+            "security": {"overallScore": "7.5/10", "overallGrade": "Good"},
+        },
+    )
+    monkeypatch.setattr(
+        scoring, "recompute_summary", lambda dims, summary, params=None: summary,
+    )
+    payload, complete = _rescore_accumulated_with_coverage(
+        _acc([_dim("security"), _dim("performance")]), Path("/reports"), "proj",
+    )
+    assert complete is False
+    # The payload is still the best available answer for THIS request.
+    assert payload["dimensions"][0]["overallScore"] == "7.5/10"
+    assert payload["dimensions"][1]["overallScore"] == "5.0/10"  # raw kept

--- a/tests/services/test_cache.py
+++ b/tests/services/test_cache.py
@@ -216,6 +216,103 @@ class TestMakeLruDimensionFetcher:
         assert call_count["n"] == 1
 
 
+# ---------------------------------------------------------------------------
+# Self-healing guards: every caller inherits them from the base factory
+# ---------------------------------------------------------------------------
+
+
+def _write_eval_files(tmp_path: Path, run_id: str, dims: tuple[str, ...]) -> None:
+    eval_dir = tmp_path / "proj" / run_id / "evaluation"
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    for d in dims:
+        (eval_dir / f"{d}.json").write_text("{}", encoding="utf-8")
+
+
+def _write_status(tmp_path: Path, run_id: str, state: str) -> None:
+    run_dir = tmp_path / "proj" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "status.json").write_text(f'{{"state": "{state}"}}', encoding="utf-8")
+
+
+class TestSelfHealingGuards:
+    """A request landing mid-run must never freeze a partial dim list.
+
+    Regression: three scoring read paths built this fetcher without the
+    dashboard's staleness guards, so a /scores request that fired while only
+    security.json was on disk froze a 1-dim entry in the shared process LRU;
+    after the run completed, the accumulated rescore read that entry, rescored
+    only security, and persisted the half-rescored payload forever.
+    """
+
+    def test_stale_entry_evicted_when_disk_count_differs(self, tmp_path):
+        _write_eval_files(tmp_path, "r1", ("flexibility", "reliability", "security"))
+        full = [_make_dim("flexibility"), _make_dim("reliability"), _make_dim("security")]
+        reader_calls = []
+
+        def reader(reports_root, project, run_id):
+            reader_calls.append(run_id)
+            return full
+
+        cache = OrderedDict()
+        # Poisoned entry: cached while only 1 of 3 dims was on disk.
+        cache[(tmp_path, "proj", "r1", "")] = [_make_dim("security")]
+        fetcher = make_lru_dimension_fetcher(
+            tmp_path, "proj", cache, threading.Lock(), 10, reader=reader,
+        )
+
+        result = fetcher("r1")
+        assert len(result) == 3
+        assert reader_calls == ["r1"]
+        # The healed entry is cached; no further reads.
+        assert len(fetcher("r1")) == 3
+        assert reader_calls == ["r1"]
+
+    def test_entry_without_disk_anchor_is_trusted(self, tmp_path):
+        """No evaluation/ dir on disk (test stubs, mocked paths) -> no eviction."""
+        cache = OrderedDict()
+        seeded = [_make_dim("security")]
+        cache[(tmp_path, "proj", "r1", "")] = seeded
+        fetcher = make_lru_dimension_fetcher(
+            tmp_path, "proj", cache, threading.Lock(), 10,
+            reader=lambda *a: pytest.fail("reader must not run on a trusted hit"),
+        )
+        assert fetcher("r1") is seeded
+
+    def test_in_progress_run_reads_fresh_and_is_not_cached(self, tmp_path):
+        _write_status(tmp_path, "r1", "running")
+        _write_eval_files(tmp_path, "r1", ("security",))
+        reader_calls = []
+
+        def reader(reports_root, project, run_id):
+            reader_calls.append(run_id)
+            return [_make_dim("security")]
+
+        cache = OrderedDict()
+        fetcher = make_lru_dimension_fetcher(
+            tmp_path, "proj", cache, threading.Lock(), 10, reader=reader,
+        )
+        fetcher("r1")
+        fetcher("r1")
+        assert reader_calls == ["r1", "r1"]  # disk read both times
+        assert cache == {}  # nothing frozen mid-run
+
+    def test_terminal_run_is_cached(self, tmp_path):
+        _write_status(tmp_path, "r1", "done")
+        _write_eval_files(tmp_path, "r1", ("security",))
+        reader_calls = []
+
+        def reader(reports_root, project, run_id):
+            reader_calls.append(run_id)
+            return [_make_dim("security")]
+
+        fetcher = make_lru_dimension_fetcher(
+            tmp_path, "proj", OrderedDict(), threading.Lock(), 10, reader=reader,
+        )
+        fetcher("r1")
+        fetcher("r1")
+        assert reader_calls == ["r1"]  # second call served from cache
+
+
 def test_make_lru_dimension_fetcher_uses_custom_reader():
     """A custom reader is invoked instead of read_run_data, and results cache."""
     import threading

--- a/tests/services/test_dashboard.py
+++ b/tests/services/test_dashboard.py
@@ -505,7 +505,7 @@ class TestStaleCacheSelfHeal:
     """
 
     def test_count_eval_files_counts_json_only(self, tmp_path):
-        from quodeq.services.dashboard import _count_eval_files
+        from quodeq.services._cache import _count_eval_files
 
         eval_dir = tmp_path / "proj" / "r1" / "evaluation"
         eval_dir.mkdir(parents=True)
@@ -518,7 +518,7 @@ class TestStaleCacheSelfHeal:
         assert _count_eval_files(tmp_path, "proj", "r1") == 3
 
     def test_count_returns_zero_when_eval_dir_missing(self, tmp_path):
-        from quodeq.services.dashboard import _count_eval_files
+        from quodeq.services._cache import _count_eval_files
         assert _count_eval_files(tmp_path, "proj", "missing") == 0
 
     def test_stale_cache_evicted_when_dim_count_mismatches_disk(

--- a/tests/services/test_score_cache_accumulated_helper.py
+++ b/tests/services/test_score_cache_accumulated_helper.py
@@ -93,6 +93,42 @@ def test_per_run_versions_does_not_persist_in_progress_keys(tmp_path, monkeypatc
         assert "r2" in load_run_keys(conn, "proj")  # terminal run persisted
 
 
+def test_cached_accumulated_not_cacheable_serves_without_persisting(tmp_path, monkeypatch):
+    """A payload the caller flags as incomplete must be served but never written.
+
+    Regression: a rescore built from a partial run read (1 of 6 dims in the
+    process LRU) was persisted under a version hash identical to the complete
+    payload's, so the half-rescored row was a permanent cache hit.
+    """
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    calls = []
+    def compute():
+        calls.append(1)
+        return {"dimensions": [], "summary": {"partial": True}}
+    r1 = cached_accumulated("proj", "v1", compute, cacheable=lambda _p: False)
+    assert r1 == {"dimensions": [], "summary": {"partial": True}}
+    # Same version misses again: nothing was persisted.
+    r2 = cached_accumulated("proj", "v1", compute, cacheable=lambda _p: False)
+    assert r2 == r1
+    assert calls == [1, 1]
+
+
+def test_cached_accumulated_cacheable_true_persists(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    calls = []
+    def compute():
+        calls.append(1)
+        return {"dimensions": [], "summary": {"x": 1}}
+    cached_accumulated("proj", "v1", compute, cacheable=lambda _p: True)
+    r2 = cached_accumulated(
+        "proj", "v1",
+        lambda: (_ for _ in ()).throw(AssertionError("recomputed on hit")),
+        cacheable=lambda _p: True,
+    )
+    assert r2 == {"dimensions": [], "summary": {"x": 1}}
+    assert calls == [1]
+
+
 def test_cached_accumulated_kill_switch(tmp_path, monkeypatch):
     monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
     monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")


### PR DESCRIPTION
A /scores request landing mid-run could cache a partial dim list (e.g. 1 of 6) in the shared process LRU: three scoring read paths built their fetcher without the staleness guards the dashboard already had. After the run completed, the accumulated rescore read that entry, rescored only the covered dimension, and persisted the half-rescored payload under a version hash identical to the correct one. Result: the Overview served raw baked scores forever while the dimension detail pages showed the dismiss-adjusted ones.

## Changes

- Push both guards into `make_lru_dimension_fetcher` so every caller inherits them: evict cached entries whose dim count disagrees with `evaluation/*.json` on disk, and read runs with a non-terminal `status.json` fresh without caching. The dashboard wrapper keeps only its PID-liveness in-progress bypass.
- Refuse to persist a partial rescore: `_rescore_accumulated_with_coverage` reports whether every dimension with a source run got rescored, and `cached_accumulated` skips the write when it did not.
- Bump the cache writer epoch to 6 so rows poisoned by prior writers (accumulated payloads, trend scalars, project summaries) rebuild once on deploy, no manual cache surgery needed.

## Tests

New: partial-entry self-heal, in-progress bypass, and trusted-stub cases in `test_cache.py`; rescore coverage flag in `test_rescore_coverage.py`; cacheable gate in `test_score_cache_accumulated_helper.py`. Suites `tests/services`, `tests/api`, `tests/tools` green (1895 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)