### PR TITLE
Readable elapsed times and one server-anchored clock on the evaluate screen

### DIFF
--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -131,8 +131,7 @@ def _dim_state(
     return "pending"
 
 
-def _parse_started_at(status: dict) -> datetime | None:
-    raw = status.get("started_at")
+def _parse_iso_utc(raw: object) -> datetime | None:
     if not isinstance(raw, str) or not raw:
         return None
     try:
@@ -146,6 +145,10 @@ def _parse_started_at(status: dict) -> datetime | None:
     return parsed
 
 
+def _parse_started_at(status: dict) -> datetime | None:
+    return _parse_iso_utc(status.get("started_at"))
+
+
 def _queue_take_timestamps(qstate: dict) -> list[float]:
     """Extract valid take-log timestamps from a queue state dict."""
     taken = qstate.get("taken")
@@ -157,20 +160,53 @@ def _queue_take_timestamps(qstate: dict) -> list[float]:
     ]
 
 
-def _dim_elapsed_s(dim_id: str, run_dir: Path, state: str) -> float | None:
-    """Per-dim elapsed time, derived from queue-state timestamps.
+def _stamped_elapsed_s(record: dict | None, state: str) -> float | None:
+    """Per-dim elapsed from the transition timestamps in dimensions.json.
 
-    The queue file is atomically rewritten on every take (new inode, fresh
-    mtime), so its mtime tracks the *last* take, not the dim start — using it
-    as the start made the running clock reset toward zero on every take.
-    Start comes from the queue's ``created_at`` (stamped at init), falling
-    back to the earliest take timestamp, then the file mtime for legacy
-    queues. For done dims the end is the latest activity signal we still
-    have: last take, evidence-file mtime, or any surviving agent streams
-    (streams are deleted at dim completion, so they rarely survive).
+    write_dim_state stamps ``started_at`` when the dimension starts and
+    ``completed_at`` / ``interrupted_at`` when it stops, so the duration is a
+    subtraction of two explicit values — no file-system forensics. None when
+    the record lacks the needed stamps (legacy runs, hard kills that never
+    reached the terminal write): the caller falls back to reconstruction.
+    """
+    if not isinstance(record, dict):
+        return None
+    start = _parse_iso_utc(record.get("started_at"))
+    if start is None:
+        return None
+    if state == "running":
+        return max(0.0, (datetime.now(timezone.utc) - start).total_seconds())
+    end = _parse_iso_utc(record.get("completed_at")) or _parse_iso_utc(record.get("interrupted_at"))
+    if end is None:
+        return None
+    return max(0.0, (end - start).total_seconds())
+
+
+def _dim_elapsed_s(dim_id: str, run_dir: Path, state: str, record: dict | None = None) -> float | None:
+    """Per-dim elapsed time.
+
+    Prefers the transition timestamps stamped in dimensions.json (see
+    _stamped_elapsed_s). The queue-state reconstruction below remains as a
+    fallback for run dirs written before those stamps were preserved,
+    external runs from older CLI versions, the consolidated pseudo-dim
+    (which has no dimensions.json entry), and dims that died without a
+    terminal transition.
+
+    Reconstruction notes: the queue file is atomically rewritten on every
+    take (new inode, fresh mtime), so its mtime tracks the *last* take, not
+    the dim start — using it as the start made the running clock reset
+    toward zero on every take. Start comes from the queue's ``created_at``
+    (stamped at init), falling back to the earliest take timestamp, then the
+    file mtime for legacy queues. For done dims the end is the latest
+    activity signal we still have: last take, evidence-file mtime, or any
+    surviving agent streams (streams are deleted at dim completion, so they
+    rarely survive).
     """
     if state == "pending":
         return None
+    stamped = _stamped_elapsed_s(record, state)
+    if stamped is not None:
+        return stamped
     queue = run_dir / "evidence" / f"{dim_id}_queue.json"
     qstate = _read_json(queue)
     if qstate is None:
@@ -373,7 +409,7 @@ def build_scan_progress(
             suppressed=matcher.is_suppressed if matcher.active else None,
             resolver=build_principle_resolver(dim_id, evaluators_dir, compiled_dir),
         )
-        elapsed = _dim_elapsed_s(dim_id, run_dir, d_state)
+        elapsed = _dim_elapsed_s(dim_id, run_dir, d_state, record)
         active = _active_agents(evidence_dir, dim_id) if d_state == "running" else 0
 
         dim_results.append(_DimProgress(

--- a/src/quodeq/shared/dimensions_state.py
+++ b/src/quodeq/shared/dimensions_state.py
@@ -67,6 +67,12 @@ def write_dim_state(
     Optional ``exit_reason`` attaches to the per-dim record on DONE, e.g.
     "done", "time_limit", "failure_streak", "cancelled", "error". The UI
     treats anything other than "done" as a partial-coverage signal.
+
+    Each transition merges into the existing record instead of replacing
+    it, so ``started_at`` (stamped on RUNNING) survives the DONE/INCOMPLETE
+    write — progress reads ``completed_at - started_at`` for a dimension's
+    duration. Safe because DONE and INCOMPLETE are terminal: no transition
+    can ever need a field cleared.
     """
     with _lock:
         data = read_dimensions(run_dir)
@@ -84,7 +90,8 @@ def write_dim_state(
                 raise IllegalDimTransitionError(
                     f"{dimension}: {prev.value} -> {state.value} not permitted",
                 )
-        entry: dict[str, Any] = {"state": state.value}
+        entry: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
+        entry["state"] = state.value
         if state == DimState.RUNNING:
             entry["started_at"] = _now_iso()
         elif state == DimState.DONE:

--- a/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
@@ -1,12 +1,13 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { StatStrip, Stat } from '../../../components/terminal/index.js';
 import { computeOverallProgress } from './scanProgressTotals.js';
 import {
-  buildJobStatCells, computeRate, buildEtaHint, msUntilNextSecond,
+  buildJobStatCells, computeRate, buildEtaHint,
   buildDimensionCycle, sumSeverities, deriveScanMode,
 } from './buildJobStatCells.js';
 import { recordRateSample, getRateSamples } from './rateSampleStore.js';
 import { useEvaluationProgress } from '../hooks/useEvaluationProgress.js';
+import { useRunElapsed } from '../hooks/useRunElapsed.js';
 
 const TERMINAL_STATES = new Set(['done', 'completed', 'failed', 'cancelled', 'lost']);
 
@@ -25,45 +26,14 @@ function sumSuppressed(progress) {
   return (progress?.dimensions || []).reduce((n, d) => n + (d?.suppressed || 0), 0);
 }
 
-// Live elapsed from wall-clock so the cell ticks every second between the 2s
-// progress polls. Falls back to the backend-reported elapsed only when the job
-// carries no usable startedAt.
-function deriveElapsedS(startedAt, endedAt, isTerminal, fallbackElapsed) {
-  if (startedAt) {
-    const start = Date.parse(startedAt);
-    if (!Number.isNaN(start)) {
-      const end = isTerminal && endedAt ? Date.parse(endedAt) : Date.now();
-      if (!Number.isNaN(end)) return Math.max(0, (end - start) / 1000);
-    }
-  }
-  if (fallbackElapsed != null && Number.isFinite(fallbackElapsed)) return fallbackElapsed;
-  return null;
-}
-
 export default function JobStatStrip({ job, liveViolations, hiddenCarriedCount = 0 }) {
   const jobId = job?.jobId;
   const isTerminal = TERMINAL_STATES.has(job?.status);
 
   const { data: progress, dataUpdatedAt } = useEvaluationProgress(jobId, isTerminal);
-
-  // Re-render aligned to each whole-second boundary of wall-clock elapsed, so
-  // ELAPSED ticks *evenly*. A fixed setInterval(1000) has its phase fixed at
-  // mount and beats against the second boundary as timer jitter drifts it,
-  // producing visible double/skip ticks. A self-correcting timeout recomputes
-  // the delay from absolute `now` each tick — it re-aligns to the boundary and
-  // never accumulates drift. Inactive on terminal states / without a startedAt
-  // (the elapsed value is then poll-derived and can't tick per-second anyway).
-  const [tick, setTick] = useState(0);
-  const startMs = job?.startedAt ? Date.parse(job.startedAt) : NaN;
-  useEffect(() => {
-    if (isTerminal || !jobId || Number.isNaN(startMs)) return undefined;
-    let id;
-    const schedule = () => {
-      id = setTimeout(() => { setTick((t) => t + 1); schedule(); }, msUntilNextSecond(Date.now() - startMs));
-    };
-    schedule();
-    return () => clearTimeout(id);
-  }, [isTerminal, jobId, startMs]);
+  // Server-anchored, per-second-ticking elapsed shared with ScanProgress, so
+  // the ELAPSED tile and the footer clock always agree.
+  const elapsedS = useRunElapsed(job, progress, dataUpdatedAt);
 
   // Throughput samples live in a module-level store (rateSampleStore.js) keyed
   // by jobId, so the sliding-window rate SURVIVES navigating out of and back
@@ -81,7 +51,6 @@ export default function JobStatStrip({ job, liveViolations, hiddenCarriedCount =
   const cells = useMemo(() => {
     if (!jobId) return [];
     const { takenFiles, totalFiles, overallPct } = computeOverallProgress(progress);
-    const elapsedS = deriveElapsedS(job?.startedAt, job?.endedAt, isTerminal, progress?.totalElapsedS);
     const liveCount = sumLiveViolations(liveViolations);
     // Current throughput from the persisted sliding window (null → "estimating…"
     // until ~30s of samples accumulate). No whole-run average: it over-reads
@@ -96,8 +65,8 @@ export default function JobStatStrip({ job, liveViolations, hiddenCarriedCount =
       sevCounts: sumSeverities(liveViolations),
       scanMode: deriveScanMode(progress),
     });
-    // `tick` drives the per-second recompute; the sample store is read (not a dep).
-  }, [jobId, job?.status, job?.startedAt, job?.endedAt, isTerminal, progress, liveViolations, hiddenCarriedCount, tick]);
+    // `elapsedS` advances once per second via useRunElapsed; the sample store is read (not a dep).
+  }, [jobId, job?.status, isTerminal, progress, liveViolations, hiddenCarriedCount, elapsedS]);
 
   if (!jobId) return null;
 

--- a/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.test.jsx
@@ -40,7 +40,7 @@ describe('JobStatStrip', () => {
     expect(await screen.findByText('63%')).toBeInTheDocument();
     expect(screen.getByText('138')).toBeInTheDocument();
     expect(screen.getByText('/ 220')).toBeInTheDocument();
-    expect(screen.getByText('2:14')).toBeInTheDocument();
+    expect(screen.getByText('2m 14s')).toBeInTheDocument();
     expect(screen.getByText('2')).toBeInTheDocument();    // violations count
     expect(screen.getByText('1 critical · 1 major')).toBeInTheDocument();
   });
@@ -56,7 +56,7 @@ describe('JobStatStrip', () => {
     expect(screen.getByText('DURATION')).toBeInTheDocument();
     expect(await screen.findByText('220')).toBeInTheDocument();
     expect(screen.getByText('13')).toBeInTheDocument();
-    expect(screen.getByText('4:32')).toBeInTheDocument();
+    expect(screen.getByText('4m 32s')).toBeInTheDocument();
   });
 
   it('renders fallback values when progress query has no data yet', () => {
@@ -132,20 +132,34 @@ describe('JobStatStrip', () => {
     nowSpy.mockRestore();
   });
 
-  it('ELAPSED reflects wall-clock from startedAt (not backend elapsed)', async () => {
+  it('ELAPSED is anchored to the server-reported elapsed, not client wall-clock', async () => {
+    // The client's clock disagrees with the server by hours (skew, suspended
+    // laptop): startedAt reads as 5s ago, but the server has measured 9999s
+    // of run time. The server value wins — every clock on the screen derives
+    // from it, so skew can't corrupt the display.
     const now = new Date('2026-06-08T10:00:00Z').getTime();
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
     getEvaluationProgress.mockResolvedValue({
       dimensions: [{ state: 'running', files: { taken: 10, total: 1000 } }],
-      totalElapsedS: 9999, // would show 166:39 if backend value were used
+      totalElapsedS: 9999,
     });
     const job = { jobId: 'job-4', status: 'running', startedAt: new Date(now - 5000).toISOString() };
     renderWithClient(<JobStatStrip job={job} liveViolations={{}} />);
-    // Wait for the poll to resolve (PROGRESS shows 1%) so we assert the
-    // post-resolution value: with the old code this would flip to backend
-    // 9999s (166:39); the new code keeps wall-clock 0:05.
     expect(await screen.findByText('1%')).toBeInTheDocument();
-    expect(screen.getByText('0:05')).toBeInTheDocument();
+    expect(screen.getByText('2h 46m 39s')).toBeInTheDocument();
+    nowSpy.mockRestore();
+  });
+
+  it('ELAPSED falls back to job wall-clock before any progress payload lands', async () => {
+    const now = new Date('2026-06-08T10:00:00Z').getTime();
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+    getEvaluationProgress.mockResolvedValue({
+      dimensions: [{ state: 'running', files: { taken: 10, total: 1000 } }],
+    });
+    const job = { jobId: 'job-4b', status: 'running', startedAt: new Date(now - 5000).toISOString() };
+    renderWithClient(<JobStatStrip job={job} liveViolations={{}} />);
+    expect(await screen.findByText('1%')).toBeInTheDocument();
+    expect(screen.getByText('5s')).toBeInTheDocument();
     nowSpy.mockRestore();
   });
 
@@ -160,9 +174,9 @@ describe('JobStatStrip', () => {
       const job = { jobId: 'job-5', status: 'running', startedAt: new Date(t0 - 5000).toISOString() };
       renderWithClient(<JobStatStrip job={job} liveViolations={{}} />);
       await vi.advanceTimersByTimeAsync(0);     // flush the initial fetch
-      expect(screen.getByText('0:05')).toBeInTheDocument();
+      expect(screen.getByText('5s')).toBeInTheDocument();
       await vi.advanceTimersByTimeAsync(2000);  // two 1s ticks
-      expect(screen.getByText('0:07')).toBeInTheDocument();
+      expect(screen.getByText('7s')).toBeInTheDocument();
     } finally {
       vi.useRealTimers();
     }

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -5,17 +5,11 @@ import { deriveScanMode } from './buildJobStatCells.js';
 import ConsoleButton from '../../../components/ConsoleButton.jsx';
 import { SectionLabel } from '../../../components/terminal/index.js';
 import { useEvaluationProgress } from '../hooks/useEvaluationProgress.js';
+import { useRunElapsed } from '../hooks/useRunElapsed.js';
+import { formatDuration, formatDurationCoarse } from '../../../utils/formatters.js';
 
 const TERMINAL_STATES = new Set(['done', 'failed', 'cancelled']);
 const STATUS_MARKERS = { arrow: '→', check: '✓', error: 'Error:', failed: 'failed' };
-
-function formatClock(s) {
-  if (s == null || !Number.isFinite(s)) return '—';
-  const total = Math.max(0, Math.floor(s));
-  const m = Math.floor(total / 60);
-  const sec = total % 60;
-  return `${m}:${String(sec).padStart(2, '0')}`;
-}
 
 function isStatusLine(line) {
   const prefixes = [STATUS_MARKERS.arrow, STATUS_MARKERS.check, STATUS_MARKERS.error];
@@ -88,7 +82,7 @@ function DimRow({ dim }) {
             title={partialTooltip}
           >{coveragePct}%</span>{dim.elapsedS != null && ' · '}</>
         )}
-        {dim.elapsedS != null && formatClock(dim.elapsedS)}
+        {dim.elapsedS != null && formatDuration(dim.elapsedS)}
       </>
     );
   } else {
@@ -97,7 +91,7 @@ function DimRow({ dim }) {
     // dangling "· —" tail. The time budget is run-level (shared across
     // dimensions, shown in the footer), so rows only get their elapsed.
     const clockPart = dim.elapsedS != null
-      ? <span className="scan-progress__budget">{formatClock(dim.elapsedS)}</span>
+      ? <span className="scan-progress__budget">{formatDuration(dim.elapsedS)}</span>
       : null;
     meta = (
       <>
@@ -144,6 +138,9 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
   // Best-effort: surface the last successful payload, ignore errors silently
   // (progress is purely informational and should never block the UI).
   const progress = progressQuery.data ?? null;
+  // Same server-anchored ticking clock the stat strip shows, so the footer
+  // total can never disagree with the ELAPSED tile.
+  const elapsedS = useRunElapsed(job, progress, progressQuery.dataUpdatedAt);
 
   useEffect(() => {
     if (evalLog.activeJobId === jobId) {
@@ -195,15 +192,15 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
   // run-level budget. Overrun can show briefly: the watchdog allows a
   // short grace past the deadline before killing the job.
   const runBudgetS = progress?.budgetS;
-  const overrun = runBudgetS > 0 && progress?.totalElapsedS > runBudgetS;
+  const overrun = runBudgetS > 0 && elapsedS > runBudgetS;
   const clockPart = isRunning && runBudgetS > 0
     ? (
       <> · <span className={overrun ? 'scan-progress__budget scan-progress__budget--overrun' : 'scan-progress__budget'}>
-        {formatClock(progress.totalElapsedS)} of {formatClock(runBudgetS)} budget
+        {formatDuration(elapsedS)} of {formatDurationCoarse(runBudgetS)} budget
       </span></>
     )
-    : progress?.totalElapsedS != null
-      ? <> · {formatClock(progress.totalElapsedS)} total</>
+    : elapsedS != null
+      ? <> · {formatDuration(elapsedS)} total</>
       : null;
 
   let summary;

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.test.jsx
@@ -231,7 +231,7 @@ describe('ScanProgress total coverage (incremental runs)', () => {
     payload.totalElapsedS = 78;
     getEvaluationProgress.mockResolvedValue(payload);
     withEvalLog(<ScanProgress job={baseJob} />, ctx);
-    expect(await screen.findByText(/1:18 of 10:00 budget/)).toBeInTheDocument();
+    expect(await screen.findByText(/1m 18s of 10m budget/)).toBeInTheDocument();
   });
 
   it('marks the footer budget as overrun once elapsed passes it', async () => {
@@ -240,7 +240,7 @@ describe('ScanProgress total coverage (incremental runs)', () => {
     payload.totalElapsedS = 640;
     getEvaluationProgress.mockResolvedValue(payload);
     const { container } = withEvalLog(<ScanProgress job={baseJob} />, ctx);
-    await screen.findByText(/10:40 of 10:00 budget/);
+    await screen.findByText(/10m 40s of 10m budget/);
     expect(container.querySelector('.scan-progress__budget--overrun')).not.toBeNull();
   });
 
@@ -255,7 +255,7 @@ describe('ScanProgress total coverage (incremental runs)', () => {
     withEvalLog(<ScanProgress job={baseJob} />, ctx);
     fireEvent.click(await screen.findByTitle('Show per-dimension detail'));
     const row = (await screen.findByText('security')).closest('.scan-progress__dim');
-    expect(row.textContent).toContain('1:18');
+    expect(row.textContent).toContain('1m 18s');
     expect(row.textContent).not.toContain('budget');
   });
 });

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
@@ -4,6 +4,7 @@
  */
 
 import { computeOverallProgress } from './scanProgressTotals.js';
+import { formatDuration } from '../../../utils/formatters.js';
 
 // Throughput estimate tuning. The eval completes only a few files per MINUTE
 // (one slow LLM call per file), so the rate is shown per minute and measured
@@ -94,12 +95,40 @@ export function msUntilNextSecond(elapsedMs) {
   return 1000 - rem;
 }
 
-export function formatClock(s) {
-  if (s == null || !Number.isFinite(s)) return '—';
-  const total = Math.max(0, Math.floor(s));
-  const m = Math.floor(total / 60);
-  const sec = total % 60;
-  return `${m}:${String(sec).padStart(2, '0')}`;
+/**
+ * One elapsed value for the whole evaluate screen, anchored to the SERVER's
+ * clock. The progress payload reports totalElapsedS computed from the run's
+ * own status.json timestamps; the client only extrapolates forward by the
+ * time since that payload landed. Anchoring to the server (instead of
+ * Date.parse(job.startedAt) vs client Date.now()) makes the clock immune to
+ * client/server clock skew and keeps every clock on the screen in lock-step
+ * — the stat strip and the footer previously mixed client wall-clock with
+ * 2s-stale poll data and visibly disagreed.
+ *
+ * Fallback order when the server hasn't reported an elapsed yet (first
+ * render before any poll, legacy runs): job wall-clock timestamps, else null.
+ * Non-running jobs freeze on the server value (or startedAt→endedAt).
+ *
+ * @param {object} args
+ * @param {boolean} args.running
+ * @param {number|null|undefined} args.serverElapsedS — progress.totalElapsedS
+ * @param {number|null|undefined} args.serverUpdatedAtMs — when that payload landed (epoch ms)
+ * @param {number} args.nowMs
+ * @param {string|null|undefined} args.startedAt — ISO, fallback only
+ * @param {string|null|undefined} args.endedAt — ISO, fallback only
+ * @returns {number|null} seconds
+ */
+export function deriveRunElapsedS({ running, serverElapsedS, serverUpdatedAtMs, nowMs, startedAt, endedAt }) {
+  if (Number.isFinite(serverElapsedS)) {
+    if (!running) return serverElapsedS;
+    const sinceMs = Number.isFinite(serverUpdatedAtMs) ? Math.max(0, nowMs - serverUpdatedAtMs) : 0;
+    return serverElapsedS + sinceMs / 1000;
+  }
+  const start = startedAt ? Date.parse(startedAt) : NaN;
+  if (Number.isNaN(start)) return null;
+  const end = !running && endedAt ? Date.parse(endedAt) : nowMs;
+  if (Number.isNaN(end)) return null;
+  return Math.max(0, (end - start) / 1000);
 }
 
 /**
@@ -184,7 +213,7 @@ function progressCell({ overallPct, takenFiles, totalFiles }) {
 function elapsedCell(elapsedS, label = 'ELAPSED', hint = null) {
   return {
     label,
-    value: formatClock(elapsedS),
+    value: formatDuration(elapsedS),
     hint,
     tone: 'default',
   };

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   buildJobStatCells,
-  formatClock,
+  deriveRunElapsedS,
   computeRate,
   RATE_WINDOW_MS,
   formatRate,
@@ -21,27 +21,62 @@ const baseInputs = {
   overallPct: 62,
   takenFiles: 138,
   totalFiles: 220,
-  elapsedS: 134,         // 02:14
+  elapsedS: 134,         // 2m 14s
   liveCount: 2,
 };
 
 // ---------------------------------------------------------------------------
-// formatClock
+// deriveRunElapsedS
 // ---------------------------------------------------------------------------
 
-test('formatClock: formats seconds as m:ss', () => {
-  assert.equal(formatClock(0), '0:00');
-  assert.equal(formatClock(59), '0:59');
-  assert.equal(formatClock(60), '1:00');
-  assert.equal(formatClock(134), '2:14');
-  assert.equal(formatClock(3661), '61:01');
+const T0 = Date.parse('2026-06-08T10:00:00Z');
+
+test('deriveRunElapsedS: running — server elapsed extrapolated by time since the poll', () => {
+  const s = deriveRunElapsedS({
+    running: true, serverElapsedS: 134, serverUpdatedAtMs: T0 - 1500, nowMs: T0,
+    startedAt: null, endedAt: null,
+  });
+  assert.equal(s, 135.5);
 });
 
-test('formatClock: returns "—" for null/undefined/non-finite', () => {
-  assert.equal(formatClock(null), '—');
-  assert.equal(formatClock(undefined), '—');
-  assert.equal(formatClock(NaN), '—');
-  assert.equal(formatClock(Infinity), '—');
+test('deriveRunElapsedS: server elapsed wins over job wall-clock timestamps (skew immunity)', () => {
+  // Client thinks the run started 5s ago; server says 9999s. Server wins.
+  const s = deriveRunElapsedS({
+    running: true, serverElapsedS: 9999, serverUpdatedAtMs: T0, nowMs: T0,
+    startedAt: new Date(T0 - 5000).toISOString(), endedAt: null,
+  });
+  assert.equal(s, 9999);
+});
+
+test('deriveRunElapsedS: non-running freezes on the server value, no extrapolation', () => {
+  const s = deriveRunElapsedS({
+    running: false, serverElapsedS: 272, serverUpdatedAtMs: T0 - 60000, nowMs: T0,
+    startedAt: null, endedAt: null,
+  });
+  assert.equal(s, 272);
+});
+
+test('deriveRunElapsedS: falls back to job timestamps before any progress payload', () => {
+  const running = deriveRunElapsedS({
+    running: true, serverElapsedS: undefined, serverUpdatedAtMs: undefined, nowMs: T0,
+    startedAt: new Date(T0 - 5000).toISOString(), endedAt: null,
+  });
+  assert.equal(running, 5);
+  const ended = deriveRunElapsedS({
+    running: false, serverElapsedS: null, serverUpdatedAtMs: undefined, nowMs: T0,
+    startedAt: new Date(T0 - 90000).toISOString(), endedAt: new Date(T0 - 30000).toISOString(),
+  });
+  assert.equal(ended, 60);
+});
+
+test('deriveRunElapsedS: null when nothing is knowable, clamped at 0 for clock regressions', () => {
+  assert.equal(deriveRunElapsedS({ running: true, nowMs: T0, startedAt: null, endedAt: null }), null);
+  assert.equal(deriveRunElapsedS({ running: true, nowMs: T0, startedAt: 'not-a-date', endedAt: null }), null);
+  const s = deriveRunElapsedS({
+    running: true, serverElapsedS: undefined, nowMs: T0,
+    startedAt: new Date(T0 + 5000).toISOString(), endedAt: null,
+  });
+  assert.equal(s, 0);
 });
 
 // ---------------------------------------------------------------------------
@@ -67,7 +102,7 @@ test('buildJobStatCells: builds 4 cells for a running job with progress data', (
   assert.equal(cells[2].value, 2);
   assert.equal(cells[2].tone, 'critical');
   assert.equal(cells[3].label, 'elapsed');
-  assert.equal(cells[3].value, '2:14');
+  assert.equal(cells[3].value, '2m 14s');
 });
 
 test('buildJobStatCells: running analyzing tile falls back while dims are unknown', () => {
@@ -116,7 +151,7 @@ test('buildJobStatCells: builds done-state cells with SCANNED + VIOLATIONS + DUR
   assert.equal(cells[2].value, 13);
   assert.equal(cells[2].tone, 'critical');
   assert.equal(cells[3].label, 'DURATION');
-  assert.equal(cells[3].value, '4:32');
+  assert.equal(cells[3].value, '4m 32s');
 });
 
 test('buildJobStatCells: uses correct tone for STATUS by status', () => {

--- a/src/quodeq/ui/src/features/evaluation/hooks/useRunElapsed.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useRunElapsed.js
@@ -1,0 +1,53 @@
+import { useEffect, useReducer } from 'react';
+import { deriveRunElapsedS, msUntilNextSecond } from '../components/buildJobStatCells.js';
+
+/**
+ * The evaluate screen's elapsed clock, in seconds. Server-anchored (see
+ * deriveRunElapsedS) and ticking once per second while the job runs, so
+ * every consumer — the stat strip's ELAPSED tile and the progress footer —
+ * reads the exact same value and can never drift apart.
+ *
+ * Ticks are aligned to the whole-second boundary of the *elapsed* value
+ * (msUntilNextSecond): a fixed 1s interval has its phase fixed at mount and
+ * beats against the boundary, producing visible double/skip ticks.
+ *
+ * @param {object|null} job — needs status, startedAt, endedAt
+ * @param {object|null} progress — the polled progress payload (totalElapsedS)
+ * @param {number|undefined} dataUpdatedAt — react-query's timestamp for when
+ *   that payload landed; the extrapolation base between polls
+ * @returns {number|null} elapsed seconds, null while unknowable
+ */
+export function useRunElapsed(job, progress, dataUpdatedAt) {
+  const running = job?.status === 'running';
+  const [, bump] = useReducer((t) => t + 1, 0);
+
+  const elapsedS = deriveRunElapsedS({
+    running,
+    serverElapsedS: progress?.totalElapsedS,
+    serverUpdatedAtMs: dataUpdatedAt,
+    nowMs: Date.now(),
+    startedAt: job?.startedAt,
+    endedAt: job?.endedAt,
+  });
+
+  const serverElapsedS = progress?.totalElapsedS;
+  const startedAt = job?.startedAt;
+  const active = running && elapsedS != null;
+  useEffect(() => {
+    if (!active) return undefined;
+    // Virtual start of the run on the client's clock: the display flips when
+    // floor((now - anchor) / 1000) changes, matching deriveRunElapsedS.
+    const anchorMs = Number.isFinite(serverElapsedS) && Number.isFinite(dataUpdatedAt)
+      ? dataUpdatedAt - serverElapsedS * 1000
+      : Date.parse(startedAt);
+    if (Number.isNaN(anchorMs)) return undefined;
+    let id;
+    const schedule = () => {
+      id = setTimeout(() => { bump(); schedule(); }, msUntilNextSecond(Date.now() - anchorMs));
+    };
+    schedule();
+    return () => clearTimeout(id);
+  }, [active, serverElapsedS, dataUpdatedAt, startedAt]);
+
+  return elapsedS;
+}

--- a/src/quodeq/ui/src/utils/formatters.duration.test.js
+++ b/src/quodeq/ui/src/utils/formatters.duration.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatDuration, formatDurationCoarse } from './formatters.js';
+
+test('formatDuration: seconds only under a minute', () => {
+  assert.equal(formatDuration(0), '0s');
+  assert.equal(formatDuration(42), '42s');
+  assert.equal(formatDuration(59.9), '59s'); // floors, never rounds up
+});
+
+test('formatDuration: minutes and seconds under an hour', () => {
+  assert.equal(formatDuration(60), '1m 0s');
+  assert.equal(formatDuration(134), '2m 14s');
+  assert.equal(formatDuration(3599), '59m 59s');
+});
+
+test('formatDuration: hours from 3600s up (the 255:12 case reads 4h 15m 12s)', () => {
+  assert.equal(formatDuration(3600), '1h 0m 0s');
+  assert.equal(formatDuration(15312), '4h 15m 12s');
+  assert.equal(formatDuration(90000), '25h 0m 0s'); // no day rollover
+});
+
+test('formatDuration: "—" for unknown, clamps negatives to 0s', () => {
+  assert.equal(formatDuration(null), '—');
+  assert.equal(formatDuration(undefined), '—');
+  assert.equal(formatDuration(NaN), '—');
+  assert.equal(formatDuration(Infinity), '—');
+  assert.equal(formatDuration(-5), '0s');
+});
+
+test('formatDurationCoarse: drops zero components for round targets', () => {
+  assert.equal(formatDurationCoarse(7200), '2h');
+  assert.equal(formatDurationCoarse(5400), '1h 30m');
+  assert.equal(formatDurationCoarse(600), '10m');
+  assert.equal(formatDurationCoarse(30), '30s');
+  assert.equal(formatDurationCoarse(0), '0s');
+});
+
+test('formatDurationCoarse: seconds appear only under a minute', () => {
+  assert.equal(formatDurationCoarse(90), '1m'); // 1m 30s truncates to the minute
+  assert.equal(formatDurationCoarse(3661), '1h 1m');
+  assert.equal(formatDurationCoarse(null), '—');
+});

--- a/src/quodeq/ui/src/utils/formatters.js
+++ b/src/quodeq/ui/src/utils/formatters.js
@@ -264,6 +264,45 @@ export function mostFrequentGrade(grades) {
   return capitalizeGrade(maxGrade);
 }
 
+/**
+ * Human-readable duration from seconds: "42s", "12m 34s", "4h 15m 12s".
+ * Floors to whole seconds so a ticking clock advances evenly; "—" when the
+ * value is unknown.
+ *
+ * @param {number|null|undefined} s
+ * @returns {string}
+ */
+export function formatDuration(s) {
+  if (s == null || !Number.isFinite(s)) return '—';
+  const total = Math.max(0, Math.floor(s));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const sec = total % 60;
+  if (h > 0) return `${h}h ${m}m ${sec}s`;
+  if (m > 0) return `${m}m ${sec}s`;
+  return `${sec}s`;
+}
+
+/**
+ * Duration for round targets like time budgets: zero components are dropped
+ * ("2h", "1h 30m", "45m"), so a 2-hour budget never reads "2h 0m 0s". Seconds
+ * appear only under a minute.
+ *
+ * @param {number|null|undefined} s
+ * @returns {string}
+ */
+export function formatDurationCoarse(s) {
+  if (s == null || !Number.isFinite(s)) return '—';
+  const total = Math.max(0, Math.round(s));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const parts = [];
+  if (h > 0) parts.push(`${h}h`);
+  if (m > 0) parts.push(`${m}m`);
+  if (parts.length === 0) parts.push(`${total % 60}s`);
+  return parts.join(' ');
+}
+
 const PERIOD_MONTH_NAMES = [
   'January', 'February', 'March', 'April', 'May', 'June',
   'July', 'August', 'September', 'October', 'November', 'December',

--- a/tests/services/test_scan_progress.py
+++ b/tests/services/test_scan_progress.py
@@ -411,6 +411,107 @@ class TestDimElapsed:
         assert 115 <= dim.elapsed_s <= 130
 
 
+class TestDimElapsedFromStamps:
+    """Transition timestamps in dimensions.json beat queue reconstruction.
+
+    write_dim_state stamps started_at/completed_at at the actual state
+    transitions, so when both ends exist the duration is exact — the
+    queue/mtime forensics stay fallback-only.
+    """
+
+    def _write_queue(self, run_dir: Path, dim: str, payload: dict) -> None:
+        (run_dir / "evidence" / f"{dim}_queue.json").write_text(
+            json.dumps(payload), encoding="utf-8",
+        )
+
+    def _write_dim_record(self, run_dir: Path, dim: str, record: dict) -> None:
+        (run_dir / "dimensions.json").write_text(
+            json.dumps({"schema_version": 1, "dimensions": {dim: record}}),
+            encoding="utf-8",
+        )
+
+    def test_running_dim_prefers_stamped_started_at(self, tmp_path: Path) -> None:
+        import time as _t
+        from datetime import datetime, timezone
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"])
+        now = _t.time()
+        # Queue says the dim started 300s ago; the stamped record says 600s.
+        self._write_queue(run_dir, "security", {
+            "created_at": now - 300,
+            "taken": [{"files": ["a.py"], "agent": "a1", "ts": now - 2}],
+            "pending": ["b.py"],
+        })
+        started = datetime.fromtimestamp(now - 600, tz=timezone.utc).isoformat()
+        self._write_dim_record(run_dir, "security", {"state": "running", "started_at": started})
+        dim = build_scan_progress("j1", run_dir).dimensions[0]
+        assert dim.state == "running"
+        assert dim.elapsed_s is not None
+        assert 595 <= dim.elapsed_s <= 610
+
+    def test_done_dim_duration_is_stamp_subtraction(self, tmp_path: Path) -> None:
+        import time as _t
+        from datetime import datetime, timezone
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"], state="done")
+        now = _t.time()
+        # Take log would reconstruct >=300s; the stamps say exactly 250s.
+        self._write_queue(run_dir, "security", {
+            "created_at": now - 400,
+            "taken": [
+                {"files": ["a.py"], "agent": "a1", "ts": now - 350},
+                {"files": ["b.py"], "agent": "a1", "ts": now - 100},
+            ],
+            "pending": [],
+        })
+        iso = lambda s: datetime.fromtimestamp(now - s, tz=timezone.utc).isoformat()  # noqa: E731
+        self._write_dim_record(run_dir, "security", {
+            "state": "done", "started_at": iso(350), "completed_at": iso(100),
+        })
+        dim = build_scan_progress("j1", run_dir).dimensions[0]
+        assert dim.state == "done"
+        assert dim.elapsed_s == 250.0
+
+    def test_interrupted_dim_uses_interrupted_at_as_end(self, tmp_path: Path) -> None:
+        import time as _t
+        from datetime import datetime, timezone
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"], state="cancelled")
+        now = _t.time()
+        self._write_queue(run_dir, "security", {
+            "created_at": now - 400,
+            "taken": [{"files": ["a.py"], "agent": "a1", "ts": now - 350}],
+            "pending": ["b.py"],
+        })
+        iso = lambda s: datetime.fromtimestamp(now - s, tz=timezone.utc).isoformat()  # noqa: E731
+        self._write_dim_record(run_dir, "security", {
+            "state": "incomplete", "started_at": iso(300), "interrupted_at": iso(120),
+        })
+        dim = build_scan_progress("j1", run_dir).dimensions[0]
+        assert dim.elapsed_s == 180.0
+
+    def test_done_dim_without_end_stamp_falls_back_to_reconstruction(self, tmp_path: Path) -> None:
+        # A hard kill can leave started_at with no terminal stamp; the queue
+        # take-log reconstruction must still produce a number.
+        import time as _t
+        from datetime import datetime, timezone
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"], state="done")
+        now = _t.time()
+        self._write_queue(run_dir, "security", {
+            "created_at": now - 400,
+            "taken": [{"files": ["a.py"], "agent": "a1", "ts": now - 100}],
+            "pending": [],
+        })
+        started = datetime.fromtimestamp(now - 350, tz=timezone.utc).isoformat()
+        self._write_dim_record(run_dir, "security", {"state": "running", "started_at": started})
+        dim = build_scan_progress("j1", run_dir).dimensions[0]
+        assert dim.state == "done"
+        # created_at (now-400) -> last take (now-100): reconstruction, not stamps.
+        assert dim.elapsed_s is not None
+        assert dim.elapsed_s >= 295
+
+
 class TestConsolidatedProgress:
     """Consolidated (grouped) runs write consolidated_* files, not per-dim
     queues, so the per-dim reader showed 0% / "estimating…" for the whole

--- a/tests/shared/test_dimensions_state.py
+++ b/tests/shared/test_dimensions_state.py
@@ -58,6 +58,34 @@ class TestStateMachine:
         assert not (tmp_path / "dimensions.json.tmp").exists()
 
 
+class TestTransitionTimestampsPreserved:
+    """Transitions merge into the record; earlier stamps survive.
+
+    Progress derives a dimension's duration as completed_at - started_at,
+    which only works if the DONE write doesn't wipe the RUNNING stamp."""
+
+    def test_started_at_survives_done(self, tmp_path: Path):
+        write_dim_state(tmp_path, "security", DimState.PENDING)
+        write_dim_state(tmp_path, "security", DimState.RUNNING)
+        started = read_dimensions(tmp_path)["dimensions"]["security"]["started_at"]
+        write_dim_state(tmp_path, "security", DimState.DONE, exit_reason="done")
+        entry = read_dimensions(tmp_path)["dimensions"]["security"]
+        assert entry["state"] == "done"
+        assert entry["started_at"] == started
+        assert entry["completed_at"]
+        assert entry["exit_reason"] == "done"
+
+    def test_started_at_survives_incomplete(self, tmp_path: Path):
+        write_dim_state(tmp_path, "security", DimState.PENDING)
+        write_dim_state(tmp_path, "security", DimState.RUNNING)
+        started = read_dimensions(tmp_path)["dimensions"]["security"]["started_at"]
+        write_dim_state(tmp_path, "security", DimState.INCOMPLETE, reason="cancelled_by_user")
+        entry = read_dimensions(tmp_path)["dimensions"]["security"]
+        assert entry["started_at"] == started
+        assert entry["interrupted_at"]
+        assert entry["reason"] == "cancelled_by_user"
+
+
 class TestRead:
     def test_missing_file_returns_empty(self, tmp_path: Path):
         assert read_dimensions(tmp_path) == {"schema_version": 1, "dimensions": {}}


### PR DESCRIPTION
## What

- Elapsed times and timers on the evaluate screen read in human units: `4h 15m 12s` instead of `255:12`, budgets as `10m` instead of `10:00`. One shared formatter replaces two duplicated M:SS helpers.
- The ELAPSED tile and the progress footer now share a single clock (`useRunElapsed`). It anchors to the server-reported `totalElapsedS` and extrapolates between polls, ticking per second.
- Per-dim elapsed on the backend comes from the `started_at`/`completed_at` stamps written at state transitions instead of being reconstructed from queue files and evidence mtimes.

## Why

The tile ticked from client wall clock while the footer showed the 2s-stale poll value, so the two clocks disagreed on screen and the footer was blank on entry until the first poll. Client clock skew could corrupt the tile outright. On the backend, `write_dim_state` replaced the record on every transition, wiping `started_at` at DONE, which is why progress had to infer durations from file-system side effects (a chain that already produced the clock-reset-on-take bug).

The old reconstruction stays as a fallback for pre-change run dirs, older external CLI runs, the consolidated pseudo-dim, and dims killed without a terminal write.

## Testing

- UI suite passes (178 files, 1469 tests). New tests for the duration formats and the server-over-client precedence.
- Backend: tests/shared, tests/services, tests/analysis all pass (2340). New tests for stamp preservation across transitions, stamped-over-reconstruction preference, the interrupted case, and the hard-kill fallback.
- Verified live against a running evaluation: tile and footer render identical values and tick together (6m 55s to 6m 58s), no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)