### PR TITLE
feat(tooling): import-checker ratchet — cover shared/llm_bridge/ci, strict core+shared, baseline ceiling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,10 +12,10 @@
 | `api/` | HTTP layer: Flask routes, security, rate limiting | core/, services/, update/, assistant/ |
 | `analysis/` | Evaluation pipeline: AI orchestration, subagents, prompts, MCP | core/, engine/, data/, services/, context/ |
 | `dashboard/` | Server/process management: build UI, start API, health checks | services/, api/, update/ |
-| `llm_bridge/` | LLM provider bridge: Ollama, OpenRouter, CLI-tool providers | (not yet covered by import checker) |
+| `llm_bridge/` | LLM provider bridge: Ollama, OpenRouter, CLI-tool providers | (nothing — leaf; one grandfathered analysis import) |
 | `terminal/` | Embedded-terminal PTY backends (Unix pty / Windows ConPTY) + manager | core/ |
 | `update/` | Update-notification subsystem (notify-only; never self-replaces the binary) | None |
-| `ci/` | CI integration: report posting, evidence reading, SARIF export | (not yet covered by import checker) |
+| `ci/` | CI integration: report posting, evidence reading, SARIF export | core/, services/, analysis/, context/ |
 | `context/` | Context enrichment: path-role classification, project shape, precedent fingerprinting | core/, data/, llm_bridge/ |
 | `ui/` | React + Vite dashboard frontend (npm project, served by the Flask API) | n/a (JavaScript) |
 | `shared/` | Cross-cutting utilities: config, logging, env helpers | None (stdlib only) |
@@ -35,11 +35,15 @@ dashboard/     -> services/, api/, update/
 terminal/      -> core/
 update/        -> (nothing)
 context/       -> core/, data/, llm_bridge/
+shared/        -> (nothing; strict — no cross-cutting blanket)
+llm_bridge/    -> (nothing)
+ci/            -> core/, services/, analysis/, context/
 ```
 
 Every checked layer may additionally import stdlib plus the cross-cutting
-`shared/` and `config/` packages. Layers not listed (`llm_bridge/`, `ci/`,
-`ui/`) are not yet covered by the checker.
+`shared/` and `config/` packages. Only `ui/` (JavaScript) and package-root
+modules (`cli.py`, `_cli_*.py`) are outside the checker. `core/` and `shared/`
+are strict: the cross-cutting allowance does not apply to them.
 
 These rules are enforced in CI by `tools/check_imports.py` via `tests/tools/test_import_layers.py`.
 Pre-existing violations are grandfathered in `tools/import_baseline.txt` (a burn-down list: fix

--- a/tests/tools/test_check_imports_rules.py
+++ b/tests/tools/test_check_imports_rules.py
@@ -1,0 +1,43 @@
+"""Unit tests for the layer-rule mechanics in tools/check_imports.py."""
+from __future__ import annotations
+
+import check_imports
+
+
+def test_shared_is_a_checked_layer():
+    assert "shared" in check_imports.LAYER_RULES
+    assert check_imports.LAYER_RULES["shared"] == set()
+
+
+def test_core_and_shared_are_strict():
+    assert check_imports.STRICT_LAYERS == {"core", "shared"}
+
+
+def test_strict_layer_denies_cross_cutting(tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text("from quodeq.shared.utils import read_json\n", encoding="utf-8")
+    violations = check_imports.check_file(f, "core")
+    assert [(lineno, target) for lineno, target, _line in violations] == [(1, "shared")]
+
+
+def test_strict_shared_denies_analysis_and_data(tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text(
+        "from quodeq.analysis._provider_cache import get_provider_configs\n"
+        "import quodeq.data\n",
+        encoding="utf-8",
+    )
+    violations = check_imports.check_file(f, "shared")
+    assert [target for _lineno, target, _line in violations] == ["analysis", "data"]
+
+
+def test_non_strict_layer_still_allows_shared(tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text("from quodeq.shared.utils import read_json\n", encoding="utf-8")
+    assert check_imports.check_file(f, "services") == []
+
+
+def test_shared_may_import_itself(tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text("from quodeq.shared.constants import DEFAULT_TIMEOUT\n", encoding="utf-8")
+    assert check_imports.check_file(f, "shared") == []

--- a/tests/tools/test_check_imports_rules.py
+++ b/tests/tools/test_check_imports_rules.py
@@ -41,3 +41,22 @@ def test_shared_may_import_itself(tmp_path):
     f = tmp_path / "mod.py"
     f.write_text("from quodeq.shared.constants import DEFAULT_TIMEOUT\n", encoding="utf-8")
     assert check_imports.check_file(f, "shared") == []
+
+
+def test_llm_bridge_is_a_leaf_layer():
+    assert check_imports.LAYER_RULES["llm_bridge"] == set()
+
+
+def test_ci_layer_rule():
+    assert check_imports.LAYER_RULES["ci"] == {"core", "services", "analysis", "context"}
+
+
+def test_llm_bridge_may_import_shared_but_not_services(tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text(
+        "from quodeq.shared.utils import read_json\n"
+        "from quodeq.services.jobs import start_job\n",
+        encoding="utf-8",
+    )
+    violations = check_imports.check_file(f, "llm_bridge")
+    assert [target for _lineno, target, _line in violations] == ["services"]

--- a/tests/tools/test_import_layers.py
+++ b/tests/tools/test_import_layers.py
@@ -20,6 +20,21 @@ def test_no_new_import_violations():
     )
 
 
+# Revise DOWNWARD as clean-architecture workstreams burn entries; NEVER raise
+# without a justification reviewed in the PR that raises it.
+BASELINE_CEILING = 35
+
+
+def test_baseline_only_shrinks():
+    """The grandfathered list is a burn-down list, not a dumping ground."""
+    count = len(check_imports.load_baseline())
+    assert count <= BASELINE_CEILING, (
+        f"Baseline grew to {count} entries (ceiling {BASELINE_CEILING}). "
+        "Fix the new import instead of grandfathering it. If growth is truly "
+        "justified, raise BASELINE_CEILING in the same PR and explain why."
+    )
+
+
 def test_baseline_has_no_stale_entries():
     """Fixing a violation must shrink the baseline, keeping it honest."""
     current = {check_imports.violation_key(v) for v in check_imports.collect_violations()}

--- a/tools/check_imports.py
+++ b/tools/check_imports.py
@@ -27,8 +27,15 @@ LAYER_RULES = {
     # context/ compiles cross-run knowledge (precedents, project shape) for the
     # analysis pipeline; llm_bridge access is for the embeddings client only.
     "context": {"core", "data", "llm_bridge"},
+    # shared/ is cross-cutting FOR OTHERS to import; itself it may import
+    # nothing but stdlib (ARCHITECTURE.md: "None (stdlib only)").
+    "shared": set(),
 }
 CROSS_CUTTING = {"shared", "config"}
+# Strict layers get NO blanket cross-cutting allowance: core/ must not import
+# shared/config (burn-down: WS4 of the clean-architecture roadmap), and
+# shared/ must not import anything. Grandfathered cases live in the baseline.
+STRICT_LAYERS = {"core", "shared"}
 IMPORT_RE = re.compile(
     r"^\s*(?:from\s+quodeq\.(\w+)|import\s+quodeq\.(\w+))"
 )
@@ -46,7 +53,9 @@ def source_layer(path: Path) -> str | None:
 def check_file(path: Path, layer: str) -> list[tuple[int, str, str]]:
     """Return list of (lineno, target_layer, line) violations."""
     violations = []
-    allowed = LAYER_RULES[layer] | CROSS_CUTTING | {layer}
+    allowed = LAYER_RULES[layer] | {layer}
+    if layer not in STRICT_LAYERS:
+        allowed |= CROSS_CUTTING
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except (OSError, UnicodeDecodeError) as e:

--- a/tools/check_imports.py
+++ b/tools/check_imports.py
@@ -30,6 +30,12 @@ LAYER_RULES = {
     # shared/ is cross-cutting FOR OTHERS to import; itself it may import
     # nothing but stdlib (ARCHITECTURE.md: "None (stdlib only)").
     "shared": set(),
+    # llm_bridge talks to LLM providers only; app knowledge flows TO it, not
+    # from it. Its one analysis import is grandfathered (burn-down: WS2/WS5).
+    "llm_bridge": set(),
+    # ci/ is a delivery mechanism (like api/): it may orchestrate services and
+    # read evaluation output, but nothing imports ci/.
+    "ci": {"core", "services", "analysis", "context"},
 }
 CROSS_CUTTING = {"shared", "config"}
 # Strict layers get NO blanket cross-cutting allowance: core/ must not import

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -8,6 +8,11 @@ src/quodeq/api/import_project.py:32:data
 src/quodeq/api/import_project.py:33:data
 src/quodeq/api/llm_bridge_routes.py:8:llm_bridge
 src/quodeq/api/routes_project_list.py:275:analysis
+src/quodeq/core/evidence/_jsonl.py:13:shared
+src/quodeq/core/evidence/parser.py:9:shared
+src/quodeq/core/standards/loader.py:10:shared
+src/quodeq/core/standards/loader.py:9:shared
+src/quodeq/core/standards/refs.py:16:shared
 src/quodeq/data/fs/project_resolver.py:17:services
 src/quodeq/data/fs/repo_clone.py:19:context
 src/quodeq/data/fs/report_parser/runs.py:190:services
@@ -25,3 +30,6 @@ src/quodeq/services/evaluation_mixin.py:540:analysis
 src/quodeq/services/jobs.py:20:analysis
 src/quodeq/services/scan_progress.py:23:analysis
 src/quodeq/services/tooling_mixin.py:17:analysis
+src/quodeq/shared/prereqs.py:10:analysis
+src/quodeq/shared/project_resolver.py:2:data
+src/quodeq/shared/repo_handler.py:2:data

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -8,6 +8,8 @@ src/quodeq/api/import_project.py:32:data
 src/quodeq/api/import_project.py:33:data
 src/quodeq/api/llm_bridge_routes.py:8:llm_bridge
 src/quodeq/api/routes_project_list.py:275:analysis
+src/quodeq/ci/review.py:129:cli_parser
+src/quodeq/ci/review.py:147:_cli_evaluation
 src/quodeq/core/evidence/_jsonl.py:13:shared
 src/quodeq/core/evidence/parser.py:9:shared
 src/quodeq/core/standards/loader.py:10:shared
@@ -21,6 +23,7 @@ src/quodeq/data/projection/grade_projector.py:132:services
 src/quodeq/data/projection/grade_projector.py:20:services
 src/quodeq/data/sqlite/state_store.py:272:services
 src/quodeq/engine/scoring_pipeline.py:10:services
+src/quodeq/llm_bridge/_providers.py:6:analysis
 src/quodeq/services/_external_jobs.py:22:analysis
 src/quodeq/services/_violations_jsonl.py:12:analysis
 src/quodeq/services/_violations_stream.py:10:analysis


### PR DESCRIPTION
First PR of the clean-architecture alignment effort (WS8 of 8 workstreams). Pure tooling: no runtime code changes.

## What

- **`shared/` is now a checked layer** and, together with `core/`, is **strict**: the blanket cross-cutting allowance (`shared`/`config`) no longer applies to them. `core -> shared` and `shared -> anything` are violations from now on.
- **`llm_bridge/` and `ci/` are now covered** (`llm_bridge` as a leaf; `ci` may use `core/services/analysis/context`).
- **Baseline ceiling test** (`test_baseline_only_shrinks`, ceiling = 35): the grandfathered list can only shrink; growing it requires editing the ceiling in the same PR with justification.
- `ARCHITECTURE.md` synced with the new rules.

## Newly grandfathered entries (the burn-down list)

| Entry | Burn-down |
|---|---|
| `core/evidence/_jsonl.py:13:shared`, `core/evidence/parser.py:9`, `core/standards/loader.py:9-10`, `core/standards/refs.py:16` | WS4 (purify core) |
| `shared/prereqs.py:10:analysis` | WS3 (rehome Run aggregate / clean shared) |
| `shared/project_resolver.py:2:data`, `shared/repo_handler.py:2:data` | WS7 (delete forwarders) |
| `llm_bridge/_providers.py:6:analysis` | WS2/WS5 |
| `ci/review.py:129:cli_parser`, `ci/review.py:147:_cli_evaluation` | **new find** — coverage exposed the CI layer importing package-root CLI internals; not in the original friction report |

24 -> 35 entries is coverage growth, not regression: every added entry is a pre-existing import that was previously invisible to the checker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)