### PR TITLE
fix(ci): build the UI on Node 22 in publish and wheel-smoke

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7.0.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install UI dependencies
         working-directory: src/quodeq/ui

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7.0.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Build UI
         working-directory: src/quodeq/ui

--- a/src/quodeq/ui/package.json
+++ b/src/quodeq/ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=22.0.0",
     "npm": ">=10.0.0"
   },
   "type": "module",


### PR DESCRIPTION
## Problem

The `smoke` check on #934 (jest-dom 6.9.1 -> 7.0.0) fails at `npm ci`:

```
npm error notsup Not compatible with your version of node/npm: @testing-library/jest-dom@7.0.0
npm error notsup Required: {"node":">=22","npm":">=6","yarn":">=1"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

jest-dom 7 raised its floor to Node >= 22, and `src/quodeq/ui/.npmrc` sets `engine-strict=true` (from the npm security hardening work), so an engine mismatch is a hard install failure rather than a warning.

`publish.yml` and `wheel-smoke.yml` were the last two workflows pinned to Node 20, and both run `npm ci` in `src/quodeq/ui`. `test.yml`, `build-dmg.yml` and `linux-desktop-smoke.yml` are already on 22, which is why `ui` passed on #934 while `smoke` did not.

## Why this matters beyond a red check

`publish.yml` is the PyPI publish workflow. Merging #934 without this leaves the next release failing at `npm ci` **after** the tag is pushed and the GitHub Release is published, which is the worst point in the release for automation to break.

## Changes

- `wheel-smoke.yml`, `publish.yml`: `node-version: '20'` -> `'22'`
- `src/quodeq/ui/package.json`: `engines.node` `>=20.0.0` -> `>=22.0.0`. With `engine-strict=true`, a contributor on Node 20 cannot install the UI dev dependencies at all, so `>=20.0.0` was a false claim.

## Verification

- `npm ci` against dependabot's package-lock (jest-dom 7.0.0) with `engine-strict=true` under Node >= 22: succeeds, 259 packages, 0 vulnerabilities. This is the exact install that fails on #934 today.
- `npm ci` + `npm run build` on the current lock: both pass, no `static/` diff.

## Merge order

This must land **before** #934. After merging, comment `@dependabot rebase` on #934 so its `pull_request` run picks up the new workflow files.