### PR TITLE
fix(lifecycle): watchdog deadline-kills are time-limit exits, not cancels

### DIFF
--- a/src/quodeq/analysis/run_lifecycle.py
+++ b/src/quodeq/analysis/run_lifecycle.py
@@ -230,12 +230,50 @@ class RunLifecycleContext:
     def _is_circuit_breaker_error(exc_type: type[BaseException] | None) -> bool:
         return RunLifecycleContext._is_named_error(exc_type, "CircuitBreakerError")
 
+    def _deadline_has_passed(self) -> bool:
+        """True when the run's own deadline is set and already behind us."""
+        if not self._deadline_at:
+            return False
+        try:
+            deadline = datetime.fromisoformat(self._deadline_at)
+        except (TypeError, ValueError):
+            return False
+        if deadline.tzinfo is None:
+            deadline = deadline.replace(tzinfo=timezone.utc)
+        return datetime.now(timezone.utc) >= deadline
+
+    def _mark_running_dims_incomplete(self, reason: str) -> None:
+        """Flip still-running dims to INCOMPLETE so none sticks at 'running' forever."""
+        from quodeq.data.fs.dimensions_state_store import (  # noqa: PLC0415 — signal path
+            DimState,
+            read_dimensions,
+            write_dim_state,
+        )
+        try:
+            entries = read_dimensions(self._run_dir).get("dimensions", {})
+        except Exception:  # noqa: BLE001 — a failing flip must not mask the exit
+            return
+        for dim, entry in entries.items():
+            if isinstance(entry, dict) and entry.get("state") == "running":
+                try:
+                    write_dim_state(self._run_dir, dim, DimState.INCOMPLETE, reason=reason)
+                except Exception as exc:  # noqa: BLE001
+                    _logger.warning("failed to mark dim %s incomplete: %s", dim, exc)
+
     def _install_signal_handlers(self) -> None:
         def _handle(signum: int, frame: Any) -> None:
             try:
                 name = signal.Signals(signum).name
             except ValueError:
                 name = f"signal_{signum}"
+            # A signal landing AFTER the run's own deadline is the watchdog
+            # enforcing the time budget (SIGTERM at deadline+grace), not a
+            # user cancel. Label it "deadline" — the UI maps that to "time
+            # limit reached", not an error — and close out running dims. The
+            # state stays CANCELLED either way: salvage scoring triggers key
+            # off terminal failed/cancelled and must keep firing.
+            deadline_enforced = self._deadline_has_passed()
+            exit_reason = "deadline" if deadline_enforced else f"signal_{name}"
             # Signal worker threads (subagent pool, AI CLI subprocess monitors)
             # to stop waiting on long-running operations and terminate promptly.
             cancellation.request_cancel()
@@ -250,13 +288,15 @@ class RunLifecycleContext:
                 dimensions=self._dimensions,
                 phase=self._phase,
                 current_dimension=self._current_dimension,
-                exit_reason=f"signal_{name}",
+                exit_reason=exit_reason,
                 deadline_at=self._deadline_at,
                 ai_provider=self._ai_provider,
                 ai_model=self._ai_model,
                 time_limit_s=self._time_limit_s,
             )
             self._current_state = RunState.CANCELLED
+            if deadline_enforced:
+                self._mark_running_dims_incomplete("time_limit")
             raise SystemExit(128 + signum)
 
         for sig in _SIGNALS_TO_HANDLE:

--- a/tests/analysis/test_run_lifecycle.py
+++ b/tests/analysis/test_run_lifecycle.py
@@ -277,3 +277,57 @@ def test_lifecycle_context_threads_provider_to_status(tmp_path: Path) -> None:
     data = read_status(tmp_path)
     assert data["ai_provider"] == "ollama"
     assert data["ai_model"] == "gemma4:26b-mlx"
+
+
+@_POSIX_SIGNALS
+def test_sigterm_after_deadline_labels_time_limit_not_cancel(tmp_path: Path) -> None:
+    """The watchdog enforcing the run's own time limit is not a user cancel.
+
+    2026-07-31 incident: a 5-min-limit run drained its in-flight agent past
+    deadline+grace, the JobManager watchdog SIGTERMed it, and the handler
+    wrote ``cancelled/signal_SIGTERM`` — the UI showed a cancelled ERROR for
+    a run that ended exactly as budgeted. When the deadline has passed, the
+    signal must be recorded as ``deadline`` (UI: "time limit reached", not an
+    error) and running dims must flip to INCOMPLETE instead of sticking at
+    ``running`` forever. State stays ``cancelled``: the salvage-scoring
+    triggers key off terminal failed/cancelled and must keep firing.
+    """
+    import os
+    from datetime import datetime, timedelta, timezone
+
+    from quodeq.data.fs.dimensions_state_store import DimState, read_dimensions, write_dim_state
+
+    past = (datetime.now(timezone.utc) - timedelta(seconds=90)).isoformat()
+    with pytest.raises(SystemExit):
+        with RunLifecycleContext(
+            run_dir=tmp_path, job_id="ext-deadline", dimensions=["clean-architecture"],
+        ) as ctx:
+            ctx.set_deadline(past)
+            write_dim_state(tmp_path, "clean-architecture", DimState.RUNNING)
+            os.kill(os.getpid(), signal.SIGTERM)
+
+    status = read_status(tmp_path)
+    assert status["state"] == "cancelled"
+    assert status["exit_reason"] == "deadline"
+    entry = read_dimensions(tmp_path)["dimensions"]["clean-architecture"]
+    assert entry["state"] == "incomplete"
+    assert entry["reason"] == "time_limit"
+
+
+@_POSIX_SIGNALS
+def test_sigterm_before_deadline_stays_a_real_cancel(tmp_path: Path) -> None:
+    """A SIGTERM while the deadline is still ahead is a genuine user cancel."""
+    import os
+    from datetime import datetime, timedelta, timezone
+
+    future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+    with pytest.raises(SystemExit):
+        with RunLifecycleContext(
+            run_dir=tmp_path, job_id="ext-user-cancel", dimensions=["security"],
+        ) as ctx:
+            ctx.set_deadline(future)
+            os.kill(os.getpid(), signal.SIGTERM)
+
+    status = read_status(tmp_path)
+    assert status["state"] == "cancelled"
+    assert status["exit_reason"] == "signal_SIGTERM"


### PR DESCRIPTION
Fixes the 2026-07-31 incident: a 5-minute-limit run drained its in-flight Gemma agent past deadline+60s grace, the JobManager watchdog SIGTERMed it, and the lifecycle handler recorded `cancelled/signal_SIGTERM` — the UI showed a cancelled ERROR for a run that ended exactly as budgeted, and its dimension stuck at `running` in dimensions.json forever.

## Change

In the lifecycle signal handler: if the run's own `deadline_at` has already passed when SIGTERM/SIGINT arrives, record `exit_reason="deadline"` (the UI's exit-reason map renders that as "time limit reached" with a carry-over hint — explicitly not an error) and flip still-running dims to `INCOMPLETE(time_limit)`. A signal arriving BEFORE the deadline stays `signal_*` — a genuine user cancel must never be relabeled.

Deliberately unchanged: `state` stays `cancelled`. The salvage-scoring triggers (status-GET on failed/cancelled jobs, the cancel path) key off terminal failed/cancelled and must keep firing so partial evidence still gets scored — which is exactly what saved the incident run's 204 findings.

TDD: both tests written first and watched fail (deadline-passed case) / pass (user-cancel guard case).

## Discovered while diagnosing — separate bug, not fixed here

Run `d8f96511` (today 21:38 UTC): user limit 60s, the pool auto-scaled its working budget to 7200s for 838 files ("Time limit auto-scaled: 60s → 7200s"), but the run-level `deadline_at` stayed at start+60s — so the watchdog killed a perfectly healthy 2-minute-old run whose own pool believed it had 2 hours. The auto-scale and the watchdog disagree about the budget; they must share one number. Filing as follow-up.

Full suite: 5337 passed / 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)