### PR TITLE
chore: sync develop with main after v1.8.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.8.1] - 2026-07-29
+
+### Features
+- **Live feed**: findings from a run that never finished (cancelled, failed, or killed) now show up as new on your next scan instead of being hidden as carried over. Only runs that actually completed mark their findings as carried forward.
+
+### Improvements
+- **Readable times on the evaluate screen**: elapsed times and budgets read in human units, so a long run shows `4h 15m 12s` instead of `255:12` and a budget shows `10m` instead of `10:00`.
+
+### Fixes
+- **Evaluate screen clocks**: the ELAPSED tile and the progress footer now share one clock anchored to the server, so the two no longer disagree on screen, the footer is no longer blank until the first poll, and a skewed clock on your machine cannot throw the tile off. Per-dimension elapsed now comes from the run's own state transitions instead of being inferred from file timestamps.
+- **Overview grades**: hidden standards no longer move the numbers you see. The hero grade letter and the project card grade are both derived from the standards you left visible, so the headline, its letter, and the card agree.
+- **Stale scores after a run**: opening a project's scores while a scan was still running could freeze a partial set of dimensions in the cache, leaving the Overview on raw scores while the dimension pages showed the dismiss-adjusted ones. Partial results are no longer cached or persisted.
+- **Multi-module projects**: repos whose root belongs to no detected subproject keep their full source tree instead of dropping every file outside a subproject. Kotlin Multiplatform repos were scanning zero files.
+- **Android detection**: projects that declare the Android Gradle plugin through a version catalog alias are now recognized as Android.
+- **Terminal**: clicking a link in the terminal opens it in your browser, instead of a warning dialog whose OK button did nothing.
+- **Security**: the evaluations route rejects repo paths outside the project, credential stripping in URLs runs in linear time on hostile input, and the remote-repo check no longer treats any URL merely containing github.com as remote.
+
 ## [1.8.0] - 2026-07-29
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <h2 align="center">AI-powered code quality and security scanner</h2>
-<p align="center"><strong>v1.8.0</strong></p>
+<p align="center"><strong>v1.8.1</strong></p>
 <p align="center">
   <a href="https://github.com/quodeq/quodeq/actions/workflows/test.yml"><img src="https://github.com/quodeq/quodeq/actions/workflows/test.yml/badge.svg" alt="Tests" /></a>
   <a href="https://github.com/quodeq/quodeq/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>

--- a/packaging/macos/launcher.sh
+++ b/packaging/macos/launcher.sh
@@ -63,7 +63,7 @@ if [ -z "$QUODEQ" ]; then
         # ranges. The release skill bumps this on every cut (see
         # .claude/skills/release/SKILL.md).
         # TODO: ship requirements.txt with hashes in the .app bundle.
-        python3 -m pip install --user --only-binary :all: --no-deps "quodeq==1.8.0" 2>&1
+        python3 -m pip install --user --only-binary :all: --no-deps "quodeq==1.8.1" 2>&1
     fi
     export PATH="$PATH:$(python3 -m site --user-base)/bin"
     QUODEQ=$(command -v quodeq 2>/dev/null)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quodeq"
-version = "1.8.0"
+version = "1.8.1"
 description = "Source code quality evaluation platform powered by AI"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -843,7 +843,7 @@ wheels = [
 
 [[package]]
 name = "quodeq"
-version = "1.8.0"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
Brings the version bump and CHANGELOG entry from main back into develop.