### PR TITLE
fix(analysis): scale local-API read timeout with subagent count

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -140,6 +140,34 @@ class ApiRunnerConfig:
     temperature: float = 0.1
     max_tokens: int | None = None
     context_size: int = 0
+    n_subagents: int = 1
+    """Pool size this call competes with; scales the local read timeout."""
+
+
+def _resolve_timeout(config: ApiRunnerConfig, *, is_openai: bool) -> httpx.Timeout:
+    """Read budget for one completion call.
+
+    Local servers serve one request per loaded model, so with N subagents a
+    queued request can wait up to (N-1) inferences before its own starts:
+    a fixed budget times out queued-but-healthy calls, and each timeout burns
+    the whole budget for zero findings. Scale the read budget linearly with N.
+    Cloud backends parallelize, so their budget stays fixed.
+    QUODEQ_API_READ_TIMEOUT (whole seconds) overrides the read budget outright.
+    """
+    base = _CLOUD_TIMEOUT if is_openai else _LOCAL_TIMEOUT
+    env_val = os.environ.get("QUODEQ_API_READ_TIMEOUT", "").strip()
+    if env_val.isdigit() and int(env_val) > 0:
+        return httpx.Timeout(
+            connect=base.connect, read=float(env_val),
+            write=base.write, pool=base.pool,
+        )
+    scale = max(1, config.n_subagents)
+    if is_openai or scale == 1:
+        return base
+    return httpx.Timeout(
+        connect=base.connect, read=base.read * scale,
+        write=base.write, pool=base.pool,
+    )
 
 
 # A dict that fails `_Finding` validation but carries the required, domain-specific
@@ -313,7 +341,7 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
     if config.max_tokens is not None:
         create_kwargs["max_tokens"] = config.max_tokens
 
-    timeout = _CLOUD_TIMEOUT if is_openai else _LOCAL_TIMEOUT
+    timeout = _resolve_timeout(config, is_openai=is_openai)
     _log.debug("Calling %s model=%s (per-finding parse)", config.api_base, config.model)
     start = time.monotonic()
     with openai.OpenAI(

--- a/src/quodeq/analysis/_pipeline.py
+++ b/src/quodeq/analysis/_pipeline.py
@@ -27,11 +27,12 @@ def _warn_if_local_api_oversubscribed(config: RunConfig) -> None:
     """Warn when subagents will queue behind one local-API inference slot.
 
     Local model servers (Ollama, llama.cpp, omlx) default to serving one
-    request per loaded model. With ``--n-subagents > 1`` the second agent
-    queues behind the first and typically exceeds the read timeout, surfacing
-    as silent timeouts. The fix is either ``--n-subagents 1`` or raising the
-    server's parallelism (e.g. ``OLLAMA_NUM_PARALLEL``). Cloud API providers
-    don't have this constraint, so we narrow the warning to loopback bases.
+    request per loaded model, so with ``--n-subagents > 1`` the extra agents
+    queue behind the first. The read timeout scales with the subagent count
+    (see ``_api_runner._resolve_timeout``) so queued calls no longer die, but
+    throughput is still capped at the server's parallelism until it is raised
+    (e.g. ``OLLAMA_NUM_PARALLEL``). Cloud API providers don't have this
+    constraint, so we narrow the warning to loopback bases.
     """
     if config.options.max_subagents <= 1:
         return
@@ -43,11 +44,10 @@ def _warn_if_local_api_oversubscribed(config: RunConfig) -> None:
         return
     log_warning(
         f"--n-subagents={config.options.max_subagents} with local provider "
-        f"'{ai_cmd}' will likely time out: local model servers serve one "
-        f"request per model by default, so subagents queue and the second "
-        f"exceeds the read timeout. Use --n-subagents 1 or raise the "
-        f"server's parallelism (e.g. OLLAMA_NUM_PARALLEL="
-        f"{config.options.max_subagents})."
+        f"'{ai_cmd}': local model servers serve one request per model by "
+        f"default, so subagents queue and add little throughput. To run "
+        f"them truly in parallel, raise the server's parallelism (e.g. "
+        f"OLLAMA_NUM_PARALLEL={config.options.max_subagents})."
     )
 
 

--- a/src/quodeq/analysis/subprocess.py
+++ b/src/quodeq/analysis/subprocess.py
@@ -441,6 +441,13 @@ def _run_api_analysis_bridge(
                 api_base=api_base,
                 api_key=api_key,
                 context_size=cfg.context_size,
+                n_subagents=max(
+                    1,
+                    getattr(
+                        getattr(cfg.run_config, "options", None),
+                        "max_subagents", 1,
+                    ),
+                ),
             ),
             compiled_dir=cfg.compiled_dir,
             dimension=cfg.dimension,

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -59,6 +59,67 @@ def api_config():
     )
 
 
+class TestResolveTimeout:
+    """The read budget scales with the subagent count on local providers.
+
+    Local servers serve one request per loaded model, so with N subagents a
+    queued request waits up to (N-1) inferences before its own starts. A fixed
+    read budget times out queued-but-healthy calls, burning the whole budget
+    for zero findings and feeding the failure-streak breaker.
+    """
+
+    def test_local_single_agent_keeps_default(self):
+        from quodeq.analysis._api_runner import _resolve_timeout
+        cfg = ApiRunnerConfig(model="m", api_base="http://localhost:11434/v1")
+        assert _resolve_timeout(cfg, is_openai=False) == _LOCAL_TIMEOUT
+
+    def test_local_read_budget_scales_with_subagents(self):
+        from quodeq.analysis._api_runner import _resolve_timeout
+        cfg = ApiRunnerConfig(
+            model="m", api_base="http://localhost:11434/v1", n_subagents=3,
+        )
+        t = _resolve_timeout(cfg, is_openai=False)
+        assert t.read == _LOCAL_TIMEOUT.read * 3
+        assert t.connect == _LOCAL_TIMEOUT.connect
+        assert t.write == _LOCAL_TIMEOUT.write
+        assert t.pool == _LOCAL_TIMEOUT.pool
+
+    def test_cloud_budget_ignores_subagents(self):
+        from quodeq.analysis._api_runner import _resolve_timeout, _CLOUD_TIMEOUT
+        cfg = ApiRunnerConfig(
+            model="m", api_base="https://api.openai.com/v1", n_subagents=3,
+        )
+        assert _resolve_timeout(cfg, is_openai=True) == _CLOUD_TIMEOUT
+
+    def test_env_override_wins(self, monkeypatch):
+        from quodeq.analysis._api_runner import _resolve_timeout
+        monkeypatch.setenv("QUODEQ_API_READ_TIMEOUT", "900")
+        cfg = ApiRunnerConfig(
+            model="m", api_base="http://localhost:11434/v1", n_subagents=2,
+        )
+        assert _resolve_timeout(cfg, is_openai=False).read == 900.0
+
+    def test_env_override_garbage_is_ignored(self, monkeypatch):
+        from quodeq.analysis._api_runner import _resolve_timeout
+        monkeypatch.setenv("QUODEQ_API_READ_TIMEOUT", "soon")
+        cfg = ApiRunnerConfig(
+            model="m", api_base="http://localhost:11434/v1", n_subagents=2,
+        )
+        assert _resolve_timeout(cfg, is_openai=False).read == _LOCAL_TIMEOUT.read * 2
+
+    def test_call_api_passes_scaled_timeout_to_client(self):
+        cfg = ApiRunnerConfig(
+            model="m", api_base="http://localhost:8000/v1",
+            api_key="k", n_subagents=2,
+        )
+        raw_client = _mock_raw_client('{"findings":[]}')
+        with patch("quodeq.analysis._api_runner.openai.OpenAI") as mock_oa:
+            mock_oa.return_value.__enter__.return_value = raw_client
+            _call_api("prompt", cfg)
+        timeout = mock_oa.call_args.kwargs["timeout"]
+        assert timeout.read == _LOCAL_TIMEOUT.read * 2
+
+
 class TestRunApiAnalysis:
     """run_api_analysis calls LLM via raw OpenAI client and writes JSONL evidence."""
 

--- a/tests/analysis/test_subprocess_coverage.py
+++ b/tests/analysis/test_subprocess_coverage.py
@@ -354,6 +354,45 @@ class TestRunApiAnalysisBridge:
             mock_api.assert_called_once()
             assert stream.read_text().strip() != ""
 
+    def test_passes_subagent_count_from_run_config(self, tmp_path):
+        """The pool's RunConfig carrier feeds max_subagents into the API
+        runner config so the read timeout can scale with queue depth."""
+        from types import SimpleNamespace
+
+        stream = tmp_path / "stream.json"
+        jsonl = tmp_path / "evidence.jsonl"
+        (tmp_path / "main.py").write_text("x = 1")
+
+        run_config = SimpleNamespace(options=SimpleNamespace(max_subagents=3))
+        cfg = AnalysisConfig(
+            ai_cmd="ollama", ai_model="llama3.1",
+            jsonl_file=jsonl, run_config=run_config,
+        )
+        provider = {"ollama": {"type": "api", "model": "llama3.1", "api_base": "http://localhost:11434/v1"}}
+
+        with patch("quodeq.analysis.subprocess.get_provider_configs", return_value=provider), \
+             patch("quodeq.analysis.api_prompt_assembly.assemble_api_prompt", return_value="prompt"), \
+             patch("quodeq.analysis._api_runner.run_api_analysis") as mock_api:
+            _run_api_analysis_bridge(tmp_path, "test", stream, cfg)
+
+        assert mock_api.call_args.kwargs["config"].n_subagents == 3
+
+    def test_defaults_subagent_count_without_run_config(self, tmp_path):
+        """Legacy callers pass no RunConfig carrier: timeout stays unscaled."""
+        stream = tmp_path / "stream.json"
+        jsonl = tmp_path / "evidence.jsonl"
+        (tmp_path / "main.py").write_text("x = 1")
+
+        cfg = AnalysisConfig(ai_cmd="ollama", ai_model="llama3.1", jsonl_file=jsonl)
+        provider = {"ollama": {"type": "api", "model": "llama3.1", "api_base": "http://localhost:11434/v1"}}
+
+        with patch("quodeq.analysis.subprocess.get_provider_configs", return_value=provider), \
+             patch("quodeq.analysis.api_prompt_assembly.assemble_api_prompt", return_value="prompt"), \
+             patch("quodeq.analysis._api_runner.run_api_analysis") as mock_api:
+            _run_api_analysis_bridge(tmp_path, "test", stream, cfg)
+
+        assert mock_api.call_args.kwargs["config"].n_subagents == 1
+
 
 # ---------------------------------------------------------------------------
 # run_analysis dispatch


### PR DESCRIPTION
## Problem

Running with `--n-subagents 2` or `3` against local Ollama (the tested optimal setup for this hardware) hits read timeouts: the server serves one request per loaded model by default, so a queued request waits up to (N-1) inferences before its own starts. The read timeout was a fixed 500s regardless of pool size.

The error handling turns each timeout into a real performance hit:
- the worker burns the **full 500s of wall time for zero findings** (`max_retries=0`, so no compounding, but the budget is still lost),
- the whole batch is marked lossy and **re-dispatches next run**,
- consecutive lossy calls feed the **failure-streak breaker**, which can cancel the dimension outright.

## Fix

- `ApiRunnerConfig` gains `n_subagents` (default 1), wired from the pool's `RunConfig` carrier (`options.max_subagents`) at the bridge dispatch site.
- New `_resolve_timeout`: local read budget scales linearly with the pool size (500s x N -> 1000s at N=2, 1500s at N=3). Connect/write/pool budgets unchanged. Cloud (`api.openai.com`) keeps its fixed 600s: cloud backends parallelize, queueing does not apply.
- `QUODEQ_API_READ_TIMEOUT` (whole seconds) overrides the read budget outright for both local and cloud.
- The oversubscription warning no longer claims the run "will likely time out" (now false); it now states the real remaining cost: subagents queue and add little throughput until server parallelism is raised (e.g. `OLLAMA_NUM_PARALLEL=N`).

## Tests (TDD)

8 new tests, all watched fail first (ImportError/AttributeError on the missing seam):
- `TestResolveTimeout` (6): n=1 keeps the exact default, n=3 scales read only, cloud ignores N, env override wins, garbage env ignored, and `_call_api` passes the scaled timeout to the client.
- Bridge wiring (2): `max_subagents=3` from the RunConfig carrier reaches the runner config; legacy callers without a carrier stay at 1.

Full suite: **5343 passed, 1 skipped**.

## Notes

- Independent of #956 (branched from develop; different files).
- Does NOT touch the run-level `deadline_at`/watchdog disagreement with the pool auto-scale (bug #2 in #956's description) — that remains a follow-up.