### PR TITLE
fix(terminal): open clicked links via the pywebview bridge, not window.open

### DIFF
--- a/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
@@ -294,6 +294,33 @@ it('copy button copies the active session selection to the clipboard', async () 
   expect(writeText).toHaveBeenCalledWith('picked text');
 });
 
+// OSC 8 hyperlinks are activated by xterm itself. Without an explicit
+// linkHandler xterm uses its built-in one, which confirms and then calls
+// window.open() with no URL — null inside pywebview's WKWebView, so clicking OK
+// did nothing. The handler must reach the pywebview bridge instead.
+it('routes OSC 8 hyperlink clicks through the pywebview bridge, not window.open', async () => {
+  const { Terminal } = await import('@xterm/xterm');
+  Terminal.mockClear();
+  const open_browser = vi.fn();
+  window.pywebview = { api: { open_browser } };
+  const windowOpen = vi.spyOn(window, 'open').mockReturnValue(null);
+  try {
+    render(<TerminalPane active />);
+    await screen.findByTestId('tty-root');
+    await waitFor(() => expect(Terminal).toHaveBeenCalled());
+
+    const { linkHandler } = Terminal.mock.calls[0][0];
+    expect(linkHandler).toBeTruthy();
+    linkHandler.activate({}, 'https://example.com/release');
+
+    expect(open_browser).toHaveBeenCalledWith('https://example.com/release');
+    expect(windowOpen).not.toHaveBeenCalled();
+  } finally {
+    windowOpen.mockRestore();
+    delete window.pywebview;
+  }
+});
+
 it('shows shell, session count, sandbox note and active cwd in the status bar', async () => {
   render(<TerminalPane active />);
   await screen.findByTestId('tty-root');

--- a/src/quodeq/ui/src/features/terminal/TerminalSessionView.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalSessionView.jsx
@@ -6,6 +6,7 @@ import { useTerminalSocket } from './useTerminalSocket.js';
 import { resolveTerminalPaths, openInEditor } from '../../api/terminal.js';
 import { createUrlLinkProvider, createFileLinkProvider } from './terminalLinks.js';
 import { themeFromCss } from './xtermTheme.js';
+import { openExternal } from '../updates/openExternal.js';
 
 // Two drawer chords are reserved for the host; return false so xterm lets them
 // bubble to the window handler instead of typing into the shell.
@@ -125,6 +126,13 @@ export default function TerminalSessionView({ sessionId, active, live, onGone, r
         cursorBlink: true,
         cursorStyle: 'bar',     // sleeker than the default square block
         theme: themeFromCss(),
+        // OSC 8 hyperlinks (emitted by gh, npm, coding CLIs…) are handled by
+        // xterm itself, not by our link providers below. Without a linkHandler
+        // xterm falls back to its built-in one, which confirms and then calls
+        // window.open() with no URL — and window.open always returns null
+        // inside pywebview's WKWebView, so clicking OK does nothing at all.
+        // Route them through openExternal, which prefers the pywebview bridge.
+        linkHandler: { activate: (_event, uri) => openExternal(uri) },
       });
       const fit = new FitAddon();
       term.loadAddon(fit);
@@ -142,7 +150,9 @@ export default function TerminalSessionView({ sessionId, active, live, onGone, r
       linkProviders.push(
         term.registerLinkProvider(createUrlLinkProvider({
           readLine,
-          openUrl: (url) => window.open(url, '_blank', 'noopener,noreferrer'),
+          // Not window.open: it returns null in the desktop app's WKWebView,
+          // so a cmd-clicked URL silently did nothing there.
+          openUrl: (url) => openExternal(url),
         })),
         term.registerLinkProvider(createFileLinkProvider({
           readLine,


### PR DESCRIPTION
Fixes #925.

## Problem

Clicking a hyperlink in the terminal pane of the desktop app pops xterm's confirmation ("Do you want to navigate to `<url>`? WARNING: This link could potentially be dangerous") and then **nothing happens when you click OK**.

That dialog is xterm's built-in OSC 8 handler, used only when no `linkHandler` is supplied — and `TerminalSessionView.jsx` supplies none, so every OSC 8 hyperlink (from `gh`, `npm`, coding CLIs) lands there:

```js
let w = window.open();          // no URL
if (w) { w.opener = null; w.location.href = uri }
else console.warn('Opening link blocked as opener could not be cleared')
```

In the desktop app that always takes the `else`: pywebview's Cocoa delegate returns `nil` from `webView_createWebViewWithConfiguration_forNavigationAction_windowFeatures_` (`webview/platforms/cocoa.py:261`), and a JS-initiated `window.open()` isn't `WKNavigationTypeLinkActivated`, so it never reaches that delegate's `webbrowser.open` branch either. Measured in a pywebview window:

```
window.open()                     -> null
window.open(url,'_blank',...)     -> null
window.pywebview.api available    -> True
```

The pane's two `registerLinkProvider` calls don't cover this — they're the regex URL/path providers, a separate mechanism from OSC 8.

## Change

- Pass `linkHandler: { activate: (_event, uri) => openExternal(uri) }` to `new Terminal(...)`, so OSC 8 links go through the pywebview bridge (`window.pywebview.api.open_browser`, exactly how the update banner already works) and xterm's confirm-then-`window.open` default never runs. `openExternal` keeps the http/https-only guard.
- Switch the URL provider's `openUrl` from `window.open(url, '_blank', 'noopener,noreferrer')` to `openExternal` as well. Same `null`, second symptom: cmd-clicking a plain `https://…` URL in the terminal was equally dead in the desktop app, with no dialog to hint at it.

Cross-feature import of `features/updates/openExternal.js` follows the existing precedent (e.g. `features/settings/server-log/ServerLogProvider.jsx` importing from `features/evaluation` and `features/side-pane`). Happy to lift it to `src/utils/` instead if you'd rather it live there now that a second feature uses it.

## Verification

- New test `routes OSC 8 hyperlink clicks through the pywebview bridge, not window.open` asserts the handler calls `pywebview.api.open_browser` with the URI and never `window.open`. Fails on `develop` (`expected undefined to be truthy` — no `linkHandler`), passes here.
- `npx vitest run` → **1468 passed** (178 files); `npm test` (`node --test`) → **381 passed**.

Not covered by automated tests: the actual click inside a native WKWebView window. The `window.open() === null` premise the fix rests on was verified directly in a pywebview window (numbers above); the end-to-end click still wants a manual smoke on a desktop build.
