### PR TITLE
fix(evaluation): abort on fatal provider errors instead of respawning agents

### DIFF
--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -434,6 +434,24 @@ def _record_deadline_if_hit(lifecycle: "RunLifecycleContext", config: "RunConfig
         lifecycle.set_exit_reason("deadline")
 
 
+def _record_provider_fatal_if_cancelled(lifecycle: "RunLifecycleContext") -> None:
+    """Tag a completed run that a dead provider cut short.
+
+    ``_raise_on_fatal_cancel`` lets the pipeline finish when files were
+    already analysed before the provider died (partial data is worth
+    keeping). Without this hook such a run finalizes with
+    ``exit_reason=null``, indistinguishable from a clean completion, and
+    the UI can't warn that the results are partial. Runs after the
+    deadline hook so the provider failure, being the actual cause, wins.
+    """
+    from quodeq.shared import cancellation
+    reason = cancellation.cancel_reason() or ""
+    if reason.startswith("provider_fatal"):
+        lifecycle.set_exit_reason("provider_fatal")
+    elif reason == "agent_failure_streak":
+        lifecycle.set_exit_reason("failure_streak")
+
+
 def _run_pipeline_with_cleanup(
     args: argparse.Namespace, inputs: ResolvedInputs, paths: tuple[Path, Path, Path],
 ) -> int:
@@ -508,6 +526,7 @@ def _run_pipeline_with_cleanup(
                     # the dashboard can distinguish a deadline-truncated run
                     # from a clean completion (exit_reason=null vs "deadline").
                     _record_deadline_if_hit(lifecycle, config)
+                    _record_provider_fatal_if_cancelled(lifecycle)
                     # run_full writes per-dimension reports as each dimension
                     # completes, so by the time it returns scoring is already
                     # done. Record the last pre-finalize phase as "scoring"

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -29,6 +29,7 @@ import openai
 from pydantic import BaseModel, Field
 
 from quodeq.analysis._drop_stats import record as _record_drop_stats
+from quodeq.analysis.errors import FatalProviderError, classify_fatal_provider_message
 from quodeq.analysis.mcp.router import CompiledContext, FindingsRouter
 
 if TYPE_CHECKING:
@@ -236,6 +237,30 @@ def _parse_findings(raw_json: str) -> tuple[list[dict], int]:
     return findings, len(dropped)
 
 
+def _classify_fatal_api_error(exc: Exception) -> tuple[str, str] | None:
+    """Return ``(reason_code, detail)`` when no retry can fix *exc*, else None.
+
+    The OpenAI SDK normalizes every OpenAI-compatible provider's errors into
+    typed exceptions with a status code, so one classifier covers ollama,
+    llamacpp, openrouter, and custom endpoints alike. 429 is fatal only when
+    the body says quota/credits (OpenAI ``insufficient_quota``, OpenRouter
+    out-of-credits): a bare 429 is a transient rate limit and stays on the
+    lossy-retry path.
+    """
+    if isinstance(exc, openai.AuthenticationError):
+        return "auth", "authentication failed (401)"
+    if isinstance(exc, openai.PermissionDeniedError):
+        return "auth", "permission denied (403)"
+    if isinstance(exc, openai.APIStatusError):
+        if exc.status_code == 402:
+            return "payment", "out of credits (402 payment required)"
+        if exc.status_code == 429:
+            reason = classify_fatal_provider_message(str(exc))
+            if reason in ("quota", "payment"):
+                return reason, "quota/credits exhausted (429)"
+    return None
+
+
 def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
     """Call the LLM raw, validate each finding independently, return ``(findings, was_lossy)``.
 
@@ -303,6 +328,16 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
             response = client.chat.completions.create(**create_kwargs)
         except Exception as exc:
             elapsed = time.monotonic() - start
+            fatal = _classify_fatal_api_error(exc)
+            if fatal is not None:
+                reason_code, detail = fatal
+                _log.error(
+                    "Model %s: %s -- no retry can succeed, aborting: %s",
+                    config.model, detail, str(exc)[:300],
+                )
+                raise FatalProviderError(
+                    f"{detail}: {str(exc)[:300]}", reason=reason_code,
+                ) from exc
             if isinstance(exc, (httpx.TimeoutException, openai.APITimeoutError)):
                 _log.warning(
                     "Model %s call timed out after %.0fs. Likely causes: "
@@ -481,7 +516,15 @@ def run_api_analysis(
     marker writes its per-file cache entry to disk before returning. Legacy
     callers that omit either remain unchanged -- no cache is written.
     """
-    findings, was_lossy = _call_api(prompt, config)
+    # A fatal provider error (quota/auth/billing) still writes 'error'
+    # markers first -- the breaker and reachability guard rely on them --
+    # then re-raises so the pool layer can cancel the run instead of
+    # respawning agents against a dead provider.
+    fatal_exc: FatalProviderError | None = None
+    try:
+        findings, was_lossy = _call_api(prompt, config)
+    except FatalProviderError as exc:
+        fatal_exc, findings, was_lossy = exc, [], True
 
     if source_file_paths:
         findings = _resolve_file_paths(findings, source_file_paths)
@@ -541,6 +584,12 @@ def run_api_analysis(
             # but lets the failure-streak breaker and the post-run
             # reachability guard see the failure and fail the run loudly.
             status = "error" if was_lossy else "ok"
-            reason = "model call failed (unreachable or errored)" if was_lossy else None
+            reason = None
+            if fatal_exc is not None:
+                reason = f"fatal provider error ({fatal_exc.reason}): {fatal_exc}"
+            elif was_lossy:
+                reason = "model call failed (unreachable or errored)"
             for path in source_file_paths:
                 router.mark_file_done(file=path, status=status, reason=reason)
+    if fatal_exc is not None:
+        raise fatal_exc

--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -100,23 +100,60 @@ def _interruption_reason(exc: BaseException | None = None) -> str:
     return "failed_exception"
 
 
-def _raise_on_fatal_cancel() -> None:
-    """Fail the run loudly when cancellation came from a dead provider.
+def _count_ok_files(run_dir: Path | None) -> int:
+    """Files successfully analysed by THIS run's workers, across all dims.
 
-    Without this, a run whose agents were killed by quota/auth exhaustion
-    (or by the pool's agent-failure-streak backstop) would end as DONE with
-    silently incomplete dimensions. Raising here gives the lifecycle exit
-    handler a typed exception to map to a distinct exit_reason.
+    ``ok`` file_done markers are written only by dispatch workers; cache
+    replays write findings without markers. So this count measures fresh
+    progress this run made, never carried-forward data.
+    """
+    if run_dir is None:
+        return 0
+    evidence_dir = Path(run_dir) / "evidence"
+    if not evidence_dir.is_dir():
+        return 0
+    total = 0
+    for jsonl in evidence_dir.glob("*_evidence.jsonl"):
+        ok, _err = _tally_markers(jsonl)
+        total += ok
+    return total
+
+
+def _raise_on_fatal_cancel(run_dir: Path | None) -> None:
+    """Fail the run loudly when a dead provider stopped it before ANY analysis.
+
+    Two outcomes, keyed on whether this run already analysed files
+    successfully (``ok`` markers, see ``_count_ok_files``):
+
+    - No successful analysis: the run is worthless. Raise so the lifecycle
+      maps it to a failed run with a distinct exit_reason, instead of DONE
+      with silently incomplete dimensions.
+    - Partial success (e.g. quota died halfway): the data is worth keeping.
+      Return without raising so the run finalizes as done; the CLI hook
+      (``_record_provider_fatal_if_cancelled``) stamps the exit_reason so
+      the UI says "stopped early, results are partial" rather than showing
+      a clean completion.
     """
     reason = cancellation.cancel_reason() or ""
-    if reason.startswith("provider_fatal"):
+    is_provider_fatal = reason.startswith("provider_fatal")
+    is_streak = reason == "agent_failure_streak"
+    if not (is_provider_fatal or is_streak):
+        return
+    ok_files = _count_ok_files(run_dir)
+    if ok_files > 0:
+        log_warning(
+            f"[loop] provider failed mid-run after {ok_files} file(s) were "
+            f"analysed -- keeping partial results, run finalizes as done "
+            f"with a stopped-early warning"
+        )
+        return
+    if is_provider_fatal:
         raise FatalProviderError(
             f"evaluation aborted: {reason.partition(':')[2].strip() or 'fatal provider error'}",
             reason="provider_fatal",
         )
-    if reason == "agent_failure_streak":
-        from quodeq.analysis.cache._failure_streak import CircuitBreakerError
-        raise CircuitBreakerError("agent_failure_streak")
+    from quodeq.analysis.cache._failure_streak import CircuitBreakerError
+    raise CircuitBreakerError("agent_failure_streak")
 
 
 def _silence_broken_stdout() -> None:
@@ -382,7 +419,7 @@ def run_incremental_loop(
     # Before the guards: the drop-ratio summary must land even when a
     # guard raises (a high drop ratio and a worthless run often co-occur).
     report_run_drop_stats()
-    _raise_on_fatal_cancel()
+    _raise_on_fatal_cancel(_run_dir_for(config))
     check_zero_findings(
         result, config.source_file_count,
         incremental_filter_active=config.options.incremental_file_filter is not None
@@ -496,7 +533,7 @@ def run_per_dimension_loop(
     # Before the guards: the drop-ratio summary must land even when a
     # guard raises (a high drop ratio and a worthless run often co-occur).
     report_run_drop_stats()
-    _raise_on_fatal_cancel()
+    _raise_on_fatal_cancel(_run_dir_for(config))
     check_zero_findings(
         result, config.source_file_count, skipped_count,
         incremental_filter_active=config.options.incremental_file_filter is not None

--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from quodeq.analysis._drop_stats import report_run_drop_stats
 from quodeq.analysis._types import RunConfig, _AnalysisContext
 from quodeq.analysis.dimension_runner import DimensionRunner, _log_dimension_result
-from quodeq.analysis.errors import EvaluationError
+from quodeq.analysis.errors import EvaluationError, FatalProviderError
 from quodeq.core.evidence.model import Evidence
 from quodeq.engine._runner_markers import emit_marker
 # NOTE: logging in inner layer - tracked for middleware extraction
@@ -78,15 +78,45 @@ def _run_dir_for(config: RunConfig) -> Path | None:
 def _interruption_reason(exc: BaseException | None = None) -> str:
     """Map a process state and optional exception to a dim-state reason.
 
+    - Fatal provider error (quota/auth/billing): 'provider_fatal'.
     - Circuit-breaker trip: returns 'circuit_breaker' (recognised so the
       lifecycle exit handler can map to exit_reason=failure_streak).
-    - Cancellation flag set (signal or breaker-via-flag): 'cancelled_signal'.
+    - Cancellation flag set: the recorded cancel cause ('provider_fatal',
+      'agent_failure_streak') when there is one, else 'cancelled_signal'.
     - Otherwise: 'failed_exception'.
     """
     from quodeq.analysis.cache._failure_streak import CircuitBreakerError
+    if isinstance(exc, FatalProviderError):
+        return "provider_fatal"
     if isinstance(exc, CircuitBreakerError):
         return "circuit_breaker"
-    return "cancelled_signal" if cancellation.is_cancelled() else "failed_exception"
+    if cancellation.is_cancelled():
+        reason = cancellation.cancel_reason() or ""
+        if reason.startswith("provider_fatal"):
+            return "provider_fatal"
+        if reason == "agent_failure_streak":
+            return "agent_failure_streak"
+        return "cancelled_signal"
+    return "failed_exception"
+
+
+def _raise_on_fatal_cancel() -> None:
+    """Fail the run loudly when cancellation came from a dead provider.
+
+    Without this, a run whose agents were killed by quota/auth exhaustion
+    (or by the pool's agent-failure-streak backstop) would end as DONE with
+    silently incomplete dimensions. Raising here gives the lifecycle exit
+    handler a typed exception to map to a distinct exit_reason.
+    """
+    reason = cancellation.cancel_reason() or ""
+    if reason.startswith("provider_fatal"):
+        raise FatalProviderError(
+            f"evaluation aborted: {reason.partition(':')[2].strip() or 'fatal provider error'}",
+            reason="provider_fatal",
+        )
+    if reason == "agent_failure_streak":
+        from quodeq.analysis.cache._failure_streak import CircuitBreakerError
+        raise CircuitBreakerError("agent_failure_streak")
 
 
 def _silence_broken_stdout() -> None:
@@ -264,20 +294,30 @@ def run_incremental_loop(
             last_exc = exc
             ev = None
         except (OSError, KeyError, ValueError, RuntimeError) as exc:
-            log_warning(f"[{idx}/{ctx.total}] {dimension} - incremental failed: {exc}, falling back to full")
             last_exc = exc
-            fallback_options = copy(config.options)
-            fallback_options.incremental_file_filter = None
-            fallback_config = replace(config, options=fallback_options)
-            try:
-                ev = runner.run(fallback_config, dimension, idx, ctx, emit_log=True)
-            except BrokenPipeError as inner_exc:
-                _silence_broken_stdout()
-                last_exc = inner_exc
+            if cancellation.is_cancelled():
+                # The run is being torn down (signal, breaker, fatal provider
+                # error): a full-scan fallback would only spawn agents that
+                # die immediately against the same dead provider.
+                log_warning(
+                    f"[{idx}/{ctx.total}] {dimension} - incremental failed: {exc}; "
+                    f"run cancelled, skipping full-scan fallback",
+                )
                 ev = None
-            except Exception as inner_exc:  # noqa: BLE001
-                last_exc = inner_exc
-                ev = None
+            else:
+                log_warning(f"[{idx}/{ctx.total}] {dimension} - incremental failed: {exc}, falling back to full")
+                fallback_options = copy(config.options)
+                fallback_options.incremental_file_filter = None
+                fallback_config = replace(config, options=fallback_options)
+                try:
+                    ev = runner.run(fallback_config, dimension, idx, ctx, emit_log=True)
+                except BrokenPipeError as inner_exc:
+                    _silence_broken_stdout()
+                    last_exc = inner_exc
+                    ev = None
+                except Exception as inner_exc:  # noqa: BLE001
+                    last_exc = inner_exc
+                    ev = None
         except Exception as exc:  # noqa: BLE001
             # Loop-level diagnostic: an unanticipated exception class would
             # otherwise propagate up silently and the lifecycle would treat
@@ -342,6 +382,7 @@ def run_incremental_loop(
     # Before the guards: the drop-ratio summary must land even when a
     # guard raises (a high drop ratio and a worthless run often co-occur).
     report_run_drop_stats()
+    _raise_on_fatal_cancel()
     check_zero_findings(
         result, config.source_file_count,
         incremental_filter_active=config.options.incremental_file_filter is not None
@@ -455,6 +496,7 @@ def run_per_dimension_loop(
     # Before the guards: the drop-ratio summary must land even when a
     # guard raises (a high drop ratio and a worthless run often co-occur).
     report_run_drop_stats()
+    _raise_on_fatal_cancel()
     check_zero_findings(
         result, config.source_file_count, skipped_count,
         incremental_filter_active=config.options.incremental_file_filter is not None

--- a/src/quodeq/analysis/_process.py
+++ b/src/quodeq/analysis/_process.py
@@ -8,7 +8,7 @@ import sys
 from pathlib import Path
 
 from quodeq.analysis._config import AnalysisConfig, _SpawnPaths
-from quodeq.analysis.errors import ProviderError
+from quodeq.analysis.errors import FatalProviderError, ProviderError, classify_fatal_provider_message
 from quodeq.analysis.stream.progress_reader import _IncrementalProgressReader
 from quodeq.shared import cancellation
 from quodeq.shared.logging import log_warning
@@ -88,7 +88,12 @@ def _run_with_heartbeat(
 
 
 def _check_process_result(process: subprocess.Popen, stream_err: Path) -> None:
-    """Raise AnalysisError if the process exited with a non-zero code."""
+    """Raise AnalysisError if the process exited with a non-zero code.
+
+    Raises FatalProviderError instead when stderr matches a known
+    unrecoverable provider message (quota exhausted, auth failure, out of
+    credits): retrying those only respawns agents that die the same way.
+    """
     if process.returncode != 0:
         stderr_text = ""
         if stream_err.exists():
@@ -96,10 +101,14 @@ def _check_process_result(process: subprocess.Popen, stream_err: Path) -> None:
                 stderr_text = _sanitize_stderr(stream_err.read_text(encoding="utf-8").strip())
             except (OSError, UnicodeDecodeError):
                 stderr_text = "(stderr unreadable)"
-        raise AnalysisError(
+        message = (
             f"AI CLI exited with code {process.returncode}"
             + (f": {stderr_text}" if stderr_text else "")
         )
+        fatal_reason = classify_fatal_provider_message(stderr_text)
+        if fatal_reason is not None:
+            raise FatalProviderError(message, reason=fatal_reason)
+        raise AnalysisError(message)
 
 
 def _spawn_and_monitor(

--- a/src/quodeq/analysis/errors.py
+++ b/src/quodeq/analysis/errors.py
@@ -1,6 +1,8 @@
 """Structured error types for the evaluation pipeline."""
 from __future__ import annotations
 
+import re
+
 
 class EvaluationError(RuntimeError):
     """Base error for evaluation pipeline failures."""
@@ -22,5 +24,59 @@ class ProviderError(EvaluationError):
     """AI provider failed (CLI exited with error, auth failure, etc.)."""
 
 
+class FatalProviderError(ProviderError):
+    """Provider failure that no retry can fix (quota exhausted, auth, billing).
+
+    Raised so the run aborts once with a clear cause instead of respawning
+    agents against a provider that will keep rejecting every call.
+    ``reason`` is a short machine-readable code: "quota", "auth", "payment".
+    """
+
+    def __init__(self, message: str, *, reason: str = "provider_fatal") -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
 class BudgetExceededError(EvaluationError):
     """Evaluation exceeded the configured time or cost budget."""
+
+
+# Fatal-message classification shared by the CLI path (stderr of the claude/
+# codex/gemini CLIs) and the API path (429 bodies). Patterns are deliberately
+# conservative: a false "fatal" aborts the whole run, while a miss only means
+# the pool-level failure-streak backstop stops the spawning a few agents
+# later. High precision over recall.
+_FATAL_MESSAGE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = tuple(
+    (reason, re.compile(pattern, re.IGNORECASE))
+    for reason, pattern in (
+        ("quota", r"insufficient[_ ]quota"),
+        ("quota", r"exceeded your current quota"),
+        ("quota", r"quota (has been )?exceeded"),
+        ("quota", r"usage limit reached"),
+        ("quota", r"out of credits"),
+        ("payment", r"credit balance is too low"),
+        ("payment", r"insufficient credits"),
+        ("payment", r"payment required"),
+        ("payment", r"billing hard limit"),
+        ("auth", r"invalid api key"),
+        ("auth", r"api key not (found|valid|set)"),
+        ("auth", r"authentication (error|failed)"),
+        ("auth", r"401 unauthorized"),
+        ("auth", r"oauth token (has )?(expired|been revoked)"),
+        ("auth", r"please run /login"),
+    )
+)
+
+
+def classify_fatal_provider_message(text: str) -> str | None:
+    """Return a fatal reason code ("quota", "auth", "payment") found in *text*.
+
+    Returns None when the text matches no known unrecoverable-failure
+    message, i.e. the failure should be treated as transient.
+    """
+    if not text:
+        return None
+    for reason, pattern in _FATAL_MESSAGE_PATTERNS:
+        if pattern.search(text):
+            return reason
+    return None

--- a/src/quodeq/analysis/subagents/_pool_loops.py
+++ b/src/quodeq/analysis/subagents/_pool_loops.py
@@ -16,11 +16,13 @@ from quodeq.analysis.subagents._pool_models import (
 from quodeq.analysis.subagents._pool_scaling import (
     EvidencePaths,
     ScaleUpContext,
+    check_agent_failure_streak,
     collect_done,
     maybe_scale_up,
     should_respawn,
 )
 from quodeq.analysis.subagents.file_queue import WorkQueue
+from quodeq.shared import cancellation
 
 _SCOUT_BUDGET_FRACTION = 0.5
 
@@ -52,9 +54,13 @@ def scout_loop(ctx: LoopContext) -> None:
         pool_start=ctx.pool_start, max_duration=ctx.max_duration, scout_timeout=scout_timeout,
     )
     ev_paths = EvidencePaths(ctx.shared_jsonl_path, ctx.evidence_dir, ctx.dimension_key)
+    if cancellation.is_cancelled():
+        return
     ctx.submit_fn()
     while ctx.futures:
         done = collect_done(ctx.futures, ctx.finished, ctx.results, ev_paths)
+        if done:
+            check_agent_failure_streak(ctx.results)
         scale_ctx = ScaleUpContext(
             ctx.queue, ctx.queue_path, ctx.submit_fn,
             deadline_at=ctx.deadline_at,
@@ -78,6 +84,8 @@ def scout_loop(ctx: LoopContext) -> None:
 def immediate_loop(ctx: LoopContext) -> None:
     """Launch all agents immediately, respawning as they complete."""
     ev_paths = EvidencePaths(ctx.shared_jsonl_path, ctx.evidence_dir, ctx.dimension_key)
+    if cancellation.is_cancelled():
+        return
     for _ in range(ctx.n_agents):
         ctx.submit_fn()
     while ctx.futures:
@@ -85,6 +93,8 @@ def immediate_loop(ctx: LoopContext) -> None:
         # threads. Enforcement is the spawn-gate in should_respawn() plus
         # the per-agent max_duration clamp set in build_agent_config().
         done = collect_done(ctx.futures, ctx.finished, ctx.results, ev_paths)
+        if done:
+            check_agent_failure_streak(ctx.results)
         if not done:
             time.sleep(_FUTURE_POLL_INTERVAL_S)
             continue

--- a/src/quodeq/analysis/subagents/_pool_scaling.py
+++ b/src/quodeq/analysis/subagents/_pool_scaling.py
@@ -1,6 +1,7 @@
 """Scaling logic: respawn decisions, scale-up computation, future collection."""
 from __future__ import annotations
 
+import os
 import time
 from collections import OrderedDict
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -16,6 +17,7 @@ from quodeq.analysis.subagents._pool_models import (
     _DEFAULT_FILES_PER_AGENT,
 )
 from quodeq.analysis.subagents.file_queue import FileQueue, WorkQueue
+from quodeq.shared import cancellation
 from quodeq.shared.logging import log_warning
 
 
@@ -80,6 +82,13 @@ def should_respawn(
     do useful work.
     """
     remaining = get_queue(queue, queue_path).remaining()
+    if cancellation.is_cancelled():
+        if remaining > 0:
+            log_warning(
+                f"  Run cancelled -- {remaining} files left, "
+                f"not spawning new agents"
+            )
+        return 0
     if deadline_at is not None and time.monotonic() >= deadline_at:
         if remaining > 0:
             log_warning(
@@ -98,6 +107,48 @@ def should_respawn(
             )
         return 0
     return remaining
+
+
+_DEFAULT_AGENT_FAILURE_STREAK = 5
+
+
+def _agent_failure_streak_limit() -> int:
+    """Consecutive whole-agent failures tolerated before the run is cancelled.
+
+    Env override QUODEQ_AGENT_FAILURE_STREAK; 0 disables the backstop.
+    """
+    raw = os.environ.get("QUODEQ_AGENT_FAILURE_STREAK", "").strip()
+    try:
+        return int(raw) if raw else _DEFAULT_AGENT_FAILURE_STREAK
+    except ValueError:
+        return _DEFAULT_AGENT_FAILURE_STREAK
+
+
+def check_agent_failure_streak(results: list[SubagentResult]) -> None:
+    """Cancel the run when every recent agent died without a single success.
+
+    Provider-agnostic backstop for failure modes the fatal-error
+    classification doesn't recognize: N consecutive dead agents means the
+    provider cannot serve this run, and respawning only burns wall-clock and
+    spams the console. Cancellation is enforced by the spawn gate
+    (``should_respawn``) and the dimension loops.
+    """
+    limit = _agent_failure_streak_limit()
+    if limit <= 0 or cancellation.is_cancelled():
+        return
+    streak = 0
+    for result in reversed(results):
+        if result.success:
+            break
+        streak += 1
+    if streak >= limit:
+        last_error = results[-1].error or "unknown error"
+        log_warning(
+            f"  {streak} consecutive subagent failures (last: {last_error}) "
+            f"-- cancelling run, provider appears unable to serve requests. "
+            f"Adjust with QUODEQ_AGENT_FAILURE_STREAK (0 disables)."
+        )
+        cancellation.request_cancel(reason="agent_failure_streak")
 
 
 def compute_scale_up(

--- a/src/quodeq/analysis/subagents/_pool_worker.py
+++ b/src/quodeq/analysis/subagents/_pool_worker.py
@@ -10,7 +10,9 @@ from quodeq.analysis.subagents._pool_models import (
     _AGENT_ID_PREFIX,
     _DEFAULT_MAX_DURATION_S,
 )
+from quodeq.analysis.errors import FatalProviderError
 from quodeq.analysis.subprocess import AnalysisConfig, AnalysisError, run_analysis
+from quodeq.shared import cancellation
 from quodeq.shared.logging import log_warning
 
 
@@ -80,6 +82,19 @@ def run_single_agent(
         return SubagentResult(
             agent_id=agent_id, jsonl_file=jsonl_file,
             stream_file=stream_file, success=True,
+        )
+    except FatalProviderError as exc:
+        # No retry can succeed (quota/auth/billing): cancel the whole run so
+        # the spawn gate and the dimension loops stop instead of respawning
+        # agents that will all die the same way.
+        log_warning(
+            f"Subagent {agent_id} hit a fatal provider error ({exc.reason}): {exc} "
+            f"-- cancelling run, no further agents will be spawned"
+        )
+        cancellation.request_cancel(reason=f"provider_fatal:{exc.reason}: {exc}")
+        return SubagentResult(
+            agent_id=agent_id, jsonl_file=jsonl_file,
+            stream_file=stream_file, success=False, error=str(exc),
         )
     except AnalysisError as exc:
         log_warning(f"Subagent {agent_id} failed: {exc}")

--- a/src/quodeq/analysis/subprocess.py
+++ b/src/quodeq/analysis/subprocess.py
@@ -28,6 +28,7 @@ from quodeq.analysis._provider_cache import get_provider_configs
 from quodeq.analysis.api_prompt_assembly import assemble_api_prompt
 from quodeq.analysis.stream.counters import count_files_in_stream
 from quodeq.analysis.subagents.file_queue import FileQueue
+from quodeq.shared import cancellation
 from quodeq.shared.utils import get_ai_cmd
 
 
@@ -414,6 +415,11 @@ def _run_api_analysis_bridge(
     standards_text = _load_standards_text(cfg.compiled_dir, cfg.dimension, overrides=overrides)
 
     for batch in _batch_files_by_size(source_files, _api_prompt_char_budget()):
+        # A cancelled run (signal, breaker, fatal provider error) must not
+        # keep burning model calls on the remaining batches.
+        if cancellation.is_cancelled():
+            _log.info("Cancellation requested -- stopping API batch dispatch")
+            break
         api_prompt = assemble_api_prompt(
             source_files=batch,
             standards_text=standards_text,

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -60,6 +60,10 @@ class _ScanProgress:
     # The time limit is one deadline for the whole run, shared across all
     # selected dimensions — never a per-dimension allowance.
     budget_s: int | None = None
+    # Run-level exit_reason from status.json (e.g. "provider_fatal",
+    # "failure_streak"). Lets the UI say WHY a failed run stopped instead of
+    # only that it did.
+    exit_reason: str | None = None
     dimensions: list[_DimProgress] = field(default_factory=list)
 
 
@@ -352,6 +356,7 @@ def build_scan_progress(
             project_files=project_files,
             total_elapsed_s=total_elapsed_s,
             budget_s=run_budget_s,
+            exit_reason=status.get("exit_reason"),
             dimensions=[_consolidated_dim_progress(run_dir)],
         )
 
@@ -372,7 +377,12 @@ def build_scan_progress(
             has_evaluation=eval_path.is_file(),
         )
         record = dim_records.get(dim_id) if isinstance(dim_records, dict) else None
-        exit_reason = record.get("exit_reason") if isinstance(record, dict) else None
+        # DONE dims carry `exit_reason`; INCOMPLETE dims carry `reason`
+        # (e.g. "provider_fatal", "cancelled_signal"). Fall back so an
+        # interrupted dim still tells the UI why it stopped.
+        exit_reason = None
+        if isinstance(record, dict):
+            exit_reason = record.get("exit_reason") or record.get("reason")
 
         if queue is not None:
             # `taken` is a list of batch entries [{"files": [...], "agent": ..., "ts": ...}, ...].
@@ -438,6 +448,7 @@ def build_scan_progress(
         project_files=project_files,
         total_elapsed_s=total_elapsed_s,
         budget_s=run_budget_s,
+        exit_reason=status.get("exit_reason"),
         dimensions=dim_results,
     )
 

--- a/src/quodeq/shared/cancellation.py
+++ b/src/quodeq/shared/cancellation.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import threading
 
 _event = threading.Event()
+_reason: str | None = None
 
 
 def get_event() -> threading.Event:
@@ -21,9 +22,25 @@ def is_cancelled() -> bool:
     return _event.is_set()
 
 
-def request_cancel() -> None:
+def request_cancel(reason: str | None = None) -> None:
+    """Set the cancellation flag, optionally recording why.
+
+    Only the first non-None *reason* wins: later callers (e.g. the signal
+    handler firing after a provider-fatal cancel) must not overwrite the
+    original cause that ``cancel_reason()`` reports.
+    """
+    global _reason
+    if reason is not None and _reason is None:
+        _reason = reason
     _event.set()
 
 
+def cancel_reason() -> str | None:
+    """Why the run was cancelled, when the canceller recorded a reason."""
+    return _reason
+
+
 def reset() -> None:
+    global _reason
+    _reason = None
     _event.clear()

--- a/src/quodeq/shared/run_lifecycle.py
+++ b/src/quodeq/shared/run_lifecycle.py
@@ -132,6 +132,12 @@ class RunLifecycleContext:
             # from regular failures so the UI can surface it differently.
             if self._current_state not in TERMINAL_STATES:
                 self._transition(RunState.FAILED, exit_reason="failure_streak")
+        elif self._is_named_error(exc_type, "FatalProviderError"):
+            # Provider reported an unrecoverable condition (quota exhausted,
+            # auth failure, out of credits). Distinct exit_reason so the
+            # History entry says why instead of a generic exception.
+            if self._current_state not in TERMINAL_STATES:
+                self._transition(RunState.FAILED, exit_reason="provider_fatal")
         else:
             # Any other exception → failed.
             if self._current_state not in TERMINAL_STATES:
@@ -209,19 +215,20 @@ class RunLifecycleContext:
                 _logger.warning("failed to seed dim state for %s: %s", dim, exc)
 
     @staticmethod
-    def _is_circuit_breaker_error(exc_type: type[BaseException] | None) -> bool:
-        """Detect CircuitBreakerError without a hard import dependency.
+    def _is_named_error(exc_type: type[BaseException] | None, name: str) -> bool:
+        """Detect an analysis-layer error class without a hard import dependency.
 
-        Lifecycle is a shared/low-level module; importing from analysis.cache
+        Lifecycle is a shared/low-level module; importing from analysis
         would invert the dependency graph. Class-name match is enough since
         we control both ends.
         """
         if exc_type is None:
             return False
-        for cls in exc_type.__mro__:
-            if cls.__name__ == "CircuitBreakerError":
-                return True
-        return False
+        return any(cls.__name__ == name for cls in exc_type.__mro__)
+
+    @staticmethod
+    def _is_circuit_breaker_error(exc_type: type[BaseException] | None) -> bool:
+        return RunLifecycleContext._is_named_error(exc_type, "CircuitBreakerError")
 
     def _install_signal_handlers(self) -> None:
         def _handle(signum: int, frame: Any) -> None:

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.jsx
@@ -7,6 +7,7 @@ import TrendBadge from '../../../components/TrendBadge.jsx';
 import { SevBadge } from '../../../components/terminal/index.js';
 import { splitScore, scoreGradeColorVar, complianceRatio, formatRunId } from '../../../utils/formatters.js';
 import { scoreToGradeLabel } from '../../../utils/gradeThresholds.js';
+import { exitReasonLabel, exitReasonHint } from '../../../models/exitReason.js';
 
 /**
  * Build a coverage record for the gauge card's footer line.
@@ -44,12 +45,14 @@ function buildPartialTooltip({ filesRead, sourceFileCount, exitReason }) {
     parts.push(`${filesRead.toLocaleString()} of ${sourceFileCount.toLocaleString()} files`);
   }
   if (typeof exitReason === 'string') {
-    parts.push(`stopped: ${exitReason}`);
+    parts.push(`stopped: ${exitReasonLabel(exitReason)}`);
     // A failure-streak (circuit-breaker) dimension is salvaged and shown with a
     // provisional score, but kept out of the overall grade. Say so explicitly.
     if (exitReason === 'failure_streak') {
       parts.push('excluded from grade');
     }
+    const hint = exitReasonHint(exitReason);
+    if (hint) parts.push(hint);
   }
   return parts.join(' · ');
 }

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.test.jsx
@@ -77,7 +77,7 @@ describe('DimensionGaugeCard', () => {
       const line = screen.getByText(coverageLineMatcher(`${dateLabel} · 28%`));
       expect(line.getAttribute('title')).toBe(
         'Partial run · 850 of 3,037 files · stopped: time limit reached · '
-          + 'Raise the time limit or scan fewer dimensions to cover the remaining files.',
+          + 'Remaining files carry over to the next run. Raise the time limit to cover more in one run.',
       );
     });
 
@@ -117,7 +117,7 @@ describe('DimensionGaugeCard', () => {
       const line = screen.getByText(coverageLineMatcher(`${dateLabel} · 100%`));
       expect(line.getAttribute('title')).toBe(
         'Partial run · 100 of 100 files · stopped: time limit reached · '
-          + 'Raise the time limit or scan fewer dimensions to cover the remaining files.',
+          + 'Remaining files carry over to the next run. Raise the time limit to cover more in one run.',
       );
     });
 
@@ -161,7 +161,7 @@ describe('DimensionGaugeCard', () => {
       const line = screen.getByText(dateLabel);
       expect(line.getAttribute('title')).toBe(
         'Partial run · stopped: time limit reached · '
-          + 'Raise the time limit or scan fewer dimensions to cover the remaining files.',
+          + 'Remaining files carry over to the next run. Raise the time limit to cover more in one run.',
       );
     });
 

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.test.jsx
@@ -61,7 +61,7 @@ describe('DimensionGaugeCard', () => {
       );
     });
 
-    it('appends "stopped: <exitReason>" to the tooltip when exitReason is set', () => {
+    it('appends "stopped: <label> · <hint>" to the tooltip when exitReason is set', () => {
       render(
         <DimensionGaugeCard
           item={{
@@ -76,7 +76,8 @@ describe('DimensionGaugeCard', () => {
       );
       const line = screen.getByText(coverageLineMatcher(`${dateLabel} · 28%`));
       expect(line.getAttribute('title')).toBe(
-        'Partial run · 850 of 3,037 files · stopped: deadline',
+        'Partial run · 850 of 3,037 files · stopped: time limit reached · '
+          + 'Raise the time limit or scan fewer dimensions to cover the remaining files.',
       );
     });
 
@@ -95,7 +96,8 @@ describe('DimensionGaugeCard', () => {
       );
       const line = screen.getByText(coverageLineMatcher(`${dateLabel} · 90%`));
       expect(line.getAttribute('title')).toBe(
-        'Partial run · 90 of 100 files · stopped: failure_streak · excluded from grade',
+        'Partial run · 90 of 100 files · stopped: repeated failures · excluded from grade · '
+          + 'Stopped after consecutive agent failures. Check that the AI provider is running and reachable, then run again.',
       );
     });
 
@@ -114,7 +116,8 @@ describe('DimensionGaugeCard', () => {
       );
       const line = screen.getByText(coverageLineMatcher(`${dateLabel} · 100%`));
       expect(line.getAttribute('title')).toBe(
-        'Partial run · 100 of 100 files · stopped: deadline',
+        'Partial run · 100 of 100 files · stopped: time limit reached · '
+          + 'Raise the time limit or scan fewer dimensions to cover the remaining files.',
       );
     });
 
@@ -157,7 +160,8 @@ describe('DimensionGaugeCard', () => {
       );
       const line = screen.getByText(dateLabel);
       expect(line.getAttribute('title')).toBe(
-        'Partial run · stopped: deadline',
+        'Partial run · stopped: time limit reached · '
+          + 'Raise the time limit or scan fewer dimensions to cover the remaining files.',
       );
     });
 

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -7,6 +7,7 @@ import { SectionLabel } from '../../../components/terminal/index.js';
 import { useEvaluationProgress } from '../hooks/useEvaluationProgress.js';
 import { useRunElapsed } from '../hooks/useRunElapsed.js';
 import { formatDuration, formatDurationCoarse } from '../../../utils/formatters.js';
+import { exitReasonInfo, exitReasonLabel, exitReasonHint } from '../../../models/exitReason.js';
 
 const TERMINAL_STATES = new Set(['done', 'failed', 'cancelled']);
 const STATUS_MARKERS = { arrow: '→', check: '✓', error: 'Error:', failed: 'failed' };
@@ -69,8 +70,9 @@ function DimRow({ dim }) {
   } else if (isDone) {
     const coveragePct = total > 0 ? Math.round((taken / total) * 100) : null;
     const isPartial = typeof dim.exitReason === 'string' && dim.exitReason !== 'done';
+    const hint = exitReasonHint(dim.exitReason);
     const partialTooltip = isPartial
-      ? `stopped: ${dim.exitReason} · ${taken} of ${total} files`
+      ? `stopped: ${exitReasonLabel(dim.exitReason)} · ${taken} of ${total} files${hint ? ` · ${hint}` : ''}`
       : undefined;
     meta = (
       <>
@@ -181,8 +183,22 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
   }
 
   // Failed / lost: show the error message inline above the progress bar.
+  // When the run recorded a recognised exit reason (status.json, surfaced
+  // through the progress payload), lead with the human label and the
+  // actionable hint; keep the raw log line underneath as the detail.
+  const failInfo = exitReasonInfo(progress?.exitReason);
+  const failDetail = lastRelevantLog(job.logs);
   const errorBanner = isFailed
-    ? <div className="scan-progress__error">{lastRelevantLog(job.logs) || 'Analysis failed'}</div>
+    ? (
+      <div className="scan-progress__error">
+        {failInfo ? (
+          <>
+            <div><strong>{failInfo.label}</strong>{failInfo.hint && <> · {failInfo.hint}</>}</div>
+            {failDetail && <div className="scan-progress__error-detail">{failDetail}</div>}
+          </>
+        ) : (failDetail || 'Analysis failed')}
+      </div>
+    )
     : isLost
       ? <div className="scan-progress__error">Server restarted, job tracking lost</div>
       : null;

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -7,7 +7,7 @@ import { SectionLabel } from '../../../components/terminal/index.js';
 import { useEvaluationProgress } from '../hooks/useEvaluationProgress.js';
 import { useRunElapsed } from '../hooks/useRunElapsed.js';
 import { formatDuration, formatDurationCoarse } from '../../../utils/formatters.js';
-import { exitReasonInfo, exitReasonLabel, exitReasonHint } from '../../../models/exitReason.js';
+import { exitReasonInfo, exitReasonLabel, exitReasonHint, exitReasonWarn } from '../../../models/exitReason.js';
 
 const TERMINAL_STATES = new Set(['done', 'failed', 'cancelled']);
 const STATUS_MARKERS = { arrow: '→', check: '✓', error: 'Error:', failed: 'failed' };
@@ -201,7 +201,17 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
     )
     : isLost
       ? <div className="scan-progress__error">Server restarted, job tracking lost</div>
-      : null;
+      // Done-with-errors: the provider died mid-run but files had already
+      // been analysed, so the run kept its partial results. Warn that the
+      // numbers below cover only part of the project.
+      : status === 'done' && failInfo && exitReasonWarn(progress?.exitReason)
+        ? (
+          <div className="scan-progress__warning">
+            <strong>{failInfo.label}</strong> · run stopped early, results are partial
+            {failInfo.hint && <> · {failInfo.hint}</>}
+          </div>
+        )
+        : null;
 
   // The time limit is one deadline for the whole run, shared across all
   // selected dimensions — so the countdown pairs total elapsed with the

--- a/src/quodeq/ui/src/models/exitReason.js
+++ b/src/quodeq/ui/src/models/exitReason.js
@@ -8,14 +8,19 @@
  * to the old verbatim behaviour instead of hiding information.
  */
 
+// Not an error: hitting the time budget is the user's own setting doing its
+// job. The hint just says what happens to the remainder.
 const TIME_LIMIT = {
   label: 'time limit reached',
-  hint: 'Raise the time limit or scan fewer dimensions to cover the remaining files.',
+  hint: 'Remaining files carry over to the next run. Raise the time limit to cover more in one run.',
 };
 
 const FAILURE_STREAK = {
   label: 'repeated failures',
   hint: 'Stopped after consecutive agent failures. Check that the AI provider is running and reachable, then run again.',
+  // A run can finish `done` with this reason when the provider died after
+  // partial progress; the UI should then warn that results are incomplete.
+  warn: true,
 };
 
 const CANCELLED = { label: 'cancelled', hint: null };
@@ -24,6 +29,7 @@ export const EXIT_REASON_INFO = {
   provider_fatal: {
     label: 'AI provider error',
     hint: 'The AI provider rejected every request: quota exhausted, out of credits, or an invalid API key. Check your plan, billing or API key, then run again.',
+    warn: true,
   },
   failure_streak: FAILURE_STREAK,
   agent_failure_streak: FAILURE_STREAK,
@@ -50,4 +56,12 @@ export function exitReasonLabel(code) {
 /** Actionable hint for a code, or null when there is nothing to suggest. */
 export function exitReasonHint(code) {
   return exitReasonInfo(code)?.hint ?? null;
+}
+
+/**
+ * True when a run that finished `done` with this reason should still show a
+ * "stopped early, results are partial" warning (provider died mid-run).
+ */
+export function exitReasonWarn(code) {
+  return exitReasonInfo(code)?.warn === true;
 }

--- a/src/quodeq/ui/src/models/exitReason.js
+++ b/src/quodeq/ui/src/models/exitReason.js
@@ -1,0 +1,53 @@
+/**
+ * Exit-reason display map — turns machine exit codes from the backend
+ * (status.json `exit_reason`, dimensions.json `exit_reason`/`reason`) into
+ * a short human label plus, where the user can actually do something, an
+ * actionable hint.
+ *
+ * Unknown codes fall back to the raw code so new backend reasons degrade
+ * to the old verbatim behaviour instead of hiding information.
+ */
+
+const TIME_LIMIT = {
+  label: 'time limit reached',
+  hint: 'Raise the time limit or scan fewer dimensions to cover the remaining files.',
+};
+
+const FAILURE_STREAK = {
+  label: 'repeated failures',
+  hint: 'Stopped after consecutive agent failures. Check that the AI provider is running and reachable, then run again.',
+};
+
+const CANCELLED = { label: 'cancelled', hint: null };
+
+export const EXIT_REASON_INFO = {
+  provider_fatal: {
+    label: 'AI provider error',
+    hint: 'The AI provider rejected every request: quota exhausted, out of credits, or an invalid API key. Check your plan, billing or API key, then run again.',
+  },
+  failure_streak: FAILURE_STREAK,
+  agent_failure_streak: FAILURE_STREAK,
+  time_limit: TIME_LIMIT,
+  deadline: TIME_LIMIT,
+  cancelled: CANCELLED,
+  cancelled_signal: CANCELLED,
+};
+
+/**
+ * @param {string|null|undefined} code
+ * @returns {{label: string, hint: string|null}|null} null for unknown/absent codes
+ */
+export function exitReasonInfo(code) {
+  if (typeof code !== 'string') return null;
+  return EXIT_REASON_INFO[code] ?? null;
+}
+
+/** Human label for a code; unknown codes pass through verbatim. */
+export function exitReasonLabel(code) {
+  return exitReasonInfo(code)?.label ?? code;
+}
+
+/** Actionable hint for a code, or null when there is nothing to suggest. */
+export function exitReasonHint(code) {
+  return exitReasonInfo(code)?.hint ?? null;
+}

--- a/src/quodeq/ui/src/models/exitReason.test.js
+++ b/src/quodeq/ui/src/models/exitReason.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { exitReasonInfo, exitReasonLabel, exitReasonHint } from './exitReason.js';
+
+test('provider_fatal maps to a label and an actionable hint', () => {
+  const info = exitReasonInfo('provider_fatal');
+  assert.equal(info.label, 'AI provider error');
+  assert.match(info.hint, /quota|credits|API key/);
+});
+
+test('failure_streak and agent_failure_streak share the same guidance', () => {
+  assert.deepEqual(exitReasonInfo('agent_failure_streak'), exitReasonInfo('failure_streak'));
+  assert.match(exitReasonHint('failure_streak'), /running and reachable/);
+});
+
+test('deadline and time_limit share the same guidance', () => {
+  assert.deepEqual(exitReasonInfo('deadline'), exitReasonInfo('time_limit'));
+  assert.equal(exitReasonLabel('deadline'), 'time limit reached');
+});
+
+test('cancelled has a label but no hint', () => {
+  assert.equal(exitReasonLabel('cancelled_signal'), 'cancelled');
+  assert.equal(exitReasonHint('cancelled'), null);
+});
+
+test('unknown codes pass through verbatim with no hint', () => {
+  assert.equal(exitReasonInfo('some_future_code'), null);
+  assert.equal(exitReasonLabel('some_future_code'), 'some_future_code');
+  assert.equal(exitReasonHint('some_future_code'), null);
+});
+
+test('absent codes yield null label and hint', () => {
+  assert.equal(exitReasonInfo(null), null);
+  assert.equal(exitReasonLabel(undefined), undefined);
+  assert.equal(exitReasonHint(null), null);
+});

--- a/src/quodeq/ui/src/models/exitReason.test.js
+++ b/src/quodeq/ui/src/models/exitReason.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { exitReasonInfo, exitReasonLabel, exitReasonHint } from './exitReason.js';
+import { exitReasonInfo, exitReasonLabel, exitReasonHint, exitReasonWarn } from './exitReason.js';
 
 test('provider_fatal maps to a label and an actionable hint', () => {
   const info = exitReasonInfo('provider_fatal');
@@ -27,6 +27,16 @@ test('unknown codes pass through verbatim with no hint', () => {
   assert.equal(exitReasonInfo('some_future_code'), null);
   assert.equal(exitReasonLabel('some_future_code'), 'some_future_code');
   assert.equal(exitReasonHint('some_future_code'), null);
+});
+
+test('provider failures warn on done runs, clean stops do not', () => {
+  assert.equal(exitReasonWarn('provider_fatal'), true);
+  assert.equal(exitReasonWarn('failure_streak'), true);
+  assert.equal(exitReasonWarn('agent_failure_streak'), true);
+  assert.equal(exitReasonWarn('time_limit'), false);
+  assert.equal(exitReasonWarn('cancelled'), false);
+  assert.equal(exitReasonWarn('unknown_code'), false);
+  assert.equal(exitReasonWarn(null), false);
 });
 
 test('absent codes yield null label and hint', () => {

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2860,6 +2860,12 @@ button.eval-provider-badge--clickable:focus-visible {
   color: var(--color-sev-critical-text, #f85149);
   border-bottom: 1px solid var(--color-border-soft, var(--color-border));
 }
+/* Raw log line under the labelled reason: keep it readable but secondary. */
+.scan-progress__error-detail {
+  margin-top: 4px;
+  font-size: 10px;
+  opacity: 0.75;
+}
 
 
 .scan-progress__bar {

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2866,6 +2866,13 @@ button.eval-provider-badge--clickable:focus-visible {
   font-size: 10px;
   opacity: 0.75;
 }
+/* Done-with-errors: run kept partial results after a provider failure. */
+.scan-progress__warning {
+  padding: 8px 10px;
+  font-size: 11px;
+  color: var(--color-sev-major-text, #d29922);
+  border-bottom: 1px solid var(--color-border-soft, var(--color-border));
+}
 
 
 .scan-progress__bar {

--- a/tests/analysis/test_fatal_provider_handling.py
+++ b/tests/analysis/test_fatal_provider_handling.py
@@ -1,6 +1,7 @@
 """Fatal provider errors (quota/auth/billing) abort the run instead of respawning agents."""
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -263,22 +264,52 @@ class TestLoopFatalMapping:
         cancellation.request_cancel()
         assert _interruption_reason() == "cancelled_signal"
 
-    def test_raise_on_fatal_cancel_raises_fatal(self):
+    def test_raise_on_fatal_cancel_raises_fatal(self, tmp_path):
         cancellation.request_cancel(reason="provider_fatal:quota: credits gone")
         with pytest.raises(FatalProviderError, match="credits gone"):
-            _raise_on_fatal_cancel()
+            _raise_on_fatal_cancel(tmp_path)
 
-    def test_raise_on_fatal_cancel_raises_breaker_for_streak(self):
+    def test_raise_on_fatal_cancel_raises_breaker_for_streak(self, tmp_path):
         cancellation.request_cancel(reason="agent_failure_streak")
         with pytest.raises(CircuitBreakerError):
-            _raise_on_fatal_cancel()
+            _raise_on_fatal_cancel(tmp_path)
 
-    def test_raise_on_fatal_cancel_noop_without_reason(self):
+    def test_raise_on_fatal_cancel_noop_without_reason(self, tmp_path):
         cancellation.request_cancel()
-        _raise_on_fatal_cancel()
+        _raise_on_fatal_cancel(tmp_path)
 
-    def test_raise_on_fatal_cancel_noop_when_not_cancelled(self):
-        _raise_on_fatal_cancel()
+    def test_raise_on_fatal_cancel_noop_when_not_cancelled(self, tmp_path):
+        _raise_on_fatal_cancel(tmp_path)
+
+    @staticmethod
+    def _write_markers(run_dir, *statuses):
+        evidence = run_dir / "evidence"
+        evidence.mkdir()
+        lines = [
+            json.dumps({"_marker": "file_done", "file": f"f{i}.py", "status": s})
+            for i, s in enumerate(statuses)
+        ]
+        (evidence / "security_evidence.jsonl").write_text(
+            "\n".join(lines) + "\n", encoding="utf-8",
+        )
+
+    def test_partial_success_keeps_run_alive(self, tmp_path):
+        """Quota died halfway: files were analysed, run finalizes as done."""
+        self._write_markers(tmp_path, "ok", "ok", "error")
+        cancellation.request_cancel(reason="provider_fatal:quota: credits gone")
+        _raise_on_fatal_cancel(tmp_path)  # must not raise
+
+    def test_partial_success_keeps_run_alive_for_streak(self, tmp_path):
+        self._write_markers(tmp_path, "ok", "error", "error")
+        cancellation.request_cancel(reason="agent_failure_streak")
+        _raise_on_fatal_cancel(tmp_path)  # must not raise
+
+    def test_error_only_markers_still_fail_the_run(self, tmp_path):
+        """Markers exist but nothing succeeded: the run produced no analysis."""
+        self._write_markers(tmp_path, "error", "error")
+        cancellation.request_cancel(reason="provider_fatal:quota: credits gone")
+        with pytest.raises(FatalProviderError):
+            _raise_on_fatal_cancel(tmp_path)
 
 
 class TestLifecycleMapping:

--- a/tests/analysis/test_fatal_provider_handling.py
+++ b/tests/analysis/test_fatal_provider_handling.py
@@ -1,0 +1,288 @@
+"""Fatal provider errors (quota/auth/billing) abort the run instead of respawning agents."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+import openai
+import pytest
+
+from quodeq.analysis._api_runner import (
+    ApiRunnerConfig,
+    _call_api,
+    _classify_fatal_api_error,
+    run_api_analysis,
+)
+from quodeq.analysis._loops import _interruption_reason, _raise_on_fatal_cancel
+from quodeq.analysis._process import AnalysisError, _check_process_result
+from quodeq.analysis.cache._failure_streak import CircuitBreakerError
+from quodeq.analysis.errors import FatalProviderError, classify_fatal_provider_message
+from quodeq.analysis.subagents._pool_models import SubagentResult
+from quodeq.analysis.subagents._pool_scaling import (
+    check_agent_failure_streak,
+    should_respawn,
+)
+from quodeq.analysis.subagents._pool_worker import WorkerContext, run_single_agent
+from quodeq.analysis.subprocess import AnalysisConfig
+from quodeq.shared import cancellation
+
+
+@pytest.fixture(autouse=True)
+def _reset_cancellation():
+    cancellation.reset()
+    yield
+    cancellation.reset()
+
+
+def _openai_error(cls, status: int, message: str):
+    response = httpx.Response(status, request=httpx.Request("POST", "http://test/v1"))
+    return cls(message, response=response, body=None)
+
+
+class TestClassifyFatalProviderMessage:
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("Error: insufficient_quota for this key", "quota"),
+            ("You exceeded your current quota, please check your plan", "quota"),
+            ("Quota exceeded for quota metric 'requests'", "quota"),
+            ("usage limit reached", "quota"),
+            ("Credit balance is too low", "payment"),
+            ("402 Payment Required", "payment"),
+            ("Invalid API key. Please run /login", "auth"),
+            ("401 Unauthorized", "auth"),
+            ("OAuth token has expired", "auth"),
+        ],
+    )
+    def test_fatal_messages(self, text, expected):
+        assert classify_fatal_provider_message(text) == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "",
+            "connection refused",
+            "model not found",
+            "rate limit exceeded, retry after 20s",
+            "server overloaded, try again",
+        ],
+    )
+    def test_transient_messages(self, text):
+        assert classify_fatal_provider_message(text) is None
+
+
+class TestClassifyFatalApiError:
+    def test_authentication_error_is_fatal(self):
+        exc = _openai_error(openai.AuthenticationError, 401, "invalid key")
+        assert _classify_fatal_api_error(exc)[0] == "auth"
+
+    def test_permission_denied_is_fatal(self):
+        exc = _openai_error(openai.PermissionDeniedError, 403, "forbidden")
+        assert _classify_fatal_api_error(exc)[0] == "auth"
+
+    def test_402_is_fatal_payment(self):
+        exc = _openai_error(openai.APIStatusError, 402, "payment required")
+        assert _classify_fatal_api_error(exc)[0] == "payment"
+
+    def test_429_with_quota_body_is_fatal(self):
+        exc = _openai_error(
+            openai.RateLimitError, 429, "insufficient_quota: check billing"
+        )
+        assert _classify_fatal_api_error(exc)[0] == "quota"
+
+    def test_bare_429_is_transient(self):
+        exc = _openai_error(openai.RateLimitError, 429, "slow down, retry soon")
+        assert _classify_fatal_api_error(exc) is None
+
+    def test_connection_error_is_transient(self):
+        exc = openai.APIConnectionError(request=httpx.Request("POST", "http://test/v1"))
+        assert _classify_fatal_api_error(exc) is None
+
+
+class TestCallApiFatal:
+    def _config(self):
+        return ApiRunnerConfig(
+            model="test-model", api_base="http://localhost:8000/v1", api_key="k",
+        )
+
+    def test_call_api_raises_fatal_on_auth_error(self):
+        client = MagicMock()
+        client.chat.completions.create.side_effect = _openai_error(
+            openai.AuthenticationError, 401, "invalid key"
+        )
+        with patch("quodeq.analysis._api_runner.openai.OpenAI") as mock_oa:
+            mock_oa.return_value.__enter__.return_value = client
+            with pytest.raises(FatalProviderError) as exc_info:
+                _call_api("prompt", self._config())
+        assert exc_info.value.reason == "auth"
+
+    def test_call_api_stays_lossy_on_transient_429(self):
+        client = MagicMock()
+        client.chat.completions.create.side_effect = _openai_error(
+            openai.RateLimitError, 429, "retry shortly"
+        )
+        with patch("quodeq.analysis._api_runner.openai.OpenAI") as mock_oa:
+            mock_oa.return_value.__enter__.return_value = client
+            findings, was_lossy = _call_api("prompt", self._config())
+        assert findings == []
+        assert was_lossy is True
+
+    def test_run_api_analysis_writes_error_markers_then_reraises(self, tmp_path):
+        jsonl_file = tmp_path / "evidence.jsonl"
+        client = MagicMock()
+        client.chat.completions.create.side_effect = _openai_error(
+            openai.AuthenticationError, 401, "invalid key"
+        )
+        with patch("quodeq.analysis._api_runner.openai.OpenAI") as mock_oa:
+            mock_oa.return_value.__enter__.return_value = client
+            with pytest.raises(FatalProviderError):
+                run_api_analysis(
+                    prompt="p", jsonl_file=jsonl_file, config=self._config(),
+                    source_file_paths=["a.py", "b.py"],
+                )
+        text = jsonl_file.read_text()
+        assert text.count('"error"') >= 2
+        assert "fatal provider error (auth)" in text
+
+
+class TestCheckProcessResult:
+    def _process(self, returncode: int) -> subprocess.Popen:
+        process = MagicMock()
+        process.returncode = returncode
+        return process
+
+    def test_quota_stderr_raises_fatal(self, tmp_path):
+        err = tmp_path / "agent.err"
+        err.write_text("Credit balance is too low", encoding="utf-8")
+        with pytest.raises(FatalProviderError) as exc_info:
+            _check_process_result(self._process(1), err)
+        assert exc_info.value.reason == "payment"
+
+    def test_usage_limit_stderr_raises_fatal(self, tmp_path):
+        err = tmp_path / "agent.err"
+        err.write_text("5-hour usage limit reached", encoding="utf-8")
+        with pytest.raises(FatalProviderError) as exc_info:
+            _check_process_result(self._process(1), err)
+        assert exc_info.value.reason == "quota"
+
+    def test_generic_stderr_raises_analysis_error(self, tmp_path):
+        err = tmp_path / "agent.err"
+        err.write_text("segfault or whatever", encoding="utf-8")
+        with pytest.raises(AnalysisError) as exc_info:
+            _check_process_result(self._process(1), err)
+        assert not isinstance(exc_info.value, FatalProviderError)
+
+    def test_zero_exit_does_not_raise(self, tmp_path):
+        _check_process_result(self._process(0), tmp_path / "missing.err")
+
+
+class _FakeQueue:
+    def __init__(self, remaining: int):
+        self._remaining = remaining
+
+    def remaining(self) -> int:
+        return self._remaining
+
+
+class TestSpawnGate:
+    def test_should_respawn_returns_zero_when_cancelled(self, tmp_path):
+        cancellation.request_cancel()
+        assert should_respawn(_FakeQueue(5), tmp_path / "q.json", 0.0, 0) == 0
+
+    def test_should_respawn_returns_remaining_when_not_cancelled(self, tmp_path):
+        assert should_respawn(_FakeQueue(5), tmp_path / "q.json", 0.0, 0) == 5
+
+
+def _result(success: bool, error: str = "") -> SubagentResult:
+    return SubagentResult(
+        agent_id="agent-0", jsonl_file=Path("x.jsonl"),
+        stream_file=Path("x.stream"), success=success, error=error,
+    )
+
+
+class TestAgentFailureStreak:
+    def test_trips_after_default_streak(self):
+        check_agent_failure_streak([_result(False, "boom")] * 5)
+        assert cancellation.is_cancelled()
+        assert cancellation.cancel_reason() == "agent_failure_streak"
+
+    def test_success_resets_streak(self):
+        results = [_result(False)] * 4 + [_result(True)] + [_result(False)] * 4
+        check_agent_failure_streak(results)
+        assert not cancellation.is_cancelled()
+
+    def test_below_threshold_does_not_trip(self):
+        check_agent_failure_streak([_result(False)] * 4)
+        assert not cancellation.is_cancelled()
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("QUODEQ_AGENT_FAILURE_STREAK", "2")
+        check_agent_failure_streak([_result(False)])
+        assert not cancellation.is_cancelled()
+        check_agent_failure_streak([_result(False)] * 2)
+        assert cancellation.is_cancelled()
+
+    def test_zero_disables(self, monkeypatch):
+        monkeypatch.setenv("QUODEQ_AGENT_FAILURE_STREAK", "0")
+        check_agent_failure_streak([_result(False)] * 50)
+        assert not cancellation.is_cancelled()
+
+
+class TestRunSingleAgentFatal:
+    def test_fatal_error_cancels_run_and_returns_failure(self, tmp_path):
+        wctx = WorkerContext(
+            dimension="security", dimension_key="security",
+            evidence_dir=tmp_path, queue_path=tmp_path / "q.json",
+        )
+        with patch(
+            "quodeq.analysis.subagents._pool_worker.run_analysis",
+            side_effect=FatalProviderError("quota gone", reason="quota"),
+        ):
+            result = run_single_agent(0, tmp_path, "prompt", AnalysisConfig(), wctx)
+        assert result.success is False
+        assert "quota gone" in result.error
+        assert cancellation.is_cancelled()
+        assert (cancellation.cancel_reason() or "").startswith("provider_fatal:quota")
+
+
+class TestLoopFatalMapping:
+    def test_interruption_reason_for_fatal_exc(self):
+        assert _interruption_reason(FatalProviderError("x")) == "provider_fatal"
+
+    def test_interruption_reason_from_cancel_reason(self):
+        cancellation.request_cancel(reason="provider_fatal:quota: details")
+        assert _interruption_reason() == "provider_fatal"
+
+    def test_interruption_reason_streak(self):
+        cancellation.request_cancel(reason="agent_failure_streak")
+        assert _interruption_reason() == "agent_failure_streak"
+
+    def test_interruption_reason_plain_cancel(self):
+        cancellation.request_cancel()
+        assert _interruption_reason() == "cancelled_signal"
+
+    def test_raise_on_fatal_cancel_raises_fatal(self):
+        cancellation.request_cancel(reason="provider_fatal:quota: credits gone")
+        with pytest.raises(FatalProviderError, match="credits gone"):
+            _raise_on_fatal_cancel()
+
+    def test_raise_on_fatal_cancel_raises_breaker_for_streak(self):
+        cancellation.request_cancel(reason="agent_failure_streak")
+        with pytest.raises(CircuitBreakerError):
+            _raise_on_fatal_cancel()
+
+    def test_raise_on_fatal_cancel_noop_without_reason(self):
+        cancellation.request_cancel()
+        _raise_on_fatal_cancel()
+
+    def test_raise_on_fatal_cancel_noop_when_not_cancelled(self):
+        _raise_on_fatal_cancel()
+
+
+class TestLifecycleMapping:
+    def test_fatal_provider_error_recognised_by_name(self):
+        from quodeq.shared.run_lifecycle import RunLifecycleContext
+        assert RunLifecycleContext._is_named_error(FatalProviderError, "FatalProviderError")
+        assert not RunLifecycleContext._is_named_error(ValueError, "FatalProviderError")

--- a/tests/services/test_scan_progress_exit_reason.py
+++ b/tests/services/test_scan_progress_exit_reason.py
@@ -34,6 +34,39 @@ def test_scan_progress_includes_exit_reason(tmp_path):
     assert security_dim["exitReason"] == "time_limit"
 
 
+def test_scan_progress_falls_back_to_incomplete_reason(tmp_path):
+    """INCOMPLETE dims store the cause under `reason`, not `exit_reason`."""
+    run = _make_run(tmp_path)
+    (run / "status.json").write_text(json.dumps({
+        "phase": "analyzing", "current_dimension": None,
+        "started_at": "2026-05-23T08:00:00+00:00",
+        "dimensions": ["security"],
+    }), encoding="utf-8")
+    (run / "dimensions.json").write_text(json.dumps({
+        "dimensions": {"security": {"state": "incomplete", "reason": "provider_fatal"}},
+    }), encoding="utf-8")
+    (run / "security_evidence.jsonl").write_text("", encoding="utf-8")
+
+    progress = build_scan_progress("job-1", run, time_limit_s=None)
+    d = progress_to_dict(progress)
+    security_dim = next(x for x in d["dimensions"] if x["id"] == "security")
+    assert security_dim["exitReason"] == "provider_fatal"
+
+
+def test_scan_progress_includes_run_level_exit_reason(tmp_path):
+    run = _make_run(tmp_path)
+    (run / "status.json").write_text(json.dumps({
+        "state": "failed", "exit_reason": "provider_fatal",
+        "phase": "analyzing", "current_dimension": None,
+        "started_at": "2026-05-23T08:00:00+00:00",
+        "dimensions": ["security"],
+    }), encoding="utf-8")
+
+    progress = build_scan_progress("job-1", run, time_limit_s=None)
+    d = progress_to_dict(progress)
+    assert d["exitReason"] == "provider_fatal"
+
+
 def test_scan_progress_omits_exit_reason_when_absent(tmp_path):
     run = _make_run(tmp_path)
     (run / "status.json").write_text(json.dumps({

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -1,7 +1,7 @@
 # Grandfathered layer-import violations. Do NOT add entries without
 # justification -- the goal is to burn this list down, not grow it.
 # Regenerate intentionally: python tools/check_imports.py --update-baseline
-src/quodeq/analysis/subprocess.py:262:llm_bridge
+src/quodeq/analysis/subprocess.py:263:llm_bridge
 src/quodeq/api/_evaluation_routes.py:21:analysis
 src/quodeq/api/import_project.py:31:data
 src/quodeq/api/import_project.py:32:data


### PR DESCRIPTION
When the provider dies mid-run (quota exhausted, out of credits, invalid API key), every agent fails the same way and the pool keeps respawning replacements until the time limit, spamming the console for up to 2 hours. This PR stops the run at the first fatal error, keeps whatever was already analysed, and tells the user why.

## What changed

- Fatal errors are classified at both sources. API path: 401/403/402 typed errors, plus 429 only when the body says quota/credits (a bare 429 stays retryable). CLI path: agent stderr matched against conservative quota/auth/billing patterns (`errors.py`).
- The first fatal error cancels the run through the existing cancellation flag, now with a recorded reason. The spawn gate stops respawning, the API bridge stops dispatching batches, and the incremental loop skips its full-scan fallback.
- Backstop for anything unclassified: 5 consecutive dead agents with no success in between cancel the run. Tunable with `QUODEQ_AGENT_FAILURE_STREAK` (0 disables).
- The UI explains it. Failed runs lead with a label and hint ("AI provider error: quota exhausted, out of credits, or an invalid API key. Check your plan, billing or API key, then run again."), raw log line kept as detail. Dim tooltips and gauge cards use the same mapping; unknown codes still render verbatim.

## Run outcome

Keyed on progress this run made (ok file_done markers, written only by workers, never by cache replays):

- Provider died before any successful analysis: run ends `failed` with `exit_reason: provider_fatal`.
- Provider died after partial progress (e.g. quota gone at 50%): the run keeps its data and ends `done` with the same exit_reason. The evaluation screen shows a warning banner: stopped early, results are partial.
- Time limit is unchanged and stays neutral (it is the user's own setting): no warning, and the tooltip now says remaining files carry over to the next run.

Either way nothing analysed is lost: ok-marked files stay cached, scored dims keep their evaluation files, only unfinished files re-dispatch next run.

## Tests

57 new tests (classification both paths, spawn gate, failure streak, reason mapping, partial-keep decision, progress payload). Full suites green: 5357 pytest, 399 node, 1469 vitest.