### PR TITLE
fix(deps): declare pydantic and bound the runtime dependency ranges

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,15 +20,24 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
     "Topic :: Software Development :: Testing",
 ]
+# Lower bounds are the versions uv.lock resolves, because CI installs with
+# `uv sync` and therefore only ever exercises the locked set. A floor below
+# that advertises support we do not test. Upper bounds stop a fresh `uv lock`
+# from crossing a major boundary unreviewed; Dependabot's uv job proposes the
+# cap bump when a new major lands. 0.x deps are capped at the next minor,
+# since 0.x minors are breaking under semver.
 dependencies = [
     "jsonschema==4.26.0",
     "flask==3.1.3",
-    "flask-sock>=0.7",
-    "pywebview>=6.2",
-    "openai>=1.0",
-    "httpx>=0.27",
-    "packaging>=23",
-    'pywinpty>=3.0.5 ; sys_platform == "win32"',
+    "flask-sock>=0.7.0,<0.8",
+    "pywebview>=6.2.1,<7",
+    "openai>=2.44.0,<3",
+    "httpx>=0.28.1,<0.29",
+    "packaging>=26.2,<27",
+    # Imported unguarded by quodeq.core.events.models; previously present only
+    # because openai depends on it. Declared so it cannot vanish underneath us.
+    "pydantic>=2.13.4,<3",
+    'pywinpty>=3.0.5,<4 ; sys_platform == "win32"',
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -852,6 +852,7 @@ dependencies = [
     { name = "jsonschema" },
     { name = "openai" },
     { name = "packaging" },
+    { name = "pydantic" },
     { name = "pywebview" },
     { name = "pywinpty", marker = "sys_platform == 'win32'" },
 ]
@@ -867,13 +868,14 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "flask", specifier = "==3.1.3" },
-    { name = "flask-sock", specifier = ">=0.7" },
-    { name = "httpx", specifier = ">=0.27" },
+    { name = "flask-sock", specifier = ">=0.7.0,<0.8" },
+    { name = "httpx", specifier = ">=0.28.1,<0.29" },
     { name = "jsonschema", specifier = "==4.26.0" },
-    { name = "openai", specifier = ">=1.0" },
-    { name = "packaging", specifier = ">=23" },
-    { name = "pywebview", specifier = ">=6.2" },
-    { name = "pywinpty", marker = "sys_platform == 'win32'", specifier = ">=3.0.5" },
+    { name = "openai", specifier = ">=2.44.0,<3" },
+    { name = "packaging", specifier = ">=26.2,<27" },
+    { name = "pydantic", specifier = ">=2.13.4,<3" },
+    { name = "pywebview", specifier = ">=6.2.1,<7" },
+    { name = "pywinpty", marker = "sys_platform == 'win32'", specifier = ">=3.0.5,<4" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## pydantic was never declared

`quodeq/core/events/models.py:8` imports pydantic unguarded at module scope. It is not in `[project].dependencies`; it resolves only because `openai` happens to require it (`openai 2.44.0` -> `pydantic 2.13.4` in `uv.lock`). Reproduced:

```
$ uv pip install --no-deps --only-binary :all: quodeq==1.8.1
$ quodeq --help
  File ".../quodeq/core/events/models.py", line 8, in <module>
    from pydantic import BaseModel, Field, ConfigDict, field_validator
ModuleNotFoundError: No module named 'pydantic'
```

Nothing is broken for users today, since a normal `pip install quodeq` pulls openai and therefore pydantic. But the dependency is real and undeclared, so it can vanish underneath us if openai ever drops it.

The other undeclared third-party imports are fine and stay as they are: `AppKit`, `Foundation`, `PyObjCTools` and `gi` are all function-local behind `sys.platform` guards, supplied by pywebview's platform extras.

## The floors advertised untested versions

CI installs with `uv sync`, so only the versions in `uv.lock` are ever exercised. `openai>=1.0` claimed support for a major we never test, and an unbounded floor lets a fresh `uv lock` cross a major boundary with no review.

| Dependency | Before | After | Locked |
|---|---|---|---|
| `flask-sock` | `>=0.7` | `>=0.7.0,<0.8` | 0.7.0 |
| `pywebview` | `>=6.2` | `>=6.2.1,<7` | 6.2.1 |
| `openai` | `>=1.0` | `>=2.44.0,<3` | 2.44.0 |
| `httpx` | `>=0.27` | `>=0.28.1,<0.29` | 0.28.1 |
| `packaging` | `>=23` | `>=26.2,<27` | 26.2 |
| `pywinpty` | `>=3.0.5` | `>=3.0.5,<4` | 3.0.5 |
| `pydantic` | *(undeclared)* | `>=2.13.4,<3` | 2.13.4 |

0.x dependencies are capped at the next minor, since 0.x minors are breaking under semver. `jsonschema==4.26.0` and `flask==3.1.3` are left alone; they were already exact and no rationale is recorded for changing them.

With #939 merged, Dependabot's uv job proposes the cap bump when a new major lands, so the ceilings do not become stale on their own.

## Verification

- `uv lock` after the change: **0 package version changes**, still 58 packages. Nothing that ships moves; the lock diff is constraint metadata plus the pydantic edge.
- `uv sync && uv run pytest -m "not integration"`: 5308 passed, 1 skipped.