### PR TITLE
feat(cache): show a cancelled run's replayed findings as new

### DIFF
--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -593,16 +593,25 @@ def run_evaluate(args: argparse.Namespace) -> int:
             _cleanup_worktree(worktree_origin, worktree_dir)
         raise
     result = _run_pipeline_with_cleanup(args, inputs, paths)
+    _, _evidence_dir, evaluation_dir = paths
+    # --diff-from / --evidence-only produce no scored reports: nothing to
+    # export and nothing consolidated into the Overview.
+    no_scored_reports = bool(
+        getattr(args, "diff_from", None) or getattr(args, "evidence_only", False)
+    )
+    # Fail-soft consolidation pass, OUTSIDE the run lifecycle (it has fully
+    # closed by now), so a failure here can never flip the run state. Marks
+    # this run's cache entries consolidated so the NEXT run replays their
+    # findings as carried forward. Gated internally on status.json reading
+    # "done", which is why a run cancelled with "keep findings", a failed
+    # run, and a killed process all leave their entries unconsolidated and
+    # their findings still read as new in the live feed.
+    if not no_scored_reports:
+        from quodeq.analysis.cache.consolidation import mark_run_consolidated
+        mark_run_consolidated(evaluation_dir.parent)
     # Fail-soft SARIF export, OUTSIDE the run lifecycle (it has fully closed by
     # now), only on success and only when scored reports exist. A SARIF error
-    # here can never flip the run state. --diff-from / --evidence-only produce
-    # no scored reports, so skip them.
-    if (
-        result == 0
-        and getattr(args, "sarif", None)
-        and not getattr(args, "diff_from", None)
-        and not getattr(args, "evidence_only", False)
-    ):
-        _, _evidence_dir, evaluation_dir = paths
+    # here can never flip the run state.
+    if result == 0 and getattr(args, "sarif", None) and not no_scored_reports:
         _write_sarif_if_requested(args, evaluation_dir)
     return result

--- a/src/quodeq/analysis/cache/cache_writer.py
+++ b/src/quodeq/analysis/cache/cache_writer.py
@@ -117,6 +117,9 @@ def build_cache_writer(
                 standards_hash=standards_hash, version=version,
                 effective_params=effective_params,
             ),
+            # Born unconsolidated: no completed run has these findings in its
+            # report yet. mark_run_consolidated flips it when this run ends done.
+            consolidated=False,
         )
         cache.put(key, entry)
 

--- a/src/quodeq/analysis/cache/consolidation.py
+++ b/src/quodeq/analysis/cache/consolidation.py
@@ -1,0 +1,111 @@
+"""Consolidation state — flip a completed run's cache entries.
+
+A cache entry is written ``consolidated=False``: the findings it holds have
+not reached any completed run's report yet. Once a run reaches ``done``,
+everything it dispatched and every unconsolidated entry it replayed IS in a
+completed run's report, so those entries flip to ``consolidated=True`` and
+later runs replay their findings as carried forward.
+
+Runs that end any other way, cancelled with "keep findings", failed, or
+killed, simply never call this. That inversion is the design: not running is
+the only thing a dead process can reliably do.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from quodeq.analysis.cache.backend import CacheBackend
+
+_logger = logging.getLogger(__name__)
+
+# Both sidecars a run leaves behind, each mapping file path -> cache key.
+# dispatch_keys holds what the run produced; replayed_unconsolidated_keys
+# holds entries from an earlier unfinished run that this run replayed and
+# has now put in its own report.
+_SIDECAR_PATTERNS = (
+    "*_dispatch_keys.json",
+    "*_replayed_unconsolidated_keys.json",
+)
+
+
+def _run_reached_done(run_dir: Path) -> bool:
+    """True only when the run's recorded state is ``done``.
+
+    Reading the recorded state rather than trusting an exit code keeps this
+    on the same source of truth the Overview uses, so the two cannot drift.
+    A missing or corrupt status is not done.
+    """
+    try:
+        data = json.loads((run_dir / "status.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    return isinstance(data, dict) and data.get("state") == "done"
+
+
+def _collect_keys(evidence_dir: Path) -> set[str]:
+    """Every cache key this run touched, from both sidecar families.
+
+    An unreadable sidecar is logged and skipped so one bad file cannot cost
+    the run its whole consolidation pass.
+    """
+    keys: set[str] = set()
+    for pattern in _SIDECAR_PATTERNS:
+        for sidecar in evidence_dir.glob(pattern):
+            try:
+                data = json.loads(sidecar.read_text(encoding="utf-8"))
+            except (OSError, ValueError) as exc:
+                _logger.warning("Could not read sidecar %s: %s", sidecar, exc)
+                continue
+            if isinstance(data, dict):
+                keys.update(str(value) for value in data.values())
+    return keys
+
+
+def mark_run_consolidated(
+    run_dir: Path, cache: CacheBackend | None = None,
+) -> None:
+    """Flip this run's cache entries to consolidated, if it reached done.
+
+    Fail-soft in every direction. A non-done run, a missing run dir, an
+    unreadable sidecar, a key with no entry, or a backend that raises all
+    leave the cache as it was. Callers invoke this OUTSIDE the run lifecycle
+    so a failure here can never flip a done run to failed.
+
+    Self-healing: entries missed by a partial pass are replayed as
+    unconsolidated hits by the next run, land in that run's replayed-keys
+    sidecar, and flip when it completes. There is no repair path to run and
+    no stuck state to recover from.
+    """
+    try:
+        if not _run_reached_done(run_dir):
+            return
+        evidence_dir = run_dir / "evidence"
+        if not evidence_dir.is_dir():
+            return
+        keys = _collect_keys(evidence_dir)
+        if not keys:
+            return
+        if cache is None:
+            from quodeq.analysis.cache.local import LocalFileBackend  # noqa: PLC0415
+            cache = LocalFileBackend()
+        flipped = 0
+        for key in sorted(keys):
+            try:
+                entry = cache.get(key)
+                if entry is None or entry.consolidated:
+                    continue
+                entry.consolidated = True
+                cache.put(key, entry)
+                flipped += 1
+            except Exception as exc:  # noqa: BLE001 — one bad entry must not stop the rest
+                _logger.warning("Could not consolidate cache entry %s: %s", key, exc)
+        _logger.info(
+            "cache: consolidated %d entries for run %s", flipped, run_dir.name,
+        )
+    except Exception:  # noqa: BLE001 — post-scan side effect, never propagates
+        _logger.warning(
+            "Consolidation pass failed for %s (evaluation results are safe)",
+            run_dir, exc_info=True,
+        )

--- a/src/quodeq/analysis/cache/dimension_helpers.py
+++ b/src/quodeq/analysis/cache/dimension_helpers.py
@@ -323,5 +323,8 @@ def persist_dispatch_results(
                 standards_hash=standards_hash, version=version,
                 effective_params=effective_params,
             ),
+            # Born unconsolidated: no completed run has these findings in its
+            # report yet. mark_run_consolidated flips it when this run ends done.
+            consolidated=False,
         )
         cache.put(key, entry)

--- a/src/quodeq/analysis/cache/dimension_helpers.py
+++ b/src/quodeq/analysis/cache/dimension_helpers.py
@@ -71,6 +71,15 @@ class ClassifyResult:
     # many reused findings predate the current model / standards / prompts,
     # so reuse across those boundaries is never silent.
     provenance_drift: dict = field(default_factory=dict)
+    # Hits from entries no COMPLETED run has consolidated yet: the producing
+    # run was cancelled with "keep findings", failed, or was killed, so the
+    # user was never shown these findings in an Overview. Kept apart from
+    # cached_findings so the replay path leaves them unstamped and the live
+    # feed shows them as this scan's own.
+    unconsolidated_findings: list[dict] = field(default_factory=list)
+    # file -> cache key for those same entries, so a run that reaches done
+    # can flip them to consolidated.
+    unconsolidated_hit_keys: dict[str, str] = field(default_factory=dict)
 
 
 # Provenance fields compared at classify time, in display order.
@@ -216,6 +225,8 @@ def classify_files_via_cache(
     misses: list[str] = []
     miss_keys: dict[str, str] = {}
     provenance_drift: dict = {}
+    unconsolidated_findings: list[dict] = []
+    unconsolidated_hit_keys: dict[str, str] = {}
     current_prov: dict | None = None  # computed lazily, only if there are hits
     for f in files:
         key = build_cache_key_for_file(config, f, dimension)
@@ -224,7 +235,11 @@ def classify_files_via_cache(
             misses.append(f)
             miss_keys[f] = key
         else:
-            cached_findings.extend(hit.findings)
+            if hit.consolidated:
+                cached_findings.extend(hit.findings)
+            else:
+                unconsolidated_findings.extend(hit.findings)
+                unconsolidated_hit_keys[f] = key
             if current_prov is None:
                 current_prov = _current_provenance(config, dimension)
             _accumulate_drift(provenance_drift, hit.provenance or {}, current_prov)
@@ -233,6 +248,8 @@ def classify_files_via_cache(
         misses=misses,
         miss_keys=miss_keys,
         provenance_drift=provenance_drift,
+        unconsolidated_findings=unconsolidated_findings,
+        unconsolidated_hit_keys=unconsolidated_hit_keys,
     )
     if not bypass_reads and run_cache is not None:
         run_cache[dimension] = (files_tuple, result)

--- a/src/quodeq/analysis/cache/dimension_helpers.py
+++ b/src/quodeq/analysis/cache/dimension_helpers.py
@@ -342,6 +342,15 @@ def persist_dispatch_results(
             ),
             # Born unconsolidated: no completed run has these findings in its
             # report yet. mark_run_consolidated flips it when this run ends done.
+            #
+            # Accepted race: two concurrent runs on one project can both treat
+            # file X as a miss. If run A reaches done and flips X to
+            # consolidated, run B's periodic-persist watcher can then rewrite
+            # X here with consolidated=False. If B is later cancelled, X reads
+            # as unconsolidated even though A already put those findings in a
+            # completed Overview, so the next run surfaces them as "new" once.
+            # Cosmetic, requires concurrent runs on one project, and
+            # self-heals on the next done run. Not fixing.
             consolidated=False,
         )
         cache.put(key, entry)

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -143,8 +143,8 @@ def _compute_files_read(
     this run ends.
 
     A source file is "reproducible" if either:
-      - it was a cache hit (``classify.cached_findings`` already carried it
-        forward — its cache entry already exists), or
+      - it was a cache hit (the file was replayed from a cache entry,
+        consolidated or not — its cache entry already exists), or
       - it was dispatched and the worker emitted ``file_done="ok"``
         (which triggers a synchronous cache write via
         ``build_cache_writer``, or the watcher's next persist tick).

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -196,7 +196,24 @@ def _emit_cached_findings(events_log: Path, findings: list[dict]) -> None:
 def _write_findings(
     jsonl: Path, findings: list[dict], *, append: bool,
     emit_events: bool = True,
+    unconsolidated: list[dict] | None = None,
 ) -> None:
+    """Replay cached findings into this run's evidence JSONL.
+
+    *findings* come from consolidated cache entries: a completed run already
+    put them in its report and the user has seen them in an Overview. Those
+    are stamped ``carried_forward`` so the live feed can hide them.
+
+    *unconsolidated* come from entries no completed run has consolidated yet,
+    because the run that produced them was cancelled with "keep findings",
+    failed, or was killed. The user was never shown those in an Overview, so
+    they are written verbatim and read as this scan's own findings.
+
+    Both groups are re-gated and both are mirrored to events.jsonl. Skipping
+    the unconsolidated group in the event log would resurrect the UI-vs-CLI
+    score disagreement that _emit_cached_findings exists to prevent.
+    """
+    pending = list(unconsolidated or [])
     # Re-gate cached findings on the replay path (issue #657). The live
     # finding path gates in FindingEnricher.enrich(); cache replay bypasses
     # enrich(), so a stale, un-gated critical R-FT-2/S-AUT-3 finding written
@@ -206,6 +223,8 @@ def _write_findings(
     # safe to apply unconditionally to every cached finding.
     for finding in findings:
         apply_provenance_gate(finding)
+    for finding in pending:
+        apply_provenance_gate(finding)
     # Every caller of this function is a cache replay -- the dispatcher
     # writes its own fresh findings and never comes through here. Stamp the
     # origin so the live evaluation feed can show only what this scan is
@@ -214,7 +233,11 @@ def _write_findings(
     # Copy, do not mutate: these dicts are owned by the cache entries, and
     # the periodic-persist watcher could otherwise write the flag back into
     # the cache, making a later fresh scan of the same file look carried.
+    #
+    # Consolidated first, then unconsolidated, so the JSONL keeps reading
+    # foundation-then-new.
     stamped = [{**finding, "carried_forward": True} for finding in findings]
+    stamped += [dict(finding) for finding in pending]
     jsonl.parent.mkdir(parents=True, exist_ok=True)
     mode = "a" if append else "w"
     with jsonl.open(mode, encoding="utf-8") as out:
@@ -304,7 +327,10 @@ def process_dimension_with_cache(
     # Dedup runs after to handle any overlap from a same-run repeat.
     if not classify.misses:
         from quodeq.analysis.subagents.jsonl_utils import deduplicate_jsonl
-        _write_findings(jsonl, classify.cached_findings, append=True)
+        _write_findings(
+            jsonl, classify.cached_findings, append=True,
+            unconsolidated=classify.unconsolidated_findings,
+        )
         if jsonl.exists():
             deduplicate_jsonl(jsonl)
         return parse_evidence_from_jsonl(
@@ -327,8 +353,14 @@ def process_dimension_with_cache(
     #     ONE final "Deduplicated ...: N unique findings" log line. Pre-fix
     #     the user saw two confusing counts -- "27 unique" (dispatch only)
     #     followed by "55 unique" (after we appended cached findings).
-    if classify.cached_findings:
-        _write_findings(jsonl, classify.cached_findings, append=True)
+    # A dimension whose every hit is unconsolidated has an EMPTY
+    # cached_findings, so guarding on that alone would skip this write and
+    # silently drop those findings from the run.
+    if classify.cached_findings or classify.unconsolidated_findings:
+        _write_findings(
+            jsonl, classify.cached_findings, append=True,
+            unconsolidated=classify.unconsolidated_findings,
+        )
 
     # Persist the per-file cache keys to a sidecar so the discard path can
     # locate this dim's V2 cache entries even after the process exits. Without
@@ -429,7 +461,12 @@ def process_dimension_with_cache(
         # watcher, so any partial completion is preserved. If we have
         # cached findings already in the JSONL (pre-written above), parse
         # them so the run still has SOMETHING to score; otherwise None.
-        if classify.cached_findings and jsonl.exists():
+        # Both replay groups count: an all-unconsolidated dimension has
+        # findings in the JSONL even though cached_findings is empty.
+        replayed_anything = bool(
+            classify.cached_findings or classify.unconsolidated_findings
+        )
+        if replayed_anything and jsonl.exists():
             return parse_evidence_from_jsonl(
                 config, dim_id, ctx, jsonl,
                 files_read=_compute_files_read(classify, jsonl, files),

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -116,6 +116,26 @@ def _jsonl_path(config: RunConfig, dim_id: str) -> Path:
     return _evidence_dir(config) / f"{dim_id}_evidence.jsonl"
 
 
+def _write_replayed_keys_sidecar(
+    config: RunConfig, dim_id: str, keys: dict[str, str],
+) -> None:
+    """Record which unconsolidated cache entries this dim replayed.
+
+    A run that reaches ``done`` consolidates not only the entries it wrote
+    but the unconsolidated ones it replayed: those findings are now in a
+    completed run's report. ``consolidation.mark_run_consolidated`` reads
+    this sidecar alongside ``<dim>_dispatch_keys.json``.
+
+    Skipped when there is nothing to record, so a run that replays only
+    consolidated entries leaves no file behind.
+    """
+    if not keys:
+        return
+    sidecar = _evidence_dir(config) / f"{dim_id}_replayed_unconsolidated_keys.json"
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(json.dumps(keys, indent=2), encoding="utf-8")
+
+
 def _compute_files_read(
     classify: ClassifyResult, jsonl_path: Path, all_files: list[str],
 ) -> int:
@@ -319,6 +339,11 @@ def process_dimension_with_cache(
     )
 
     jsonl = _jsonl_path(config, dim_id)
+
+    # Written BEFORE the all-hits branch so one call site covers both replay
+    # paths. A fully cached dimension writes no dispatch_keys sidecar (it
+    # never dispatches), so without this it would never flip its entries.
+    _write_replayed_keys_sidecar(config, dim_id, classify.unconsolidated_hit_keys)
 
     # All-hits short-circuit: no dispatch needed.
     # We append (not overwrite) because callers may invoke us multiple times

--- a/src/quodeq/analysis/cache/entry.py
+++ b/src/quodeq/analysis/cache/entry.py
@@ -43,7 +43,8 @@ def build_provenance(
 
     Single source of truth for the provenance shape, so the three cache-write
     sites (cache_writer, persist_dispatch_results, runner.analyze_unit) stay
-    identical. ``version`` defaults to the current quodeq version.
+    identical. Those three sites also all pass ``consolidated=False``.
+    ``version`` defaults to the current quodeq version.
     ``effective_params`` records the resolved threshold params the findings
     were judged under (``{req_id: {param: value}}``; ``{}`` when unknown)."""
     return {
@@ -79,6 +80,16 @@ class CacheEntry:
     provenance: dict = field(default_factory=dict)
     created_at: str = field(default_factory=_utc_now)
     cache_format_version: int = ENTRY_FORMAT_VERSION
+    # Whether a COMPLETED run has consolidated these findings into its
+    # report. Written False at creation and flipped to True by
+    # consolidation.mark_run_consolidated when a run reaches state=done.
+    # A run that was cancelled with "keep findings", failed, or was killed
+    # never flips its entries, so a later run replays their findings as
+    # this scan's own rather than hiding them as carried forward.
+    #
+    # Defaults True so entries written before this field existed load as
+    # consolidated and behave exactly as they did before.
+    consolidated: bool = True
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), separators=(",", ":"))

--- a/src/quodeq/analysis/cache/runner.py
+++ b/src/quodeq/analysis/cache/runner.py
@@ -128,6 +128,9 @@ def analyze_unit(
             standards_hash=unit.standards_hash,
             effective_params=unit.effective_params,
         ),
+        # Born unconsolidated: no completed run has these findings in its
+        # report yet. mark_run_consolidated flips it when this run ends done.
+        consolidated=False,
     )
     cache.put(key, entry)
     return UnitResult(entry=entry, cache_hit=False)

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -550,9 +550,10 @@ def _discard_run_state(reports_dir: str, job: dict) -> None:
     only this run's dispatched (cache-miss) keys, so entries written by
     earlier kept runs are not touched.
 
-    All per-dim scratch (queue, fingerprint, evidence JSONL, sidecar) is
-    removed so the status-GET scoring path cannot resurrect a report from
-    leftover evidence. The caller removes the run directory itself.
+    All per-dim scratch (queue, fingerprint, evidence JSONL, dispatch-keys
+    and replayed-keys sidecars) is removed so the status-GET scoring path
+    cannot resurrect a report from leftover evidence. The caller removes the
+    run directory itself.
     """
     project = job.get("outputProject")
     run_id = job.get("outputRunId")
@@ -584,6 +585,9 @@ def _discard_run_state(reports_dir: str, job: dict) -> None:
     scratch_patterns = (
         "*_queue.json", "*_fingerprint.json",
         "*_evidence.jsonl", "*_dispatch_keys.json",
+        # Entries listed here belong to EARLIER runs, so they are cleaned up
+        # as scratch but deliberately not fed to the cache-deletion loop above.
+        "*_replayed_unconsolidated_keys.json",
     )
     for pattern in scratch_patterns:
         for victim in evidence_dir.glob(pattern):

--- a/tests/analysis/cache/test_cache_writer.py
+++ b/tests/analysis/cache/test_cache_writer.py
@@ -335,3 +335,37 @@ def test_written_entry_records_effective_params(tmp_path):
     entry = LocalFileBackend(root=cache_root).get(key)
     assert entry is not None
     assert entry.provenance["effective_params"]["M-ANA-2"]["max_lines"] == 60
+
+
+def test_cache_writer_marks_the_entry_unconsolidated(tmp_path):
+    """A freshly produced finding has not reached any completed run's report
+    yet. The entry is born unconsolidated and stays that way until the run
+    that produced it reaches done."""
+    from quodeq.analysis.cache.cache_writer import build_cache_writer
+    from quodeq.analysis.cache.local import LocalFileBackend
+
+    src_root = tmp_path / "src"
+    src_root.mkdir()
+    (src_root / "Foo.kt").write_text("class Foo")
+
+    cache_root = tmp_path / "cache"
+    write = build_cache_writer(
+        cache_root=cache_root,
+        src_root=src_root,
+        standards_dir=None,
+        dimension="security",
+        model_id="sonnet",
+        language="kotlin",
+    )
+    write("Foo.kt", [{"file": "Foo.kt", "line": 1, "t": "violation"}])
+
+    backend = LocalFileBackend(root=cache_root)
+    entries = [
+        # LocalFileBackend shards keys as <root>/key[:2]/key[2:]/entry.json,
+        # so the full key is the two parent directory names concatenated.
+        backend.get(p.parent.parent.name + p.parent.name)
+        for p in cache_root.rglob("entry.json")
+    ]
+    written = [e for e in entries if e is not None]
+    assert written, "expected the writer to persist one entry"
+    assert all(e.consolidated is False for e in written)

--- a/tests/analysis/cache/test_consolidation.py
+++ b/tests/analysis/cache/test_consolidation.py
@@ -174,7 +174,7 @@ def test_a_raising_backend_never_propagates(tmp_path: Path, caplog):
         mark_run_consolidated(run_dir, backend)
 
     assert backend.touched == 1, "the backend was never consulted"
-    assert "disk on fire" in caplog.text
+    assert "Could not consolidate cache entry" in caplog.text
 
 
 def test_missing_evidence_dir_is_a_no_op(tmp_path: Path):

--- a/tests/analysis/cache/test_consolidation.py
+++ b/tests/analysis/cache/test_consolidation.py
@@ -1,0 +1,218 @@
+"""mark_run_consolidated — the one place a run's findings become "carried".
+
+A cache entry is born unconsolidated. Only a run that reaches state=done
+flips its entries, which is what lets the live feed show a cancelled run's
+replayed findings as this scan's own.
+
+Every failure mode here is a no-op by design: the function runs as a
+post-scan side effect outside the run lifecycle, so a raise would be the
+one thing that could turn a completed run into a failed one.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis.cache.consolidation import mark_run_consolidated
+from quodeq.analysis.cache.entry import CacheEntry
+from quodeq.analysis.cache.local import LocalFileBackend
+
+
+def _entry(key: str, *, consolidated: bool = False) -> CacheEntry:
+    return CacheEntry(
+        key=key, schema_version=1,
+        findings=[{"file": "a.py", "line": 1, "t": "violation"}],
+        files_read=1, file_path="a.py", dimension="security",
+        model_id="test-model", consolidated=consolidated,
+    )
+
+
+def _run_dir(tmp_path: Path, state: str | None, sidecars: dict[str, dict]) -> Path:
+    run_dir = tmp_path / "reports" / "proj" / "run1"
+    evidence = run_dir / "evidence"
+    evidence.mkdir(parents=True)
+    if state is not None:
+        (run_dir / "status.json").write_text(json.dumps({"state": state}))
+    for name, payload in sidecars.items():
+        (evidence / name).write_text(json.dumps(payload))
+    return run_dir
+
+
+@pytest.fixture
+def cache(tmp_path: Path) -> LocalFileBackend:
+    return LocalFileBackend(root=tmp_path / "cache")
+
+
+def test_done_run_flips_dispatched_entries(tmp_path: Path, cache):
+    cache.put("key1", _entry("key1"))
+    run_dir = _run_dir(
+        tmp_path, "done", {"security_dispatch_keys.json": {"a.py": "key1"}},
+    )
+
+    mark_run_consolidated(run_dir, cache)
+
+    assert cache.get("key1").consolidated is True
+
+
+def test_done_run_flips_replayed_unconsolidated_entries(tmp_path: Path, cache):
+    """The findings a completed run replayed are now in ITS report too."""
+    cache.put("key2", _entry("key2"))
+    run_dir = _run_dir(
+        tmp_path, "done",
+        {"security_replayed_unconsolidated_keys.json": {"a.py": "key2"}},
+    )
+
+    mark_run_consolidated(run_dir, cache)
+
+    assert cache.get("key2").consolidated is True
+
+
+def test_done_run_flips_both_sidecars_across_dimensions(tmp_path: Path, cache):
+    for key in ("key1", "key2", "key3"):
+        cache.put(key, _entry(key))
+    run_dir = _run_dir(tmp_path, "done", {
+        "security_dispatch_keys.json": {"a.py": "key1"},
+        "flexibility_dispatch_keys.json": {"b.py": "key2"},
+        "security_replayed_unconsolidated_keys.json": {"c.py": "key3"},
+    })
+
+    mark_run_consolidated(run_dir, cache)
+
+    assert all(cache.get(k).consolidated is True for k in ("key1", "key2", "key3"))
+
+
+@pytest.mark.parametrize("state", ["cancelled", "failed", "in_progress", "pending"])
+def test_non_done_run_leaves_entries_unconsolidated(tmp_path: Path, cache, state):
+    """The whole feature. A run the user cancelled with "keep findings" never
+    consolidated anything, so its findings must replay as new."""
+    cache.put("key1", _entry("key1"))
+    run_dir = _run_dir(
+        tmp_path, state, {"security_dispatch_keys.json": {"a.py": "key1"}},
+    )
+
+    mark_run_consolidated(run_dir, cache)
+
+    assert cache.get("key1").consolidated is False
+
+
+def test_missing_status_json_leaves_entries_unconsolidated(tmp_path: Path, cache):
+    """A killed process may never have written a terminal status."""
+    cache.put("key1", _entry("key1"))
+    run_dir = _run_dir(
+        tmp_path, None, {"security_dispatch_keys.json": {"a.py": "key1"}},
+    )
+
+    mark_run_consolidated(run_dir, cache)
+
+    assert cache.get("key1").consolidated is False
+
+
+def test_corrupt_status_json_leaves_entries_unconsolidated(tmp_path: Path, cache):
+    cache.put("key1", _entry("key1"))
+    run_dir = _run_dir(
+        tmp_path, None, {"security_dispatch_keys.json": {"a.py": "key1"}},
+    )
+    (run_dir / "status.json").write_text("{not json")
+
+    mark_run_consolidated(run_dir, cache)
+
+    assert cache.get("key1").consolidated is False
+
+
+def test_corrupt_sidecar_does_not_stop_the_other_sidecars(tmp_path: Path, cache):
+    cache.put("key1", _entry("key1"))
+    run_dir = _run_dir(tmp_path, "done", {
+        "security_dispatch_keys.json": {"a.py": "key1"},
+    })
+    (run_dir / "evidence" / "flexibility_dispatch_keys.json").write_text("{not json")
+
+    mark_run_consolidated(run_dir, cache)
+
+    assert cache.get("key1").consolidated is True
+
+
+def test_missing_entry_is_skipped(tmp_path: Path, cache):
+    """A file that errored mid-dispatch has a key in the sidecar but no entry.
+    The key must be skipped, not written back as a fabricated entry."""
+    run_dir = _run_dir(
+        tmp_path, "done", {"security_dispatch_keys.json": {"a.py": "ghost"}},
+    )
+
+    mark_run_consolidated(run_dir, cache)
+
+    assert cache.get("ghost") is None
+    assert list((tmp_path / "cache").rglob("entry.json")) == []
+
+
+def test_a_raising_backend_never_propagates(tmp_path: Path, caplog):
+    """Fail-soft is the contract, not a comment. This runs outside the run
+    lifecycle precisely so it can never flip a done run to failed.
+
+    caplog proves the failing branch was actually reached: without it, a test
+    that merely "does not raise" would also pass if the function had bailed
+    early for an unrelated reason and never touched the backend at all."""
+    class _Exploding:
+        def __init__(self) -> None:
+            self.touched = 0
+
+        def get(self, key):
+            self.touched += 1
+            raise RuntimeError("disk on fire")
+
+        def put(self, key, entry):
+            raise AssertionError("put must never be reached after get raised")
+
+    backend = _Exploding()
+    run_dir = _run_dir(
+        tmp_path, "done", {"security_dispatch_keys.json": {"a.py": "key1"}},
+    )
+
+    with caplog.at_level(logging.WARNING):
+        mark_run_consolidated(run_dir, backend)
+
+    assert backend.touched == 1, "the backend was never consulted"
+    assert "disk on fire" in caplog.text
+
+
+def test_missing_evidence_dir_is_a_no_op(tmp_path: Path):
+    """No evidence dir means no sidecars, so the cache must not be opened."""
+    class _Forbidden:
+        def get(self, key):
+            raise AssertionError("cache must not be consulted")
+
+        def put(self, key, entry):
+            raise AssertionError("cache must not be consulted")
+
+    run_dir = tmp_path / "reports" / "proj" / "run1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "status.json").write_text(json.dumps({"state": "done"}))
+
+    mark_run_consolidated(run_dir, _Forbidden())
+
+
+def test_already_consolidated_entries_are_not_rewritten(tmp_path: Path, cache):
+    """Avoids rewriting every entry on every run of a fully cached project."""
+    class _RecordingPut:
+        def __init__(self, inner) -> None:
+            self._inner = inner
+            self.puts: list[str] = []
+
+        def get(self, key):
+            return self._inner.get(key)
+
+        def put(self, key, entry) -> None:
+            self.puts.append(key)
+            self._inner.put(key, entry)
+
+    cache.put("key1", _entry("key1", consolidated=True))
+    recording = _RecordingPut(cache)
+    run_dir = _run_dir(
+        tmp_path, "done", {"security_dispatch_keys.json": {"a.py": "key1"}},
+    )
+
+    mark_run_consolidated(run_dir, recording)
+
+    assert recording.puts == []

--- a/tests/analysis/cache/test_dimension_helpers.py
+++ b/tests/analysis/cache/test_dimension_helpers.py
@@ -547,3 +547,35 @@ class TestRoundTrip:
         second = classify_files_via_cache(config, "security", files, cache)
         assert second.misses == []
         assert {f["file"] for f in second.cached_findings} == set(files)
+
+
+def test_persist_dispatch_results_marks_entries_unconsolidated(tmp_path):
+    """The periodic-persist watcher path must agree with the synchronous
+    cache_writer path: both produce unconsolidated entries."""
+    import json as _json
+
+    from quodeq.analysis.cache.dimension_helpers import (
+        build_cache_key_for_file,
+        persist_dispatch_results,
+    )
+    from quodeq.analysis.cache.local import LocalFileBackend
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.py").write_text("x")
+    config = _make_config(src)
+
+    jsonl = tmp_path / "security_evidence.jsonl"
+    jsonl.write_text(
+        _json.dumps({"file": "a.py", "line": 1, "t": "violation", "p": "P1"}) + "\n"
+        + _json.dumps({"_marker": "file_done", "file": "a.py", "status": "ok"}) + "\n"
+    )
+
+    cache = LocalFileBackend(root=tmp_path / "cache")
+    key = build_cache_key_for_file(config, "a.py", "security")
+    persist_dispatch_results(
+        config, "security", miss_files=["a.py"],
+        jsonl_path=jsonl, miss_keys={"a.py": key}, cache=cache,
+    )
+
+    assert cache.get(key).consolidated is False

--- a/tests/analysis/cache/test_dimension_helpers.py
+++ b/tests/analysis/cache/test_dimension_helpers.py
@@ -543,10 +543,14 @@ class TestRoundTrip:
             jsonl_path=jsonl, miss_keys=first.miss_keys, cache=cache,
         )
 
-        # Second call: cache should be fully populated → all hits.
+        # Second call: cache should be fully populated → all hits. The
+        # entries persist_dispatch_results just wrote are unconsolidated
+        # (no COMPLETED run has consolidated them yet), so they land in
+        # unconsolidated_findings, not cached_findings.
         second = classify_files_via_cache(config, "security", files, cache)
         assert second.misses == []
-        assert {f["file"] for f in second.cached_findings} == set(files)
+        assert second.cached_findings == []
+        assert {f["file"] for f in second.unconsolidated_findings} == set(files)
 
 
 def test_persist_dispatch_results_marks_entries_unconsolidated(tmp_path):
@@ -579,3 +583,100 @@ def test_persist_dispatch_results_marks_entries_unconsolidated(tmp_path):
     )
 
     assert cache.get(key).consolidated is False
+
+
+def test_classify_splits_hits_by_consolidation_state(tmp_path):
+    """A hit from a run that never completed must stay out of cached_findings,
+    so the replay path does not stamp it carried_forward."""
+    from quodeq.analysis.cache.dimension_helpers import (
+        build_cache_key_for_file,
+        classify_files_via_cache,
+    )
+    from quodeq.analysis.cache.entry import CacheEntry
+    from quodeq.analysis.cache.local import LocalFileBackend
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.py").write_text("x")
+    (src / "b.py").write_text("y")
+    config = _make_config(src)
+
+    cache = LocalFileBackend(root=tmp_path / "cache")
+    for name, consolidated in (("a.py", True), ("b.py", False)):
+        key = build_cache_key_for_file(config, name, "security")
+        cache.put(key, CacheEntry(
+            key=key, schema_version=1,
+            findings=[{"file": name, "line": 1, "t": "violation", "p": "P1"}],
+            files_read=1, file_path=name, dimension="security",
+            model_id="test-model", consolidated=consolidated,
+        ))
+
+    result = classify_files_via_cache(
+        config, "security", ["a.py", "b.py"], cache,
+    )
+
+    assert result.misses == []
+    assert [f["file"] for f in result.cached_findings] == ["a.py"]
+    assert [f["file"] for f in result.unconsolidated_findings] == ["b.py"]
+    assert set(result.unconsolidated_hit_keys) == {"b.py"}
+    assert result.unconsolidated_hit_keys["b.py"] == build_cache_key_for_file(
+        config, "b.py", "security",
+    )
+
+
+def test_classify_leaves_unconsolidated_fields_empty_when_all_hits_consolidated(tmp_path):
+    from quodeq.analysis.cache.dimension_helpers import (
+        build_cache_key_for_file,
+        classify_files_via_cache,
+    )
+    from quodeq.analysis.cache.entry import CacheEntry
+    from quodeq.analysis.cache.local import LocalFileBackend
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.py").write_text("x")
+    config = _make_config(src)
+
+    cache = LocalFileBackend(root=tmp_path / "cache")
+    key = build_cache_key_for_file(config, "a.py", "security")
+    cache.put(key, CacheEntry(
+        key=key, schema_version=1,
+        findings=[{"file": "a.py", "line": 1, "t": "violation", "p": "P1"}],
+        files_read=1, file_path="a.py", dimension="security",
+        model_id="test-model", consolidated=True,
+    ))
+
+    result = classify_files_via_cache(config, "security", ["a.py"], cache)
+
+    assert result.unconsolidated_findings == []
+    assert result.unconsolidated_hit_keys == {}
+
+
+def test_classify_treats_a_legacy_entry_as_consolidated(tmp_path):
+    """An entry stored before the field existed has no consolidated key.
+    from_json defaults it True, so it must land in cached_findings."""
+    from quodeq.analysis.cache.dimension_helpers import (
+        build_cache_key_for_file,
+        classify_files_via_cache,
+    )
+    from quodeq.analysis.cache.entry import CacheEntry
+    from quodeq.analysis.cache.local import LocalFileBackend
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.py").write_text("x")
+    config = _make_config(src)
+
+    cache = LocalFileBackend(root=tmp_path / "cache")
+    key = build_cache_key_for_file(config, "a.py", "security")
+    cache.put(key, CacheEntry(
+        key=key, schema_version=1,
+        findings=[{"file": "a.py", "line": 1, "t": "violation", "p": "P1"}],
+        files_read=1, file_path="a.py", dimension="security",
+        model_id="test-model",
+    ))
+
+    result = classify_files_via_cache(config, "security", ["a.py"], cache)
+
+    assert [f["file"] for f in result.cached_findings] == ["a.py"]
+    assert result.unconsolidated_findings == []

--- a/tests/analysis/cache/test_dimension_runner_carried_forward.py
+++ b/tests/analysis/cache/test_dimension_runner_carried_forward.py
@@ -79,3 +79,133 @@ def test_only_cache_replays_are_flagged(tmp_path: Path, cache):
     by_title = {ln["w"]: ln for ln in lines if "_marker" not in ln}
     assert by_title["carry-a"].get("carried_forward") is True
     assert by_title["fresh-b"].get("carried_forward", False) is False
+
+
+def test_write_findings_does_not_stamp_unconsolidated_replays(tmp_path: Path):
+    """A finding produced by a run that never completed was never consolidated
+    into an Overview. Replaying it must read as this scan's own finding."""
+    jsonl = tmp_path / "security_evidence.jsonl"
+    _write_findings(
+        jsonl, [_finding("carry-a")], append=False, emit_events=False,
+        unconsolidated=[dict(_finding("pending-b"), file="b.py")],
+    )
+    written = [json.loads(ln) for ln in jsonl.read_text().splitlines() if ln.strip()]
+    by_title = {ln["w"]: ln for ln in written}
+    assert by_title["carry-a"]["carried_forward"] is True
+    assert "carried_forward" not in by_title["pending-b"]
+
+
+def test_write_findings_orders_consolidated_replays_first(tmp_path: Path):
+    """Foundation-then-new ordering in the JSONL, matching the existing
+    carried-before-fresh contract."""
+    jsonl = tmp_path / "security_evidence.jsonl"
+    _write_findings(
+        jsonl, [_finding("carry-a")], append=False, emit_events=False,
+        unconsolidated=[dict(_finding("pending-b"), file="b.py")],
+    )
+    written = [json.loads(ln) for ln in jsonl.read_text().splitlines() if ln.strip()]
+    assert [ln["w"] for ln in written] == ["carry-a", "pending-b"]
+
+
+def test_write_findings_does_not_stamp_the_unconsolidated_source_dicts(tmp_path: Path):
+    jsonl = tmp_path / "security_evidence.jsonl"
+    source = [dict(_finding("pending-b"), file="b.py")]
+    _write_findings(
+        jsonl, [], append=False, emit_events=False, unconsolidated=source,
+    )
+    assert "carried_forward" not in source[0]
+
+
+def test_write_findings_accepts_only_unconsolidated(tmp_path: Path):
+    """A dimension whose every hit is unconsolidated still writes findings."""
+    jsonl = tmp_path / "security_evidence.jsonl"
+    _write_findings(
+        jsonl, [], append=False, emit_events=False,
+        unconsolidated=[dict(_finding("pending-b"), file="b.py")],
+    )
+    written = [json.loads(ln) for ln in jsonl.read_text().splitlines() if ln.strip()]
+    assert [ln["w"] for ln in written] == ["pending-b"]
+
+
+def test_all_unconsolidated_hits_are_still_written(tmp_path: Path, cache):
+    """Two truthiness guards used to test classify.cached_findings to decide
+    whether to write anything. Splitting the list makes both false when every
+    hit is unconsolidated, which would silently DROP those findings from the
+    run rather than merely mis-flagging them."""
+    from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
+    from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+
+    config, _src = _setup(tmp_path, {"a.py": "x", "b.py": "y"})
+
+    key = build_cache_key_for_file(config, "a.py", "security")
+    cache.put(key, CacheEntry(
+        key=key, schema_version=1,
+        findings=[dict(_finding("pending-a"), file="a.py")],
+        files_read=1, file_path="a.py", dimension="security",
+        model_id="test-model", consolidated=False,
+    ))
+
+    def fake_dispatch(cfg, dim_id, idx, ctx, callbacks):
+        jsonl = (cfg.work_dir or cfg.src) / f"{dim_id}_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        with jsonl.open("a") as out:
+            out.write(json.dumps(dict(_finding("fresh-b"), file="b.py", p="P2")) + "\n")
+            out.write(json.dumps({"_marker": "file_done", "file": "b.py", "status": "ok"}) + "\n")
+        return _make_dummy_evidence(files_read=1)
+
+    with patch(
+        "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+        new=fake_dispatch,
+    ):
+        process_dimension_with_cache(
+            config, "security", 1, _make_ctx(), _make_callbacks(), cache=cache,
+        )
+
+    jsonl_path = (config.work_dir or config.src) / "security_evidence.jsonl"
+    lines = [json.loads(ln) for ln in jsonl_path.read_text().splitlines() if ln.strip()]
+    titles = {ln["w"] for ln in lines if "_marker" not in ln}
+    assert "pending-a" in titles, "unconsolidated hit was dropped from the run"
+
+
+def test_three_way_split_carried_pending_and_fresh(tmp_path: Path, cache):
+    """The headline case: a consolidated hit is carried, an unconsolidated hit
+    is not, and a dispatched finding is not."""
+    from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
+    from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+
+    config, _src = _setup(tmp_path, {"a.py": "x", "b.py": "y", "c.py": "z"})
+
+    for name, title, consolidated in (
+        ("a.py", "carry-a", True),
+        ("b.py", "pending-b", False),
+    ):
+        key = build_cache_key_for_file(config, name, "security")
+        cache.put(key, CacheEntry(
+            key=key, schema_version=1,
+            findings=[dict(_finding(title), file=name)],
+            files_read=1, file_path=name, dimension="security",
+            model_id="test-model", consolidated=consolidated,
+        ))
+
+    def fake_dispatch(cfg, dim_id, idx, ctx, callbacks):
+        jsonl = (cfg.work_dir or cfg.src) / f"{dim_id}_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        with jsonl.open("a") as out:
+            out.write(json.dumps(dict(_finding("fresh-c"), file="c.py", p="P2")) + "\n")
+            out.write(json.dumps({"_marker": "file_done", "file": "c.py", "status": "ok"}) + "\n")
+        return _make_dummy_evidence(files_read=1)
+
+    with patch(
+        "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+        new=fake_dispatch,
+    ):
+        process_dimension_with_cache(
+            config, "security", 1, _make_ctx(), _make_callbacks(), cache=cache,
+        )
+
+    jsonl_path = (config.work_dir or config.src) / "security_evidence.jsonl"
+    lines = [json.loads(ln) for ln in jsonl_path.read_text().splitlines() if ln.strip()]
+    by_title = {ln["w"]: ln for ln in lines if "_marker" not in ln}
+    assert by_title["carry-a"].get("carried_forward") is True
+    assert by_title["pending-b"].get("carried_forward", False) is False
+    assert by_title["fresh-c"].get("carried_forward", False) is False

--- a/tests/analysis/cache/test_dimension_runner_carried_forward.py
+++ b/tests/analysis/cache/test_dimension_runner_carried_forward.py
@@ -209,3 +209,53 @@ def test_three_way_split_carried_pending_and_fresh(tmp_path: Path, cache):
     assert by_title["carry-a"].get("carried_forward") is True
     assert by_title["pending-b"].get("carried_forward", False) is False
     assert by_title["fresh-c"].get("carried_forward", False) is False
+
+
+def test_replayed_unconsolidated_keys_sidecar_is_written_on_the_all_hits_path(
+    tmp_path: Path, cache,
+):
+    """A fully cached dimension dispatches nothing, so it writes no
+    dispatch_keys sidecar. Without this one it would never flip its entries
+    and its findings would replay as new forever."""
+    from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
+    from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+
+    config, _src = _setup(tmp_path, {"a.py": "x"})
+
+    key = build_cache_key_for_file(config, "a.py", "security")
+    cache.put(key, CacheEntry(
+        key=key, schema_version=1,
+        findings=[dict(_finding("pending-a"), file="a.py")],
+        files_read=1, file_path="a.py", dimension="security",
+        model_id="test-model", consolidated=False,
+    ))
+
+    process_dimension_with_cache(
+        config, "security", 1, _make_ctx(), _make_callbacks(), cache=cache,
+    )
+
+    sidecar = (config.work_dir or config.src) / "security_replayed_unconsolidated_keys.json"
+    assert sidecar.is_file()
+    assert json.loads(sidecar.read_text()) == {"a.py": key}
+
+
+def test_no_sidecar_when_every_hit_is_already_consolidated(tmp_path: Path, cache):
+    from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
+    from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+
+    config, _src = _setup(tmp_path, {"a.py": "x"})
+
+    key = build_cache_key_for_file(config, "a.py", "security")
+    cache.put(key, CacheEntry(
+        key=key, schema_version=1,
+        findings=[dict(_finding("carry-a"), file="a.py")],
+        files_read=1, file_path="a.py", dimension="security",
+        model_id="test-model", consolidated=True,
+    ))
+
+    process_dimension_with_cache(
+        config, "security", 1, _make_ctx(), _make_callbacks(), cache=cache,
+    )
+
+    sidecar = (config.work_dir or config.src) / "security_replayed_unconsolidated_keys.json"
+    assert not sidecar.exists()

--- a/tests/analysis/cache/test_dimension_runner_carried_forward.py
+++ b/tests/analysis/cache/test_dimension_runner_carried_forward.py
@@ -167,6 +167,50 @@ def test_all_unconsolidated_hits_are_still_written(tmp_path: Path, cache):
     assert "pending-a" in titles, "unconsolidated hit was dropped from the run"
 
 
+def test_salvage_path_keeps_unconsolidated_hits_when_dispatch_returns_none(
+    tmp_path: Path, cache,
+):
+    """The ``miss_evidence is None`` salvage branch has its own truthiness
+    guard (``replayed_anything``). Like the pre-dispatch write guard above,
+    it used to test only ``classify.cached_findings``, so a dimension whose
+    every hit is unconsolidated would compute ``replayed_anything=False`` and
+    return None -- discarding an unconsolidated finding that was already
+    sitting in the JSONL."""
+    from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
+    from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+
+    config, _src = _setup(tmp_path, {"a.py": "x", "b.py": "y"})
+
+    key = build_cache_key_for_file(config, "a.py", "security")
+    cache.put(key, CacheEntry(
+        key=key, schema_version=1,
+        findings=[dict(_finding("pending-a"), file="a.py")],
+        files_read=1, file_path="a.py", dimension="security",
+        model_id="test-model", consolidated=False,
+    ))
+    # b.py has no cache entry, so it lands in classify.misses and dispatch is
+    # actually attempted (and not the all-hits short-circuit above).
+
+    def fake_dispatch(cfg, dim_id, idx, ctx, callbacks):
+        return None
+
+    with patch(
+        "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+        new=fake_dispatch,
+    ):
+        evidence = process_dimension_with_cache(
+            config, "security", 1, _make_ctx(), _make_callbacks(), cache=cache,
+        )
+
+    assert evidence is not None, (
+        "salvage-path guard dropped an all-unconsolidated dimension's findings"
+    )
+    jsonl_path = (config.work_dir or config.src) / "security_evidence.jsonl"
+    lines = [json.loads(ln) for ln in jsonl_path.read_text().splitlines() if ln.strip()]
+    titles = {ln["w"] for ln in lines if "_marker" not in ln}
+    assert "pending-a" in titles, "unconsolidated hit was dropped from the run"
+
+
 def test_three_way_split_carried_pending_and_fresh(tmp_path: Path, cache):
     """The headline case: a consolidated hit is carried, an unconsolidated hit
     is not, and a dispatched finding is not."""

--- a/tests/analysis/cache/test_dimension_runner_carried_forward.py
+++ b/tests/analysis/cache/test_dimension_runner_carried_forward.py
@@ -259,3 +259,82 @@ def test_no_sidecar_when_every_hit_is_already_consolidated(tmp_path: Path, cache
 
     sidecar = (config.work_dir or config.src) / "security_replayed_unconsolidated_keys.json"
     assert not sidecar.exists()
+
+
+def test_cancelled_run_findings_stay_new_until_a_run_completes(tmp_path: Path):
+    """The user story.
+
+    Run 1 is cancelled with "keep findings", so its findings never reach an
+    Overview. Run 2 replays them: they must read as THIS scan's findings,
+    because the user has still never been shown them consolidated. Run 2
+    completes, which consolidates them. Run 3 replays them as carried.
+    """
+    from quodeq.analysis.cache.consolidation import mark_run_consolidated
+    from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+    from quodeq.analysis.cache.local import LocalFileBackend
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.py").write_text("x")
+    shared_cache = LocalFileBackend(root=tmp_path / "cache")
+
+    def _run_config(run_id: str):
+        """A config whose work_dir IS <run_dir>/evidence, so the sidecars land
+        where mark_run_consolidated looks for them."""
+        from tests.analysis.cache.test_dimension_runner import _make_config
+        run_dir = tmp_path / "reports" / "proj" / run_id
+        (run_dir / "evidence").mkdir(parents=True, exist_ok=True)
+        return _make_config(
+            src, work_dir=run_dir / "evidence", file_names=["a.py"],
+        ), run_dir
+
+    def fake_dispatch(cfg, dim_id, idx, ctx, callbacks):
+        jsonl = (cfg.work_dir or cfg.src) / f"{dim_id}_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        with jsonl.open("a") as out:
+            out.write(json.dumps(dict(_finding("found-a"), file="a.py")) + "\n")
+            out.write(json.dumps({"_marker": "file_done", "file": "a.py", "status": "ok"}) + "\n")
+        return _make_dummy_evidence(files_read=1)
+
+    def _titles_with_flag(config) -> dict:
+        jsonl = (config.work_dir or config.src) / "security_evidence.jsonl"
+        lines = [json.loads(ln) for ln in jsonl.read_text().splitlines() if ln.strip()]
+        return {
+            ln["w"]: ln.get("carried_forward", False)
+            for ln in lines if "_marker" not in ln
+        }
+
+    # Run 1: dispatches a.py, then the user cancels with "keep findings".
+    # A cancelled run never calls mark_run_consolidated.
+    config1, run_dir1 = _run_config("run1")
+    with patch(
+        "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+        new=fake_dispatch,
+    ):
+        process_dimension_with_cache(
+            config1, "security", 1, _make_ctx(), _make_callbacks(), cache=shared_cache,
+        )
+    (run_dir1 / "status.json").write_text(json.dumps({"state": "cancelled"}))
+    mark_run_consolidated(run_dir1, shared_cache)  # no-op: not done
+
+    # Run 2: a.py is now a cache hit, but an UNCONSOLIDATED one.
+    config2, run_dir2 = _run_config("run2")
+    process_dimension_with_cache(
+        config2, "security", 1, _make_ctx(), _make_callbacks(), cache=shared_cache,
+    )
+    assert _titles_with_flag(config2) == {"found-a": False}, (
+        "a cancelled run's findings must still read as new"
+    )
+
+    # Run 2 completes, which consolidates the entry it replayed.
+    (run_dir2 / "status.json").write_text(json.dumps({"state": "done"}))
+    mark_run_consolidated(run_dir2, shared_cache)
+
+    # Run 3: the same hit now reads as carried forward.
+    config3, _run_dir3 = _run_config("run3")
+    process_dimension_with_cache(
+        config3, "security", 1, _make_ctx(), _make_callbacks(), cache=shared_cache,
+    )
+    assert _titles_with_flag(config3) == {"found-a": True}, (
+        "a completed run consolidated these findings; they are carried now"
+    )

--- a/tests/analysis/cache/test_entry.py
+++ b/tests/analysis/cache/test_entry.py
@@ -134,3 +134,31 @@ class TestProvenanceEffectiveParams:
             model_id="m", prompts_hash="p", standards_hash="s", version="1.0",
         )
         assert prov["effective_params"] == {}
+
+
+def test_entry_without_consolidated_key_loads_as_consolidated():
+    """Entries written before consolidation tracking existed must keep
+    replaying as carried forward, so the first run after an upgrade behaves
+    exactly as it did before. Defaulting to False instead would surface every
+    pre-existing cache entry as a brand new finding, once, on every project."""
+    payload = json.dumps({
+        "key": "abc123",
+        "schema_version": 1,
+        "findings": [],
+        "files_read": 1,
+        "file_path": "a.py",
+        "dimension": "security",
+        "model_id": "claude-opus-4-7",
+    })
+    assert CacheEntry.from_json(payload).consolidated is True
+
+
+def test_consolidated_false_survives_the_json_round_trip():
+    entry = _make(consolidated=False)
+    assert CacheEntry.from_json(entry.to_json()).consolidated is False
+
+
+def test_entry_format_version_is_unchanged_by_the_consolidated_field():
+    """from_json tolerates missing and unknown keys in both directions, so
+    adding a field needs no format bump and no migration."""
+    assert ENTRY_FORMAT_VERSION == 2

--- a/tests/analysis/cache/test_runner.py
+++ b/tests/analysis/cache/test_runner.py
@@ -258,3 +258,26 @@ class TestEmptyResults:
         assert second.cache_hit is True
         assert second.entry.findings == []
         assert len(dispatcher.calls) == 1
+
+
+def test_analyze_unit_marks_a_dispatched_entry_unconsolidated(cache: LocalFileBackend):
+    """The three cache write sites must agree. analyze_unit is not on a
+    production path today, but entry.build_provenance's docstring asserts the
+    three stay identical, so it moves with them."""
+    dispatcher = _RecordingDispatcher()
+    result = analyze_unit(_unit(), cache=cache, dispatcher=dispatcher)
+    assert result.entry.consolidated is False
+
+
+def test_analyze_unit_preserves_consolidated_on_a_hit(cache: LocalFileBackend):
+    """A hit returns the stored entry untouched, whatever its state."""
+    dispatcher = _RecordingDispatcher()
+    unit = _unit()
+    first = analyze_unit(unit, cache=cache, dispatcher=dispatcher)
+    stored = cache.get(first.entry.key)
+    stored.consolidated = True
+    cache.put(first.entry.key, stored)
+
+    second = analyze_unit(unit, cache=cache, dispatcher=dispatcher)
+    assert second.cache_hit is True
+    assert second.entry.consolidated is True

--- a/tests/services/test_cancel_discard_purge.py
+++ b/tests/services/test_cancel_discard_purge.py
@@ -24,7 +24,7 @@ import pytest
 
 from quodeq.analysis.cache import CacheEntry, LocalFileBackend
 from quodeq.core.types import JobSnapshot
-from quodeq.services.evaluation_mixin import FsEvaluationMixin
+from quodeq.services.evaluation_mixin import FsEvaluationMixin, _discard_run_state
 from quodeq.services.filesystem import FilesystemActionProvider
 from quodeq.shared.dimensions_state import DimState, write_dim_state
 from quodeq.shared.run_status import RunState, write_status
@@ -385,3 +385,46 @@ class TestRouteDiscardBlocksScoringResurrection:
             assert not scored.wait(timeout=0.3), (
                 "status GET resurrected scoring for a discarded run"
             )
+
+
+def test_discard_removes_the_replayed_keys_sidecar(tmp_path: Path):
+    """Every per-dim scratch file must go, or the status-GET scoring path can
+    resurrect state from leftovers."""
+    reports = tmp_path / "reports"
+    evidence = reports / "proj" / "run1" / "evidence"
+    evidence.mkdir(parents=True)
+    sidecar = evidence / "security_replayed_unconsolidated_keys.json"
+    sidecar.write_text(json.dumps({"a.py": "key-a"}))
+
+    _discard_run_state(str(reports), {"outputProject": "proj", "outputRunId": "run1"})
+
+    assert not sidecar.exists()
+
+
+def test_discard_does_not_delete_replayed_cache_entries(tmp_path: Path, monkeypatch):
+    """The replayed entries were written by an EARLIER run. Discard wipes only
+    what this run created; deleting these would destroy a prior kept run's
+    cached work."""
+    reports = tmp_path / "reports"
+    evidence = reports / "proj" / "run1" / "evidence"
+    evidence.mkdir(parents=True)
+    (evidence / "security_dispatch_keys.json").write_text(
+        json.dumps({"b.py": "key-mine"})
+    )
+    (evidence / "security_replayed_unconsolidated_keys.json").write_text(
+        json.dumps({"a.py": "key-theirs"})
+    )
+
+    deleted: list[str] = []
+
+    class _FakeCache:
+        def delete(self, key: str) -> None:
+            deleted.append(key)
+
+    monkeypatch.setattr(
+        "quodeq.services.evaluation_mixin._open_cache", lambda: _FakeCache(),
+    )
+
+    _discard_run_state(str(reports), {"outputProject": "proj", "outputRunId": "run1"})
+
+    assert deleted == ["key-mine"]

--- a/tests/test_cli_consolidation_wiring.py
+++ b/tests/test_cli_consolidation_wiring.py
@@ -1,0 +1,96 @@
+"""run_evaluate must consolidate this run's cache entries after it ends.
+
+The flip runs OUTSIDE RunLifecycleContext, alongside the fail-soft SARIF
+export, so a failure in it can never turn a completed run into a failed one.
+It is skipped for the modes that produce no scored reports, because nothing
+of theirs reaches the Overview.
+
+The seam is patched at the three boundaries run_evaluate calls out through,
+so no real pipeline, AI provider, or repo is involved.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from quodeq import _cli_evaluation
+from quodeq._cli_resolution import ResolvedInputs
+from quodeq.analysis.manifest_models import SourceManifest
+
+
+def _args(tmp_path: Path, **overrides) -> argparse.Namespace:
+    """The attribute set run_evaluate reads before reaching the tail.
+
+    dry_run=True skips check_evaluate_prereqs, so no AI provider is needed.
+    """
+    defaults = dict(
+        repo=str(tmp_path / "src"),
+        output=str(tmp_path / "reports"),
+        legacy_incremental=False,
+        clean_scan=False,
+        diff_from=None,
+        dry_run=True,
+        sarif=None,
+        evidence_only=False,
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+@pytest.fixture
+def wired(tmp_path: Path, monkeypatch):
+    """Patch run_evaluate's three outward calls; record consolidation calls."""
+    src = tmp_path / "src"
+    src.mkdir()
+    evaluation_dir = tmp_path / "reports" / "proj" / "run1" / "evaluation"
+    evaluation_dir.mkdir(parents=True)
+    evidence_dir = evaluation_dir.parent / "evidence"
+    evidence_dir.mkdir()
+    paths = (tmp_path / "reports", evidence_dir, evaluation_dir)
+
+    monkeypatch.setattr(
+        _cli_evaluation, "_resolve_evaluation_inputs",
+        lambda a: ResolvedInputs(
+            src=src, language="python",
+            manifest=SourceManifest(), dims_data={"applies": []},
+        ),
+    )
+    monkeypatch.setattr(_cli_evaluation, "_setup_run_dirs", lambda a, s: paths)
+    monkeypatch.setattr(
+        _cli_evaluation, "_run_pipeline_with_cleanup", lambda a, i, p: 0,
+    )
+
+    calls: list[Path] = []
+    # run_evaluate imports this locally, so it resolves at call time and
+    # patching the source module is enough.
+    monkeypatch.setattr(
+        "quodeq.analysis.cache.consolidation.mark_run_consolidated",
+        lambda run_dir, cache=None: calls.append(run_dir),
+    )
+    return calls, evaluation_dir.parent
+
+
+def test_run_evaluate_consolidates_the_run_dir(tmp_path: Path, wired):
+    calls, run_dir = wired
+    assert _cli_evaluation.run_evaluate(_args(tmp_path)) == 0
+    assert calls == [run_dir]
+
+
+def test_run_evaluate_skips_consolidation_for_evidence_only(tmp_path: Path, wired):
+    """--evidence-only produces no scored reports, so nothing reaches the
+    Overview and its entries must stay unconsolidated."""
+    calls, _run_dir = wired
+    assert _cli_evaluation.run_evaluate(_args(tmp_path, evidence_only=True)) == 0
+    assert calls == []
+
+
+def test_run_evaluate_skips_consolidation_for_diff_from(tmp_path: Path, wired, monkeypatch):
+    """--diff-from is evidence-only output for a specific ref. Same reason."""
+    calls, _run_dir = wired
+    monkeypatch.setattr(
+        _cli_evaluation, "resolve_diff_files", lambda src, ref: {"changed.py"},
+    )
+    assert _cli_evaluation.run_evaluate(_args(tmp_path, diff_from="main")) == 0
+    assert calls == []


### PR DESCRIPTION
## Summary

Findings produced by a run that never completed (cancelled with "keep findings", failed, or killed) were hidden from the live feed on the next evaluation, because every cache replay was stamped `carried_forward`. Those findings were never consolidated into the Overview, so the user was never shown them anywhere.

A cache entry now records whether a completed run has consolidated it. Entries are written unconsolidated; a fail-soft post-run pass flips them only when the run's `status.json` records `state: "done"`. Replays stamp `carried_forward` only for consolidated entries.

Cancelled, failed, and killed runs are handled by running no hook at all, which is the only thing a dead process can reliably do. That inversion is the design: an entry is born unconsolidated rather than being marked so by a cancel handler, because `kill -9` runs no handler.

## How it works

- `CacheEntry.consolidated: bool = True`, written `False` at all three cache write sites.
- `classify_files_via_cache` splits hits into consolidated and unconsolidated groups, plus `unconsolidated_hit_keys`.
- `_write_findings` stamps `carried_forward` only on the consolidated group; the rest are written with the key absent, so they parse downstream as new.
- A run records the unconsolidated entries it replayed in `<dim>_replayed_unconsolidated_keys.json`, written once right after classify so it covers both the all-hits short-circuit and the dispatch path.
- `mark_run_consolidated` flips both sidecars' keys, gated on `status.json`.

## Notes

- The default is `True`, so entries already on disk behave exactly as before. No format bump, no migration. The trade is that findings cached by previously cancelled runs stay carried until their files change; defaulting to `False` would instead surface every pre-existing entry as new, once, on every project.
- The consolidation pass runs outside `RunLifecycleContext`, beside the SARIF export, so a failure can never flip a done run to failed.
- Discard adds the new sidecar to scratch cleanup but deliberately not to the cache-deletion loop: those entries belong to an earlier kept run.
- Backend only. The UI already filters on `carriedForward`; an unconsolidated replay simply arrives without the flag.
- Time-limit-truncated runs end `done` and so do consolidate, matching the Overview. A deleted `done` run leaves its findings marked consolidated, an accepted approximation.

## Test plan

- `pytest -m "not integration"`: 5258 passed, 1 skipped, no failures.
- End-to-end test pins the full lifecycle: run 1 cancelled-keep, run 2 replays as new and completes, run 3 replays as carried. Mutation-verified against all four links (no-op the flip, loosen the status gate, stamp the unconsolidated group, no-op the sidecar), each breaks it.
- Both truthiness guards in `process_dimension_with_cache` are individually pinned, including the salvage path, where a regression would silently drop findings from the run rather than mislabel them.
- Live verification pending on the author's machine.

## Stacking

Based on `feat/live-feed-new-findings`, which is not yet merged. Retarget to `develop` after that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)