### PR TITLE
refactor: serialization-boundary ratchet (WS6)

### DIFF
--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -22,7 +22,7 @@ from quodeq.analysis._provider_cache import get_provider_configs
 from quodeq.api.routes import _reports_dir
 from quodeq.services.base import ActionProvider
 from quodeq.services.evaluation_mixin import _score_completed_evidence
-from quodeq.services.scan_progress import build_scan_progress, progress_to_dict
+from quodeq.services.scan_progress import build_scan_progress
 from quodeq.services.run_events import read_dimensions
 from quodeq.shared.utils import is_repo_url
 
@@ -229,7 +229,7 @@ def register_evaluation_item_routes(app: Flask, provider: ActionProvider) -> Non
         if progress is None:
             body, status = error_response("Run not ready", HTTPStatus.NOT_FOUND, "NOT_FOUND")
             return jsonify(body), status
-        return jsonify(to_camel_dict(progress_to_dict(progress)))
+        return jsonify(to_camel_dict(progress))
 
     @app.delete("/api/evaluations/<job_id>")
     def cancel_or_delete_evaluation(job_id: str) -> Response | tuple[Response, int]:

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -451,18 +451,3 @@ def build_scan_progress(
         exit_reason=status.get("exit_reason"),
         dimensions=dim_results,
     )
-
-
-def progress_to_dict(progress: _ScanProgress) -> dict:
-    """Serialize the dataclass tree to a camelCase dict for jsonify.
-
-    Uses to_camel_dict so dataclass field names like ``exit_reason`` and
-    ``estimate_reason`` become ``exitReason`` and ``estimateReason`` in the
-    JSON the client sees. The route still wraps the result in to_camel_dict;
-    that second pass is a no-op for already-camelCased dicts.
-    """
-    from quodeq.core.types import to_camel_dict
-    result = to_camel_dict(progress)
-    if not isinstance(result, dict):
-        return {}
-    return result

--- a/tests/services/test_scan_progress.py
+++ b/tests/services/test_scan_progress.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from quodeq.services.scan_progress import build_scan_progress, progress_to_dict
+from quodeq.core.types import to_camel_dict
+from quodeq.services.scan_progress import build_scan_progress
 
 
 def _write_status(run_dir: Path, *, dimensions: list[str], state: str = "running",
@@ -322,7 +323,7 @@ class TestCoverageFields:
         )
 
         progress = build_scan_progress("j1", run_dir)
-        payload = progress_to_dict(progress)
+        payload = to_camel_dict(progress)
         dim = payload["dimensions"][0]
         assert dim["filesCached"] == 80
         assert dim["filesProjectTotal"] == 100

--- a/tests/services/test_scan_progress_exit_reason.py
+++ b/tests/services/test_scan_progress_exit_reason.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from quodeq.services.scan_progress import build_scan_progress, progress_to_dict
+from quodeq.core.types import to_camel_dict
+from quodeq.services.scan_progress import build_scan_progress
 
 
 def _make_run(tmp_path: Path) -> Path:
@@ -29,7 +30,7 @@ def test_scan_progress_includes_exit_reason(tmp_path):
     (run / "security_evidence.jsonl").write_text("", encoding="utf-8")
 
     progress = build_scan_progress("job-1", run, time_limit_s=None)
-    d = progress_to_dict(progress)
+    d = to_camel_dict(progress)
     security_dim = next(x for x in d["dimensions"] if x["id"] == "security")
     assert security_dim["exitReason"] == "time_limit"
 
@@ -48,7 +49,7 @@ def test_scan_progress_falls_back_to_incomplete_reason(tmp_path):
     (run / "security_evidence.jsonl").write_text("", encoding="utf-8")
 
     progress = build_scan_progress("job-1", run, time_limit_s=None)
-    d = progress_to_dict(progress)
+    d = to_camel_dict(progress)
     security_dim = next(x for x in d["dimensions"] if x["id"] == "security")
     assert security_dim["exitReason"] == "provider_fatal"
 
@@ -63,7 +64,7 @@ def test_scan_progress_includes_run_level_exit_reason(tmp_path):
     }), encoding="utf-8")
 
     progress = build_scan_progress("job-1", run, time_limit_s=None)
-    d = progress_to_dict(progress)
+    d = to_camel_dict(progress)
     assert d["exitReason"] == "provider_fatal"
 
 
@@ -80,6 +81,6 @@ def test_scan_progress_omits_exit_reason_when_absent(tmp_path):
     (run / "security_evidence.jsonl").write_text("", encoding="utf-8")
 
     progress = build_scan_progress("job-1", run, time_limit_s=None)
-    d = progress_to_dict(progress)
+    d = to_camel_dict(progress)
     security_dim = next(x for x in d["dimensions"] if x["id"] == "security")
     assert security_dim.get("exitReason") is None

--- a/tests/tools/test_serialization_boundary.py
+++ b/tests/tools/test_serialization_boundary.py
@@ -1,0 +1,63 @@
+"""Serialization-boundary ratchet: to_camel_dict belongs at wire boundaries.
+
+``to_camel_dict`` produces the JSON wire format. The HTTP routes in ``api/``
+are the canonical wire boundary; every other use must be a DECLARED boundary
+listed below with its reason. The test fails when a new undeclared use
+appears (fix: serialize at the route instead) and when a declared file no
+longer uses it (fix: delete the entry — the list only shrinks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parent.parent.parent / "src" / "quodeq"
+
+# Relative to src/quodeq. Every entry is a wire boundary that is NOT an HTTP
+# route, with the reason it serializes. Burn-down candidates are marked.
+DECLARED_WIRE_BOUNDARIES: dict[str, str] = {
+    "core/types/_serialization.py": "defines the serializer",
+    "core/types/__init__.py": "re-exports the serializer",
+    "assistant/tools/_read_tools.py": "assistant tool output is its own wire (LLM-facing)",
+    "analysis/_report_scoring.py": "dimension report files on disk are camelCase (stored contract)",
+    "data/fs/report_parser/_eval_parsing.py": "parses stored camelCase findings back out (stored contract)",
+    "services/accumulated.py": "payload feeds both routes and the persisted score cache — burn-down: WS5/scoring reader",
+    "services/rescore.py": "envelope consumed by routes AND services/scoring — burn-down: WS5/scoring reader",
+    "services/_projects_cache.py": "cache stores the final wire payload it serves",
+    "services/dashboard.py": "run-dim LRU stores wire payloads — burn-down: WS5/scoring reader",
+    "services/_fs_reports.py": "violation responses cached in wire shape — burn-down: WS5",
+    "services/scoring/__init__.py": "scoring payloads flow into SSE + caches in wire shape — burn-down: WS5/scoring reader",
+}
+
+
+def _files_using_to_camel_dict() -> set[str]:
+    out: set[str] = set()
+    for py in SRC_ROOT.rglob("*.py"):
+        rel = py.relative_to(SRC_ROOT).as_posix()
+        if rel.startswith("api/"):
+            continue
+        try:
+            text = py.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if "to_camel_dict" in text:
+            out.add(rel)
+    return out
+
+
+def test_no_undeclared_serialization_outside_routes():
+    used = _files_using_to_camel_dict()
+    undeclared = sorted(used - set(DECLARED_WIRE_BOUNDARIES))
+    assert undeclared == [], (
+        "to_camel_dict used outside api/ in undeclared file(s). Serialize at "
+        "the route instead, or (only for a genuine non-HTTP wire boundary) "
+        "add a declared entry with its reason:\n" + "\n".join(undeclared)
+    )
+
+
+def test_declared_boundaries_are_not_stale():
+    used = _files_using_to_camel_dict()
+    stale = sorted(set(DECLARED_WIRE_BOUNDARIES) - used)
+    assert stale == [], (
+        "Declared wire boundaries no longer use to_camel_dict — delete their "
+        "entries (the list only shrinks):\n" + "\n".join(stale)
+    )


### PR DESCRIPTION
WS6 of the clean-architecture alignment (stacked on #952 -> #951 -> #950 -> #949 -> #948 -> #947; **retarget base when parents merge**).

## Why this shape instead of a wholesale sweep

Scouting changed the plan. `to_camel_dict` on a plain dict passes keys through unchanged (only dataclasses are converted), so route-level wraps are idempotent — but the remaining service-level call sites are not merely route-bound: they feed the persisted score cache, the run-dim LRU, the projects cache, and SSE payloads, all of which store wire-shaped data by design. Ripping serialization out of those paths wholesale is exactly the cache-shape regression class this codebase's history warns about. So WS6 delivers the invariant as an **enforced ratchet with declared exceptions**, mirroring the import baseline:

- **`tests/tools/test_serialization_boundary.py`** — any `to_camel_dict` outside `api/` must be a declared wire boundary with a written reason; undeclared uses fail CI, and stale declarations must be deleted (the list only shrinks). Five entries are explicitly marked as WS5 burn-down candidates (they dissolve when the scoring reader/use-case work lands).
- **Fixed the one documented double-serialization**: `progress_to_dict` is deleted; the scan-progress route serializes the dataclass once. Service tests now assert against `to_camel_dict` directly.

Declared non-HTTP wire boundaries (with reasons in the test): assistant tool output, dimension report files on disk, stored-findings parsing, and the cache/SSE-entangled scoring paths.

Full suite: 5331 passed / 1 skipped (+2: the ratchet's own tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)