### PR TITLE
fix(cache): heal accumulated rows poisoned before the partial-dim guards

### DIFF
--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -364,8 +364,12 @@ def accumulated_cache_version(
         # only status-independent scoped versions and lost that guard). v5:
         # dimensions are no longer scoped to the last-5-runs configured
         # standard; payloads written with scoping omit dimensions whose last
-        # valid run is older and must rebuild.
-        "algo": 5,
+        # valid run is older and must rebuild. v6: heal rows poisoned before
+        # PR #924's partial-dim guards — a mid-run partial rescore persisted
+        # under algo 5 hashes identically to a correct recompute, so without
+        # this bump it is served forever (tests/services/
+        # test_accumulated_version_heals_poison.py pins the keyspace exit).
+        "algo": 6,
         "params": _params_fingerprint(params),
         "runs": sorted(list(t) for t in run_versions),
         "as_of": as_of or "",

--- a/tests/services/test_accumulated_partial_not_persisted.py
+++ b/tests/services/test_accumulated_partial_not_persisted.py
@@ -1,0 +1,85 @@
+"""The persist gate: a partial accumulated rescore must never enter the cache.
+
+End-to-end mutation cover for the ``cacheable=lambda: rescore_complete[0]``
+gate in ``get_project_scores`` (added with PR #924's guards but previously
+untested — neutralizing it left the whole suite green). The scenario is the
+2026-07-29 production incident: a rescore that covers only a subset of a
+run's dimensions may be SERVED once, but persisting it makes the partial
+payload a permanent cache hit that survives run completion.
+
+The assertion is on the persist call itself (``write_cached_accumulated``),
+not on score values: the shared fixtures bake no findings, so a poisoned and
+a correct payload can be score-identical — the write is the only reliable
+observable.
+"""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.services import score_cache, scoring
+from quodeq.services.dashboard import clear_shared_dimension_cache
+from quodeq.services.dismissed import dismiss_finding
+from quodeq.services.scoring import get_project_scores
+from tests.services._scalar_fixtures import build_projected_run
+
+
+@pytest.fixture(autouse=True)
+def _fresh_lru():
+    clear_shared_dimension_cache()
+    yield
+    clear_shared_dimension_cache()
+
+
+@pytest.fixture()
+def project(tmp_path):
+    reports = tmp_path / "evaluations"
+    build_projected_run(
+        reports, "proj", "20260101T000000",
+        {"security": (7.0, "Fair"), "performance": (6.0, "Adequate")},
+    )
+    # An active dismissal engages the rescore path (complete=True otherwise).
+    dismiss_finding(reports / "proj", {"req": "R1", "file": "a.py", "line": 1})
+    return reports
+
+
+@pytest.fixture()
+def persist_spy(monkeypatch):
+    calls: list = []
+    real_write = score_cache.write_cached_accumulated
+
+    def spying_write(conn, project_name, version, payload):
+        calls.append(version)
+        return real_write(conn, project_name, version, payload)
+
+    monkeypatch.setattr(score_cache, "write_cached_accumulated", spying_write)
+    return calls
+
+
+def test_partial_rescore_is_served_but_not_persisted(project, monkeypatch, persist_spy):
+    real = scoring._rescore_runs_by_dimension
+
+    def partial(dims, reports_root, project_name, dismissed, deleted=None, params=None):
+        full = real(dims, reports_root, project_name, dismissed, deleted, params=params)
+        # Simulate the incident: only the first-finished dimension came back.
+        return {k: v for k, v in full.items() if k == "security"}
+
+    monkeypatch.setattr(scoring, "_rescore_runs_by_dimension", partial)
+
+    payload = get_project_scores(project, "proj")
+
+    assert payload is not None, "partial coverage must degrade to serving, not erroring"
+    assert persist_spy == [], (
+        "a rescore that covered 1 of 2 dimensions was persisted to the "
+        "accumulated cache — it will be served forever (the 2026-07-29 bug)"
+    )
+
+
+def test_complete_rescore_is_persisted(project, persist_spy):
+    """The discriminating arm: the same flow WITH full coverage does persist."""
+    payload = get_project_scores(project, "proj")
+
+    assert payload is not None
+    assert len(persist_spy) == 1, (
+        "a fully-covered rescore should be written to the accumulated cache "
+        "exactly once — if this stopped happening the gate is over-blocking"
+    )

--- a/tests/services/test_accumulated_version_heals_poison.py
+++ b/tests/services/test_accumulated_version_heals_poison.py
@@ -1,0 +1,45 @@
+"""Regression pin: the accumulated-cache algo salt must invalidate pre-#924 rows.
+
+The 2026-07-29 partial-dim-set fix (PR #924) added the staleness guards and
+the ``cacheable=`` persist gate, but did NOT bump the algo salt. Any
+accumulated row poisoned BEFORE that fix (a mid-run partial dim list rescored
+and persisted — see the 2026-07-29 live diagnosis) still hashes to the same
+version as a correct recompute, so it is served forever and never self-heals.
+
+Bumping the salt is the healing mechanism: every pre-bump row misses on its
+next read and is recomputed under the guards. The literal below is the exact
+algo-5 hash for this fixed input; if a refactor ever reverts the salt (or
+otherwise reproduces the algo-5 keyspace), this test fails.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from quodeq.core.scoring.params import DEFAULT_PARAMS
+from quodeq.services.score_cache import accumulated_cache_version
+
+# accumulated_cache_version() output for the input below under algo 5 —
+# the keyspace in which poisoned pre-#924 rows live.
+_ALGO5_HASH = "24c0a1de1b6ecbdfd056dfe5f80ba7876d1e9815babb450dec729d47d53bc09b"
+
+_FIXED_INPUT = (
+    Path("/tmp/does-not-matter"),
+    DEFAULT_PARAMS,
+    [("run-a", "complete", "scoped-v-1")],
+    None,
+)
+
+
+def test_version_left_the_algo5_keyspace():
+    """Rows persisted under algo 5 (incl. poisoned ones) must never hit again."""
+    current = accumulated_cache_version(*_FIXED_INPUT)
+    assert current != _ALGO5_HASH, (
+        "accumulated_cache_version reproduces the algo-5 keyspace: rows "
+        "poisoned before PR #924's guards would be served again. Bump the "
+        "algo salt in score_cache.py instead of reverting it."
+    )
+
+
+def test_version_is_deterministic():
+    """The healing bump must not accidentally make the version non-deterministic."""
+    assert accumulated_cache_version(*_FIXED_INPUT) == accumulated_cache_version(*_FIXED_INPUT)


### PR DESCRIPTION
Closes the remaining gap in the 2026-07-29 dim-cache-poison incident (Overview stuck on RAW grades while detail pages showed dismiss-adjusted ones).

## What the investigation found

PR #924 already shipped three of the four needed defenses: the in-progress bypass and stale-count eviction in the shared LRU fetcher, the coverage tracking in `_rescore_accumulated_with_coverage`, and the `cacheable=` persist gate in `get_project_scores`. Two gaps remained:

1. **No healing for rows poisoned before the guards existed.** The salt stayed at `algo: 5`, so a pre-#924 poisoned row (like the one diagnosed live on 2026-07-29 at 07:38, hours before the fix merged at 12:01) hashes identically to a correct recompute — a permanent cache hit. **Bumping to `algo: 6` flushes the entire pre-guard keyspace on next read.** Every affected install self-heals on upgrade; no manual sqlite surgery.
2. **The persist gate was untested.** Mutation check: replacing `cacheable=lambda: rescore_complete[0]` with `lambda: True` left the whole suite green. The other two guards passed their mutation checks (1 failure each); this one had nothing.

## Changes

- `algo: 5 -> 6` with the healing rationale in the version comment
- `test_accumulated_version_heals_poison.py` — pins the exact algo-5 hash for a fixed input and asserts the version has left that keyspace (fails if the salt is ever reverted)
- `test_accumulated_partial_not_persisted.py` — spy on `write_cached_accumulated`: a 1-of-2-dims rescore must be served but never persisted; the complete-coverage arm must persist exactly once. Verified two-sided: passes on real code, fails with the gate neutralized.

Deliberately NOT addressed here: the retired-dimension ghost (`dimensionCount: 7` incl. `clean-architecture` vs the Overview's 6) noted in the same diagnosis — that's the possible Bug-A regression from the v5 unscoping change and deserves its own investigation.

Full suite: 5335 passed / 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)