### PR TITLE
chore(deps): monitor uv.lock and keep TanStack packages grouped

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,22 @@ version: 2
 # Cooldown defers PRs until a release has settled, defending against
 # compromised versions that get yanked within hours of publication.
 # See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown
+#
+# SCOPE: every `directory`/`directories` value below is deliberately narrow.
+# tests/fixtures/discipline_corpus/ holds ~40 synthetic manifests (package.json,
+# pyproject.toml, go.mod, Cargo.toml, Gemfile, Dockerfile, requirements.txt)
+# that exist ONLY as inputs to language/framework detection tests. Their pinned
+# versions are assertions. Do NOT widen these paths or use wildcards to "get
+# full coverage": Dependabot would open PRs against fixtures, break detection
+# tests, and bury the real updates in noise.
 updates:
-  - package-ecosystem: "pip"
+  # This project is uv-managed: pyproject.toml declares loose floors and
+  # uv.lock holds the versions we actually ship. The "pip" ecosystem opened
+  # ZERO PRs in the repo's entire history (vs 14 npm, 7 github-actions),
+  # because a floor like `openai>=1.0` already permits every newer release,
+  # so pip sees nothing to bump, and uv.lock is not a pip-ecosystem artifact.
+  # "uv" reads uv.lock, so the 58 locked packages are finally monitored.
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -44,6 +58,13 @@ updates:
           - "@types/react"
           - "@types/react-dom"
           - "@testing-library/react"
+      # TanStack ships react-query and its devtools in lockstep and expects
+      # matching versions. They drifted apart once already (react-query
+      # 5.101.4 against react-query-devtools 5.101.3) because nothing kept
+      # them together. Same failure class as react/react-dom above.
+      tanstack:
+        patterns:
+          - "@tanstack/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Scope note: this is about version updates, not security

Dependabot **security** coverage for Python was already working and is unchanged by this PR. Verified on this repo:

- `repos/quodeq/quodeq/vulnerability-alerts` -> `204` (alerts enabled)
- `repos/quodeq/quodeq/automated-security-fixes` -> `{"enabled":true,"paused":false}`
- dependency graph already parses `uv.lock`: **59 pypi** packages alongside 289 npm, 9 githubactions
- 0 open alerts, 0 alerts ever

What was inert is the scheduled **version update** job. That is what this PR fixes.

## Gap 1: Python version updates never ran

The `pip` ecosystem has opened **zero** PRs in this repo's entire history:

| Ecosystem | Dependabot version-update PRs |
|---|---|
| `npm_and_yarn` | 14 |
| `github_actions` | 7 |
| `pip` | **0** |

This project is uv-managed. `pyproject.toml` declares loose floors (`openai>=1.0`, `httpx>=0.27`, `packaging>=23`) that already permit every newer release, so `pip` sees nothing to bump, and `uv.lock` is not a pip-ecosystem artifact. Result: routine freshness of the 58 locked runtime packages was never proposed, e.g. `openai` sits at 2.44.0 in `uv.lock` against 2.50.0 on PyPI.

Switching to `package-ecosystem: "uv"` makes the version-update job read `uv.lock`.

## Gap 2: TanStack packages can drift apart

`@tanstack/react-query` is pinned 5.101.4 while `@tanstack/react-query-devtools` is 5.101.3. TanStack expects those in lockstep. The `react` group already exists for exactly this reason (after #596/#599 broke `npm ci` with ERESOLVE from splitting react/react-dom); this adds the equivalent `tanstack` group.

## Also: recorded why the scopes stay narrow

`tests/fixtures/discipline_corpus/` holds ~40 synthetic manifests (`package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, `Gemfile`, `Dockerfile`, `requirements.txt`) that exist only as inputs to language/framework detection tests. Their pinned versions are assertions. A future "let's get full coverage" change using wildcards would open PRs against fixtures and break those tests, so the reasoning is now a comment in the file.

## Verification

- `package-ecosystem: "uv"` is listed in GitHub's Dependabot options reference as an ecosystem distinct from `pip`.
- Cooldown applies only to version updates: "This default cooldown does not apply to security updates." So the 2-7 day cooldown here never delays a CVE fix.
- YAML parses clean; the three entries resolve to `uv /`, `npm /src/quodeq/ui` (groups: react, tanstack), `github-actions /`.
- Dependabot validates this config itself on push. If `uv` were rejected it surfaces on the Dependabot tab rather than failing CI, so worth a glance there after merge.