### PR TITLE
Release v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.8.1] - 2026-07-29
+
+### Features
+- **Live feed**: findings from a run that never finished (cancelled, failed, or killed) now show up as new on your next scan instead of being hidden as carried over. Only runs that actually completed mark their findings as carried forward.
+
+### Improvements
+- **Readable times on the evaluate screen**: elapsed times and budgets read in human units, so a long run shows `4h 15m 12s` instead of `255:12` and a budget shows `10m` instead of `10:00`.
+
+### Fixes
+- **Evaluate screen clocks**: the ELAPSED tile and the progress footer now share one clock anchored to the server, so the two no longer disagree on screen, the footer is no longer blank until the first poll, and a skewed clock on your machine cannot throw the tile off. Per-dimension elapsed now comes from the run's own state transitions instead of being inferred from file timestamps.
+- **Overview grades**: hidden standards no longer move the numbers you see. The hero grade letter and the project card grade are both derived from the standards you left visible, so the headline, its letter, and the card agree.
+- **Stale scores after a run**: opening a project's scores while a scan was still running could freeze a partial set of dimensions in the cache, leaving the Overview on raw scores while the dimension pages showed the dismiss-adjusted ones. Partial results are no longer cached or persisted.
+- **Multi-module projects**: repos whose root belongs to no detected subproject keep their full source tree instead of dropping every file outside a subproject. Kotlin Multiplatform repos were scanning zero files.
+- **Android detection**: projects that declare the Android Gradle plugin through a version catalog alias are now recognized as Android.
+- **Terminal**: clicking a link in the terminal opens it in your browser, instead of a warning dialog whose OK button did nothing.
+- **Security**: the evaluations route rejects repo paths outside the project, credential stripping in URLs runs in linear time on hostile input, and the remote-repo check no longer treats any URL merely containing github.com as remote.
+
 ## [1.8.0] - 2026-07-29
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <h2 align="center">AI-powered code quality and security scanner</h2>
-<p align="center"><strong>v1.8.0</strong></p>
+<p align="center"><strong>v1.8.1</strong></p>
 <p align="center">
   <a href="https://github.com/quodeq/quodeq/actions/workflows/test.yml"><img src="https://github.com/quodeq/quodeq/actions/workflows/test.yml/badge.svg" alt="Tests" /></a>
   <a href="https://github.com/quodeq/quodeq/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>

--- a/packaging/macos/launcher.sh
+++ b/packaging/macos/launcher.sh
@@ -63,7 +63,7 @@ if [ -z "$QUODEQ" ]; then
         # ranges. The release skill bumps this on every cut (see
         # .claude/skills/release/SKILL.md).
         # TODO: ship requirements.txt with hashes in the .app bundle.
-        python3 -m pip install --user --only-binary :all: --no-deps "quodeq==1.8.0" 2>&1
+        python3 -m pip install --user --only-binary :all: --no-deps "quodeq==1.8.1" 2>&1
     fi
     export PATH="$PATH:$(python3 -m site --user-base)/bin"
     QUODEQ=$(command -v quodeq 2>/dev/null)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quodeq"
-version = "1.8.0"
+version = "1.8.1"
 description = "Source code quality evaluation platform powered by AI"
 readme = "README.md"
 license = "MIT"

--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -593,16 +593,25 @@ def run_evaluate(args: argparse.Namespace) -> int:
             _cleanup_worktree(worktree_origin, worktree_dir)
         raise
     result = _run_pipeline_with_cleanup(args, inputs, paths)
+    _, _evidence_dir, evaluation_dir = paths
+    # --diff-from / --evidence-only produce no scored reports: nothing to
+    # export and nothing consolidated into the Overview.
+    no_scored_reports = bool(
+        getattr(args, "diff_from", None) or getattr(args, "evidence_only", False)
+    )
+    # Fail-soft consolidation pass, OUTSIDE the run lifecycle (it has fully
+    # closed by now), so a failure here can never flip the run state. Marks
+    # this run's cache entries consolidated so the NEXT run replays their
+    # findings as carried forward. Gated internally on status.json reading
+    # "done", which is why a run cancelled with "keep findings", a failed
+    # run, and a killed process all leave their entries unconsolidated and
+    # their findings still read as new in the live feed.
+    if not no_scored_reports:
+        from quodeq.analysis.cache.consolidation import mark_run_consolidated
+        mark_run_consolidated(evaluation_dir.parent)
     # Fail-soft SARIF export, OUTSIDE the run lifecycle (it has fully closed by
     # now), only on success and only when scored reports exist. A SARIF error
-    # here can never flip the run state. --diff-from / --evidence-only produce
-    # no scored reports, so skip them.
-    if (
-        result == 0
-        and getattr(args, "sarif", None)
-        and not getattr(args, "diff_from", None)
-        and not getattr(args, "evidence_only", False)
-    ):
-        _, _evidence_dir, evaluation_dir = paths
+    # here can never flip the run state.
+    if result == 0 and getattr(args, "sarif", None) and not no_scored_reports:
         _write_sarif_if_requested(args, evaluation_dir)
     return result

--- a/src/quodeq/analysis/cache/cache_writer.py
+++ b/src/quodeq/analysis/cache/cache_writer.py
@@ -117,6 +117,9 @@ def build_cache_writer(
                 standards_hash=standards_hash, version=version,
                 effective_params=effective_params,
             ),
+            # Born unconsolidated: no completed run has these findings in its
+            # report yet. mark_run_consolidated flips it when this run ends done.
+            consolidated=False,
         )
         cache.put(key, entry)
 

--- a/src/quodeq/analysis/cache/consolidation.py
+++ b/src/quodeq/analysis/cache/consolidation.py
@@ -1,0 +1,111 @@
+"""Consolidation state — flip a completed run's cache entries.
+
+A cache entry is written ``consolidated=False``: the findings it holds have
+not reached any completed run's report yet. Once a run reaches ``done``,
+everything it dispatched and every unconsolidated entry it replayed IS in a
+completed run's report, so those entries flip to ``consolidated=True`` and
+later runs replay their findings as carried forward.
+
+Runs that end any other way, cancelled with "keep findings", failed, or
+killed, simply never call this. That inversion is the design: not running is
+the only thing a dead process can reliably do.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from quodeq.analysis.cache.backend import CacheBackend
+
+_logger = logging.getLogger(__name__)
+
+# Both sidecars a run leaves behind, each mapping file path -> cache key.
+# dispatch_keys holds what the run produced; replayed_unconsolidated_keys
+# holds entries from an earlier unfinished run that this run replayed and
+# has now put in its own report.
+_SIDECAR_PATTERNS = (
+    "*_dispatch_keys.json",
+    "*_replayed_unconsolidated_keys.json",
+)
+
+
+def _run_reached_done(run_dir: Path) -> bool:
+    """True only when the run's recorded state is ``done``.
+
+    Reading the recorded state rather than trusting an exit code keeps this
+    on the same source of truth the Overview uses, so the two cannot drift.
+    A missing or corrupt status is not done.
+    """
+    try:
+        data = json.loads((run_dir / "status.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    return isinstance(data, dict) and data.get("state") == "done"
+
+
+def _collect_keys(evidence_dir: Path) -> set[str]:
+    """Every cache key this run touched, from both sidecar families.
+
+    An unreadable sidecar is logged and skipped so one bad file cannot cost
+    the run its whole consolidation pass.
+    """
+    keys: set[str] = set()
+    for pattern in _SIDECAR_PATTERNS:
+        for sidecar in evidence_dir.glob(pattern):
+            try:
+                data = json.loads(sidecar.read_text(encoding="utf-8"))
+            except (OSError, ValueError) as exc:
+                _logger.warning("Could not read sidecar %s: %s", sidecar, exc)
+                continue
+            if isinstance(data, dict):
+                keys.update(str(value) for value in data.values())
+    return keys
+
+
+def mark_run_consolidated(
+    run_dir: Path, cache: CacheBackend | None = None,
+) -> None:
+    """Flip this run's cache entries to consolidated, if it reached done.
+
+    Fail-soft in every direction. A non-done run, a missing run dir, an
+    unreadable sidecar, a key with no entry, or a backend that raises all
+    leave the cache as it was. Callers invoke this OUTSIDE the run lifecycle
+    so a failure here can never flip a done run to failed.
+
+    Self-healing: entries missed by a partial pass are replayed as
+    unconsolidated hits by the next run, land in that run's replayed-keys
+    sidecar, and flip when it completes. There is no repair path to run and
+    no stuck state to recover from.
+    """
+    try:
+        if not _run_reached_done(run_dir):
+            return
+        evidence_dir = run_dir / "evidence"
+        if not evidence_dir.is_dir():
+            return
+        keys = _collect_keys(evidence_dir)
+        if not keys:
+            return
+        if cache is None:
+            from quodeq.analysis.cache.local import LocalFileBackend  # noqa: PLC0415
+            cache = LocalFileBackend()
+        flipped = 0
+        for key in sorted(keys):
+            try:
+                entry = cache.get(key)
+                if entry is None or entry.consolidated:
+                    continue
+                entry.consolidated = True
+                cache.put(key, entry)
+                flipped += 1
+            except Exception as exc:  # noqa: BLE001 — one bad entry must not stop the rest
+                _logger.warning("Could not consolidate cache entry %s: %s", key, exc)
+        _logger.info(
+            "cache: consolidated %d entries for run %s", flipped, run_dir.name,
+        )
+    except Exception:  # noqa: BLE001 — post-scan side effect, never propagates
+        _logger.warning(
+            "Consolidation pass failed for %s (evaluation results are safe)",
+            run_dir, exc_info=True,
+        )

--- a/src/quodeq/analysis/cache/dimension_helpers.py
+++ b/src/quodeq/analysis/cache/dimension_helpers.py
@@ -323,5 +323,8 @@ def persist_dispatch_results(
                 standards_hash=standards_hash, version=version,
                 effective_params=effective_params,
             ),
+            # Born unconsolidated: no completed run has these findings in its
+            # report yet. mark_run_consolidated flips it when this run ends done.
+            consolidated=False,
         )
         cache.put(key, entry)

--- a/src/quodeq/analysis/cache/dimension_helpers.py
+++ b/src/quodeq/analysis/cache/dimension_helpers.py
@@ -71,6 +71,15 @@ class ClassifyResult:
     # many reused findings predate the current model / standards / prompts,
     # so reuse across those boundaries is never silent.
     provenance_drift: dict = field(default_factory=dict)
+    # Hits from entries no COMPLETED run has consolidated yet: the producing
+    # run was cancelled with "keep findings", failed, or was killed, so the
+    # user was never shown these findings in an Overview. Kept apart from
+    # cached_findings so the replay path leaves them unstamped and the live
+    # feed shows them as this scan's own.
+    unconsolidated_findings: list[dict] = field(default_factory=list)
+    # file -> cache key for those same entries, so a run that reaches done
+    # can flip them to consolidated.
+    unconsolidated_hit_keys: dict[str, str] = field(default_factory=dict)
 
 
 # Provenance fields compared at classify time, in display order.
@@ -216,6 +225,8 @@ def classify_files_via_cache(
     misses: list[str] = []
     miss_keys: dict[str, str] = {}
     provenance_drift: dict = {}
+    unconsolidated_findings: list[dict] = []
+    unconsolidated_hit_keys: dict[str, str] = {}
     current_prov: dict | None = None  # computed lazily, only if there are hits
     for f in files:
         key = build_cache_key_for_file(config, f, dimension)
@@ -224,7 +235,11 @@ def classify_files_via_cache(
             misses.append(f)
             miss_keys[f] = key
         else:
-            cached_findings.extend(hit.findings)
+            if hit.consolidated:
+                cached_findings.extend(hit.findings)
+            else:
+                unconsolidated_findings.extend(hit.findings)
+                unconsolidated_hit_keys[f] = key
             if current_prov is None:
                 current_prov = _current_provenance(config, dimension)
             _accumulate_drift(provenance_drift, hit.provenance or {}, current_prov)
@@ -233,6 +248,8 @@ def classify_files_via_cache(
         misses=misses,
         miss_keys=miss_keys,
         provenance_drift=provenance_drift,
+        unconsolidated_findings=unconsolidated_findings,
+        unconsolidated_hit_keys=unconsolidated_hit_keys,
     )
     if not bypass_reads and run_cache is not None:
         run_cache[dimension] = (files_tuple, result)

--- a/src/quodeq/analysis/cache/dimension_helpers.py
+++ b/src/quodeq/analysis/cache/dimension_helpers.py
@@ -342,6 +342,15 @@ def persist_dispatch_results(
             ),
             # Born unconsolidated: no completed run has these findings in its
             # report yet. mark_run_consolidated flips it when this run ends done.
+            #
+            # Accepted race: two concurrent runs on one project can both treat
+            # file X as a miss. If run A reaches done and flips X to
+            # consolidated, run B's periodic-persist watcher can then rewrite
+            # X here with consolidated=False. If B is later cancelled, X reads
+            # as unconsolidated even though A already put those findings in a
+            # completed Overview, so the next run surfaces them as "new" once.
+            # Cosmetic, requires concurrent runs on one project, and
+            # self-heals on the next done run. Not fixing.
             consolidated=False,
         )
         cache.put(key, entry)

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -143,8 +143,8 @@ def _compute_files_read(
     this run ends.
 
     A source file is "reproducible" if either:
-      - it was a cache hit (``classify.cached_findings`` already carried it
-        forward — its cache entry already exists), or
+      - it was a cache hit (the file was replayed from a cache entry,
+        consolidated or not — its cache entry already exists), or
       - it was dispatched and the worker emitted ``file_done="ok"``
         (which triggers a synchronous cache write via
         ``build_cache_writer``, or the watcher's next persist tick).

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -196,7 +196,24 @@ def _emit_cached_findings(events_log: Path, findings: list[dict]) -> None:
 def _write_findings(
     jsonl: Path, findings: list[dict], *, append: bool,
     emit_events: bool = True,
+    unconsolidated: list[dict] | None = None,
 ) -> None:
+    """Replay cached findings into this run's evidence JSONL.
+
+    *findings* come from consolidated cache entries: a completed run already
+    put them in its report and the user has seen them in an Overview. Those
+    are stamped ``carried_forward`` so the live feed can hide them.
+
+    *unconsolidated* come from entries no completed run has consolidated yet,
+    because the run that produced them was cancelled with "keep findings",
+    failed, or was killed. The user was never shown those in an Overview, so
+    they are written verbatim and read as this scan's own findings.
+
+    Both groups are re-gated and both are mirrored to events.jsonl. Skipping
+    the unconsolidated group in the event log would resurrect the UI-vs-CLI
+    score disagreement that _emit_cached_findings exists to prevent.
+    """
+    pending = list(unconsolidated or [])
     # Re-gate cached findings on the replay path (issue #657). The live
     # finding path gates in FindingEnricher.enrich(); cache replay bypasses
     # enrich(), so a stale, un-gated critical R-FT-2/S-AUT-3 finding written
@@ -206,6 +223,8 @@ def _write_findings(
     # safe to apply unconditionally to every cached finding.
     for finding in findings:
         apply_provenance_gate(finding)
+    for finding in pending:
+        apply_provenance_gate(finding)
     # Every caller of this function is a cache replay -- the dispatcher
     # writes its own fresh findings and never comes through here. Stamp the
     # origin so the live evaluation feed can show only what this scan is
@@ -214,7 +233,11 @@ def _write_findings(
     # Copy, do not mutate: these dicts are owned by the cache entries, and
     # the periodic-persist watcher could otherwise write the flag back into
     # the cache, making a later fresh scan of the same file look carried.
+    #
+    # Consolidated first, then unconsolidated, so the JSONL keeps reading
+    # foundation-then-new.
     stamped = [{**finding, "carried_forward": True} for finding in findings]
+    stamped += [dict(finding) for finding in pending]
     jsonl.parent.mkdir(parents=True, exist_ok=True)
     mode = "a" if append else "w"
     with jsonl.open(mode, encoding="utf-8") as out:
@@ -304,7 +327,10 @@ def process_dimension_with_cache(
     # Dedup runs after to handle any overlap from a same-run repeat.
     if not classify.misses:
         from quodeq.analysis.subagents.jsonl_utils import deduplicate_jsonl
-        _write_findings(jsonl, classify.cached_findings, append=True)
+        _write_findings(
+            jsonl, classify.cached_findings, append=True,
+            unconsolidated=classify.unconsolidated_findings,
+        )
         if jsonl.exists():
             deduplicate_jsonl(jsonl)
         return parse_evidence_from_jsonl(
@@ -327,8 +353,14 @@ def process_dimension_with_cache(
     #     ONE final "Deduplicated ...: N unique findings" log line. Pre-fix
     #     the user saw two confusing counts -- "27 unique" (dispatch only)
     #     followed by "55 unique" (after we appended cached findings).
-    if classify.cached_findings:
-        _write_findings(jsonl, classify.cached_findings, append=True)
+    # A dimension whose every hit is unconsolidated has an EMPTY
+    # cached_findings, so guarding on that alone would skip this write and
+    # silently drop those findings from the run.
+    if classify.cached_findings or classify.unconsolidated_findings:
+        _write_findings(
+            jsonl, classify.cached_findings, append=True,
+            unconsolidated=classify.unconsolidated_findings,
+        )
 
     # Persist the per-file cache keys to a sidecar so the discard path can
     # locate this dim's V2 cache entries even after the process exits. Without
@@ -429,7 +461,12 @@ def process_dimension_with_cache(
         # watcher, so any partial completion is preserved. If we have
         # cached findings already in the JSONL (pre-written above), parse
         # them so the run still has SOMETHING to score; otherwise None.
-        if classify.cached_findings and jsonl.exists():
+        # Both replay groups count: an all-unconsolidated dimension has
+        # findings in the JSONL even though cached_findings is empty.
+        replayed_anything = bool(
+            classify.cached_findings or classify.unconsolidated_findings
+        )
+        if replayed_anything and jsonl.exists():
             return parse_evidence_from_jsonl(
                 config, dim_id, ctx, jsonl,
                 files_read=_compute_files_read(classify, jsonl, files),

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -116,6 +116,26 @@ def _jsonl_path(config: RunConfig, dim_id: str) -> Path:
     return _evidence_dir(config) / f"{dim_id}_evidence.jsonl"
 
 
+def _write_replayed_keys_sidecar(
+    config: RunConfig, dim_id: str, keys: dict[str, str],
+) -> None:
+    """Record which unconsolidated cache entries this dim replayed.
+
+    A run that reaches ``done`` consolidates not only the entries it wrote
+    but the unconsolidated ones it replayed: those findings are now in a
+    completed run's report. ``consolidation.mark_run_consolidated`` reads
+    this sidecar alongside ``<dim>_dispatch_keys.json``.
+
+    Skipped when there is nothing to record, so a run that replays only
+    consolidated entries leaves no file behind.
+    """
+    if not keys:
+        return
+    sidecar = _evidence_dir(config) / f"{dim_id}_replayed_unconsolidated_keys.json"
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(json.dumps(keys, indent=2), encoding="utf-8")
+
+
 def _compute_files_read(
     classify: ClassifyResult, jsonl_path: Path, all_files: list[str],
 ) -> int:
@@ -319,6 +339,11 @@ def process_dimension_with_cache(
     )
 
     jsonl = _jsonl_path(config, dim_id)
+
+    # Written BEFORE the all-hits branch so one call site covers both replay
+    # paths. A fully cached dimension writes no dispatch_keys sidecar (it
+    # never dispatches), so without this it would never flip its entries.
+    _write_replayed_keys_sidecar(config, dim_id, classify.unconsolidated_hit_keys)
 
     # All-hits short-circuit: no dispatch needed.
     # We append (not overwrite) because callers may invoke us multiple times

--- a/src/quodeq/analysis/cache/entry.py
+++ b/src/quodeq/analysis/cache/entry.py
@@ -43,7 +43,8 @@ def build_provenance(
 
     Single source of truth for the provenance shape, so the three cache-write
     sites (cache_writer, persist_dispatch_results, runner.analyze_unit) stay
-    identical. ``version`` defaults to the current quodeq version.
+    identical. Those three sites also all pass ``consolidated=False``.
+    ``version`` defaults to the current quodeq version.
     ``effective_params`` records the resolved threshold params the findings
     were judged under (``{req_id: {param: value}}``; ``{}`` when unknown)."""
     return {
@@ -79,6 +80,16 @@ class CacheEntry:
     provenance: dict = field(default_factory=dict)
     created_at: str = field(default_factory=_utc_now)
     cache_format_version: int = ENTRY_FORMAT_VERSION
+    # Whether a COMPLETED run has consolidated these findings into its
+    # report. Written False at creation and flipped to True by
+    # consolidation.mark_run_consolidated when a run reaches state=done.
+    # A run that was cancelled with "keep findings", failed, or was killed
+    # never flips its entries, so a later run replays their findings as
+    # this scan's own rather than hiding them as carried forward.
+    #
+    # Defaults True so entries written before this field existed load as
+    # consolidated and behave exactly as they did before.
+    consolidated: bool = True
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), separators=(",", ":"))

--- a/src/quodeq/analysis/cache/runner.py
+++ b/src/quodeq/analysis/cache/runner.py
@@ -128,6 +128,9 @@ def analyze_unit(
             standards_hash=unit.standards_hash,
             effective_params=unit.effective_params,
         ),
+        # Born unconsolidated: no completed run has these findings in its
+        # report yet. mark_run_consolidated flips it when this run ends done.
+        consolidated=False,
     )
     cache.put(key, entry)
     return UnitResult(entry=entry, cache_hit=False)

--- a/src/quodeq/analysis/manifest_build.py
+++ b/src/quodeq/analysis/manifest_build.py
@@ -185,8 +185,9 @@ def _walk_and_partition_by_scope(
     """Walk *src* once, bucketing files by their owning subproject scope.
 
     Each file is assigned to the deepest scope path that contains it. Files outside
-    every scope are silently dropped — they don't belong to any classified
-    subproject and shouldn't appear in any target.
+    every scope are dropped — they don't belong to any classified subproject and
+    shouldn't appear in any target. Callers that must not lose unclassified source
+    pass ``"."`` among *scope_paths* as a catch-all (see _build_multi_scope_manifest).
     """
     ignore_patterns = ignore_patterns or []
     files_by_scope_lang: dict[str, dict[str, list[str]]] = {s: {} for s in scope_paths}
@@ -230,6 +231,17 @@ def _build_multi_scope_manifest(
     """Produce a manifest with one target group per detected subproject scope."""
     scope_paths = [rel for rel, _ in sub_results]
     matches_by_scope = {rel: matches for rel, matches in sub_results}
+    if "." not in matches_by_scope:
+        # No rule classified the repo root, but source can still live outside every
+        # detected subproject — e.g. a Kotlin Multiplatform repo where only
+        # ``iosApp/`` matches (via *.xcodeproj) while the Gradle/Kotlin root does
+        # not. Without a catch-all root scope those files are dropped and the
+        # manifest comes back with no targets, which downstream reads as "no
+        # source files". "." is depth 0 in _deepest_scope, so it only claims files
+        # no more specific scope owns, and _MIN_FILES_PER_TARGET still keeps a
+        # handful of stray root files from becoming a target.
+        scope_paths.append(".")
+        matches_by_scope["."] = []
     files_by_scope, ext_counts_overall, ext_counts_by_scope_lang = _walk_and_partition_by_scope(
         src, ext_map, skip_dirs, skip_patterns, scope_paths,
         ignore_patterns=ignore_patterns,

--- a/src/quodeq/analysis/manifest_build.py
+++ b/src/quodeq/analysis/manifest_build.py
@@ -140,7 +140,10 @@ def _walk_and_group(
     walk_root = src
     if scope_path:
         candidate = src / scope_path
-        if candidate.is_dir():
+        # Containment mirrors the CLI --scope guard (_cli_resolution): a
+        # scope that resolves outside the repo (traversal segments or a
+        # symlink) must not widen the walk; fall back to the full repo.
+        if candidate.is_dir() and candidate.resolve().is_relative_to(src.resolve()):
             walk_root = candidate
 
     ignore_patterns = ignore_patterns or []

--- a/src/quodeq/api/_evaluation_helpers.py
+++ b/src/quodeq/api/_evaluation_helpers.py
@@ -11,6 +11,7 @@ from flask import Response, jsonify, request
 from quodeq.api.helpers import error_response
 from quodeq.services.tooling_mixin import get_allowed_client_ids as _get_allowed_ai_cmds
 from quodeq.services.base import _DEFAULT_MAX_SUBAGENTS, _DEFAULT_TIME_LIMIT
+from quodeq.shared.validation import validate_relative_scope
 
 # Userinfo cannot contain an unencoded "/", so excluding it keeps matches
 # identical while a failing scan stays linear (no polynomial backtracking
@@ -100,6 +101,10 @@ def _build_evaluation_options(payload: dict) -> "EvaluationOptions":
     ai_model = payload.get("aiModel") or None
     subagent_model = payload.get("subagentModel") or ai_model  # default to orchestrator
     clean_scan = _resolve_clean_scan(payload)
+    scope_path = payload.get("scopePath") or None
+    if scope_path is not None:
+        # ValueError propagates to the route's 400 INVALID_INPUT handler.
+        validate_relative_scope(str(scope_path))
     return EvaluationOptions(
         discipline=payload.get("discipline"),
         dimensions=payload.get("dimensions") or "",
@@ -114,7 +119,7 @@ def _build_evaluation_options(payload: dict) -> "EvaluationOptions":
         per_dimension=bool(payload.get("perDimension", False)),
         context_size=max(0, min(_MAX_CONTEXT_SIZE, _coerce_int(payload.get("contextSize"), 0))),
         branch=payload.get("branch") or None,
-        scope_path=payload.get("scopePath") or None,
+        scope_path=scope_path,
         provider_api_key=str(payload.get("apiKey") or ""),
         provider_api_base=str(payload.get("apiBase") or ""),
     )

--- a/src/quodeq/api/_evaluation_helpers.py
+++ b/src/quodeq/api/_evaluation_helpers.py
@@ -12,7 +12,10 @@ from quodeq.api.helpers import error_response
 from quodeq.services.tooling_mixin import get_allowed_client_ids as _get_allowed_ai_cmds
 from quodeq.services.base import _DEFAULT_MAX_SUBAGENTS, _DEFAULT_TIME_LIMIT
 
-_CREDENTIALS_RE = re.compile(r"(https?://)([^@]+)@")
+# Userinfo cannot contain an unencoded "/", so excluding it keeps matches
+# identical while a failing scan stays linear (no polynomial backtracking
+# on inputs like repeated "http://" runs).
+_CREDENTIALS_RE = re.compile(r"(https?://)([^/@]+)@")
 _logger = logging.getLogger(__name__)
 
 # Bounds for user-supplied evaluation parameters

--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -16,7 +16,7 @@ from quodeq.api._evaluation_helpers import (
     _sanitize_url,
     _validate_ai_cmd,
 )
-from quodeq.api.helpers import error_response, validate_evaluation_payload
+from quodeq.api.helpers import error_response, scan_target_error, validate_evaluation_payload
 from quodeq.core.types import to_camel_dict
 from quodeq.analysis._provider_cache import get_provider_configs
 from quodeq.api.routes import _reports_dir
@@ -24,6 +24,7 @@ from quodeq.services.base import ActionProvider
 from quodeq.services.evaluation_mixin import _score_completed_evidence
 from quodeq.services.scan_progress import build_scan_progress, progress_to_dict
 from quodeq.shared.dimensions_state import read_dimensions
+from quodeq.shared.utils import is_repo_url
 
 _logger = logging.getLogger(__name__)
 
@@ -134,6 +135,20 @@ def register_evaluation_list_routes(app: Flask, provider: ActionProvider, eval_r
         except ValueError as exc:
             body, status = error_response(str(exc), HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
             return jsonify(body), status
+        # Same allowlist as /api/scan and POST /api/projects: starting an
+        # evaluation registers + scans the directory and persists its file
+        # tree, so an unvalidated local path would leak arbitrary readable
+        # directories through project endpoints.
+        try:
+            is_url = is_repo_url(str(repo))
+        except ValueError:
+            body, status = error_response("Invalid repo URL", HTTPStatus.BAD_REQUEST, "INVALID_REPO_URL")
+            return jsonify(body), status
+        if not is_url:
+            err = scan_target_error(Path(str(repo)).resolve(), _reports_dir())
+            if err is not None:
+                body, status = err
+                return jsonify(body), status
         try:
             job = provider.start_evaluation(repo=repo, reports_dir=_reports_dir(), options=options)
         except (FileNotFoundError, ValueError):

--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -145,7 +145,7 @@ def register_evaluation_list_routes(app: Flask, provider: ActionProvider, eval_r
             body, status = error_response("Invalid repo URL", HTTPStatus.BAD_REQUEST, "INVALID_REPO_URL")
             return jsonify(body), status
         if not is_url:
-            err = scan_target_error(Path(str(repo)).resolve(), _reports_dir())
+            err = scan_target_error(str(repo), _reports_dir())
             if err is not None:
                 body, status = err
                 return jsonify(body), status

--- a/src/quodeq/api/helpers.py
+++ b/src/quodeq/api/helpers.py
@@ -1,6 +1,7 @@
 """Shared helpers for action API modules."""
 from __future__ import annotations
 
+import os
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any
@@ -16,24 +17,26 @@ def error_response(message: str, status: int, code: str) -> tuple[dict[str, Any]
 _BLOCKED_SCAN_PATHS = ("/proc", "/sys", "/dev", "/etc", "/var/run", "/private/etc", "/private/var/run")
 
 
-def scan_target_error(target_path: Path, reports_root: str) -> tuple[dict[str, Any], int] | None:
-    """Validate a resolved directory path against the scan allowlist.
+def scan_target_error(target_path: Path | str, reports_root: str) -> tuple[dict[str, Any], int] | None:
+    """Validate a directory path against the scan allowlist.
 
     Shared by /api/scan, create_project's local-repo branch, and
     start_evaluation so all enforce the same rules: the path must live under
     the user's home or the evaluations directory, and must not be a blocked
     system path. Returns an ``error_response`` tuple on rejection, or None
     when the path is allowed.
+
+    Uses the realpath + startswith form (not pathlib is_relative_to) — it is
+    the containment shape CodeQL/Snyk recognize as a barrier.
     """
-    _home = Path.home().resolve()
-    _eval_dir = Path(reports_root).resolve()
-    _allowed_roots = (_home, _eval_dir)
-    if not any(target_path == root or target_path.is_relative_to(root) for root in _allowed_roots):
+    candidate = os.path.realpath(str(target_path))
+    _allowed_roots = (os.path.realpath(str(Path.home())), os.path.realpath(reports_root))
+    if not any(candidate == root or candidate.startswith(root + os.sep) for root in _allowed_roots):
         return error_response(
             "Scan path must be under home directory", HTTPStatus.FORBIDDEN, "FORBIDDEN",
         )
     # Block scanning system directories to prevent information disclosure
-    if any(str(target_path).startswith(b) for b in _BLOCKED_SCAN_PATHS):
+    if any(candidate.startswith(b) for b in _BLOCKED_SCAN_PATHS):
         return error_response("Cannot scan system directories", HTTPStatus.FORBIDDEN, "FORBIDDEN")
     return None
 

--- a/src/quodeq/api/helpers.py
+++ b/src/quodeq/api/helpers.py
@@ -13,6 +13,31 @@ def error_response(message: str, status: int, code: str) -> tuple[dict[str, Any]
     return {"error": message, "code": code}, status
 
 
+_BLOCKED_SCAN_PATHS = ("/proc", "/sys", "/dev", "/etc", "/var/run", "/private/etc", "/private/var/run")
+
+
+def scan_target_error(target_path: Path, reports_root: str) -> tuple[dict[str, Any], int] | None:
+    """Validate a resolved directory path against the scan allowlist.
+
+    Shared by /api/scan, create_project's local-repo branch, and
+    start_evaluation so all enforce the same rules: the path must live under
+    the user's home or the evaluations directory, and must not be a blocked
+    system path. Returns an ``error_response`` tuple on rejection, or None
+    when the path is allowed.
+    """
+    _home = Path.home().resolve()
+    _eval_dir = Path(reports_root).resolve()
+    _allowed_roots = (_home, _eval_dir)
+    if not any(target_path == root or target_path.is_relative_to(root) for root in _allowed_roots):
+        return error_response(
+            "Scan path must be under home directory", HTTPStatus.FORBIDDEN, "FORBIDDEN",
+        )
+    # Block scanning system directories to prevent information disclosure
+    if any(str(target_path).startswith(b) for b in _BLOCKED_SCAN_PATHS):
+        return error_response("Cannot scan system directories", HTTPStatus.FORBIDDEN, "FORBIDDEN")
+    return None
+
+
 def validate_evaluation_payload(payload: dict[str, Any]) -> str | None:
     """Validate the evaluate request payload.
 

--- a/src/quodeq/api/routes_project_list.py
+++ b/src/quodeq/api/routes_project_list.py
@@ -10,38 +10,16 @@ from pathlib import Path
 
 from flask import Flask, Response, jsonify, request
 
-from quodeq.api.helpers import error_response
+from quodeq.api.helpers import error_response, scan_target_error as _scan_target_error
 from quodeq.api.import_project import import_project as _import_project
 from quodeq.api.routes_common import reports_dir
 from quodeq.api.zip import export_project_zip
 from quodeq.services._fs_clone import CloneError
 from quodeq.services._fs_scan import scan_project
 from quodeq.services.base import ActionProvider
-from quodeq.shared.validation import validate_path_segment
+from quodeq.shared.validation import validate_path_segment, validate_relative_scope
 
 _logger = logging.getLogger(__name__)
-_BLOCKED_SCAN_PATHS = ("/proc", "/sys", "/dev", "/etc", "/var/run", "/private/etc", "/private/var/run")
-
-
-def _scan_target_error(target_path: Path, reports_root: str) -> tuple[dict, int] | None:
-    """Validate a resolved directory path against the scan allowlist.
-
-    Shared by /api/scan and create_project's local-repo branch so both enforce
-    the same rules: the path must live under the user's home or the
-    evaluations directory, and must not be a blocked system path. Returns an
-    ``error_response`` tuple on rejection, or None when the path is allowed.
-    """
-    _home = Path.home().resolve()
-    _eval_dir = Path(reports_root).resolve()
-    _allowed_roots = (_home, _eval_dir)
-    if not any(target_path == root or target_path.is_relative_to(root) for root in _allowed_roots):
-        return error_response(
-            "Scan path must be under home directory", HTTPStatus.FORBIDDEN, "FORBIDDEN",
-        )
-    # Block scanning system directories to prevent information disclosure
-    if any(str(target_path).startswith(b) for b in _BLOCKED_SCAN_PATHS):
-        return error_response("Cannot scan system directories", HTTPStatus.FORBIDDEN, "FORBIDDEN")
-    return None
 
 
 def _find_existing_project(reports_root: str, repo: str, scope_path: str | None) -> str | None:
@@ -163,6 +141,11 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
     @app.patch("/api/projects/<project>/path")
     def update_project_path(project: str) -> Response | tuple[Response, int]:
         """Update the local filesystem path for a project."""
+        try:
+            validate_path_segment(project)
+        except ValueError:
+            body, status = error_response("Invalid project name", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+            return jsonify(body), status
         return _handle_update_project_path(provider)
 
     @app.get("/api/projects/<project>/export")
@@ -183,11 +166,21 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
     @app.delete("/api/projects/<project>")
     def delete_project(project: str) -> Response | tuple[Response, int]:
         """Delete a project and all its run data."""
+        try:
+            validate_path_segment(project)
+        except ValueError:
+            body, status = error_response("Invalid project name", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+            return jsonify(body), status
         return _handle_delete_project(provider)
 
     @app.get("/api/projects/<project>/info")
     def project_info(project: str) -> Response | tuple[Response, int]:
         """Return repository metadata for a project."""
+        try:
+            validate_path_segment(project)
+        except ValueError:
+            body, status = error_response("Invalid project name", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+            return jsonify(body), status
         info = provider.get_project_info(reports_dir(), project)
         if not info:
             body, status = error_response("Project info not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
@@ -306,6 +299,12 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
             return jsonify(body), status
 
         scope_path = data.get("scopePath") or None
+        if scope_path is not None:
+            try:
+                validate_relative_scope(str(scope_path))
+            except ValueError as exc:
+                body, status = error_response(str(exc), HTTPStatus.BAD_REQUEST, "INVALID_SCOPE")
+                return jsonify(body), status
         discipline = data.get("discipline") or None
         clone_dest = data.get("cloneDest") or None
         ephemeral = bool(data.get("ephemeral", False))

--- a/src/quodeq/api/standards_visibility_routes.py
+++ b/src/quodeq/api/standards_visibility_routes.py
@@ -22,6 +22,7 @@ from quodeq.core.standards.visibility import (
     validate_visible_ids,
 )
 from quodeq.services.standards import StandardsService
+from quodeq.shared.validation import validate_path_segment
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +52,10 @@ def register_visibility_routes(app: Flask) -> None:
 
     @app.get("/api/projects/<project_id>/standards-visibility")
     def get_standards_visibility(project_id: str) -> Response:
+        try:
+            validate_path_segment(project_id)
+        except ValueError:
+            return error_response("Invalid project id", HTTPStatus.BAD_REQUEST, "bad_request")
         root = _repo_root(project_id)
         if root is None:
             return error_response("Project has no local repository",
@@ -59,6 +64,10 @@ def register_visibility_routes(app: Flask) -> None:
 
     @app.put("/api/projects/<project_id>/standards-visibility")
     def put_standards_visibility(project_id: str) -> Response:
+        try:
+            validate_path_segment(project_id)
+        except ValueError:
+            return error_response("Invalid project id", HTTPStatus.BAD_REQUEST, "bad_request")
         root = _repo_root(project_id)
         if root is None:
             return error_response("Project has no local repository",

--- a/src/quodeq/data/config/disciplines.conf
+++ b/src/quodeq/data/config/disciplines.conf
@@ -120,7 +120,7 @@ detect_contains=com.android
 detect_file_alt=build.gradle.kts
 detect_contains_alt=com.android
 detect_file_alt2=gradle/libs.versions.toml
-detect_contains_alt2=com.android.tools.build
+detect_contains_alt2=com.android
 detect_priority=2
 suggested_topics=Kotlin Code Standards,Clean Architecture,SOLID Principles,DDD Principles,Android Engineering Standards,Modern Android Development Standards
 

--- a/src/quodeq/services/_cache.py
+++ b/src/quodeq/services/_cache.py
@@ -5,6 +5,7 @@ duplicate I/O when multiple threads request the same uncached key.
 """
 from __future__ import annotations
 
+import json
 import logging
 import threading
 from collections import OrderedDict
@@ -34,6 +35,61 @@ class _CacheContext:
     def get_reader(self) -> _Reader:
         """Return the configured reader, defaulting to read_run_data."""
         return self.reader if self.reader is not None else read_run_data
+
+
+# Terminal status.json states, mirroring data/fs/report_parser/runs.py. Any
+# other state means the run's evaluation/ set may still be growing.
+_TERMINAL_RUN_STATES = frozenset({"done", "failed", "cancelled"})
+
+
+def _count_eval_files(reports_root: Path, project: str, run_id: str) -> int:
+    """Count ``evaluation/*.json`` files on disk for a run.
+
+    Used to detect a stale cache: if the cached dim list has a different
+    count from what's currently on disk, the cache is wrong and must be
+    evicted. One ``listdir`` per cached lookup -- cheap.
+    """
+    eval_dir = reports_root / project / run_id / "evaluation"
+    if not eval_dir.is_dir():
+        return 0
+    try:
+        return sum(1 for p in eval_dir.iterdir() if p.suffix == ".json")
+    except OSError:
+        return 0
+
+
+def _run_is_in_progress(reports_root: Path, project: str, run_id: str) -> bool:
+    """True when the run's ``status.json`` reports a non-terminal state.
+
+    A missing or unreadable status.json counts as terminal: legacy runs never
+    wrote one and their data is immutable. The PID-liveness refinement in
+    ``data/fs/report_parser/runs.py`` is deliberately not replicated here -- a
+    run that crashed without flipping its state reads fresh forever, which is
+    the safe direction for a cache guard.
+    """
+    status_path = reports_root / project / run_id / "status.json"
+    if not status_path.is_file():
+        return False
+    try:
+        data = json.loads(status_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    state = data.get("state") if isinstance(data, dict) else None
+    return isinstance(state, str) and state not in _TERMINAL_RUN_STATES
+
+
+def _cached_entry_is_stale(
+    reports_root: Path, project: str, run_id: str, cached: list[DimensionResult],
+) -> bool:
+    """True when the cached dim count disagrees with ``evaluation/*.json`` on disk.
+
+    Anchored on the evaluation/ directory existing: without disk state to
+    compare against (unit tests that pre-seed the cache), the entry is trusted.
+    """
+    eval_dir = reports_root / project / run_id / "evaluation"
+    if not eval_dir.is_dir():
+        return False
+    return len(cached) != _count_eval_files(reports_root, project, run_id)
 
 
 def _fetch_dimensions_from_disk(
@@ -119,6 +175,19 @@ def make_lru_dimension_fetcher(
     that at most one thread performs disk I/O for any given cache key.  Other
     threads that request the same key while I/O is in progress wait on the
     event and then read the result from the cache.
+
+    Self-healing guards (every caller inherits them, so a request landing
+    mid-run can never freeze a partial dim list in the cache):
+
+    1. **On-disk count validation.** A cached entry whose dim count disagrees
+       with the run's ``evaluation/*.json`` count is stale (e.g. it was
+       populated while the run was still writing dims) -- evict and re-read.
+       Only applies when an evaluation/ directory exists on disk; entries
+       pre-seeded without disk state (test stubs) are trusted.
+
+    2. **In-progress bypass.** Runs whose ``status.json`` state is non-terminal
+       have a growing evaluation/ set. Read directly from disk and don't
+       cache, so the next request also reads fresh.
     """
     ctx = _CacheContext(cache=cache, lock=lock, max_size=max_size, reader=reader)
 
@@ -127,7 +196,15 @@ def make_lru_dimension_fetcher(
 
         cached = _cache_lookup(key, ctx)
         if cached is not None:
-            return cached
+            if not _cached_entry_is_stale(reports_root, project, run_id, cached):
+                return cached
+            with ctx.lock:
+                ctx.cache.pop(key, None)
+
+        if _run_is_in_progress(reports_root, project, run_id):
+            return _fetch_dimensions_from_disk(
+                reports_root, project, run_id, ctx.get_reader(),
+            )
 
         with ctx.lock:
             if key in ctx.cache:

--- a/src/quodeq/services/_fs_metadata.py
+++ b/src/quodeq/services/_fs_metadata.py
@@ -7,6 +7,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from quodeq.core.standards.visibility import load_visible_standard_ids
 from quodeq.services.ports import RunInfo, read_run_data, safe_read_dir, summarize_dimensions
 from quodeq.shared.validation import validate_path_segment
 
@@ -62,6 +63,24 @@ def _read_repo_info(reports_root: Path, entry_name: str) -> dict[str, Any]:
         return {}
 
 
+def _local_repo_root(reports_root: Path, entry_name: str) -> Path | None:
+    """The analyzed repo's local working copy, or None when there isn't one.
+
+    Same gate as the API's ``repo_attach_info``: a recorded path that is not
+    an online URL and still exists as a directory. Online projects and moved
+    working copies resolve to None, which downstream visibility lookups treat
+    as "use the default selection".
+    """
+    info = _read_repo_info(reports_root, entry_name)
+    path = info.get("path")
+    if not path or not isinstance(path, str):
+        return None
+    if str(info.get("location", "")).lower() == "online" or "://" in path:
+        return None
+    root = Path(path)
+    return root if root.is_dir() else None
+
+
 def _read_accumulated_summary(
     reports_root: Path, entry_name: str, runs: list[RunInfo],
     params: "ScoringParams | None" = None,
@@ -73,6 +92,13 @@ def _read_accumulated_summary(
     repositories-screen grade agrees with the Overview / explorer / trend.
     *params* (loaded from the saved formula when None) keeps the aggregate
     threshold labels and dimension weights consistent with the dashboard.
+
+    The card also scopes to the project's visible-standards selection: the
+    Overview headline averages only visible dimensions (the client filters
+    the accumulated payload), so a card computed over ALL dimensions shows a
+    different grade whenever a hidden dimension's score diverges. The
+    selection is folded into the cache version so toggling a standard
+    invalidates the cached card.
     """
     if params is None:
         from quodeq.services import grade_formula  # noqa: PLC0415
@@ -82,9 +108,12 @@ def _read_accumulated_summary(
         accumulated_cache_version, cached_project_summary, per_run_versions,
     )
     project_dir = reports_root / entry_name
+    visible = load_visible_standard_ids(_local_repo_root(reports_root, entry_name))
+    visible_set = set(visible)
     run_versions = per_run_versions(
         project_dir, entry_name, params, [(r.run_id, r.status) for r in runs])
-    version = accumulated_cache_version(project_dir, params, run_versions, as_of=None)
+    version = accumulated_cache_version(
+        project_dir, params, run_versions, as_of=None, visible_dims=visible)
 
     def _compute() -> dict:
         try:
@@ -109,8 +138,11 @@ def _read_accumulated_summary(
                     # Same trust gate as the accumulated Overview
                     # (_has_valid_score): skip a coverage-0 stub so the card
                     # falls through to a real older run instead of showing
-                    # the stub's inflated grade.
-                    if d.dimension and d.dimension not in latest_by_dim and _has_valid_score(d):
+                    # the stub's inflated grade. Hidden standards are skipped
+                    # entirely: the Overview headline excludes them, and a
+                    # dimension the user cannot see must not move the grade.
+                    if (d.dimension and d.dimension.lower() in visible_set
+                            and d.dimension not in latest_by_dim and _has_valid_score(d)):
                         latest_by_dim[d.dimension] = d
                         validate_path_segment(run.run_id)
                         run_dir_by_dim[d.dimension] = project_dir / run.run_id

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -201,22 +201,6 @@ def _rescore_run_dimensions(
     ]
 
 
-def _count_eval_files(reports_root: Path, project: str, run_id: str) -> int:
-    """Count ``evaluation/*.json`` files on disk for a run.
-
-    Used to detect a stale cache: if the cached dim list has a different
-    count from what's currently on disk, the cache is wrong and must be
-    evicted. One ``listdir`` per cached lookup -- cheap.
-    """
-    eval_dir = reports_root / project / run_id / "evaluation"
-    if not eval_dir.is_dir():
-        return 0
-    try:
-        return sum(1 for p in eval_dir.iterdir() if p.suffix == ".json")
-    except OSError:
-        return 0
-
-
 def _make_status_aware_fetcher(
     reports_root: Path,
     project: str,
@@ -226,48 +210,23 @@ def _make_status_aware_fetcher(
     max_size: int | None = None,
     version: str = "",
 ) -> Callable[[str], list[DimensionResult]]:
-    """Return a fetcher with two self-healing properties on top of the LRU cache.
+    """Return a fetcher that reads in-progress runs fresh, never from cache.
 
-    1. **In-progress bypass.** Runs with status=in_progress have a mutable
-       on-disk evaluation/ set as dims finish. We read directly from disk
-       and don't write to cache, so the next request also reads fresh.
-
-    2. **On-disk count validation for terminal runs.** Even after a run
-       completes, the cache may hold a stale partial dim set -- e.g. if
-       it was populated by a request that fired between dims being scored
-       (a window opened by the BrokenPipe-during-success-log regression
-       PR #481 fixed). On lookup, we count evaluation/*.json files and
-       compare against the cached length. Mismatch -> evict, re-read.
-
-    Cost: one extra ``listdir`` per cached lookup. Cheap (eval/ is small).
+    The base LRU fetcher (``make_lru_dimension_fetcher``) already self-heals:
+    on-disk count validation plus a status.json in-progress bypass. This
+    wrapper adds the richer status from *runs* (``list_runs`` folds in a
+    PID-liveness check that status.json alone can't see), so a run whose
+    process is still alive reads fresh even before its state flips.
     """
-    resolved_cache = cache if cache is not None else _SHARED_RUN_DIM_CACHE
-    resolved_lock = lock if lock is not None else _SHARED_RUN_DIM_LOCK
     cached = _make_run_dimension_fetcher(
         reports_root, project,
-        cache=resolved_cache, lock=resolved_lock, max_size=max_size, version=version,
+        cache=cache, lock=lock, max_size=max_size, version=version,
     )
     status_by_id = {r.run_id: r.status for r in runs}
 
     def fetch(run_id: str) -> list[DimensionResult]:
         if status_by_id.get(run_id) == "in_progress":
             return read_run_data(reports_root, project, run_id)
-        # Validate any cached entry against the on-disk count. If they
-        # disagree, the cache is stale -- evict so the cached() call below
-        # re-reads from disk and re-caches with the correct value. We only
-        # validate when an actual evaluation/ directory exists on disk:
-        # without that anchor we'd evict every test stub that pre-seeds
-        # the cache without creating disk state.
-        key = (reports_root, project, run_id, version)
-        with resolved_lock:
-            cached_dims = resolved_cache.get(key)
-        if cached_dims is not None:
-            eval_dir = reports_root / project / run_id / "evaluation"
-            if eval_dir.is_dir():
-                on_disk = _count_eval_files(reports_root, project, run_id)
-                if len(cached_dims) != on_disk:
-                    with resolved_lock:
-                        resolved_cache.pop(key, None)
         return cached(run_id)
 
     return fetch

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -550,9 +550,10 @@ def _discard_run_state(reports_dir: str, job: dict) -> None:
     only this run's dispatched (cache-miss) keys, so entries written by
     earlier kept runs are not touched.
 
-    All per-dim scratch (queue, fingerprint, evidence JSONL, sidecar) is
-    removed so the status-GET scoring path cannot resurrect a report from
-    leftover evidence. The caller removes the run directory itself.
+    All per-dim scratch (queue, fingerprint, evidence JSONL, dispatch-keys
+    and replayed-keys sidecars) is removed so the status-GET scoring path
+    cannot resurrect a report from leftover evidence. The caller removes the
+    run directory itself.
     """
     project = job.get("outputProject")
     run_id = job.get("outputRunId")
@@ -584,6 +585,9 @@ def _discard_run_state(reports_dir: str, job: dict) -> None:
     scratch_patterns = (
         "*_queue.json", "*_fingerprint.json",
         "*_evidence.jsonl", "*_dispatch_keys.json",
+        # Entries listed here belong to EARLIER runs, so they are cleaned up
+        # as scratch but deliberately not fed to the cache-deletion loop above.
+        "*_replayed_unconsolidated_keys.json",
     )
     for pattern in scratch_patterns:
         for victim in evidence_dir.glob(pattern):

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -38,7 +38,10 @@ _LOCATION_LOCAL = "local"
 # Mirrors _CREDENTIALS_RE in quodeq.api._evaluation_helpers. Not imported from
 # there: services must not depend on the api layer (no other services module
 # does), so the pattern is duplicated here rather than layered across.
-_CREDENTIALS_RE = re.compile(r"(https?://)([^@]+)@")
+# Userinfo cannot contain an unencoded "/", so excluding it keeps matches
+# identical while a failing scan stays linear (no polynomial backtracking
+# on inputs like repeated "http://" runs).
+_CREDENTIALS_RE = re.compile(r"(https?://)([^/@]+)@")
 
 
 def _strip_credentials(url: str) -> str:

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -131,8 +131,7 @@ def _dim_state(
     return "pending"
 
 
-def _parse_started_at(status: dict) -> datetime | None:
-    raw = status.get("started_at")
+def _parse_iso_utc(raw: object) -> datetime | None:
     if not isinstance(raw, str) or not raw:
         return None
     try:
@@ -146,6 +145,10 @@ def _parse_started_at(status: dict) -> datetime | None:
     return parsed
 
 
+def _parse_started_at(status: dict) -> datetime | None:
+    return _parse_iso_utc(status.get("started_at"))
+
+
 def _queue_take_timestamps(qstate: dict) -> list[float]:
     """Extract valid take-log timestamps from a queue state dict."""
     taken = qstate.get("taken")
@@ -157,20 +160,53 @@ def _queue_take_timestamps(qstate: dict) -> list[float]:
     ]
 
 
-def _dim_elapsed_s(dim_id: str, run_dir: Path, state: str) -> float | None:
-    """Per-dim elapsed time, derived from queue-state timestamps.
+def _stamped_elapsed_s(record: dict | None, state: str) -> float | None:
+    """Per-dim elapsed from the transition timestamps in dimensions.json.
 
-    The queue file is atomically rewritten on every take (new inode, fresh
-    mtime), so its mtime tracks the *last* take, not the dim start — using it
-    as the start made the running clock reset toward zero on every take.
-    Start comes from the queue's ``created_at`` (stamped at init), falling
-    back to the earliest take timestamp, then the file mtime for legacy
-    queues. For done dims the end is the latest activity signal we still
-    have: last take, evidence-file mtime, or any surviving agent streams
-    (streams are deleted at dim completion, so they rarely survive).
+    write_dim_state stamps ``started_at`` when the dimension starts and
+    ``completed_at`` / ``interrupted_at`` when it stops, so the duration is a
+    subtraction of two explicit values — no file-system forensics. None when
+    the record lacks the needed stamps (legacy runs, hard kills that never
+    reached the terminal write): the caller falls back to reconstruction.
+    """
+    if not isinstance(record, dict):
+        return None
+    start = _parse_iso_utc(record.get("started_at"))
+    if start is None:
+        return None
+    if state == "running":
+        return max(0.0, (datetime.now(timezone.utc) - start).total_seconds())
+    end = _parse_iso_utc(record.get("completed_at")) or _parse_iso_utc(record.get("interrupted_at"))
+    if end is None:
+        return None
+    return max(0.0, (end - start).total_seconds())
+
+
+def _dim_elapsed_s(dim_id: str, run_dir: Path, state: str, record: dict | None = None) -> float | None:
+    """Per-dim elapsed time.
+
+    Prefers the transition timestamps stamped in dimensions.json (see
+    _stamped_elapsed_s). The queue-state reconstruction below remains as a
+    fallback for run dirs written before those stamps were preserved,
+    external runs from older CLI versions, the consolidated pseudo-dim
+    (which has no dimensions.json entry), and dims that died without a
+    terminal transition.
+
+    Reconstruction notes: the queue file is atomically rewritten on every
+    take (new inode, fresh mtime), so its mtime tracks the *last* take, not
+    the dim start — using it as the start made the running clock reset
+    toward zero on every take. Start comes from the queue's ``created_at``
+    (stamped at init), falling back to the earliest take timestamp, then the
+    file mtime for legacy queues. For done dims the end is the latest
+    activity signal we still have: last take, evidence-file mtime, or any
+    surviving agent streams (streams are deleted at dim completion, so they
+    rarely survive).
     """
     if state == "pending":
         return None
+    stamped = _stamped_elapsed_s(record, state)
+    if stamped is not None:
+        return stamped
     queue = run_dir / "evidence" / f"{dim_id}_queue.json"
     qstate = _read_json(queue)
     if qstate is None:
@@ -373,7 +409,7 @@ def build_scan_progress(
             suppressed=matcher.is_suppressed if matcher.active else None,
             resolver=build_principle_resolver(dim_id, evaluators_dir, compiled_dir),
         )
-        elapsed = _dim_elapsed_s(dim_id, run_dir, d_state)
+        elapsed = _dim_elapsed_s(dim_id, run_dir, d_state, record)
         active = _active_agents(evidence_dir, dim_id) if d_state == "running" else 0
 
         dim_results.append(_DimProgress(

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -335,6 +335,7 @@ def load_run_keys(
 def accumulated_cache_version(
     project_dir: Path, params: ScoringParams,
     run_versions: list[tuple], as_of: str | None,
+    visible_dims: tuple[str, ...] | None = None,
 ) -> str:
     """Version for the accumulated cache: params + the per-run fingerprints +
     *as_of*. Composing per-run fingerprints means a dismiss/delete on one run
@@ -348,6 +349,12 @@ def accumulated_cache_version(
     params + intersecting suppressions — so without status folded in, a run
     completing mid-poll would recompute the same version and serve a stale
     payload that omitted the just-finished (now eligible) run.
+
+    *visible_dims* is folded in only by payloads that are COMPUTED over the
+    visible-standards selection (the project-card summary): toggling a
+    standard must invalidate them. Payloads that return every dimension and
+    leave filtering to the client (the accumulated Overview) pass None, so
+    their hashes are unaffected by visibility edits.
     """
     payload = json.dumps({
         # Bump when the accumulated / project-card computation changes, so
@@ -362,6 +369,7 @@ def accumulated_cache_version(
         "params": _params_fingerprint(params),
         "runs": sorted(list(t) for t in run_versions),
         "as_of": as_of or "",
+        **({} if visible_dims is None else {"visible": sorted(visible_dims)}),
     }, sort_keys=True)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -41,7 +41,15 @@ _BUSY_TIMEOUT_MS = 5000
 # formula to the run's own evidence jsonl (services/evidence_rescore), so
 # scores cached by the prior writer differ for the SAME suppression state and
 # params; this bump rebuilds them on the evidence basis once.
-_CACHE_WRITER_EPOCH = "5"
+# "6": three scoring read paths built their run-dimension fetcher without the
+# staleness guards (in-progress bypass + eval-file-count validation), so a
+# request landing mid-run could freeze a partial dim list in the process LRU;
+# later writes built from it persisted half-rescored accumulated payloads and
+# partial scalar sets whose version hash can never self-invalidate. The guards
+# now live in the shared fetcher and the accumulated writer refuses
+# partial-coverage payloads; this bump rebuilds rows the prior writer may have
+# poisoned.
+_CACHE_WRITER_EPOCH = "6"
 
 # Shared-root isolation seam (Phase 2): when serving read endpoints from a
 # second (shared) clone, the score cache must not mix rows with the local
@@ -405,11 +413,18 @@ def per_run_versions(
 
 def cached_accumulated(
     project: str, version: str, compute: Callable[[], dict],
+    cacheable: Callable[[dict], bool] | None = None,
 ) -> dict:
     """Read-through cache for the accumulated payload.
 
     Hit -> return the deserialized cached payload. Miss (or kill switch / cache
     error) -> call *compute*, cache the result best-effort, return it.
+
+    *cacheable*, when given, is called with the computed result before it is
+    persisted; returning False serves the result without caching it. This lets
+    the caller withhold payloads it knows are incomplete (e.g. a rescore that
+    covered only part of the dimensions), which would otherwise freeze under a
+    version hash that cannot self-invalidate.
     """
     if score_cache_disabled():
         return compute()
@@ -421,6 +436,8 @@ def cached_accumulated(
     except sqlite3.Error:
         return compute()
     result = compute()
+    if cacheable is not None and not cacheable(result):
+        return result
     try:
         with open_score_cache() as conn:
             write_cached_accumulated(conn, project, version, result)

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -479,6 +479,15 @@ def _rescore_runs_by_dimension(
     return rescored_by_dim
 
 
+def _dims_expecting_rescore(dims: list[dict]) -> set[str]:
+    """Dimension keys that carry a source run and therefore expect a rescore."""
+    return {
+        (d.get("dimension") or "").lower()
+        for d in dims
+        if (d.get("dimension") or "") and (d.get("fromRunId") or d.get("runId"))
+    }
+
+
 def _merge_rescored_dims(dims: list[dict], rescored_by_dim: dict[str, dict]) -> list[dict]:
     """Merge rescored data into accumulated dimensions."""
     new_dims = []
@@ -500,34 +509,60 @@ def _merge_rescored_dims(dims: list[dict], rescored_by_dim: dict[str, dict]) -> 
     return new_dims
 
 
+def _rescore_accumulated_with_coverage(
+    accumulated: dict[str, Any],
+    reports_root: Path,
+    project: str,
+    params: ScoringParams = DEFAULT_PARAMS,
+) -> tuple[dict[str, Any], bool]:
+    """Apply rescore to an accumulated response dict (in-place compatible shape).
+
+    Filters dismissed violations from each dimension, recalculates scores,
+    and recomputes the summary.
+
+    Returns ``(payload, complete)``. ``complete`` is False when at least one
+    dimension that has a source run got no rescored entry back (e.g. the run
+    read returned a partial dim set), in which case the missing dimensions
+    keep their raw baked scores and the payload MUST NOT be persisted: its
+    version hash cannot tell it apart from a fully rescored one.
+    """
+    project_dir = reports_root / project
+    dismissed = dismissed_keys(project_dir)
+    deleted = deleted_keys(project_dir)
+    if (not dismissed and not deleted) or not accumulated:
+        return accumulated, True
+
+    dims = accumulated.get("dimensions", [])
+    if not dims:
+        return accumulated, True
+
+    rescored_by_dim = _rescore_runs_by_dimension(
+        dims, reports_root, project, dismissed, deleted, params=params,
+    )
+    missing = _dims_expecting_rescore(dims) - set(rescored_by_dim)
+    if missing:
+        _logger.warning(
+            "accumulated rescore for %s covered %d of %d dimensions (missing: %s); "
+            "serving the partial result without caching it",
+            project, len(rescored_by_dim), len(dims), sorted(missing),
+        )
+    new_dims = _merge_rescored_dims(dims, rescored_by_dim)
+
+    new_summary = recompute_summary(new_dims, accumulated.get("summary", {}), params=params)
+    return {**accumulated, "dimensions": new_dims, "summary": new_summary}, not missing
+
+
 def _rescore_accumulated_response(
     accumulated: dict[str, Any],
     reports_root: Path,
     project: str,
     params: ScoringParams = DEFAULT_PARAMS,
 ) -> dict[str, Any]:
-    """Apply rescore to an accumulated response dict (in-place compatible shape).
-
-    Filters dismissed violations from each dimension, recalculates scores,
-    and recomputes the summary.
-    """
-    project_dir = reports_root / project
-    dismissed = dismissed_keys(project_dir)
-    deleted = deleted_keys(project_dir)
-    if (not dismissed and not deleted) or not accumulated:
-        return accumulated
-
-    dims = accumulated.get("dimensions", [])
-    if not dims:
-        return accumulated
-
-    rescored_by_dim = _rescore_runs_by_dimension(
-        dims, reports_root, project, dismissed, deleted, params=params,
+    """`_rescore_accumulated_with_coverage` for callers that don't persist."""
+    payload, _complete = _rescore_accumulated_with_coverage(
+        accumulated, reports_root, project, params=params,
     )
-    new_dims = _merge_rescored_dims(dims, rescored_by_dim)
-
-    new_summary = recompute_summary(new_dims, accumulated.get("summary", {}), params=params)
-    return {**accumulated, "dimensions": new_dims, "summary": new_summary}
+    return payload
 
 
 def rescore_accumulated(
@@ -579,12 +614,21 @@ def get_project_scores(
             "availableRuns": [],
         }
 
-    # Build accumulated using the existing service (returns full data with violations)
+    # Build accumulated using the existing service (returns full data with
+    # violations). The rescore-coverage flag rides in a cell so the cacheable
+    # gate below can see it: a payload whose rescore missed dimensions must be
+    # served but never persisted (its version hash can't self-invalidate).
+    rescore_complete = [True]
+
     def _compute_accumulated_payload() -> dict:
         acc = compute_accumulated(str(reports_root), project, as_of, params=params)
         if acc is None:
             acc = {"dimensions": [], "summary": {}}
-        return _rescore_accumulated_response(acc, reports_root, project, params=params)
+        payload, complete = _rescore_accumulated_with_coverage(
+            acc, reports_root, project, params=params,
+        )
+        rescore_complete[0] = complete
+        return payload
 
     if find_children(reports_root, project):
         # Parent aggregation pulls child projects' dismissals/runs into the
@@ -598,7 +642,10 @@ def get_project_scores(
                              [(r.run_id, r.status) for r in all_runs]),
             as_of,
         )
-        accumulated = cached_accumulated(project, acc_version, _compute_accumulated_payload)
+        accumulated = cached_accumulated(
+            project, acc_version, _compute_accumulated_payload,
+            cacheable=lambda _payload: rescore_complete[0],
+        )
 
     # Build trend using the appropriate fetcher: scalar fast path when there
     # are no active dismissals/deletions, rescoring (findings) path otherwise.

--- a/src/quodeq/shared/dimensions_state.py
+++ b/src/quodeq/shared/dimensions_state.py
@@ -67,6 +67,12 @@ def write_dim_state(
     Optional ``exit_reason`` attaches to the per-dim record on DONE, e.g.
     "done", "time_limit", "failure_streak", "cancelled", "error". The UI
     treats anything other than "done" as a partial-coverage signal.
+
+    Each transition merges into the existing record instead of replacing
+    it, so ``started_at`` (stamped on RUNNING) survives the DONE/INCOMPLETE
+    write — progress reads ``completed_at - started_at`` for a dimension's
+    duration. Safe because DONE and INCOMPLETE are terminal: no transition
+    can ever need a field cleared.
     """
     with _lock:
         data = read_dimensions(run_dir)
@@ -84,7 +90,8 @@ def write_dim_state(
                 raise IllegalDimTransitionError(
                     f"{dimension}: {prev.value} -> {state.value} not permitted",
                 )
-        entry: dict[str, Any] = {"state": state.value}
+        entry: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
+        entry["state"] = state.value
         if state == DimState.RUNNING:
             entry["started_at"] = _now_iso()
         elif state == DimState.DONE:

--- a/src/quodeq/shared/validation.py
+++ b/src/quodeq/shared/validation.py
@@ -14,6 +14,21 @@ def validate_path_segment(*segments: str) -> None:
             )
 
 
+def validate_relative_scope(scope: str) -> None:
+    """Raise ValueError unless *scope* is a plain relative subpath.
+
+    Scope paths (``scopePath`` in project/evaluation payloads) may contain
+    forward slashes to point at a nested folder, but must not be absolute,
+    drive-qualified, backslashed, or contain traversal segments.
+    """
+    if "\0" in scope or "\\" in scope:
+        raise ValueError(f"Invalid scope path: {scope!r}. Use a forward-slash relative path.")
+    if scope.startswith("/") or (len(scope) > 1 and scope[1] == ":"):
+        raise ValueError(f"Invalid scope path: {scope!r}. Scope must be relative to the repository root.")
+    if any(part == ".." for part in scope.split("/")):
+        raise ValueError(f"Invalid scope path: {scope!r}. Parent-directory segments are not allowed.")
+
+
 def validate_resolved_within(path: Path, root: Path) -> None:
     """Raise ValueError if *path* resolves outside *root*."""
     if not path.resolve().is_relative_to(root.resolve()):

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
@@ -127,7 +127,9 @@ export default function EvaluationForm({ onStart, disabled, selectedProject }) {
     cleanScan, setCleanScan,
   } = useEvaluationForm(onStart, showToast);
 
-  const isLocalRepo = !!repo && !repo.startsWith('http') && !repo.startsWith('git@') && !repo.includes('github.com');
+  // Anchored: a schemeless paste like "github.com/org/repo" is remote, but a
+  // local folder whose path merely contains "github.com" is not.
+  const isLocalRepo = !!repo && !repo.startsWith('http') && !repo.startsWith('git@') && !/^(www\.)?github\.com\//i.test(repo);
   const { scanData } = useScanData(null, isLocalRepo ? repo : null);
 
   // Submit stays clickable when no standards are selected so the snackbar

--- a/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
@@ -1,12 +1,13 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { StatStrip, Stat } from '../../../components/terminal/index.js';
 import { computeOverallProgress } from './scanProgressTotals.js';
 import {
-  buildJobStatCells, computeRate, buildEtaHint, msUntilNextSecond,
+  buildJobStatCells, computeRate, buildEtaHint,
   buildDimensionCycle, sumSeverities, deriveScanMode,
 } from './buildJobStatCells.js';
 import { recordRateSample, getRateSamples } from './rateSampleStore.js';
 import { useEvaluationProgress } from '../hooks/useEvaluationProgress.js';
+import { useRunElapsed } from '../hooks/useRunElapsed.js';
 
 const TERMINAL_STATES = new Set(['done', 'completed', 'failed', 'cancelled', 'lost']);
 
@@ -25,45 +26,14 @@ function sumSuppressed(progress) {
   return (progress?.dimensions || []).reduce((n, d) => n + (d?.suppressed || 0), 0);
 }
 
-// Live elapsed from wall-clock so the cell ticks every second between the 2s
-// progress polls. Falls back to the backend-reported elapsed only when the job
-// carries no usable startedAt.
-function deriveElapsedS(startedAt, endedAt, isTerminal, fallbackElapsed) {
-  if (startedAt) {
-    const start = Date.parse(startedAt);
-    if (!Number.isNaN(start)) {
-      const end = isTerminal && endedAt ? Date.parse(endedAt) : Date.now();
-      if (!Number.isNaN(end)) return Math.max(0, (end - start) / 1000);
-    }
-  }
-  if (fallbackElapsed != null && Number.isFinite(fallbackElapsed)) return fallbackElapsed;
-  return null;
-}
-
 export default function JobStatStrip({ job, liveViolations, hiddenCarriedCount = 0 }) {
   const jobId = job?.jobId;
   const isTerminal = TERMINAL_STATES.has(job?.status);
 
   const { data: progress, dataUpdatedAt } = useEvaluationProgress(jobId, isTerminal);
-
-  // Re-render aligned to each whole-second boundary of wall-clock elapsed, so
-  // ELAPSED ticks *evenly*. A fixed setInterval(1000) has its phase fixed at
-  // mount and beats against the second boundary as timer jitter drifts it,
-  // producing visible double/skip ticks. A self-correcting timeout recomputes
-  // the delay from absolute `now` each tick — it re-aligns to the boundary and
-  // never accumulates drift. Inactive on terminal states / without a startedAt
-  // (the elapsed value is then poll-derived and can't tick per-second anyway).
-  const [tick, setTick] = useState(0);
-  const startMs = job?.startedAt ? Date.parse(job.startedAt) : NaN;
-  useEffect(() => {
-    if (isTerminal || !jobId || Number.isNaN(startMs)) return undefined;
-    let id;
-    const schedule = () => {
-      id = setTimeout(() => { setTick((t) => t + 1); schedule(); }, msUntilNextSecond(Date.now() - startMs));
-    };
-    schedule();
-    return () => clearTimeout(id);
-  }, [isTerminal, jobId, startMs]);
+  // Server-anchored, per-second-ticking elapsed shared with ScanProgress, so
+  // the ELAPSED tile and the footer clock always agree.
+  const elapsedS = useRunElapsed(job, progress, dataUpdatedAt);
 
   // Throughput samples live in a module-level store (rateSampleStore.js) keyed
   // by jobId, so the sliding-window rate SURVIVES navigating out of and back
@@ -81,7 +51,6 @@ export default function JobStatStrip({ job, liveViolations, hiddenCarriedCount =
   const cells = useMemo(() => {
     if (!jobId) return [];
     const { takenFiles, totalFiles, overallPct } = computeOverallProgress(progress);
-    const elapsedS = deriveElapsedS(job?.startedAt, job?.endedAt, isTerminal, progress?.totalElapsedS);
     const liveCount = sumLiveViolations(liveViolations);
     // Current throughput from the persisted sliding window (null → "estimating…"
     // until ~30s of samples accumulate). No whole-run average: it over-reads
@@ -96,8 +65,8 @@ export default function JobStatStrip({ job, liveViolations, hiddenCarriedCount =
       sevCounts: sumSeverities(liveViolations),
       scanMode: deriveScanMode(progress),
     });
-    // `tick` drives the per-second recompute; the sample store is read (not a dep).
-  }, [jobId, job?.status, job?.startedAt, job?.endedAt, isTerminal, progress, liveViolations, hiddenCarriedCount, tick]);
+    // `elapsedS` advances once per second via useRunElapsed; the sample store is read (not a dep).
+  }, [jobId, job?.status, isTerminal, progress, liveViolations, hiddenCarriedCount, elapsedS]);
 
   if (!jobId) return null;
 

--- a/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.test.jsx
@@ -40,7 +40,7 @@ describe('JobStatStrip', () => {
     expect(await screen.findByText('63%')).toBeInTheDocument();
     expect(screen.getByText('138')).toBeInTheDocument();
     expect(screen.getByText('/ 220')).toBeInTheDocument();
-    expect(screen.getByText('2:14')).toBeInTheDocument();
+    expect(screen.getByText('2m 14s')).toBeInTheDocument();
     expect(screen.getByText('2')).toBeInTheDocument();    // violations count
     expect(screen.getByText('1 critical · 1 major')).toBeInTheDocument();
   });
@@ -56,7 +56,7 @@ describe('JobStatStrip', () => {
     expect(screen.getByText('DURATION')).toBeInTheDocument();
     expect(await screen.findByText('220')).toBeInTheDocument();
     expect(screen.getByText('13')).toBeInTheDocument();
-    expect(screen.getByText('4:32')).toBeInTheDocument();
+    expect(screen.getByText('4m 32s')).toBeInTheDocument();
   });
 
   it('renders fallback values when progress query has no data yet', () => {
@@ -132,20 +132,34 @@ describe('JobStatStrip', () => {
     nowSpy.mockRestore();
   });
 
-  it('ELAPSED reflects wall-clock from startedAt (not backend elapsed)', async () => {
+  it('ELAPSED is anchored to the server-reported elapsed, not client wall-clock', async () => {
+    // The client's clock disagrees with the server by hours (skew, suspended
+    // laptop): startedAt reads as 5s ago, but the server has measured 9999s
+    // of run time. The server value wins — every clock on the screen derives
+    // from it, so skew can't corrupt the display.
     const now = new Date('2026-06-08T10:00:00Z').getTime();
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
     getEvaluationProgress.mockResolvedValue({
       dimensions: [{ state: 'running', files: { taken: 10, total: 1000 } }],
-      totalElapsedS: 9999, // would show 166:39 if backend value were used
+      totalElapsedS: 9999,
     });
     const job = { jobId: 'job-4', status: 'running', startedAt: new Date(now - 5000).toISOString() };
     renderWithClient(<JobStatStrip job={job} liveViolations={{}} />);
-    // Wait for the poll to resolve (PROGRESS shows 1%) so we assert the
-    // post-resolution value: with the old code this would flip to backend
-    // 9999s (166:39); the new code keeps wall-clock 0:05.
     expect(await screen.findByText('1%')).toBeInTheDocument();
-    expect(screen.getByText('0:05')).toBeInTheDocument();
+    expect(screen.getByText('2h 46m 39s')).toBeInTheDocument();
+    nowSpy.mockRestore();
+  });
+
+  it('ELAPSED falls back to job wall-clock before any progress payload lands', async () => {
+    const now = new Date('2026-06-08T10:00:00Z').getTime();
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+    getEvaluationProgress.mockResolvedValue({
+      dimensions: [{ state: 'running', files: { taken: 10, total: 1000 } }],
+    });
+    const job = { jobId: 'job-4b', status: 'running', startedAt: new Date(now - 5000).toISOString() };
+    renderWithClient(<JobStatStrip job={job} liveViolations={{}} />);
+    expect(await screen.findByText('1%')).toBeInTheDocument();
+    expect(screen.getByText('5s')).toBeInTheDocument();
     nowSpy.mockRestore();
   });
 
@@ -160,9 +174,9 @@ describe('JobStatStrip', () => {
       const job = { jobId: 'job-5', status: 'running', startedAt: new Date(t0 - 5000).toISOString() };
       renderWithClient(<JobStatStrip job={job} liveViolations={{}} />);
       await vi.advanceTimersByTimeAsync(0);     // flush the initial fetch
-      expect(screen.getByText('0:05')).toBeInTheDocument();
+      expect(screen.getByText('5s')).toBeInTheDocument();
       await vi.advanceTimersByTimeAsync(2000);  // two 1s ticks
-      expect(screen.getByText('0:07')).toBeInTheDocument();
+      expect(screen.getByText('7s')).toBeInTheDocument();
     } finally {
       vi.useRealTimers();
     }

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -5,17 +5,11 @@ import { deriveScanMode } from './buildJobStatCells.js';
 import ConsoleButton from '../../../components/ConsoleButton.jsx';
 import { SectionLabel } from '../../../components/terminal/index.js';
 import { useEvaluationProgress } from '../hooks/useEvaluationProgress.js';
+import { useRunElapsed } from '../hooks/useRunElapsed.js';
+import { formatDuration, formatDurationCoarse } from '../../../utils/formatters.js';
 
 const TERMINAL_STATES = new Set(['done', 'failed', 'cancelled']);
 const STATUS_MARKERS = { arrow: '→', check: '✓', error: 'Error:', failed: 'failed' };
-
-function formatClock(s) {
-  if (s == null || !Number.isFinite(s)) return '—';
-  const total = Math.max(0, Math.floor(s));
-  const m = Math.floor(total / 60);
-  const sec = total % 60;
-  return `${m}:${String(sec).padStart(2, '0')}`;
-}
 
 function isStatusLine(line) {
   const prefixes = [STATUS_MARKERS.arrow, STATUS_MARKERS.check, STATUS_MARKERS.error];
@@ -88,7 +82,7 @@ function DimRow({ dim }) {
             title={partialTooltip}
           >{coveragePct}%</span>{dim.elapsedS != null && ' · '}</>
         )}
-        {dim.elapsedS != null && formatClock(dim.elapsedS)}
+        {dim.elapsedS != null && formatDuration(dim.elapsedS)}
       </>
     );
   } else {
@@ -97,7 +91,7 @@ function DimRow({ dim }) {
     // dangling "· —" tail. The time budget is run-level (shared across
     // dimensions, shown in the footer), so rows only get their elapsed.
     const clockPart = dim.elapsedS != null
-      ? <span className="scan-progress__budget">{formatClock(dim.elapsedS)}</span>
+      ? <span className="scan-progress__budget">{formatDuration(dim.elapsedS)}</span>
       : null;
     meta = (
       <>
@@ -144,6 +138,9 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
   // Best-effort: surface the last successful payload, ignore errors silently
   // (progress is purely informational and should never block the UI).
   const progress = progressQuery.data ?? null;
+  // Same server-anchored ticking clock the stat strip shows, so the footer
+  // total can never disagree with the ELAPSED tile.
+  const elapsedS = useRunElapsed(job, progress, progressQuery.dataUpdatedAt);
 
   useEffect(() => {
     if (evalLog.activeJobId === jobId) {
@@ -195,15 +192,15 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
   // run-level budget. Overrun can show briefly: the watchdog allows a
   // short grace past the deadline before killing the job.
   const runBudgetS = progress?.budgetS;
-  const overrun = runBudgetS > 0 && progress?.totalElapsedS > runBudgetS;
+  const overrun = runBudgetS > 0 && elapsedS > runBudgetS;
   const clockPart = isRunning && runBudgetS > 0
     ? (
       <> · <span className={overrun ? 'scan-progress__budget scan-progress__budget--overrun' : 'scan-progress__budget'}>
-        {formatClock(progress.totalElapsedS)} of {formatClock(runBudgetS)} budget
+        {formatDuration(elapsedS)} of {formatDurationCoarse(runBudgetS)} budget
       </span></>
     )
-    : progress?.totalElapsedS != null
-      ? <> · {formatClock(progress.totalElapsedS)} total</>
+    : elapsedS != null
+      ? <> · {formatDuration(elapsedS)} total</>
       : null;
 
   let summary;

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.test.jsx
@@ -231,7 +231,7 @@ describe('ScanProgress total coverage (incremental runs)', () => {
     payload.totalElapsedS = 78;
     getEvaluationProgress.mockResolvedValue(payload);
     withEvalLog(<ScanProgress job={baseJob} />, ctx);
-    expect(await screen.findByText(/1:18 of 10:00 budget/)).toBeInTheDocument();
+    expect(await screen.findByText(/1m 18s of 10m budget/)).toBeInTheDocument();
   });
 
   it('marks the footer budget as overrun once elapsed passes it', async () => {
@@ -240,7 +240,7 @@ describe('ScanProgress total coverage (incremental runs)', () => {
     payload.totalElapsedS = 640;
     getEvaluationProgress.mockResolvedValue(payload);
     const { container } = withEvalLog(<ScanProgress job={baseJob} />, ctx);
-    await screen.findByText(/10:40 of 10:00 budget/);
+    await screen.findByText(/10m 40s of 10m budget/);
     expect(container.querySelector('.scan-progress__budget--overrun')).not.toBeNull();
   });
 
@@ -255,7 +255,7 @@ describe('ScanProgress total coverage (incremental runs)', () => {
     withEvalLog(<ScanProgress job={baseJob} />, ctx);
     fireEvent.click(await screen.findByTitle('Show per-dimension detail'));
     const row = (await screen.findByText('security')).closest('.scan-progress__dim');
-    expect(row.textContent).toContain('1:18');
+    expect(row.textContent).toContain('1m 18s');
     expect(row.textContent).not.toContain('budget');
   });
 });

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
@@ -4,6 +4,7 @@
  */
 
 import { computeOverallProgress } from './scanProgressTotals.js';
+import { formatDuration } from '../../../utils/formatters.js';
 
 // Throughput estimate tuning. The eval completes only a few files per MINUTE
 // (one slow LLM call per file), so the rate is shown per minute and measured
@@ -94,12 +95,40 @@ export function msUntilNextSecond(elapsedMs) {
   return 1000 - rem;
 }
 
-export function formatClock(s) {
-  if (s == null || !Number.isFinite(s)) return '—';
-  const total = Math.max(0, Math.floor(s));
-  const m = Math.floor(total / 60);
-  const sec = total % 60;
-  return `${m}:${String(sec).padStart(2, '0')}`;
+/**
+ * One elapsed value for the whole evaluate screen, anchored to the SERVER's
+ * clock. The progress payload reports totalElapsedS computed from the run's
+ * own status.json timestamps; the client only extrapolates forward by the
+ * time since that payload landed. Anchoring to the server (instead of
+ * Date.parse(job.startedAt) vs client Date.now()) makes the clock immune to
+ * client/server clock skew and keeps every clock on the screen in lock-step
+ * — the stat strip and the footer previously mixed client wall-clock with
+ * 2s-stale poll data and visibly disagreed.
+ *
+ * Fallback order when the server hasn't reported an elapsed yet (first
+ * render before any poll, legacy runs): job wall-clock timestamps, else null.
+ * Non-running jobs freeze on the server value (or startedAt→endedAt).
+ *
+ * @param {object} args
+ * @param {boolean} args.running
+ * @param {number|null|undefined} args.serverElapsedS — progress.totalElapsedS
+ * @param {number|null|undefined} args.serverUpdatedAtMs — when that payload landed (epoch ms)
+ * @param {number} args.nowMs
+ * @param {string|null|undefined} args.startedAt — ISO, fallback only
+ * @param {string|null|undefined} args.endedAt — ISO, fallback only
+ * @returns {number|null} seconds
+ */
+export function deriveRunElapsedS({ running, serverElapsedS, serverUpdatedAtMs, nowMs, startedAt, endedAt }) {
+  if (Number.isFinite(serverElapsedS)) {
+    if (!running) return serverElapsedS;
+    const sinceMs = Number.isFinite(serverUpdatedAtMs) ? Math.max(0, nowMs - serverUpdatedAtMs) : 0;
+    return serverElapsedS + sinceMs / 1000;
+  }
+  const start = startedAt ? Date.parse(startedAt) : NaN;
+  if (Number.isNaN(start)) return null;
+  const end = !running && endedAt ? Date.parse(endedAt) : nowMs;
+  if (Number.isNaN(end)) return null;
+  return Math.max(0, (end - start) / 1000);
 }
 
 /**
@@ -184,7 +213,7 @@ function progressCell({ overallPct, takenFiles, totalFiles }) {
 function elapsedCell(elapsedS, label = 'ELAPSED', hint = null) {
   return {
     label,
-    value: formatClock(elapsedS),
+    value: formatDuration(elapsedS),
     hint,
     tone: 'default',
   };

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   buildJobStatCells,
-  formatClock,
+  deriveRunElapsedS,
   computeRate,
   RATE_WINDOW_MS,
   formatRate,
@@ -21,27 +21,62 @@ const baseInputs = {
   overallPct: 62,
   takenFiles: 138,
   totalFiles: 220,
-  elapsedS: 134,         // 02:14
+  elapsedS: 134,         // 2m 14s
   liveCount: 2,
 };
 
 // ---------------------------------------------------------------------------
-// formatClock
+// deriveRunElapsedS
 // ---------------------------------------------------------------------------
 
-test('formatClock: formats seconds as m:ss', () => {
-  assert.equal(formatClock(0), '0:00');
-  assert.equal(formatClock(59), '0:59');
-  assert.equal(formatClock(60), '1:00');
-  assert.equal(formatClock(134), '2:14');
-  assert.equal(formatClock(3661), '61:01');
+const T0 = Date.parse('2026-06-08T10:00:00Z');
+
+test('deriveRunElapsedS: running — server elapsed extrapolated by time since the poll', () => {
+  const s = deriveRunElapsedS({
+    running: true, serverElapsedS: 134, serverUpdatedAtMs: T0 - 1500, nowMs: T0,
+    startedAt: null, endedAt: null,
+  });
+  assert.equal(s, 135.5);
 });
 
-test('formatClock: returns "—" for null/undefined/non-finite', () => {
-  assert.equal(formatClock(null), '—');
-  assert.equal(formatClock(undefined), '—');
-  assert.equal(formatClock(NaN), '—');
-  assert.equal(formatClock(Infinity), '—');
+test('deriveRunElapsedS: server elapsed wins over job wall-clock timestamps (skew immunity)', () => {
+  // Client thinks the run started 5s ago; server says 9999s. Server wins.
+  const s = deriveRunElapsedS({
+    running: true, serverElapsedS: 9999, serverUpdatedAtMs: T0, nowMs: T0,
+    startedAt: new Date(T0 - 5000).toISOString(), endedAt: null,
+  });
+  assert.equal(s, 9999);
+});
+
+test('deriveRunElapsedS: non-running freezes on the server value, no extrapolation', () => {
+  const s = deriveRunElapsedS({
+    running: false, serverElapsedS: 272, serverUpdatedAtMs: T0 - 60000, nowMs: T0,
+    startedAt: null, endedAt: null,
+  });
+  assert.equal(s, 272);
+});
+
+test('deriveRunElapsedS: falls back to job timestamps before any progress payload', () => {
+  const running = deriveRunElapsedS({
+    running: true, serverElapsedS: undefined, serverUpdatedAtMs: undefined, nowMs: T0,
+    startedAt: new Date(T0 - 5000).toISOString(), endedAt: null,
+  });
+  assert.equal(running, 5);
+  const ended = deriveRunElapsedS({
+    running: false, serverElapsedS: null, serverUpdatedAtMs: undefined, nowMs: T0,
+    startedAt: new Date(T0 - 90000).toISOString(), endedAt: new Date(T0 - 30000).toISOString(),
+  });
+  assert.equal(ended, 60);
+});
+
+test('deriveRunElapsedS: null when nothing is knowable, clamped at 0 for clock regressions', () => {
+  assert.equal(deriveRunElapsedS({ running: true, nowMs: T0, startedAt: null, endedAt: null }), null);
+  assert.equal(deriveRunElapsedS({ running: true, nowMs: T0, startedAt: 'not-a-date', endedAt: null }), null);
+  const s = deriveRunElapsedS({
+    running: true, serverElapsedS: undefined, nowMs: T0,
+    startedAt: new Date(T0 + 5000).toISOString(), endedAt: null,
+  });
+  assert.equal(s, 0);
 });
 
 // ---------------------------------------------------------------------------
@@ -67,7 +102,7 @@ test('buildJobStatCells: builds 4 cells for a running job with progress data', (
   assert.equal(cells[2].value, 2);
   assert.equal(cells[2].tone, 'critical');
   assert.equal(cells[3].label, 'elapsed');
-  assert.equal(cells[3].value, '2:14');
+  assert.equal(cells[3].value, '2m 14s');
 });
 
 test('buildJobStatCells: running analyzing tile falls back while dims are unknown', () => {
@@ -116,7 +151,7 @@ test('buildJobStatCells: builds done-state cells with SCANNED + VIOLATIONS + DUR
   assert.equal(cells[2].value, 13);
   assert.equal(cells[2].tone, 'critical');
   assert.equal(cells[3].label, 'DURATION');
-  assert.equal(cells[3].value, '4:32');
+  assert.equal(cells[3].value, '4m 32s');
 });
 
 test('buildJobStatCells: uses correct tone for STATUS by status', () => {

--- a/src/quodeq/ui/src/features/evaluation/hooks/useRunElapsed.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useRunElapsed.js
@@ -1,0 +1,53 @@
+import { useEffect, useReducer } from 'react';
+import { deriveRunElapsedS, msUntilNextSecond } from '../components/buildJobStatCells.js';
+
+/**
+ * The evaluate screen's elapsed clock, in seconds. Server-anchored (see
+ * deriveRunElapsedS) and ticking once per second while the job runs, so
+ * every consumer — the stat strip's ELAPSED tile and the progress footer —
+ * reads the exact same value and can never drift apart.
+ *
+ * Ticks are aligned to the whole-second boundary of the *elapsed* value
+ * (msUntilNextSecond): a fixed 1s interval has its phase fixed at mount and
+ * beats against the boundary, producing visible double/skip ticks.
+ *
+ * @param {object|null} job — needs status, startedAt, endedAt
+ * @param {object|null} progress — the polled progress payload (totalElapsedS)
+ * @param {number|undefined} dataUpdatedAt — react-query's timestamp for when
+ *   that payload landed; the extrapolation base between polls
+ * @returns {number|null} elapsed seconds, null while unknowable
+ */
+export function useRunElapsed(job, progress, dataUpdatedAt) {
+  const running = job?.status === 'running';
+  const [, bump] = useReducer((t) => t + 1, 0);
+
+  const elapsedS = deriveRunElapsedS({
+    running,
+    serverElapsedS: progress?.totalElapsedS,
+    serverUpdatedAtMs: dataUpdatedAt,
+    nowMs: Date.now(),
+    startedAt: job?.startedAt,
+    endedAt: job?.endedAt,
+  });
+
+  const serverElapsedS = progress?.totalElapsedS;
+  const startedAt = job?.startedAt;
+  const active = running && elapsedS != null;
+  useEffect(() => {
+    if (!active) return undefined;
+    // Virtual start of the run on the client's clock: the display flips when
+    // floor((now - anchor) / 1000) changes, matching deriveRunElapsedS.
+    const anchorMs = Number.isFinite(serverElapsedS) && Number.isFinite(dataUpdatedAt)
+      ? dataUpdatedAt - serverElapsedS * 1000
+      : Date.parse(startedAt);
+    if (Number.isNaN(anchorMs)) return undefined;
+    let id;
+    const schedule = () => {
+      id = setTimeout(() => { bump(); schedule(); }, msUntilNextSecond(Date.now() - anchorMs));
+    };
+    schedule();
+    return () => clearTimeout(id);
+  }, [active, serverElapsedS, dataUpdatedAt, startedAt]);
+
+  return elapsedS;
+}

--- a/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
@@ -294,6 +294,33 @@ it('copy button copies the active session selection to the clipboard', async () 
   expect(writeText).toHaveBeenCalledWith('picked text');
 });
 
+// OSC 8 hyperlinks are activated by xterm itself. Without an explicit
+// linkHandler xterm uses its built-in one, which confirms and then calls
+// window.open() with no URL — null inside pywebview's WKWebView, so clicking OK
+// did nothing. The handler must reach the pywebview bridge instead.
+it('routes OSC 8 hyperlink clicks through the pywebview bridge, not window.open', async () => {
+  const { Terminal } = await import('@xterm/xterm');
+  Terminal.mockClear();
+  const open_browser = vi.fn();
+  window.pywebview = { api: { open_browser } };
+  const windowOpen = vi.spyOn(window, 'open').mockReturnValue(null);
+  try {
+    render(<TerminalPane active />);
+    await screen.findByTestId('tty-root');
+    await waitFor(() => expect(Terminal).toHaveBeenCalled());
+
+    const { linkHandler } = Terminal.mock.calls[0][0];
+    expect(linkHandler).toBeTruthy();
+    linkHandler.activate({}, 'https://example.com/release');
+
+    expect(open_browser).toHaveBeenCalledWith('https://example.com/release');
+    expect(windowOpen).not.toHaveBeenCalled();
+  } finally {
+    windowOpen.mockRestore();
+    delete window.pywebview;
+  }
+});
+
 it('shows shell, session count, sandbox note and active cwd in the status bar', async () => {
   render(<TerminalPane active />);
   await screen.findByTestId('tty-root');

--- a/src/quodeq/ui/src/features/terminal/TerminalSessionView.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalSessionView.jsx
@@ -6,6 +6,7 @@ import { useTerminalSocket } from './useTerminalSocket.js';
 import { resolveTerminalPaths, openInEditor } from '../../api/terminal.js';
 import { createUrlLinkProvider, createFileLinkProvider } from './terminalLinks.js';
 import { themeFromCss } from './xtermTheme.js';
+import { openExternal } from '../updates/openExternal.js';
 
 // Two drawer chords are reserved for the host; return false so xterm lets them
 // bubble to the window handler instead of typing into the shell.
@@ -125,6 +126,13 @@ export default function TerminalSessionView({ sessionId, active, live, onGone, r
         cursorBlink: true,
         cursorStyle: 'bar',     // sleeker than the default square block
         theme: themeFromCss(),
+        // OSC 8 hyperlinks (emitted by gh, npm, coding CLIs…) are handled by
+        // xterm itself, not by our link providers below. Without a linkHandler
+        // xterm falls back to its built-in one, which confirms and then calls
+        // window.open() with no URL — and window.open always returns null
+        // inside pywebview's WKWebView, so clicking OK does nothing at all.
+        // Route them through openExternal, which prefers the pywebview bridge.
+        linkHandler: { activate: (_event, uri) => openExternal(uri) },
       });
       const fit = new FitAddon();
       term.loadAddon(fit);
@@ -142,7 +150,9 @@ export default function TerminalSessionView({ sessionId, active, live, onGone, r
       linkProviders.push(
         term.registerLinkProvider(createUrlLinkProvider({
           readLine,
-          openUrl: (url) => window.open(url, '_blank', 'noopener,noreferrer'),
+          // Not window.open: it returns null in the desktop app's WKWebView,
+          // so a cmd-clicked URL silently did nothing there.
+          openUrl: (url) => openExternal(url),
         })),
         term.registerLinkProvider(createFileLinkProvider({
           readLine,

--- a/src/quodeq/ui/src/utils/formatters.duration.test.js
+++ b/src/quodeq/ui/src/utils/formatters.duration.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatDuration, formatDurationCoarse } from './formatters.js';
+
+test('formatDuration: seconds only under a minute', () => {
+  assert.equal(formatDuration(0), '0s');
+  assert.equal(formatDuration(42), '42s');
+  assert.equal(formatDuration(59.9), '59s'); // floors, never rounds up
+});
+
+test('formatDuration: minutes and seconds under an hour', () => {
+  assert.equal(formatDuration(60), '1m 0s');
+  assert.equal(formatDuration(134), '2m 14s');
+  assert.equal(formatDuration(3599), '59m 59s');
+});
+
+test('formatDuration: hours from 3600s up (the 255:12 case reads 4h 15m 12s)', () => {
+  assert.equal(formatDuration(3600), '1h 0m 0s');
+  assert.equal(formatDuration(15312), '4h 15m 12s');
+  assert.equal(formatDuration(90000), '25h 0m 0s'); // no day rollover
+});
+
+test('formatDuration: "—" for unknown, clamps negatives to 0s', () => {
+  assert.equal(formatDuration(null), '—');
+  assert.equal(formatDuration(undefined), '—');
+  assert.equal(formatDuration(NaN), '—');
+  assert.equal(formatDuration(Infinity), '—');
+  assert.equal(formatDuration(-5), '0s');
+});
+
+test('formatDurationCoarse: drops zero components for round targets', () => {
+  assert.equal(formatDurationCoarse(7200), '2h');
+  assert.equal(formatDurationCoarse(5400), '1h 30m');
+  assert.equal(formatDurationCoarse(600), '10m');
+  assert.equal(formatDurationCoarse(30), '30s');
+  assert.equal(formatDurationCoarse(0), '0s');
+});
+
+test('formatDurationCoarse: seconds appear only under a minute', () => {
+  assert.equal(formatDurationCoarse(90), '1m'); // 1m 30s truncates to the minute
+  assert.equal(formatDurationCoarse(3661), '1h 1m');
+  assert.equal(formatDurationCoarse(null), '—');
+});

--- a/src/quodeq/ui/src/utils/formatters.js
+++ b/src/quodeq/ui/src/utils/formatters.js
@@ -264,6 +264,45 @@ export function mostFrequentGrade(grades) {
   return capitalizeGrade(maxGrade);
 }
 
+/**
+ * Human-readable duration from seconds: "42s", "12m 34s", "4h 15m 12s".
+ * Floors to whole seconds so a ticking clock advances evenly; "—" when the
+ * value is unknown.
+ *
+ * @param {number|null|undefined} s
+ * @returns {string}
+ */
+export function formatDuration(s) {
+  if (s == null || !Number.isFinite(s)) return '—';
+  const total = Math.max(0, Math.floor(s));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const sec = total % 60;
+  if (h > 0) return `${h}h ${m}m ${sec}s`;
+  if (m > 0) return `${m}m ${sec}s`;
+  return `${sec}s`;
+}
+
+/**
+ * Duration for round targets like time budgets: zero components are dropped
+ * ("2h", "1h 30m", "45m"), so a 2-hour budget never reads "2h 0m 0s". Seconds
+ * appear only under a minute.
+ *
+ * @param {number|null|undefined} s
+ * @returns {string}
+ */
+export function formatDurationCoarse(s) {
+  if (s == null || !Number.isFinite(s)) return '—';
+  const total = Math.max(0, Math.round(s));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const parts = [];
+  if (h > 0) parts.push(`${h}h`);
+  if (m > 0) parts.push(`${m}m`);
+  if (parts.length === 0) parts.push(`${total % 60}s`);
+  return parts.join(' ');
+}
+
 const PERIOD_MONTH_NAMES = [
   'January', 'February', 'March', 'April', 'May', 'June',
   'July', 'August', 'September', 'October', 'November', 'December',

--- a/src/quodeq/ui/src/utils/scoreFiltering.accumulated.test.js
+++ b/src/quodeq/ui/src/utils/scoreFiltering.accumulated.test.js
@@ -25,3 +25,30 @@ test('populated trend still wins (unchanged behavior)', () => {
   const out = filterAccumulatedByVisibleStandards(ACC, VISIBLE, trend, 'r1');
   assert.equal(out.summary.numericAverage, 8.2);
 });
+
+// The backend's overallGrade averages ALL dimensions, hidden ones included.
+// The grade word must be re-derived from the recomputed (visible-only)
+// average, or a hidden low-scoring dimension shows e.g. "grade C" next to a
+// 7.5 score computed without it.
+
+test('overallGrade is re-derived from the visible-only average', () => {
+  const acc = {
+    dimensions: [
+      { dimension: 'security', totals: { violationCount: 0, complianceCount: 0 } },
+      { dimension: 'clean-architecture', totals: { violationCount: 0, complianceCount: 0 } },
+    ],
+    // Backend average includes the hidden dim: (7.5 + 4.0) / 2 → Adequate.
+    summary: { numericAverage: 5.8, overallGrade: 'Adequate' },
+  };
+  const trend = [{ runId: 'r1', numericAverage: 7.5 }];
+  const out = filterAccumulatedByVisibleStandards(acc, new Set(['security']), trend, 'r1');
+  assert.equal(out.summary.numericAverage, 7.5);
+  assert.equal(out.summary.overallGrade, 'Good');
+});
+
+test('overallGrade is null when no average is computable', () => {
+  const acc = { dimensions: [], summary: { overallGrade: 'Good' } };
+  const out = filterAccumulatedByVisibleStandards(acc, new Set(), [], null);
+  assert.equal(out.summary.numericAverage, null);
+  assert.equal(out.summary.overallGrade, null);
+});

--- a/src/quodeq/ui/src/utils/scoreFiltering.js
+++ b/src/quodeq/ui/src/utils/scoreFiltering.js
@@ -6,6 +6,7 @@
  */
 
 import { bucketKey, isBucketEligible } from './dailyGrouping.js';
+import { scoreToGradeLabel } from './gradeThresholds.js';
 import { countBySeverity } from './severity.js';
 
 const roundOneDecimal = (n) => Math.round(n * 10) / 10;
@@ -140,6 +141,11 @@ export function filterAccumulatedByVisibleStandards(accumulated, visibleSet, fil
       ...accumulated.summary,
       numericAverage,
       previousNumericAverage: prevAvg,
+      // Re-derive the grade word from the recomputed average: the backend's
+      // overallGrade is computed over ALL dimensions, so passing it through
+      // lets a hidden dimension's score set the letter next to a number it
+      // no longer matches (score from visible dims, grade from everything).
+      overallGrade: scoreToGradeLabel(numericAverage),
       totalViolations,
       totalCompliance,
       severity,

--- a/tests/analysis/cache/test_cache_writer.py
+++ b/tests/analysis/cache/test_cache_writer.py
@@ -335,3 +335,37 @@ def test_written_entry_records_effective_params(tmp_path):
     entry = LocalFileBackend(root=cache_root).get(key)
     assert entry is not None
     assert entry.provenance["effective_params"]["M-ANA-2"]["max_lines"] == 60
+
+
+def test_cache_writer_marks_the_entry_unconsolidated(tmp_path):
+    """A freshly produced finding has not reached any completed run's report
+    yet. The entry is born unconsolidated and stays that way until the run
+    that produced it reaches done."""
+    from quodeq.analysis.cache.cache_writer import build_cache_writer
+    from quodeq.analysis.cache.local import LocalFileBackend
+
+    src_root = tmp_path / "src"
+    src_root.mkdir()
+    (src_root / "Foo.kt").write_text("class Foo")
+
+    cache_root = tmp_path / "cache"
+    write = build_cache_writer(
+        cache_root=cache_root,
+        src_root=src_root,
+        standards_dir=None,
+        dimension="security",
+        model_id="sonnet",
+        language="kotlin",
+    )
+    write("Foo.kt", [{"file": "Foo.kt", "line": 1, "t": "violation"}])
+
+    backend = LocalFileBackend(root=cache_root)
+    entries = [
+        # LocalFileBackend shards keys as <root>/key[:2]/key[2:]/entry.json,
+        # so the full key is the two parent directory names concatenated.
+        backend.get(p.parent.parent.name + p.parent.name)
+        for p in cache_root.rglob("entry.json")
+    ]
+    written = [e for e in entries if e is not None]
+    assert written, "expected the writer to persist one entry"
+    assert all(e.consolidated is False for e in written)

--- a/tests/analysis/cache/test_consolidation.py
+++ b/tests/analysis/cache/test_consolidation.py
@@ -174,7 +174,7 @@ def test_a_raising_backend_never_propagates(tmp_path: Path, caplog):
         mark_run_consolidated(run_dir, backend)
 
     assert backend.touched == 1, "the backend was never consulted"
-    assert "disk on fire" in caplog.text
+    assert "Could not consolidate cache entry" in caplog.text
 
 
 def test_missing_evidence_dir_is_a_no_op(tmp_path: Path):

--- a/tests/analysis/cache/test_consolidation.py
+++ b/tests/analysis/cache/test_consolidation.py
@@ -1,0 +1,218 @@
+"""mark_run_consolidated — the one place a run's findings become "carried".
+
+A cache entry is born unconsolidated. Only a run that reaches state=done
+flips its entries, which is what lets the live feed show a cancelled run's
+replayed findings as this scan's own.
+
+Every failure mode here is a no-op by design: the function runs as a
+post-scan side effect outside the run lifecycle, so a raise would be the
+one thing that could turn a completed run into a failed one.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis.cache.consolidation import mark_run_consolidated
+from quodeq.analysis.cache.entry import CacheEntry
+from quodeq.analysis.cache.local import LocalFileBackend
+
+
+def _entry(key: str, *, consolidated: bool = False) -> CacheEntry:
+    return CacheEntry(
+        key=key, schema_version=1,
+        findings=[{"file": "a.py", "line": 1, "t": "violation"}],
+        files_read=1, file_path="a.py", dimension="security",
+        model_id="test-model", consolidated=consolidated,
+    )
+
+
+def _run_dir(tmp_path: Path, state: str | None, sidecars: dict[str, dict]) -> Path:
+    run_dir = tmp_path / "reports" / "proj" / "run1"
+    evidence = run_dir / "evidence"
+    evidence.mkdir(parents=True)
+    if state is not None:
+        (run_dir / "status.json").write_text(json.dumps({"state": state}))
+    for name, payload in sidecars.items():
+        (evidence / name).write_text(json.dumps(payload))
+    return run_dir
+
+
+@pytest.fixture
+def cache(tmp_path: Path) -> LocalFileBackend:
+    return LocalFileBackend(root=tmp_path / "cache")
+
+
+def test_done_run_flips_dispatched_entries(tmp_path: Path, cache):
+    cache.put("key1", _entry("key1"))
+    run_dir = _run_dir(
+        tmp_path, "done", {"security_dispatch_keys.json": {"a.py": "key1"}},
+    )
+
+    mark_run_consolidated(run_dir, cache)
+
+    assert cache.get("key1").consolidated is True
+
+
+def test_done_run_flips_replayed_unconsolidated_entries(tmp_path: Path, cache):
+    """The findings a completed run replayed are now in ITS report too."""
+    cache.put("key2", _entry("key2"))
+    run_dir = _run_dir(
+        tmp_path, "done",
+        {"security_replayed_unconsolidated_keys.json": {"a.py": "key2"}},
+    )
+
+    mark_run_consolidated(run_dir, cache)
+
+    assert cache.get("key2").consolidated is True
+
+
+def test_done_run_flips_both_sidecars_across_dimensions(tmp_path: Path, cache):
+    for key in ("key1", "key2", "key3"):
+        cache.put(key, _entry(key))
+    run_dir = _run_dir(tmp_path, "done", {
+        "security_dispatch_keys.json": {"a.py": "key1"},
+        "flexibility_dispatch_keys.json": {"b.py": "key2"},
+        "security_replayed_unconsolidated_keys.json": {"c.py": "key3"},
+    })
+
+    mark_run_consolidated(run_dir, cache)
+
+    assert all(cache.get(k).consolidated is True for k in ("key1", "key2", "key3"))
+
+
+@pytest.mark.parametrize("state", ["cancelled", "failed", "in_progress", "pending"])
+def test_non_done_run_leaves_entries_unconsolidated(tmp_path: Path, cache, state):
+    """The whole feature. A run the user cancelled with "keep findings" never
+    consolidated anything, so its findings must replay as new."""
+    cache.put("key1", _entry("key1"))
+    run_dir = _run_dir(
+        tmp_path, state, {"security_dispatch_keys.json": {"a.py": "key1"}},
+    )
+
+    mark_run_consolidated(run_dir, cache)
+
+    assert cache.get("key1").consolidated is False
+
+
+def test_missing_status_json_leaves_entries_unconsolidated(tmp_path: Path, cache):
+    """A killed process may never have written a terminal status."""
+    cache.put("key1", _entry("key1"))
+    run_dir = _run_dir(
+        tmp_path, None, {"security_dispatch_keys.json": {"a.py": "key1"}},
+    )
+
+    mark_run_consolidated(run_dir, cache)
+
+    assert cache.get("key1").consolidated is False
+
+
+def test_corrupt_status_json_leaves_entries_unconsolidated(tmp_path: Path, cache):
+    cache.put("key1", _entry("key1"))
+    run_dir = _run_dir(
+        tmp_path, None, {"security_dispatch_keys.json": {"a.py": "key1"}},
+    )
+    (run_dir / "status.json").write_text("{not json")
+
+    mark_run_consolidated(run_dir, cache)
+
+    assert cache.get("key1").consolidated is False
+
+
+def test_corrupt_sidecar_does_not_stop_the_other_sidecars(tmp_path: Path, cache):
+    cache.put("key1", _entry("key1"))
+    run_dir = _run_dir(tmp_path, "done", {
+        "security_dispatch_keys.json": {"a.py": "key1"},
+    })
+    (run_dir / "evidence" / "flexibility_dispatch_keys.json").write_text("{not json")
+
+    mark_run_consolidated(run_dir, cache)
+
+    assert cache.get("key1").consolidated is True
+
+
+def test_missing_entry_is_skipped(tmp_path: Path, cache):
+    """A file that errored mid-dispatch has a key in the sidecar but no entry.
+    The key must be skipped, not written back as a fabricated entry."""
+    run_dir = _run_dir(
+        tmp_path, "done", {"security_dispatch_keys.json": {"a.py": "ghost"}},
+    )
+
+    mark_run_consolidated(run_dir, cache)
+
+    assert cache.get("ghost") is None
+    assert list((tmp_path / "cache").rglob("entry.json")) == []
+
+
+def test_a_raising_backend_never_propagates(tmp_path: Path, caplog):
+    """Fail-soft is the contract, not a comment. This runs outside the run
+    lifecycle precisely so it can never flip a done run to failed.
+
+    caplog proves the failing branch was actually reached: without it, a test
+    that merely "does not raise" would also pass if the function had bailed
+    early for an unrelated reason and never touched the backend at all."""
+    class _Exploding:
+        def __init__(self) -> None:
+            self.touched = 0
+
+        def get(self, key):
+            self.touched += 1
+            raise RuntimeError("disk on fire")
+
+        def put(self, key, entry):
+            raise AssertionError("put must never be reached after get raised")
+
+    backend = _Exploding()
+    run_dir = _run_dir(
+        tmp_path, "done", {"security_dispatch_keys.json": {"a.py": "key1"}},
+    )
+
+    with caplog.at_level(logging.WARNING):
+        mark_run_consolidated(run_dir, backend)
+
+    assert backend.touched == 1, "the backend was never consulted"
+    assert "disk on fire" in caplog.text
+
+
+def test_missing_evidence_dir_is_a_no_op(tmp_path: Path):
+    """No evidence dir means no sidecars, so the cache must not be opened."""
+    class _Forbidden:
+        def get(self, key):
+            raise AssertionError("cache must not be consulted")
+
+        def put(self, key, entry):
+            raise AssertionError("cache must not be consulted")
+
+    run_dir = tmp_path / "reports" / "proj" / "run1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "status.json").write_text(json.dumps({"state": "done"}))
+
+    mark_run_consolidated(run_dir, _Forbidden())
+
+
+def test_already_consolidated_entries_are_not_rewritten(tmp_path: Path, cache):
+    """Avoids rewriting every entry on every run of a fully cached project."""
+    class _RecordingPut:
+        def __init__(self, inner) -> None:
+            self._inner = inner
+            self.puts: list[str] = []
+
+        def get(self, key):
+            return self._inner.get(key)
+
+        def put(self, key, entry) -> None:
+            self.puts.append(key)
+            self._inner.put(key, entry)
+
+    cache.put("key1", _entry("key1", consolidated=True))
+    recording = _RecordingPut(cache)
+    run_dir = _run_dir(
+        tmp_path, "done", {"security_dispatch_keys.json": {"a.py": "key1"}},
+    )
+
+    mark_run_consolidated(run_dir, recording)
+
+    assert recording.puts == []

--- a/tests/analysis/cache/test_dimension_helpers.py
+++ b/tests/analysis/cache/test_dimension_helpers.py
@@ -547,3 +547,35 @@ class TestRoundTrip:
         second = classify_files_via_cache(config, "security", files, cache)
         assert second.misses == []
         assert {f["file"] for f in second.cached_findings} == set(files)
+
+
+def test_persist_dispatch_results_marks_entries_unconsolidated(tmp_path):
+    """The periodic-persist watcher path must agree with the synchronous
+    cache_writer path: both produce unconsolidated entries."""
+    import json as _json
+
+    from quodeq.analysis.cache.dimension_helpers import (
+        build_cache_key_for_file,
+        persist_dispatch_results,
+    )
+    from quodeq.analysis.cache.local import LocalFileBackend
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.py").write_text("x")
+    config = _make_config(src)
+
+    jsonl = tmp_path / "security_evidence.jsonl"
+    jsonl.write_text(
+        _json.dumps({"file": "a.py", "line": 1, "t": "violation", "p": "P1"}) + "\n"
+        + _json.dumps({"_marker": "file_done", "file": "a.py", "status": "ok"}) + "\n"
+    )
+
+    cache = LocalFileBackend(root=tmp_path / "cache")
+    key = build_cache_key_for_file(config, "a.py", "security")
+    persist_dispatch_results(
+        config, "security", miss_files=["a.py"],
+        jsonl_path=jsonl, miss_keys={"a.py": key}, cache=cache,
+    )
+
+    assert cache.get(key).consolidated is False

--- a/tests/analysis/cache/test_dimension_helpers.py
+++ b/tests/analysis/cache/test_dimension_helpers.py
@@ -543,10 +543,14 @@ class TestRoundTrip:
             jsonl_path=jsonl, miss_keys=first.miss_keys, cache=cache,
         )
 
-        # Second call: cache should be fully populated → all hits.
+        # Second call: cache should be fully populated → all hits. The
+        # entries persist_dispatch_results just wrote are unconsolidated
+        # (no COMPLETED run has consolidated them yet), so they land in
+        # unconsolidated_findings, not cached_findings.
         second = classify_files_via_cache(config, "security", files, cache)
         assert second.misses == []
-        assert {f["file"] for f in second.cached_findings} == set(files)
+        assert second.cached_findings == []
+        assert {f["file"] for f in second.unconsolidated_findings} == set(files)
 
 
 def test_persist_dispatch_results_marks_entries_unconsolidated(tmp_path):
@@ -579,3 +583,100 @@ def test_persist_dispatch_results_marks_entries_unconsolidated(tmp_path):
     )
 
     assert cache.get(key).consolidated is False
+
+
+def test_classify_splits_hits_by_consolidation_state(tmp_path):
+    """A hit from a run that never completed must stay out of cached_findings,
+    so the replay path does not stamp it carried_forward."""
+    from quodeq.analysis.cache.dimension_helpers import (
+        build_cache_key_for_file,
+        classify_files_via_cache,
+    )
+    from quodeq.analysis.cache.entry import CacheEntry
+    from quodeq.analysis.cache.local import LocalFileBackend
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.py").write_text("x")
+    (src / "b.py").write_text("y")
+    config = _make_config(src)
+
+    cache = LocalFileBackend(root=tmp_path / "cache")
+    for name, consolidated in (("a.py", True), ("b.py", False)):
+        key = build_cache_key_for_file(config, name, "security")
+        cache.put(key, CacheEntry(
+            key=key, schema_version=1,
+            findings=[{"file": name, "line": 1, "t": "violation", "p": "P1"}],
+            files_read=1, file_path=name, dimension="security",
+            model_id="test-model", consolidated=consolidated,
+        ))
+
+    result = classify_files_via_cache(
+        config, "security", ["a.py", "b.py"], cache,
+    )
+
+    assert result.misses == []
+    assert [f["file"] for f in result.cached_findings] == ["a.py"]
+    assert [f["file"] for f in result.unconsolidated_findings] == ["b.py"]
+    assert set(result.unconsolidated_hit_keys) == {"b.py"}
+    assert result.unconsolidated_hit_keys["b.py"] == build_cache_key_for_file(
+        config, "b.py", "security",
+    )
+
+
+def test_classify_leaves_unconsolidated_fields_empty_when_all_hits_consolidated(tmp_path):
+    from quodeq.analysis.cache.dimension_helpers import (
+        build_cache_key_for_file,
+        classify_files_via_cache,
+    )
+    from quodeq.analysis.cache.entry import CacheEntry
+    from quodeq.analysis.cache.local import LocalFileBackend
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.py").write_text("x")
+    config = _make_config(src)
+
+    cache = LocalFileBackend(root=tmp_path / "cache")
+    key = build_cache_key_for_file(config, "a.py", "security")
+    cache.put(key, CacheEntry(
+        key=key, schema_version=1,
+        findings=[{"file": "a.py", "line": 1, "t": "violation", "p": "P1"}],
+        files_read=1, file_path="a.py", dimension="security",
+        model_id="test-model", consolidated=True,
+    ))
+
+    result = classify_files_via_cache(config, "security", ["a.py"], cache)
+
+    assert result.unconsolidated_findings == []
+    assert result.unconsolidated_hit_keys == {}
+
+
+def test_classify_treats_a_legacy_entry_as_consolidated(tmp_path):
+    """An entry stored before the field existed has no consolidated key.
+    from_json defaults it True, so it must land in cached_findings."""
+    from quodeq.analysis.cache.dimension_helpers import (
+        build_cache_key_for_file,
+        classify_files_via_cache,
+    )
+    from quodeq.analysis.cache.entry import CacheEntry
+    from quodeq.analysis.cache.local import LocalFileBackend
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.py").write_text("x")
+    config = _make_config(src)
+
+    cache = LocalFileBackend(root=tmp_path / "cache")
+    key = build_cache_key_for_file(config, "a.py", "security")
+    cache.put(key, CacheEntry(
+        key=key, schema_version=1,
+        findings=[{"file": "a.py", "line": 1, "t": "violation", "p": "P1"}],
+        files_read=1, file_path="a.py", dimension="security",
+        model_id="test-model",
+    ))
+
+    result = classify_files_via_cache(config, "security", ["a.py"], cache)
+
+    assert [f["file"] for f in result.cached_findings] == ["a.py"]
+    assert result.unconsolidated_findings == []

--- a/tests/analysis/cache/test_dimension_runner_carried_forward.py
+++ b/tests/analysis/cache/test_dimension_runner_carried_forward.py
@@ -79,3 +79,133 @@ def test_only_cache_replays_are_flagged(tmp_path: Path, cache):
     by_title = {ln["w"]: ln for ln in lines if "_marker" not in ln}
     assert by_title["carry-a"].get("carried_forward") is True
     assert by_title["fresh-b"].get("carried_forward", False) is False
+
+
+def test_write_findings_does_not_stamp_unconsolidated_replays(tmp_path: Path):
+    """A finding produced by a run that never completed was never consolidated
+    into an Overview. Replaying it must read as this scan's own finding."""
+    jsonl = tmp_path / "security_evidence.jsonl"
+    _write_findings(
+        jsonl, [_finding("carry-a")], append=False, emit_events=False,
+        unconsolidated=[dict(_finding("pending-b"), file="b.py")],
+    )
+    written = [json.loads(ln) for ln in jsonl.read_text().splitlines() if ln.strip()]
+    by_title = {ln["w"]: ln for ln in written}
+    assert by_title["carry-a"]["carried_forward"] is True
+    assert "carried_forward" not in by_title["pending-b"]
+
+
+def test_write_findings_orders_consolidated_replays_first(tmp_path: Path):
+    """Foundation-then-new ordering in the JSONL, matching the existing
+    carried-before-fresh contract."""
+    jsonl = tmp_path / "security_evidence.jsonl"
+    _write_findings(
+        jsonl, [_finding("carry-a")], append=False, emit_events=False,
+        unconsolidated=[dict(_finding("pending-b"), file="b.py")],
+    )
+    written = [json.loads(ln) for ln in jsonl.read_text().splitlines() if ln.strip()]
+    assert [ln["w"] for ln in written] == ["carry-a", "pending-b"]
+
+
+def test_write_findings_does_not_stamp_the_unconsolidated_source_dicts(tmp_path: Path):
+    jsonl = tmp_path / "security_evidence.jsonl"
+    source = [dict(_finding("pending-b"), file="b.py")]
+    _write_findings(
+        jsonl, [], append=False, emit_events=False, unconsolidated=source,
+    )
+    assert "carried_forward" not in source[0]
+
+
+def test_write_findings_accepts_only_unconsolidated(tmp_path: Path):
+    """A dimension whose every hit is unconsolidated still writes findings."""
+    jsonl = tmp_path / "security_evidence.jsonl"
+    _write_findings(
+        jsonl, [], append=False, emit_events=False,
+        unconsolidated=[dict(_finding("pending-b"), file="b.py")],
+    )
+    written = [json.loads(ln) for ln in jsonl.read_text().splitlines() if ln.strip()]
+    assert [ln["w"] for ln in written] == ["pending-b"]
+
+
+def test_all_unconsolidated_hits_are_still_written(tmp_path: Path, cache):
+    """Two truthiness guards used to test classify.cached_findings to decide
+    whether to write anything. Splitting the list makes both false when every
+    hit is unconsolidated, which would silently DROP those findings from the
+    run rather than merely mis-flagging them."""
+    from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
+    from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+
+    config, _src = _setup(tmp_path, {"a.py": "x", "b.py": "y"})
+
+    key = build_cache_key_for_file(config, "a.py", "security")
+    cache.put(key, CacheEntry(
+        key=key, schema_version=1,
+        findings=[dict(_finding("pending-a"), file="a.py")],
+        files_read=1, file_path="a.py", dimension="security",
+        model_id="test-model", consolidated=False,
+    ))
+
+    def fake_dispatch(cfg, dim_id, idx, ctx, callbacks):
+        jsonl = (cfg.work_dir or cfg.src) / f"{dim_id}_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        with jsonl.open("a") as out:
+            out.write(json.dumps(dict(_finding("fresh-b"), file="b.py", p="P2")) + "\n")
+            out.write(json.dumps({"_marker": "file_done", "file": "b.py", "status": "ok"}) + "\n")
+        return _make_dummy_evidence(files_read=1)
+
+    with patch(
+        "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+        new=fake_dispatch,
+    ):
+        process_dimension_with_cache(
+            config, "security", 1, _make_ctx(), _make_callbacks(), cache=cache,
+        )
+
+    jsonl_path = (config.work_dir or config.src) / "security_evidence.jsonl"
+    lines = [json.loads(ln) for ln in jsonl_path.read_text().splitlines() if ln.strip()]
+    titles = {ln["w"] for ln in lines if "_marker" not in ln}
+    assert "pending-a" in titles, "unconsolidated hit was dropped from the run"
+
+
+def test_three_way_split_carried_pending_and_fresh(tmp_path: Path, cache):
+    """The headline case: a consolidated hit is carried, an unconsolidated hit
+    is not, and a dispatched finding is not."""
+    from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
+    from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+
+    config, _src = _setup(tmp_path, {"a.py": "x", "b.py": "y", "c.py": "z"})
+
+    for name, title, consolidated in (
+        ("a.py", "carry-a", True),
+        ("b.py", "pending-b", False),
+    ):
+        key = build_cache_key_for_file(config, name, "security")
+        cache.put(key, CacheEntry(
+            key=key, schema_version=1,
+            findings=[dict(_finding(title), file=name)],
+            files_read=1, file_path=name, dimension="security",
+            model_id="test-model", consolidated=consolidated,
+        ))
+
+    def fake_dispatch(cfg, dim_id, idx, ctx, callbacks):
+        jsonl = (cfg.work_dir or cfg.src) / f"{dim_id}_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        with jsonl.open("a") as out:
+            out.write(json.dumps(dict(_finding("fresh-c"), file="c.py", p="P2")) + "\n")
+            out.write(json.dumps({"_marker": "file_done", "file": "c.py", "status": "ok"}) + "\n")
+        return _make_dummy_evidence(files_read=1)
+
+    with patch(
+        "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+        new=fake_dispatch,
+    ):
+        process_dimension_with_cache(
+            config, "security", 1, _make_ctx(), _make_callbacks(), cache=cache,
+        )
+
+    jsonl_path = (config.work_dir or config.src) / "security_evidence.jsonl"
+    lines = [json.loads(ln) for ln in jsonl_path.read_text().splitlines() if ln.strip()]
+    by_title = {ln["w"]: ln for ln in lines if "_marker" not in ln}
+    assert by_title["carry-a"].get("carried_forward") is True
+    assert by_title["pending-b"].get("carried_forward", False) is False
+    assert by_title["fresh-c"].get("carried_forward", False) is False

--- a/tests/analysis/cache/test_dimension_runner_carried_forward.py
+++ b/tests/analysis/cache/test_dimension_runner_carried_forward.py
@@ -209,3 +209,53 @@ def test_three_way_split_carried_pending_and_fresh(tmp_path: Path, cache):
     assert by_title["carry-a"].get("carried_forward") is True
     assert by_title["pending-b"].get("carried_forward", False) is False
     assert by_title["fresh-c"].get("carried_forward", False) is False
+
+
+def test_replayed_unconsolidated_keys_sidecar_is_written_on_the_all_hits_path(
+    tmp_path: Path, cache,
+):
+    """A fully cached dimension dispatches nothing, so it writes no
+    dispatch_keys sidecar. Without this one it would never flip its entries
+    and its findings would replay as new forever."""
+    from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
+    from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+
+    config, _src = _setup(tmp_path, {"a.py": "x"})
+
+    key = build_cache_key_for_file(config, "a.py", "security")
+    cache.put(key, CacheEntry(
+        key=key, schema_version=1,
+        findings=[dict(_finding("pending-a"), file="a.py")],
+        files_read=1, file_path="a.py", dimension="security",
+        model_id="test-model", consolidated=False,
+    ))
+
+    process_dimension_with_cache(
+        config, "security", 1, _make_ctx(), _make_callbacks(), cache=cache,
+    )
+
+    sidecar = (config.work_dir or config.src) / "security_replayed_unconsolidated_keys.json"
+    assert sidecar.is_file()
+    assert json.loads(sidecar.read_text()) == {"a.py": key}
+
+
+def test_no_sidecar_when_every_hit_is_already_consolidated(tmp_path: Path, cache):
+    from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
+    from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+
+    config, _src = _setup(tmp_path, {"a.py": "x"})
+
+    key = build_cache_key_for_file(config, "a.py", "security")
+    cache.put(key, CacheEntry(
+        key=key, schema_version=1,
+        findings=[dict(_finding("carry-a"), file="a.py")],
+        files_read=1, file_path="a.py", dimension="security",
+        model_id="test-model", consolidated=True,
+    ))
+
+    process_dimension_with_cache(
+        config, "security", 1, _make_ctx(), _make_callbacks(), cache=cache,
+    )
+
+    sidecar = (config.work_dir or config.src) / "security_replayed_unconsolidated_keys.json"
+    assert not sidecar.exists()

--- a/tests/analysis/cache/test_dimension_runner_carried_forward.py
+++ b/tests/analysis/cache/test_dimension_runner_carried_forward.py
@@ -167,6 +167,50 @@ def test_all_unconsolidated_hits_are_still_written(tmp_path: Path, cache):
     assert "pending-a" in titles, "unconsolidated hit was dropped from the run"
 
 
+def test_salvage_path_keeps_unconsolidated_hits_when_dispatch_returns_none(
+    tmp_path: Path, cache,
+):
+    """The ``miss_evidence is None`` salvage branch has its own truthiness
+    guard (``replayed_anything``). Like the pre-dispatch write guard above,
+    it used to test only ``classify.cached_findings``, so a dimension whose
+    every hit is unconsolidated would compute ``replayed_anything=False`` and
+    return None -- discarding an unconsolidated finding that was already
+    sitting in the JSONL."""
+    from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
+    from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+
+    config, _src = _setup(tmp_path, {"a.py": "x", "b.py": "y"})
+
+    key = build_cache_key_for_file(config, "a.py", "security")
+    cache.put(key, CacheEntry(
+        key=key, schema_version=1,
+        findings=[dict(_finding("pending-a"), file="a.py")],
+        files_read=1, file_path="a.py", dimension="security",
+        model_id="test-model", consolidated=False,
+    ))
+    # b.py has no cache entry, so it lands in classify.misses and dispatch is
+    # actually attempted (and not the all-hits short-circuit above).
+
+    def fake_dispatch(cfg, dim_id, idx, ctx, callbacks):
+        return None
+
+    with patch(
+        "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+        new=fake_dispatch,
+    ):
+        evidence = process_dimension_with_cache(
+            config, "security", 1, _make_ctx(), _make_callbacks(), cache=cache,
+        )
+
+    assert evidence is not None, (
+        "salvage-path guard dropped an all-unconsolidated dimension's findings"
+    )
+    jsonl_path = (config.work_dir or config.src) / "security_evidence.jsonl"
+    lines = [json.loads(ln) for ln in jsonl_path.read_text().splitlines() if ln.strip()]
+    titles = {ln["w"] for ln in lines if "_marker" not in ln}
+    assert "pending-a" in titles, "unconsolidated hit was dropped from the run"
+
+
 def test_three_way_split_carried_pending_and_fresh(tmp_path: Path, cache):
     """The headline case: a consolidated hit is carried, an unconsolidated hit
     is not, and a dispatched finding is not."""

--- a/tests/analysis/cache/test_dimension_runner_carried_forward.py
+++ b/tests/analysis/cache/test_dimension_runner_carried_forward.py
@@ -259,3 +259,82 @@ def test_no_sidecar_when_every_hit_is_already_consolidated(tmp_path: Path, cache
 
     sidecar = (config.work_dir or config.src) / "security_replayed_unconsolidated_keys.json"
     assert not sidecar.exists()
+
+
+def test_cancelled_run_findings_stay_new_until_a_run_completes(tmp_path: Path):
+    """The user story.
+
+    Run 1 is cancelled with "keep findings", so its findings never reach an
+    Overview. Run 2 replays them: they must read as THIS scan's findings,
+    because the user has still never been shown them consolidated. Run 2
+    completes, which consolidates them. Run 3 replays them as carried.
+    """
+    from quodeq.analysis.cache.consolidation import mark_run_consolidated
+    from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+    from quodeq.analysis.cache.local import LocalFileBackend
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.py").write_text("x")
+    shared_cache = LocalFileBackend(root=tmp_path / "cache")
+
+    def _run_config(run_id: str):
+        """A config whose work_dir IS <run_dir>/evidence, so the sidecars land
+        where mark_run_consolidated looks for them."""
+        from tests.analysis.cache.test_dimension_runner import _make_config
+        run_dir = tmp_path / "reports" / "proj" / run_id
+        (run_dir / "evidence").mkdir(parents=True, exist_ok=True)
+        return _make_config(
+            src, work_dir=run_dir / "evidence", file_names=["a.py"],
+        ), run_dir
+
+    def fake_dispatch(cfg, dim_id, idx, ctx, callbacks):
+        jsonl = (cfg.work_dir or cfg.src) / f"{dim_id}_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        with jsonl.open("a") as out:
+            out.write(json.dumps(dict(_finding("found-a"), file="a.py")) + "\n")
+            out.write(json.dumps({"_marker": "file_done", "file": "a.py", "status": "ok"}) + "\n")
+        return _make_dummy_evidence(files_read=1)
+
+    def _titles_with_flag(config) -> dict:
+        jsonl = (config.work_dir or config.src) / "security_evidence.jsonl"
+        lines = [json.loads(ln) for ln in jsonl.read_text().splitlines() if ln.strip()]
+        return {
+            ln["w"]: ln.get("carried_forward", False)
+            for ln in lines if "_marker" not in ln
+        }
+
+    # Run 1: dispatches a.py, then the user cancels with "keep findings".
+    # A cancelled run never calls mark_run_consolidated.
+    config1, run_dir1 = _run_config("run1")
+    with patch(
+        "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+        new=fake_dispatch,
+    ):
+        process_dimension_with_cache(
+            config1, "security", 1, _make_ctx(), _make_callbacks(), cache=shared_cache,
+        )
+    (run_dir1 / "status.json").write_text(json.dumps({"state": "cancelled"}))
+    mark_run_consolidated(run_dir1, shared_cache)  # no-op: not done
+
+    # Run 2: a.py is now a cache hit, but an UNCONSOLIDATED one.
+    config2, run_dir2 = _run_config("run2")
+    process_dimension_with_cache(
+        config2, "security", 1, _make_ctx(), _make_callbacks(), cache=shared_cache,
+    )
+    assert _titles_with_flag(config2) == {"found-a": False}, (
+        "a cancelled run's findings must still read as new"
+    )
+
+    # Run 2 completes, which consolidates the entry it replayed.
+    (run_dir2 / "status.json").write_text(json.dumps({"state": "done"}))
+    mark_run_consolidated(run_dir2, shared_cache)
+
+    # Run 3: the same hit now reads as carried forward.
+    config3, _run_dir3 = _run_config("run3")
+    process_dimension_with_cache(
+        config3, "security", 1, _make_ctx(), _make_callbacks(), cache=shared_cache,
+    )
+    assert _titles_with_flag(config3) == {"found-a": True}, (
+        "a completed run consolidated these findings; they are carried now"
+    )

--- a/tests/analysis/cache/test_entry.py
+++ b/tests/analysis/cache/test_entry.py
@@ -134,3 +134,31 @@ class TestProvenanceEffectiveParams:
             model_id="m", prompts_hash="p", standards_hash="s", version="1.0",
         )
         assert prov["effective_params"] == {}
+
+
+def test_entry_without_consolidated_key_loads_as_consolidated():
+    """Entries written before consolidation tracking existed must keep
+    replaying as carried forward, so the first run after an upgrade behaves
+    exactly as it did before. Defaulting to False instead would surface every
+    pre-existing cache entry as a brand new finding, once, on every project."""
+    payload = json.dumps({
+        "key": "abc123",
+        "schema_version": 1,
+        "findings": [],
+        "files_read": 1,
+        "file_path": "a.py",
+        "dimension": "security",
+        "model_id": "claude-opus-4-7",
+    })
+    assert CacheEntry.from_json(payload).consolidated is True
+
+
+def test_consolidated_false_survives_the_json_round_trip():
+    entry = _make(consolidated=False)
+    assert CacheEntry.from_json(entry.to_json()).consolidated is False
+
+
+def test_entry_format_version_is_unchanged_by_the_consolidated_field():
+    """from_json tolerates missing and unknown keys in both directions, so
+    adding a field needs no format bump and no migration."""
+    assert ENTRY_FORMAT_VERSION == 2

--- a/tests/analysis/cache/test_runner.py
+++ b/tests/analysis/cache/test_runner.py
@@ -258,3 +258,26 @@ class TestEmptyResults:
         assert second.cache_hit is True
         assert second.entry.findings == []
         assert len(dispatcher.calls) == 1
+
+
+def test_analyze_unit_marks_a_dispatched_entry_unconsolidated(cache: LocalFileBackend):
+    """The three cache write sites must agree. analyze_unit is not on a
+    production path today, but entry.build_provenance's docstring asserts the
+    three stay identical, so it moves with them."""
+    dispatcher = _RecordingDispatcher()
+    result = analyze_unit(_unit(), cache=cache, dispatcher=dispatcher)
+    assert result.entry.consolidated is False
+
+
+def test_analyze_unit_preserves_consolidated_on_a_hit(cache: LocalFileBackend):
+    """A hit returns the stored entry untouched, whatever its state."""
+    dispatcher = _RecordingDispatcher()
+    unit = _unit()
+    first = analyze_unit(unit, cache=cache, dispatcher=dispatcher)
+    stored = cache.get(first.entry.key)
+    stored.consolidated = True
+    cache.put(first.entry.key, stored)
+
+    second = analyze_unit(unit, cache=cache, dispatcher=dispatcher)
+    assert second.cache_hit is True
+    assert second.entry.consolidated is True

--- a/tests/api/test_codeql_triage_guards.py
+++ b/tests/api/test_codeql_triage_guards.py
@@ -1,0 +1,193 @@
+"""Guards added in the CodeQL alert triage.
+
+Covers the two real path-injection gaps the triage found:
+- ``POST /api/evaluations`` must apply the same scan allowlist as
+  ``/api/scan`` and ``POST /api/projects`` (its ``repo`` body field used to
+  accept any readable directory and persist its file tree).
+- ``scopePath`` must be a plain relative subpath at both entry routes, and
+  the manifest walk must not follow a persisted scope outside the repo.
+
+Plus the consistency hardenings: route-level project-id validation on
+info/delete/path and the standards-visibility pair.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.api.app import create_app
+from quodeq.shared.validation import validate_relative_scope
+
+_ORIGIN = {"Origin": "http://localhost"}
+
+
+@pytest.fixture()
+def app_client(tmp_path, monkeypatch):
+    evaluations_dir = tmp_path / "evaluations"
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(evaluations_dir))
+    app = create_app(test_config={"TESTING": True})
+    with app.test_client() as c:
+        yield c, tmp_path.resolve()
+
+
+def _patch_home(home: Path):
+    return patch("pathlib.Path.home", new=classmethod(lambda cls: home))
+
+
+# ---------------------------------------------------------------------------
+# POST /api/evaluations repo allowlist (G1)
+# ---------------------------------------------------------------------------
+
+def test_start_evaluation_rejects_repo_outside_home(app_client):
+    c, home = app_client
+    with _patch_home(home):
+        resp = c.post("/api/evaluations", json={"repo": "/usr/share"}, headers=_ORIGIN)
+    assert resp.status_code == 403, resp.get_json()
+    assert resp.get_json()["code"] == "FORBIDDEN"
+
+
+def test_start_evaluation_rejects_blocked_system_dir(app_client):
+    c, home = app_client
+    with _patch_home(home):
+        resp = c.post("/api/evaluations", json={"repo": "/etc"}, headers=_ORIGIN)
+    assert resp.status_code == 403, resp.get_json()
+
+
+def test_start_evaluation_rejects_traversal_scope_path(app_client):
+    c, home = app_client
+    repo = home / "myrepo"
+    repo.mkdir()
+    with _patch_home(home):
+        resp = c.post(
+            "/api/evaluations",
+            json={"repo": str(repo), "scopePath": "../../etc"},
+            headers=_ORIGIN,
+        )
+    assert resp.status_code == 400, resp.get_json()
+    assert "scope" in (resp.get_json().get("error") or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/projects scopePath validation (G2, entry side)
+# ---------------------------------------------------------------------------
+
+def test_create_project_rejects_traversal_scope_path(app_client):
+    c, home = app_client
+    repo = home / "myrepo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    with _patch_home(home):
+        resp = c.post(
+            "/api/projects",
+            json={"repo": str(repo), "scopePath": "../outside"},
+            headers=_ORIGIN,
+        )
+    assert resp.status_code == 400, resp.get_json()
+    assert resp.get_json()["code"] == "INVALID_SCOPE"
+
+
+def test_create_project_rejects_absolute_scope_path(app_client):
+    c, home = app_client
+    repo = home / "myrepo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    with _patch_home(home):
+        resp = c.post(
+            "/api/projects",
+            json={"repo": str(repo), "scopePath": "/etc"},
+            headers=_ORIGIN,
+        )
+    assert resp.status_code == 400, resp.get_json()
+    assert resp.get_json()["code"] == "INVALID_SCOPE"
+
+
+# ---------------------------------------------------------------------------
+# validate_relative_scope unit behavior
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad", ["../x", "a/../../b", "/abs", "C:evil", "a\\b", "a\0b"])
+def test_validate_relative_scope_rejects(bad):
+    with pytest.raises(ValueError):
+        validate_relative_scope(bad)
+
+
+@pytest.mark.parametrize("ok", ["src", "src/backend", "a.b/c-d_e", "src/with..dots"])
+def test_validate_relative_scope_accepts(ok):
+    validate_relative_scope(ok)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Manifest walk containment (G2, sink side)
+# ---------------------------------------------------------------------------
+
+def test_walk_and_group_ignores_escaping_scope(tmp_path):
+    from quodeq.analysis.manifest_build import _walk_and_group
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.py").write_text("x = 1\n")
+    src = tmp_path / "repo"
+    src.mkdir()
+    (src / "main.py").write_text("y = 2\n")
+
+    files_by_lang, _, _ = _walk_and_group(
+        src, {".py": "python"}, set(), [], scope_path="../outside",
+    )
+    all_files = [f for files in files_by_lang.values() for f in files]
+    assert not any("secret" in f for f in all_files)
+    assert any("main.py" in f for f in all_files)
+
+
+def test_walk_and_group_ignores_symlink_scope_escape(tmp_path):
+    from quodeq.analysis.manifest_build import _walk_and_group
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.py").write_text("x = 1\n")
+    src = tmp_path / "repo"
+    src.mkdir()
+    (src / "main.py").write_text("y = 2\n")
+    (src / "link").symlink_to(outside)
+
+    files_by_lang, _, _ = _walk_and_group(
+        src, {".py": "python"}, set(), [], scope_path="link",
+    )
+    all_files = [f for files in files_by_lang.values() for f in files]
+    assert not any("secret" in f for f in all_files)
+
+
+def test_walk_and_group_valid_scope_still_narrows(tmp_path):
+    from quodeq.analysis.manifest_build import _walk_and_group
+
+    src = tmp_path / "repo"
+    (src / "sub").mkdir(parents=True)
+    (src / "root.py").write_text("a = 1\n")
+    (src / "sub" / "inner.py").write_text("b = 2\n")
+
+    files_by_lang, _, _ = _walk_and_group(
+        src, {".py": "python"}, set(), [], scope_path="sub",
+    )
+    all_files = [f for files in files_by_lang.values() for f in files]
+    assert any("inner.py" in f for f in all_files)
+    assert not any("root.py" in f for f in all_files)
+
+
+# ---------------------------------------------------------------------------
+# Route-level project-id validation consistency
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("method,path", [
+    ("get", "/api/projects/{pid}/info"),
+    ("delete", "/api/projects/{pid}"),
+    ("patch", "/api/projects/{pid}/path"),
+    ("get", "/api/projects/{pid}/standards-visibility"),
+    ("put", "/api/projects/{pid}/standards-visibility"),
+])
+def test_traversal_project_id_rejected(app_client, method, path):
+    c, home = app_client
+    url = path.format(pid="..%5Cetc")  # backslash traversal survives URL routing
+    with _patch_home(home):
+        resp = getattr(c, method)(url, headers=_ORIGIN, json={})
+    assert resp.status_code == 400, (method, path, resp.status_code)

--- a/tests/api/test_power_selector_backend.py
+++ b/tests/api/test_power_selector_backend.py
@@ -154,10 +154,13 @@ class TestApiRouteSubagentModel:
         app = create_app(self._make_capturing_provider(captured))
         client = app.test_client()
 
-        response = client.post("/api/evaluations", json={
-            "repo": str(tmp_path),
-            "subagentModel": _MODEL_SONNET,
-        }, headers={"Origin": "http://localhost"})
+        # tmp_path is outside the real home dir; the route's scan allowlist
+        # only admits paths under home or the evaluations dir.
+        with patch("pathlib.Path.home", new=classmethod(lambda cls: tmp_path)):
+            response = client.post("/api/evaluations", json={
+                "repo": str(tmp_path),
+                "subagentModel": _MODEL_SONNET,
+            }, headers={"Origin": "http://localhost"})
         assert response.status_code == 202
         assert captured.get("options") is not None
         assert captured["options"].subagent_model == _MODEL_SONNET
@@ -169,9 +172,10 @@ class TestApiRouteSubagentModel:
         app = create_app(self._make_capturing_provider(captured))
         client = app.test_client()
 
-        response = client.post("/api/evaluations", json={
-            "repo": str(tmp_path),
-        }, headers={"Origin": "http://localhost"})
+        with patch("pathlib.Path.home", new=classmethod(lambda cls: tmp_path)):
+            response = client.post("/api/evaluations", json={
+                "repo": str(tmp_path),
+            }, headers={"Origin": "http://localhost"})
         assert captured.get("options") is not None
         assert captured["options"].subagent_model is None
 

--- a/tests/engine/test_manifest.py
+++ b/tests/engine/test_manifest.py
@@ -282,6 +282,53 @@ def test_build_monorepo_partitions_files_by_subproject(
     assert all(f.startswith("apps/web/") for f in web.source_files)
 
 
+def test_monorepo_keeps_source_outside_detected_subprojects(tmp_path: Path) -> None:
+    """A repo whose only *detected* subproject is a nested one must not lose the
+    source tree living outside it.
+
+    Kotlin Multiplatform is the real-world case: ``iosApp/`` is recognised via
+    ``*.xcodeproj``, but the Gradle/Kotlin root is not (its plugins come from a
+    version catalog, so no ``com.android`` literal appears in build.gradle.kts).
+    Without a catch-all root scope every ``.kt`` file is dropped and the manifest
+    comes back empty, which downstream reads as "no source files".
+    """
+    from quodeq.config.paths import default_paths
+
+    kmp_detection = {
+        "extensions": {".kt": "kotlin", ".swift": "swift"},
+        "skip_dirs": ["build", ".gradle"],
+        "skip_patterns": [],
+    }
+
+    _write(tmp_path / "settings.gradle.kts", 'rootProject.name = "app"\n')
+    _write(
+        tmp_path / "build.gradle.kts",
+        "plugins {\n    alias(libs.plugins.androidApplication) apply false\n}\n",
+    )
+    for name in ("App", "Main", "Repo", "Model"):
+        _write(tmp_path / f"composeApp/src/commonMain/kotlin/{name}.kt", "class X\n")
+
+    _write(tmp_path / "iosApp/iosApp.xcodeproj/project.pbxproj", "// pbxproj\n")
+    for name in ("ContentView", "iosAppApp", "Theme"):
+        _write(tmp_path / f"iosApp/iosApp/{name}.swift", "import SwiftUI\n")
+
+    disciplines_conf = default_paths().disciplines_conf
+    if not disciplines_conf.exists():
+        pytest.skip("disciplines.conf not installed")
+
+    manifest = build_manifest(tmp_path, kmp_detection, disciplines_conf=disciplines_conf)
+
+    kotlin_files = [
+        f for t in manifest.targets if t.language == "kotlin" for f in t.source_files
+    ]
+    assert len(kotlin_files) == 4
+    assert manifest.total_files == 7
+    assert manifest.language_stats == {".kt": 4, ".swift": 3}
+
+    swift = next(t for t in manifest.targets if t.language == "swift")
+    assert swift.scope_path == "iosApp"
+
+
 def test_monorepo_walk_applies_skip_patterns(tmp_path: Path, detection: dict) -> None:
     """The multi-scope (monorepo) walk honours skip_patterns too."""
     from quodeq.config.paths import default_paths

--- a/tests/fixtures/discipline_corpus/mobile_android_version_catalog/expected.json
+++ b/tests/fixtures/discipline_corpus/mobile_android_version_catalog/expected.json
@@ -1,0 +1,7 @@
+{
+  "matches": [
+    "mobile_android"
+  ],
+  "primary": "mobile_android",
+  "language": "kotlin"
+}

--- a/tests/fixtures/discipline_corpus/mobile_android_version_catalog/repo/build.gradle.kts
+++ b/tests/fixtures/discipline_corpus/mobile_android_version_catalog/repo/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    alias(libs.plugins.kotlinMultiplatform) apply false
+    alias(libs.plugins.androidApplication) apply false
+}

--- a/tests/fixtures/discipline_corpus/mobile_android_version_catalog/repo/composeApp/src/commonMain/kotlin/App.kt
+++ b/tests/fixtures/discipline_corpus/mobile_android_version_catalog/repo/composeApp/src/commonMain/kotlin/App.kt
@@ -1,0 +1,1 @@
+class App

--- a/tests/fixtures/discipline_corpus/mobile_android_version_catalog/repo/gradle/libs.versions.toml
+++ b/tests/fixtures/discipline_corpus/mobile_android_version_catalog/repo/gradle/libs.versions.toml
@@ -1,0 +1,7 @@
+[versions]
+agp = "8.7.3"
+kotlin = "2.1.0"
+
+[plugins]
+androidApplication = { id = "com.android.application", version.ref = "agp" }
+kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/tests/services/scoring/test_rescore_coverage.py
+++ b/tests/services/scoring/test_rescore_coverage.py
@@ -1,0 +1,89 @@
+"""Rescore coverage: a partial rescore must be flagged so it is never persisted.
+
+Regression: `_rescore_runs_by_dimension` silently treats a dimension missing
+from the run read as "keep the raw score". When the run-dimension fetcher
+served a partial dim list (1 of 6 dims frozen in the process LRU mid-run),
+only that one dimension was rescored, and the half-rescored accumulated
+payload was cached under a version hash identical to the complete payload's,
+so the Overview served raw baked scores forever while the detail pages showed
+the dismiss-adjusted ones.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import quodeq.services.scoring as scoring
+from quodeq.services.scoring import (
+    _dims_expecting_rescore,
+    _rescore_accumulated_with_coverage,
+)
+
+
+def _acc(dims):
+    return {"project": "proj", "dimensions": dims, "summary": {}}
+
+
+def _dim(name, run_id="r1", score="5.0/10"):
+    return {"dimension": name, "runId": run_id, "overallScore": score}
+
+
+def test_dims_expecting_rescore_needs_a_source_run():
+    dims = [
+        _dim("security"),
+        {"dimension": "performance"},  # no runId -> nothing to rescore from
+        {"dimension": "", "runId": "r1"},
+    ]
+    assert _dims_expecting_rescore(dims) == {"security"}
+
+
+def test_no_suppressions_is_complete(monkeypatch):
+    monkeypatch.setattr(scoring, "dismissed_keys", lambda pdir: set())
+    monkeypatch.setattr(scoring, "deleted_keys", lambda pdir: set())
+    payload, complete = _rescore_accumulated_with_coverage(
+        _acc([_dim("security")]), Path("/reports"), "proj",
+    )
+    assert complete is True
+    assert payload["dimensions"] == [_dim("security")]
+
+
+def test_full_coverage_is_complete(monkeypatch):
+    monkeypatch.setattr(scoring, "dismissed_keys", lambda pdir: {("R1", "a.py", 1)})
+    monkeypatch.setattr(scoring, "deleted_keys", lambda pdir: set())
+    monkeypatch.setattr(
+        scoring, "_rescore_runs_by_dimension",
+        lambda dims, root, project, dismissed, deleted=None, params=None: {
+            "security": {"overallScore": "7.5/10", "overallGrade": "Good"},
+            "performance": {"overallScore": "8.2/10", "overallGrade": "Good"},
+        },
+    )
+    monkeypatch.setattr(
+        scoring, "recompute_summary", lambda dims, summary, params=None: summary,
+    )
+    payload, complete = _rescore_accumulated_with_coverage(
+        _acc([_dim("security"), _dim("performance")]), Path("/reports"), "proj",
+    )
+    assert complete is True
+    assert payload["dimensions"][0]["overallScore"] == "7.5/10"
+    assert payload["dimensions"][1]["overallScore"] == "8.2/10"
+
+
+def test_partial_coverage_is_flagged_incomplete(monkeypatch):
+    """Rescore came back for security only: serve it, but flag it uncacheable."""
+    monkeypatch.setattr(scoring, "dismissed_keys", lambda pdir: {("R1", "a.py", 1)})
+    monkeypatch.setattr(scoring, "deleted_keys", lambda pdir: set())
+    monkeypatch.setattr(
+        scoring, "_rescore_runs_by_dimension",
+        lambda dims, root, project, dismissed, deleted=None, params=None: {
+            "security": {"overallScore": "7.5/10", "overallGrade": "Good"},
+        },
+    )
+    monkeypatch.setattr(
+        scoring, "recompute_summary", lambda dims, summary, params=None: summary,
+    )
+    payload, complete = _rescore_accumulated_with_coverage(
+        _acc([_dim("security"), _dim("performance")]), Path("/reports"), "proj",
+    )
+    assert complete is False
+    # The payload is still the best available answer for THIS request.
+    assert payload["dimensions"][0]["overallScore"] == "7.5/10"
+    assert payload["dimensions"][1]["overallScore"] == "5.0/10"  # raw kept

--- a/tests/services/test_cache.py
+++ b/tests/services/test_cache.py
@@ -216,6 +216,103 @@ class TestMakeLruDimensionFetcher:
         assert call_count["n"] == 1
 
 
+# ---------------------------------------------------------------------------
+# Self-healing guards: every caller inherits them from the base factory
+# ---------------------------------------------------------------------------
+
+
+def _write_eval_files(tmp_path: Path, run_id: str, dims: tuple[str, ...]) -> None:
+    eval_dir = tmp_path / "proj" / run_id / "evaluation"
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    for d in dims:
+        (eval_dir / f"{d}.json").write_text("{}", encoding="utf-8")
+
+
+def _write_status(tmp_path: Path, run_id: str, state: str) -> None:
+    run_dir = tmp_path / "proj" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "status.json").write_text(f'{{"state": "{state}"}}', encoding="utf-8")
+
+
+class TestSelfHealingGuards:
+    """A request landing mid-run must never freeze a partial dim list.
+
+    Regression: three scoring read paths built this fetcher without the
+    dashboard's staleness guards, so a /scores request that fired while only
+    security.json was on disk froze a 1-dim entry in the shared process LRU;
+    after the run completed, the accumulated rescore read that entry, rescored
+    only security, and persisted the half-rescored payload forever.
+    """
+
+    def test_stale_entry_evicted_when_disk_count_differs(self, tmp_path):
+        _write_eval_files(tmp_path, "r1", ("flexibility", "reliability", "security"))
+        full = [_make_dim("flexibility"), _make_dim("reliability"), _make_dim("security")]
+        reader_calls = []
+
+        def reader(reports_root, project, run_id):
+            reader_calls.append(run_id)
+            return full
+
+        cache = OrderedDict()
+        # Poisoned entry: cached while only 1 of 3 dims was on disk.
+        cache[(tmp_path, "proj", "r1", "")] = [_make_dim("security")]
+        fetcher = make_lru_dimension_fetcher(
+            tmp_path, "proj", cache, threading.Lock(), 10, reader=reader,
+        )
+
+        result = fetcher("r1")
+        assert len(result) == 3
+        assert reader_calls == ["r1"]
+        # The healed entry is cached; no further reads.
+        assert len(fetcher("r1")) == 3
+        assert reader_calls == ["r1"]
+
+    def test_entry_without_disk_anchor_is_trusted(self, tmp_path):
+        """No evaluation/ dir on disk (test stubs, mocked paths) -> no eviction."""
+        cache = OrderedDict()
+        seeded = [_make_dim("security")]
+        cache[(tmp_path, "proj", "r1", "")] = seeded
+        fetcher = make_lru_dimension_fetcher(
+            tmp_path, "proj", cache, threading.Lock(), 10,
+            reader=lambda *a: pytest.fail("reader must not run on a trusted hit"),
+        )
+        assert fetcher("r1") is seeded
+
+    def test_in_progress_run_reads_fresh_and_is_not_cached(self, tmp_path):
+        _write_status(tmp_path, "r1", "running")
+        _write_eval_files(tmp_path, "r1", ("security",))
+        reader_calls = []
+
+        def reader(reports_root, project, run_id):
+            reader_calls.append(run_id)
+            return [_make_dim("security")]
+
+        cache = OrderedDict()
+        fetcher = make_lru_dimension_fetcher(
+            tmp_path, "proj", cache, threading.Lock(), 10, reader=reader,
+        )
+        fetcher("r1")
+        fetcher("r1")
+        assert reader_calls == ["r1", "r1"]  # disk read both times
+        assert cache == {}  # nothing frozen mid-run
+
+    def test_terminal_run_is_cached(self, tmp_path):
+        _write_status(tmp_path, "r1", "done")
+        _write_eval_files(tmp_path, "r1", ("security",))
+        reader_calls = []
+
+        def reader(reports_root, project, run_id):
+            reader_calls.append(run_id)
+            return [_make_dim("security")]
+
+        fetcher = make_lru_dimension_fetcher(
+            tmp_path, "proj", OrderedDict(), threading.Lock(), 10, reader=reader,
+        )
+        fetcher("r1")
+        fetcher("r1")
+        assert reader_calls == ["r1"]  # second call served from cache
+
+
 def test_make_lru_dimension_fetcher_uses_custom_reader():
     """A custom reader is invoked instead of read_run_data, and results cache."""
     import threading

--- a/tests/services/test_cancel_discard_purge.py
+++ b/tests/services/test_cancel_discard_purge.py
@@ -24,7 +24,7 @@ import pytest
 
 from quodeq.analysis.cache import CacheEntry, LocalFileBackend
 from quodeq.core.types import JobSnapshot
-from quodeq.services.evaluation_mixin import FsEvaluationMixin
+from quodeq.services.evaluation_mixin import FsEvaluationMixin, _discard_run_state
 from quodeq.services.filesystem import FilesystemActionProvider
 from quodeq.shared.dimensions_state import DimState, write_dim_state
 from quodeq.shared.run_status import RunState, write_status
@@ -385,3 +385,46 @@ class TestRouteDiscardBlocksScoringResurrection:
             assert not scored.wait(timeout=0.3), (
                 "status GET resurrected scoring for a discarded run"
             )
+
+
+def test_discard_removes_the_replayed_keys_sidecar(tmp_path: Path):
+    """Every per-dim scratch file must go, or the status-GET scoring path can
+    resurrect state from leftovers."""
+    reports = tmp_path / "reports"
+    evidence = reports / "proj" / "run1" / "evidence"
+    evidence.mkdir(parents=True)
+    sidecar = evidence / "security_replayed_unconsolidated_keys.json"
+    sidecar.write_text(json.dumps({"a.py": "key-a"}))
+
+    _discard_run_state(str(reports), {"outputProject": "proj", "outputRunId": "run1"})
+
+    assert not sidecar.exists()
+
+
+def test_discard_does_not_delete_replayed_cache_entries(tmp_path: Path, monkeypatch):
+    """The replayed entries were written by an EARLIER run. Discard wipes only
+    what this run created; deleting these would destroy a prior kept run's
+    cached work."""
+    reports = tmp_path / "reports"
+    evidence = reports / "proj" / "run1" / "evidence"
+    evidence.mkdir(parents=True)
+    (evidence / "security_dispatch_keys.json").write_text(
+        json.dumps({"b.py": "key-mine"})
+    )
+    (evidence / "security_replayed_unconsolidated_keys.json").write_text(
+        json.dumps({"a.py": "key-theirs"})
+    )
+
+    deleted: list[str] = []
+
+    class _FakeCache:
+        def delete(self, key: str) -> None:
+            deleted.append(key)
+
+    monkeypatch.setattr(
+        "quodeq.services.evaluation_mixin._open_cache", lambda: _FakeCache(),
+    )
+
+    _discard_run_state(str(reports), {"outputProject": "proj", "outputRunId": "run1"})
+
+    assert deleted == ["key-mine"]

--- a/tests/services/test_dashboard.py
+++ b/tests/services/test_dashboard.py
@@ -505,7 +505,7 @@ class TestStaleCacheSelfHeal:
     """
 
     def test_count_eval_files_counts_json_only(self, tmp_path):
-        from quodeq.services.dashboard import _count_eval_files
+        from quodeq.services._cache import _count_eval_files
 
         eval_dir = tmp_path / "proj" / "r1" / "evaluation"
         eval_dir.mkdir(parents=True)
@@ -518,7 +518,7 @@ class TestStaleCacheSelfHeal:
         assert _count_eval_files(tmp_path, "proj", "r1") == 3
 
     def test_count_returns_zero_when_eval_dir_missing(self, tmp_path):
-        from quodeq.services.dashboard import _count_eval_files
+        from quodeq.services._cache import _count_eval_files
         assert _count_eval_files(tmp_path, "proj", "missing") == 0
 
     def test_stale_cache_evicted_when_dim_count_mismatches_disk(

--- a/tests/services/test_fs_metadata.py
+++ b/tests/services/test_fs_metadata.py
@@ -198,7 +198,7 @@ class TestReadAccumulatedSummary:
         mock_read.return_value = [
             DimensionResult(dimension="security", overall_score="8.0", source_file_count=10),
             DimensionResult(dimension="reliability", overall_score="7.0"),
-            DimensionResult(dimension="clean-architecture", overall_score="4.0"),
+            DimensionResult(dimension="performance", overall_score="4.0"),
         ]
         mock_summarize.return_value = type(
             "S", (), {"overall_grade": "A", "numeric_average": 7.5},
@@ -207,11 +207,115 @@ class TestReadAccumulatedSummary:
         runs = [RunInfo(run_id="run-new", date_iso="2026-01-02", date_label="Jan 02")]
         _read_accumulated_summary(reports_root, project, runs)
 
-        # summarize_dimensions must see ALL dims, including the one missing
-        # from the latest config.
+        # summarize_dimensions must see ALL (visible) dims, including the one
+        # missing from the latest config.
         called_dims = mock_summarize.call_args[0][0]
         names = sorted(d.dimension for d in called_dims)
-        assert names == ["clean-architecture", "reliability", "security"], names
+        assert names == ["performance", "reliability", "security"], names
+
+    @patch("quodeq.services._fs_metadata.summarize_dimensions")
+    @patch("quodeq.services._fs_metadata.read_run_data")
+    def test_card_summary_excludes_hidden_standards(
+        self, mock_read, mock_summarize, tmp_path, monkeypatch,
+    ):
+        """Dims outside the visible-standards selection must not move the
+        card grade: the Overview headline excludes them (the client filters
+        the accumulated payload by the same selection)."""
+        from quodeq.core.standards.visibility import save_visible_standard_ids
+        from quodeq.core.types import DimensionResult
+        from quodeq.services.ports import RunInfo
+
+        monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
+        reports_root = tmp_path / "evaluations"
+        project = "proj"
+        (reports_root / project / "run-new").mkdir(parents=True)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        save_visible_standard_ids(repo, ["security"])
+        (reports_root / project / "repository_info.json").write_text(
+            json.dumps({"name": project, "path": str(repo), "location": "local"}),
+            encoding="utf-8",
+        )
+        mock_read.return_value = [
+            DimensionResult(dimension="Security", overall_score="8.0"),
+            DimensionResult(dimension="reliability", overall_score="7.0"),
+        ]
+        mock_summarize.return_value = type(
+            "S", (), {"overall_grade": "A", "numeric_average": 8.0},
+        )()
+
+        runs = [RunInfo(run_id="run-new", date_iso="2026-01-02", date_label="Jan 02")]
+        _read_accumulated_summary(reports_root, project, runs)
+
+        # Matching is case-insensitive (the selection stores lowercase ids).
+        called_dims = mock_summarize.call_args[0][0]
+        assert [d.dimension for d in called_dims] == ["Security"]
+
+    @patch("quodeq.services._fs_metadata.summarize_dimensions")
+    @patch("quodeq.services._fs_metadata.read_run_data")
+    def test_card_summary_default_selection_hides_non_iso_dims(
+        self, mock_read, mock_summarize, tmp_path, monkeypatch,
+    ):
+        """Without a visibility file the six ISO defaults apply, so a retired
+        non-default dim (clean-architecture) no longer drags the card grade
+        while being invisible on the Overview."""
+        from quodeq.core.types import DimensionResult
+        from quodeq.services.ports import RunInfo
+
+        monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
+        reports_root = tmp_path / "evaluations"
+        project = "proj"
+        (reports_root / project / "run-new").mkdir(parents=True)
+        mock_read.return_value = [
+            DimensionResult(dimension="security", overall_score="8.0"),
+            DimensionResult(dimension="clean-architecture", overall_score="4.0"),
+        ]
+        mock_summarize.return_value = type(
+            "S", (), {"overall_grade": "A", "numeric_average": 8.0},
+        )()
+
+        runs = [RunInfo(run_id="run-new", date_iso="2026-01-02", date_label="Jan 02")]
+        _read_accumulated_summary(reports_root, project, runs)
+
+        called_dims = mock_summarize.call_args[0][0]
+        assert [d.dimension for d in called_dims] == ["security"]
+
+    @patch("quodeq.services._fs_metadata.read_run_data")
+    def test_card_summary_recomputes_when_visibility_changes(
+        self, mock_read, tmp_path, monkeypatch,
+    ):
+        """The selection is folded into the cache version: editing
+        standards-visibility.json must invalidate the persisted card summary,
+        not serve the grade computed under the previous selection."""
+        from quodeq.core.standards.visibility import save_visible_standard_ids
+        from quodeq.core.types import DimensionResult
+        from quodeq.services.ports import RunInfo
+
+        monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+        reports_root = tmp_path / "evaluations"
+        project = "proj"
+        (reports_root / project / "run-new").mkdir(parents=True)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (reports_root / project / "repository_info.json").write_text(
+            json.dumps({"name": project, "path": str(repo), "location": "local"}),
+            encoding="utf-8",
+        )
+        mock_read.return_value = [
+            DimensionResult(dimension="security", overall_score="9.0",
+                            overall_grade="Exemplary"),
+            DimensionResult(dimension="reliability", overall_score="5.0",
+                            overall_grade="Adequate"),
+        ]
+        runs = [RunInfo(run_id="run-new", date_iso="2026-01-02", date_label="Jan 02")]
+
+        save_visible_standard_ids(repo, ["security", "reliability"])
+        _, score_both, _ = _read_accumulated_summary(reports_root, project, runs)
+        save_visible_standard_ids(repo, ["security"])
+        _, score_one, _ = _read_accumulated_summary(reports_root, project, runs)
+
+        assert score_both == 7.0
+        assert score_one == 9.0
 
     def test_project_card_reflects_overlaid_sql_grades_and_loaded_params(
         self, tmp_path, monkeypatch,

--- a/tests/services/test_scan_progress.py
+++ b/tests/services/test_scan_progress.py
@@ -411,6 +411,107 @@ class TestDimElapsed:
         assert 115 <= dim.elapsed_s <= 130
 
 
+class TestDimElapsedFromStamps:
+    """Transition timestamps in dimensions.json beat queue reconstruction.
+
+    write_dim_state stamps started_at/completed_at at the actual state
+    transitions, so when both ends exist the duration is exact — the
+    queue/mtime forensics stay fallback-only.
+    """
+
+    def _write_queue(self, run_dir: Path, dim: str, payload: dict) -> None:
+        (run_dir / "evidence" / f"{dim}_queue.json").write_text(
+            json.dumps(payload), encoding="utf-8",
+        )
+
+    def _write_dim_record(self, run_dir: Path, dim: str, record: dict) -> None:
+        (run_dir / "dimensions.json").write_text(
+            json.dumps({"schema_version": 1, "dimensions": {dim: record}}),
+            encoding="utf-8",
+        )
+
+    def test_running_dim_prefers_stamped_started_at(self, tmp_path: Path) -> None:
+        import time as _t
+        from datetime import datetime, timezone
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"])
+        now = _t.time()
+        # Queue says the dim started 300s ago; the stamped record says 600s.
+        self._write_queue(run_dir, "security", {
+            "created_at": now - 300,
+            "taken": [{"files": ["a.py"], "agent": "a1", "ts": now - 2}],
+            "pending": ["b.py"],
+        })
+        started = datetime.fromtimestamp(now - 600, tz=timezone.utc).isoformat()
+        self._write_dim_record(run_dir, "security", {"state": "running", "started_at": started})
+        dim = build_scan_progress("j1", run_dir).dimensions[0]
+        assert dim.state == "running"
+        assert dim.elapsed_s is not None
+        assert 595 <= dim.elapsed_s <= 610
+
+    def test_done_dim_duration_is_stamp_subtraction(self, tmp_path: Path) -> None:
+        import time as _t
+        from datetime import datetime, timezone
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"], state="done")
+        now = _t.time()
+        # Take log would reconstruct >=300s; the stamps say exactly 250s.
+        self._write_queue(run_dir, "security", {
+            "created_at": now - 400,
+            "taken": [
+                {"files": ["a.py"], "agent": "a1", "ts": now - 350},
+                {"files": ["b.py"], "agent": "a1", "ts": now - 100},
+            ],
+            "pending": [],
+        })
+        iso = lambda s: datetime.fromtimestamp(now - s, tz=timezone.utc).isoformat()  # noqa: E731
+        self._write_dim_record(run_dir, "security", {
+            "state": "done", "started_at": iso(350), "completed_at": iso(100),
+        })
+        dim = build_scan_progress("j1", run_dir).dimensions[0]
+        assert dim.state == "done"
+        assert dim.elapsed_s == 250.0
+
+    def test_interrupted_dim_uses_interrupted_at_as_end(self, tmp_path: Path) -> None:
+        import time as _t
+        from datetime import datetime, timezone
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"], state="cancelled")
+        now = _t.time()
+        self._write_queue(run_dir, "security", {
+            "created_at": now - 400,
+            "taken": [{"files": ["a.py"], "agent": "a1", "ts": now - 350}],
+            "pending": ["b.py"],
+        })
+        iso = lambda s: datetime.fromtimestamp(now - s, tz=timezone.utc).isoformat()  # noqa: E731
+        self._write_dim_record(run_dir, "security", {
+            "state": "incomplete", "started_at": iso(300), "interrupted_at": iso(120),
+        })
+        dim = build_scan_progress("j1", run_dir).dimensions[0]
+        assert dim.elapsed_s == 180.0
+
+    def test_done_dim_without_end_stamp_falls_back_to_reconstruction(self, tmp_path: Path) -> None:
+        # A hard kill can leave started_at with no terminal stamp; the queue
+        # take-log reconstruction must still produce a number.
+        import time as _t
+        from datetime import datetime, timezone
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"], state="done")
+        now = _t.time()
+        self._write_queue(run_dir, "security", {
+            "created_at": now - 400,
+            "taken": [{"files": ["a.py"], "agent": "a1", "ts": now - 100}],
+            "pending": [],
+        })
+        started = datetime.fromtimestamp(now - 350, tz=timezone.utc).isoformat()
+        self._write_dim_record(run_dir, "security", {"state": "running", "started_at": started})
+        dim = build_scan_progress("j1", run_dir).dimensions[0]
+        assert dim.state == "done"
+        # created_at (now-400) -> last take (now-100): reconstruction, not stamps.
+        assert dim.elapsed_s is not None
+        assert dim.elapsed_s >= 295
+
+
 class TestConsolidatedProgress:
     """Consolidated (grouped) runs write consolidated_* files, not per-dim
     queues, so the per-dim reader showed 0% / "estimating…" for the whole

--- a/tests/services/test_score_cache_accumulated_helper.py
+++ b/tests/services/test_score_cache_accumulated_helper.py
@@ -93,6 +93,42 @@ def test_per_run_versions_does_not_persist_in_progress_keys(tmp_path, monkeypatc
         assert "r2" in load_run_keys(conn, "proj")  # terminal run persisted
 
 
+def test_cached_accumulated_not_cacheable_serves_without_persisting(tmp_path, monkeypatch):
+    """A payload the caller flags as incomplete must be served but never written.
+
+    Regression: a rescore built from a partial run read (1 of 6 dims in the
+    process LRU) was persisted under a version hash identical to the complete
+    payload's, so the half-rescored row was a permanent cache hit.
+    """
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    calls = []
+    def compute():
+        calls.append(1)
+        return {"dimensions": [], "summary": {"partial": True}}
+    r1 = cached_accumulated("proj", "v1", compute, cacheable=lambda _p: False)
+    assert r1 == {"dimensions": [], "summary": {"partial": True}}
+    # Same version misses again: nothing was persisted.
+    r2 = cached_accumulated("proj", "v1", compute, cacheable=lambda _p: False)
+    assert r2 == r1
+    assert calls == [1, 1]
+
+
+def test_cached_accumulated_cacheable_true_persists(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    calls = []
+    def compute():
+        calls.append(1)
+        return {"dimensions": [], "summary": {"x": 1}}
+    cached_accumulated("proj", "v1", compute, cacheable=lambda _p: True)
+    r2 = cached_accumulated(
+        "proj", "v1",
+        lambda: (_ for _ in ()).throw(AssertionError("recomputed on hit")),
+        cacheable=lambda _p: True,
+    )
+    assert r2 == {"dimensions": [], "summary": {"x": 1}}
+    assert calls == [1]
+
+
 def test_cached_accumulated_kill_switch(tmp_path, monkeypatch):
     monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
     monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")

--- a/tests/services/test_score_cache_accumulated_helper.py
+++ b/tests/services/test_score_cache_accumulated_helper.py
@@ -39,6 +39,24 @@ def test_version_stable_regardless_of_run_order(tmp_path, monkeypatch):
     assert a == b  # run-set is order-independent (sorted)
 
 
+def test_version_folds_visible_dims_only_when_given(tmp_path, monkeypatch):
+    """visible_dims invalidates visibility-scoped payloads (project card) on a
+    selection change, while None-passing callers (accumulated Overview, which
+    returns every dim and lets the client filter) keep their hashes."""
+    _patch_keys(monkeypatch)
+    pd = tmp_path / "proj"; pd.mkdir()
+    runs = [("r1", "complete")]
+    base = accumulated_cache_version(pd, DEFAULT_PARAMS, runs, None)
+    six = accumulated_cache_version(
+        pd, DEFAULT_PARAMS, runs, None, visible_dims=("security", "reliability"))
+    one = accumulated_cache_version(
+        pd, DEFAULT_PARAMS, runs, None, visible_dims=("security",))
+    assert len({base, six, one}) == 3
+    # Selection is order-independent (sorted before hashing).
+    assert six == accumulated_cache_version(
+        pd, DEFAULT_PARAMS, runs, None, visible_dims=("reliability", "security"))
+
+
 def test_cached_accumulated_miss_then_hit(tmp_path, monkeypatch):
     monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
     calls = []

--- a/tests/shared/test_dimensions_state.py
+++ b/tests/shared/test_dimensions_state.py
@@ -58,6 +58,34 @@ class TestStateMachine:
         assert not (tmp_path / "dimensions.json.tmp").exists()
 
 
+class TestTransitionTimestampsPreserved:
+    """Transitions merge into the record; earlier stamps survive.
+
+    Progress derives a dimension's duration as completed_at - started_at,
+    which only works if the DONE write doesn't wipe the RUNNING stamp."""
+
+    def test_started_at_survives_done(self, tmp_path: Path):
+        write_dim_state(tmp_path, "security", DimState.PENDING)
+        write_dim_state(tmp_path, "security", DimState.RUNNING)
+        started = read_dimensions(tmp_path)["dimensions"]["security"]["started_at"]
+        write_dim_state(tmp_path, "security", DimState.DONE, exit_reason="done")
+        entry = read_dimensions(tmp_path)["dimensions"]["security"]
+        assert entry["state"] == "done"
+        assert entry["started_at"] == started
+        assert entry["completed_at"]
+        assert entry["exit_reason"] == "done"
+
+    def test_started_at_survives_incomplete(self, tmp_path: Path):
+        write_dim_state(tmp_path, "security", DimState.PENDING)
+        write_dim_state(tmp_path, "security", DimState.RUNNING)
+        started = read_dimensions(tmp_path)["dimensions"]["security"]["started_at"]
+        write_dim_state(tmp_path, "security", DimState.INCOMPLETE, reason="cancelled_by_user")
+        entry = read_dimensions(tmp_path)["dimensions"]["security"]
+        assert entry["started_at"] == started
+        assert entry["interrupted_at"]
+        assert entry["reason"] == "cancelled_by_user"
+
+
 class TestRead:
     def test_missing_file_returns_empty(self, tmp_path: Path):
         assert read_dimensions(tmp_path) == {"schema_version": 1, "dimensions": {}}

--- a/tests/test_cli_consolidation_wiring.py
+++ b/tests/test_cli_consolidation_wiring.py
@@ -1,0 +1,96 @@
+"""run_evaluate must consolidate this run's cache entries after it ends.
+
+The flip runs OUTSIDE RunLifecycleContext, alongside the fail-soft SARIF
+export, so a failure in it can never turn a completed run into a failed one.
+It is skipped for the modes that produce no scored reports, because nothing
+of theirs reaches the Overview.
+
+The seam is patched at the three boundaries run_evaluate calls out through,
+so no real pipeline, AI provider, or repo is involved.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from quodeq import _cli_evaluation
+from quodeq._cli_resolution import ResolvedInputs
+from quodeq.analysis.manifest_models import SourceManifest
+
+
+def _args(tmp_path: Path, **overrides) -> argparse.Namespace:
+    """The attribute set run_evaluate reads before reaching the tail.
+
+    dry_run=True skips check_evaluate_prereqs, so no AI provider is needed.
+    """
+    defaults = dict(
+        repo=str(tmp_path / "src"),
+        output=str(tmp_path / "reports"),
+        legacy_incremental=False,
+        clean_scan=False,
+        diff_from=None,
+        dry_run=True,
+        sarif=None,
+        evidence_only=False,
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+@pytest.fixture
+def wired(tmp_path: Path, monkeypatch):
+    """Patch run_evaluate's three outward calls; record consolidation calls."""
+    src = tmp_path / "src"
+    src.mkdir()
+    evaluation_dir = tmp_path / "reports" / "proj" / "run1" / "evaluation"
+    evaluation_dir.mkdir(parents=True)
+    evidence_dir = evaluation_dir.parent / "evidence"
+    evidence_dir.mkdir()
+    paths = (tmp_path / "reports", evidence_dir, evaluation_dir)
+
+    monkeypatch.setattr(
+        _cli_evaluation, "_resolve_evaluation_inputs",
+        lambda a: ResolvedInputs(
+            src=src, language="python",
+            manifest=SourceManifest(), dims_data={"applies": []},
+        ),
+    )
+    monkeypatch.setattr(_cli_evaluation, "_setup_run_dirs", lambda a, s: paths)
+    monkeypatch.setattr(
+        _cli_evaluation, "_run_pipeline_with_cleanup", lambda a, i, p: 0,
+    )
+
+    calls: list[Path] = []
+    # run_evaluate imports this locally, so it resolves at call time and
+    # patching the source module is enough.
+    monkeypatch.setattr(
+        "quodeq.analysis.cache.consolidation.mark_run_consolidated",
+        lambda run_dir, cache=None: calls.append(run_dir),
+    )
+    return calls, evaluation_dir.parent
+
+
+def test_run_evaluate_consolidates_the_run_dir(tmp_path: Path, wired):
+    calls, run_dir = wired
+    assert _cli_evaluation.run_evaluate(_args(tmp_path)) == 0
+    assert calls == [run_dir]
+
+
+def test_run_evaluate_skips_consolidation_for_evidence_only(tmp_path: Path, wired):
+    """--evidence-only produces no scored reports, so nothing reaches the
+    Overview and its entries must stay unconsolidated."""
+    calls, _run_dir = wired
+    assert _cli_evaluation.run_evaluate(_args(tmp_path, evidence_only=True)) == 0
+    assert calls == []
+
+
+def test_run_evaluate_skips_consolidation_for_diff_from(tmp_path: Path, wired, monkeypatch):
+    """--diff-from is evidence-only output for a specific ref. Same reason."""
+    calls, _run_dir = wired
+    monkeypatch.setattr(
+        _cli_evaluation, "resolve_diff_files", lambda src, ref: {"changed.py"},
+    )
+    assert _cli_evaluation.run_evaluate(_args(tmp_path, diff_from="main")) == 0
+    assert calls == []

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -7,7 +7,7 @@ src/quodeq/api/import_project.py:31:data
 src/quodeq/api/import_project.py:32:data
 src/quodeq/api/import_project.py:33:data
 src/quodeq/api/llm_bridge_routes.py:8:llm_bridge
-src/quodeq/api/routes_project_list.py:282:analysis
+src/quodeq/api/routes_project_list.py:275:analysis
 src/quodeq/data/fs/project_resolver.py:17:services
 src/quodeq/data/fs/repo_clone.py:19:context
 src/quodeq/data/fs/report_parser/runs.py:190:services
@@ -21,7 +21,7 @@ src/quodeq/services/_violations_jsonl.py:12:analysis
 src/quodeq/services/_violations_stream.py:10:analysis
 src/quodeq/services/_violations_stream.py:11:analysis
 src/quodeq/services/evaluation_mixin.py:22:analysis
-src/quodeq/services/evaluation_mixin.py:537:analysis
+src/quodeq/services/evaluation_mixin.py:540:analysis
 src/quodeq/services/jobs.py:20:analysis
 src/quodeq/services/scan_progress.py:23:analysis
 src/quodeq/services/tooling_mixin.py:17:analysis

--- a/uv.lock
+++ b/uv.lock
@@ -843,7 +843,7 @@ wheels = [
 
 [[package]]
 name = "quodeq"
-version = "1.8.0"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
Cuts v1.8.1. The CHANGELOG entry in this PR has the full notes.

Covers PRs #920, #922, #923, #924, #926, #927, #928, #929.

Pre-flight on `401e3c86`:
- pytest: 5308 passed, 1 skipped
- node --test: 392 passed
- vitest: 1469 passed (178 files)
- vite build: clean, no `static/` diff

The GitHub Release body will carry the combined changelog (full 1.8.x line plus earlier `.0` sections, floored at 1.0.0).