### PR TITLE
fix(scores): keep hidden standards out of displayed aggregates

### DIFF
--- a/src/quodeq/services/_fs_metadata.py
+++ b/src/quodeq/services/_fs_metadata.py
@@ -7,6 +7,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from quodeq.core.standards.visibility import load_visible_standard_ids
 from quodeq.services.ports import RunInfo, read_run_data, safe_read_dir, summarize_dimensions
 from quodeq.shared.validation import validate_path_segment
 
@@ -62,6 +63,24 @@ def _read_repo_info(reports_root: Path, entry_name: str) -> dict[str, Any]:
         return {}
 
 
+def _local_repo_root(reports_root: Path, entry_name: str) -> Path | None:
+    """The analyzed repo's local working copy, or None when there isn't one.
+
+    Same gate as the API's ``repo_attach_info``: a recorded path that is not
+    an online URL and still exists as a directory. Online projects and moved
+    working copies resolve to None, which downstream visibility lookups treat
+    as "use the default selection".
+    """
+    info = _read_repo_info(reports_root, entry_name)
+    path = info.get("path")
+    if not path or not isinstance(path, str):
+        return None
+    if str(info.get("location", "")).lower() == "online" or "://" in path:
+        return None
+    root = Path(path)
+    return root if root.is_dir() else None
+
+
 def _read_accumulated_summary(
     reports_root: Path, entry_name: str, runs: list[RunInfo],
     params: "ScoringParams | None" = None,
@@ -73,6 +92,13 @@ def _read_accumulated_summary(
     repositories-screen grade agrees with the Overview / explorer / trend.
     *params* (loaded from the saved formula when None) keeps the aggregate
     threshold labels and dimension weights consistent with the dashboard.
+
+    The card also scopes to the project's visible-standards selection: the
+    Overview headline averages only visible dimensions (the client filters
+    the accumulated payload), so a card computed over ALL dimensions shows a
+    different grade whenever a hidden dimension's score diverges. The
+    selection is folded into the cache version so toggling a standard
+    invalidates the cached card.
     """
     if params is None:
         from quodeq.services import grade_formula  # noqa: PLC0415
@@ -82,9 +108,12 @@ def _read_accumulated_summary(
         accumulated_cache_version, cached_project_summary, per_run_versions,
     )
     project_dir = reports_root / entry_name
+    visible = load_visible_standard_ids(_local_repo_root(reports_root, entry_name))
+    visible_set = set(visible)
     run_versions = per_run_versions(
         project_dir, entry_name, params, [(r.run_id, r.status) for r in runs])
-    version = accumulated_cache_version(project_dir, params, run_versions, as_of=None)
+    version = accumulated_cache_version(
+        project_dir, params, run_versions, as_of=None, visible_dims=visible)
 
     def _compute() -> dict:
         try:
@@ -109,8 +138,11 @@ def _read_accumulated_summary(
                     # Same trust gate as the accumulated Overview
                     # (_has_valid_score): skip a coverage-0 stub so the card
                     # falls through to a real older run instead of showing
-                    # the stub's inflated grade.
-                    if d.dimension and d.dimension not in latest_by_dim and _has_valid_score(d):
+                    # the stub's inflated grade. Hidden standards are skipped
+                    # entirely: the Overview headline excludes them, and a
+                    # dimension the user cannot see must not move the grade.
+                    if (d.dimension and d.dimension.lower() in visible_set
+                            and d.dimension not in latest_by_dim and _has_valid_score(d)):
                         latest_by_dim[d.dimension] = d
                         validate_path_segment(run.run_id)
                         run_dir_by_dim[d.dimension] = project_dir / run.run_id

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -335,6 +335,7 @@ def load_run_keys(
 def accumulated_cache_version(
     project_dir: Path, params: ScoringParams,
     run_versions: list[tuple], as_of: str | None,
+    visible_dims: tuple[str, ...] | None = None,
 ) -> str:
     """Version for the accumulated cache: params + the per-run fingerprints +
     *as_of*. Composing per-run fingerprints means a dismiss/delete on one run
@@ -348,6 +349,12 @@ def accumulated_cache_version(
     params + intersecting suppressions — so without status folded in, a run
     completing mid-poll would recompute the same version and serve a stale
     payload that omitted the just-finished (now eligible) run.
+
+    *visible_dims* is folded in only by payloads that are COMPUTED over the
+    visible-standards selection (the project-card summary): toggling a
+    standard must invalidate them. Payloads that return every dimension and
+    leave filtering to the client (the accumulated Overview) pass None, so
+    their hashes are unaffected by visibility edits.
     """
     payload = json.dumps({
         # Bump when the accumulated / project-card computation changes, so
@@ -362,6 +369,7 @@ def accumulated_cache_version(
         "params": _params_fingerprint(params),
         "runs": sorted(list(t) for t in run_versions),
         "as_of": as_of or "",
+        **({} if visible_dims is None else {"visible": sorted(visible_dims)}),
     }, sort_keys=True)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 

--- a/src/quodeq/ui/src/utils/scoreFiltering.accumulated.test.js
+++ b/src/quodeq/ui/src/utils/scoreFiltering.accumulated.test.js
@@ -25,3 +25,30 @@ test('populated trend still wins (unchanged behavior)', () => {
   const out = filterAccumulatedByVisibleStandards(ACC, VISIBLE, trend, 'r1');
   assert.equal(out.summary.numericAverage, 8.2);
 });
+
+// The backend's overallGrade averages ALL dimensions, hidden ones included.
+// The grade word must be re-derived from the recomputed (visible-only)
+// average, or a hidden low-scoring dimension shows e.g. "grade C" next to a
+// 7.5 score computed without it.
+
+test('overallGrade is re-derived from the visible-only average', () => {
+  const acc = {
+    dimensions: [
+      { dimension: 'security', totals: { violationCount: 0, complianceCount: 0 } },
+      { dimension: 'clean-architecture', totals: { violationCount: 0, complianceCount: 0 } },
+    ],
+    // Backend average includes the hidden dim: (7.5 + 4.0) / 2 → Adequate.
+    summary: { numericAverage: 5.8, overallGrade: 'Adequate' },
+  };
+  const trend = [{ runId: 'r1', numericAverage: 7.5 }];
+  const out = filterAccumulatedByVisibleStandards(acc, new Set(['security']), trend, 'r1');
+  assert.equal(out.summary.numericAverage, 7.5);
+  assert.equal(out.summary.overallGrade, 'Good');
+});
+
+test('overallGrade is null when no average is computable', () => {
+  const acc = { dimensions: [], summary: { overallGrade: 'Good' } };
+  const out = filterAccumulatedByVisibleStandards(acc, new Set(), [], null);
+  assert.equal(out.summary.numericAverage, null);
+  assert.equal(out.summary.overallGrade, null);
+});

--- a/src/quodeq/ui/src/utils/scoreFiltering.js
+++ b/src/quodeq/ui/src/utils/scoreFiltering.js
@@ -6,6 +6,7 @@
  */
 
 import { bucketKey, isBucketEligible } from './dailyGrouping.js';
+import { scoreToGradeLabel } from './gradeThresholds.js';
 import { countBySeverity } from './severity.js';
 
 const roundOneDecimal = (n) => Math.round(n * 10) / 10;
@@ -140,6 +141,11 @@ export function filterAccumulatedByVisibleStandards(accumulated, visibleSet, fil
       ...accumulated.summary,
       numericAverage,
       previousNumericAverage: prevAvg,
+      // Re-derive the grade word from the recomputed average: the backend's
+      // overallGrade is computed over ALL dimensions, so passing it through
+      // lets a hidden dimension's score set the letter next to a number it
+      // no longer matches (score from visible dims, grade from everything).
+      overallGrade: scoreToGradeLabel(numericAverage),
       totalViolations,
       totalCompliance,
       severity,

--- a/tests/services/test_fs_metadata.py
+++ b/tests/services/test_fs_metadata.py
@@ -198,7 +198,7 @@ class TestReadAccumulatedSummary:
         mock_read.return_value = [
             DimensionResult(dimension="security", overall_score="8.0", source_file_count=10),
             DimensionResult(dimension="reliability", overall_score="7.0"),
-            DimensionResult(dimension="clean-architecture", overall_score="4.0"),
+            DimensionResult(dimension="performance", overall_score="4.0"),
         ]
         mock_summarize.return_value = type(
             "S", (), {"overall_grade": "A", "numeric_average": 7.5},
@@ -207,11 +207,115 @@ class TestReadAccumulatedSummary:
         runs = [RunInfo(run_id="run-new", date_iso="2026-01-02", date_label="Jan 02")]
         _read_accumulated_summary(reports_root, project, runs)
 
-        # summarize_dimensions must see ALL dims, including the one missing
-        # from the latest config.
+        # summarize_dimensions must see ALL (visible) dims, including the one
+        # missing from the latest config.
         called_dims = mock_summarize.call_args[0][0]
         names = sorted(d.dimension for d in called_dims)
-        assert names == ["clean-architecture", "reliability", "security"], names
+        assert names == ["performance", "reliability", "security"], names
+
+    @patch("quodeq.services._fs_metadata.summarize_dimensions")
+    @patch("quodeq.services._fs_metadata.read_run_data")
+    def test_card_summary_excludes_hidden_standards(
+        self, mock_read, mock_summarize, tmp_path, monkeypatch,
+    ):
+        """Dims outside the visible-standards selection must not move the
+        card grade: the Overview headline excludes them (the client filters
+        the accumulated payload by the same selection)."""
+        from quodeq.core.standards.visibility import save_visible_standard_ids
+        from quodeq.core.types import DimensionResult
+        from quodeq.services.ports import RunInfo
+
+        monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
+        reports_root = tmp_path / "evaluations"
+        project = "proj"
+        (reports_root / project / "run-new").mkdir(parents=True)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        save_visible_standard_ids(repo, ["security"])
+        (reports_root / project / "repository_info.json").write_text(
+            json.dumps({"name": project, "path": str(repo), "location": "local"}),
+            encoding="utf-8",
+        )
+        mock_read.return_value = [
+            DimensionResult(dimension="Security", overall_score="8.0"),
+            DimensionResult(dimension="reliability", overall_score="7.0"),
+        ]
+        mock_summarize.return_value = type(
+            "S", (), {"overall_grade": "A", "numeric_average": 8.0},
+        )()
+
+        runs = [RunInfo(run_id="run-new", date_iso="2026-01-02", date_label="Jan 02")]
+        _read_accumulated_summary(reports_root, project, runs)
+
+        # Matching is case-insensitive (the selection stores lowercase ids).
+        called_dims = mock_summarize.call_args[0][0]
+        assert [d.dimension for d in called_dims] == ["Security"]
+
+    @patch("quodeq.services._fs_metadata.summarize_dimensions")
+    @patch("quodeq.services._fs_metadata.read_run_data")
+    def test_card_summary_default_selection_hides_non_iso_dims(
+        self, mock_read, mock_summarize, tmp_path, monkeypatch,
+    ):
+        """Without a visibility file the six ISO defaults apply, so a retired
+        non-default dim (clean-architecture) no longer drags the card grade
+        while being invisible on the Overview."""
+        from quodeq.core.types import DimensionResult
+        from quodeq.services.ports import RunInfo
+
+        monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
+        reports_root = tmp_path / "evaluations"
+        project = "proj"
+        (reports_root / project / "run-new").mkdir(parents=True)
+        mock_read.return_value = [
+            DimensionResult(dimension="security", overall_score="8.0"),
+            DimensionResult(dimension="clean-architecture", overall_score="4.0"),
+        ]
+        mock_summarize.return_value = type(
+            "S", (), {"overall_grade": "A", "numeric_average": 8.0},
+        )()
+
+        runs = [RunInfo(run_id="run-new", date_iso="2026-01-02", date_label="Jan 02")]
+        _read_accumulated_summary(reports_root, project, runs)
+
+        called_dims = mock_summarize.call_args[0][0]
+        assert [d.dimension for d in called_dims] == ["security"]
+
+    @patch("quodeq.services._fs_metadata.read_run_data")
+    def test_card_summary_recomputes_when_visibility_changes(
+        self, mock_read, tmp_path, monkeypatch,
+    ):
+        """The selection is folded into the cache version: editing
+        standards-visibility.json must invalidate the persisted card summary,
+        not serve the grade computed under the previous selection."""
+        from quodeq.core.standards.visibility import save_visible_standard_ids
+        from quodeq.core.types import DimensionResult
+        from quodeq.services.ports import RunInfo
+
+        monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+        reports_root = tmp_path / "evaluations"
+        project = "proj"
+        (reports_root / project / "run-new").mkdir(parents=True)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (reports_root / project / "repository_info.json").write_text(
+            json.dumps({"name": project, "path": str(repo), "location": "local"}),
+            encoding="utf-8",
+        )
+        mock_read.return_value = [
+            DimensionResult(dimension="security", overall_score="9.0",
+                            overall_grade="Exemplary"),
+            DimensionResult(dimension="reliability", overall_score="5.0",
+                            overall_grade="Adequate"),
+        ]
+        runs = [RunInfo(run_id="run-new", date_iso="2026-01-02", date_label="Jan 02")]
+
+        save_visible_standard_ids(repo, ["security", "reliability"])
+        _, score_both, _ = _read_accumulated_summary(reports_root, project, runs)
+        save_visible_standard_ids(repo, ["security"])
+        _, score_one, _ = _read_accumulated_summary(reports_root, project, runs)
+
+        assert score_both == 7.0
+        assert score_one == 9.0
 
     def test_project_card_reflects_overlaid_sql_grades_and_loaded_params(
         self, tmp_path, monkeypatch,

--- a/tests/services/test_score_cache_accumulated_helper.py
+++ b/tests/services/test_score_cache_accumulated_helper.py
@@ -39,6 +39,24 @@ def test_version_stable_regardless_of_run_order(tmp_path, monkeypatch):
     assert a == b  # run-set is order-independent (sorted)
 
 
+def test_version_folds_visible_dims_only_when_given(tmp_path, monkeypatch):
+    """visible_dims invalidates visibility-scoped payloads (project card) on a
+    selection change, while None-passing callers (accumulated Overview, which
+    returns every dim and lets the client filter) keep their hashes."""
+    _patch_keys(monkeypatch)
+    pd = tmp_path / "proj"; pd.mkdir()
+    runs = [("r1", "complete")]
+    base = accumulated_cache_version(pd, DEFAULT_PARAMS, runs, None)
+    six = accumulated_cache_version(
+        pd, DEFAULT_PARAMS, runs, None, visible_dims=("security", "reliability"))
+    one = accumulated_cache_version(
+        pd, DEFAULT_PARAMS, runs, None, visible_dims=("security",))
+    assert len({base, six, one}) == 3
+    # Selection is order-independent (sorted before hashing).
+    assert six == accumulated_cache_version(
+        pd, DEFAULT_PARAMS, runs, None, visible_dims=("reliability", "security"))
+
+
 def test_cached_accumulated_miss_then_hit(tmp_path, monkeypatch):
     monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
     calls = []


### PR DESCRIPTION
## What

A deselected standard is hidden on the Overview but still moved two displayed numbers. Concretely: with clean-architecture hidden (default selection), the hero showed 7.5 next to "grade C", and the project card showed a different grade than the Overview headline.

Two seams:

- The hero score is recomputed client-side from visible dimensions, but the grade letter passed through the backend's `overallGrade`, which averages every dimension including hidden ones.
- The project-card grade (`_read_accumulated_summary`) averaged all dimensions with no visibility filter, and its cache version could not see visibility edits, so even a fixed computation would have served the stale grade.

## Changes

- `scoreFiltering.js`: `filterAccumulatedByVisibleStandards` re-derives `overallGrade` from the recomputed visible-only average via `scoreToGradeLabel` (same thresholds the server serves at boot). Also fixes the exported overview report, which reads the same summary.
- `_fs_metadata.py`: the card summary scopes to the project's visible-standards selection (`.quodeq/standards-visibility.json` in the analyzed repo, same file the Overview client filter uses). Resolution mirrors `repo_attach_info`: online or moved repos fall back to the six ISO defaults, matching the UI default.
- `score_cache.py`: `accumulated_cache_version` takes an optional `visible_dims` that only the card path passes, so toggling a standard invalidates the cached card. Overview payload hashes are untouched (that path returns every dim and the client filters), and old card rows miss automatically because the version input changed shape. No writer-epoch bump needed.

The #753 behavior (dims absent from the latest run's config are kept) is unchanged within the visible set; the regression test now uses a default-visible dimension.

## Verification

- Backend: tests/services + tests/core 1321 passed, tests/api 714 passed.
- UI: 383 passed.
- New tests: hidden standard excluded from the card, default selection hides non-ISO dims, visibility edit invalidates the persisted card summary, grade letter re-derived from the visible-only average.

🤖 Generated with [Claude Code](https://claude.com/claude-code)