### PR TITLE
fix(analysis): ratchet the run deadline to follow the pool's granted budget

### DIFF
--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -520,6 +520,10 @@ def _run_pipeline_with_cleanup(
                             datetime.now(timezone.utc) + timedelta(seconds=budget_s)
                         ).isoformat()
                         lifecycle.set_deadline(deadline_iso)
+                        # Let the pool auto-scale push the deadline outward
+                        # in status.json too, so the dashboard countdown and
+                        # exit-reason labeling track the granted budget.
+                        config.options.on_deadline_extended = lifecycle.set_deadline
                     result = _execute_pipeline(args, config, evidence_dir, evaluation_dir)
                     # If the loops broke out on --max-duration, the pipeline
                     # returns cleanly with no exception. Tag the lifecycle so

--- a/src/quodeq/analysis/_types.py
+++ b/src/quodeq/analysis/_types.py
@@ -7,6 +7,7 @@ mutual dependencies.
 """
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -35,6 +36,10 @@ class AnalysisOptions:
     consolidated: bool = True
     time_limit: int | None = None
     deadline_at: float | None = None
+    # Invoked with the new ISO deadline whenever the pool auto-scale ratchets
+    # ``deadline_at`` forward — wired by the CLI layer to the lifecycle so
+    # status.json (dashboard countdown, exit-reason labeling) follows.
+    on_deadline_extended: Callable[[str], None] | None = None
     incremental: bool = True
     incremental_file_filter: set[str] | None = None
     dry_run: bool = False

--- a/src/quodeq/analysis/subagents/_pool_launcher.py
+++ b/src/quodeq/analysis/subagents/_pool_launcher.py
@@ -2,15 +2,18 @@
 from __future__ import annotations
 
 import os
+import time
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from quodeq.analysis._types import RunConfig
+from quodeq.analysis._runner_markers import emit_marker
+from quodeq.analysis._types import AnalysisOptions, RunConfig
 from quodeq.analysis.subprocess import AnalysisConfig, count_files_from_stream
 from quodeq.analysis.subagents.pool import PoolOptions, PoolPaths, SubagentPool
 from quodeq.shared.constants import DEFAULT_TIME_LIMIT
-from quodeq.shared.logging import log_info
+from quodeq.shared.logging import log_info, log_warning
 from quodeq.shared.utils import get_ai_cmd
 
 _MAX_FILES_PER_AGENT = 30
@@ -45,6 +48,34 @@ def _resolve_time_limit(user_budget: int | None, queue_size: int) -> int:
         return base
     needed = queue_size * _SECONDS_PER_FILE_AUTOSCALE
     return min(_MAX_AUTO_POOL_BUDGET, max(base, needed))
+
+
+def _extend_run_deadline(options: AnalysisOptions, time_limit: int) -> None:
+    """Ratchet the run-level deadline forward to cover this pool's budget.
+
+    The granted (possibly auto-scaled) pool budget can exceed the run
+    deadline computed from the user's original limit; without this, the
+    job watchdog SIGTERMs a healthy run at original-limit+grace while the
+    pool believes it has hours left. Never shortens the deadline, and
+    leaves unlimited runs (no deadline) alone. Emits a marker so the job
+    watchdog follows, and notifies the lifecycle (via the CLI-wired
+    callback) so status.json and the dashboard countdown follow too.
+    """
+    if time_limit == _UNLIMITED_BUDGET or options.deadline_at is None:
+        return
+    new_deadline = time.monotonic() + time_limit
+    if new_deadline <= options.deadline_at:
+        return
+    options.deadline_at = new_deadline
+    new_iso = (
+        datetime.now(timezone.utc) + timedelta(seconds=time_limit)
+    ).isoformat()
+    emit_marker("deadline_extended", deadline_at=new_iso, budget_s=time_limit)
+    if options.on_deadline_extended is not None:
+        try:
+            options.on_deadline_extended(new_iso)
+        except Exception as exc:  # noqa: BLE001 — a status write must not kill the launch
+            log_warning(f"deadline extension notify failed: {exc}")
 
 
 def _compute_files_per_agent(total_files: int) -> int:
@@ -86,6 +117,10 @@ def _launch_pool(
             f"  [{dim_id}] Time limit auto-scaled: {base_user_budget}s → {time_limit}s"
             f" for {queue_size} files"
         )
+    # Must happen BEFORE base_ac is built: the pool snapshots deadline_at,
+    # and every deadline consumer (watchdog, drain checks, dashboard
+    # countdown) must agree on the granted budget, not the pre-scale one.
+    _extend_run_deadline(config.options, time_limit)
     base_ac = AnalysisConfig(
         analysis_budget=config.options.analysis_budget,
         compiled_dir=compiled_dir,

--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -276,7 +276,10 @@ class JobManager:
         elif phase in ("analyzing", "scoring"):
             job.current_dimension = marker.get("dimension")
             job.phase = phase
-        elif phase == "analyzing_start":
+        elif phase in ("analyzing_start", "deadline_extended"):
+            # deadline_extended: the pool auto-scale ratcheted the run
+            # deadline forward; the watchdog must follow or it kills a
+            # healthy run at the original deadline.
             job.deadline_at = marker.get("deadline_at")
         elif phase == "report_path":
             project = marker.get("project")

--- a/tests/analysis/test_time_limit_autoscale.py
+++ b/tests/analysis/test_time_limit_autoscale.py
@@ -9,6 +9,12 @@ fair slice of wallclock time, capped at a hard upper bound.
 """
 from __future__ import annotations
 
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from quodeq.analysis._types import AnalysisOptions, RunConfig
 from quodeq.analysis.subagents._pool_launcher import (
     _MAX_AUTO_POOL_BUDGET,
     _SECONDS_PER_FILE_AUTOSCALE,
@@ -54,3 +60,118 @@ class TestResolveTimeLimit:
     def test_runaway_queue_capped_at_max(self) -> None:
         assert _resolve_time_limit(None, 100_000) == _MAX_AUTO_POOL_BUDGET
         assert _resolve_time_limit(900, 100_000) == _MAX_AUTO_POOL_BUDGET
+
+
+class TestExtendRunDeadline:
+    """The run-level deadline must follow the pool's granted budget.
+
+    The auto-scaled pool budget can exceed the run deadline computed from
+    the user's original limit; without ratcheting the deadline forward,
+    the job watchdog SIGTERMs a healthy run at original-limit+grace while
+    the pool believes it has hours left (observed: run d8f96511, limit
+    60s auto-scaled to 7200s, killed at start+121s).
+    """
+
+    def test_extends_deadline_emits_marker_and_notifies(self):
+        from quodeq.analysis.subagents._pool_launcher import _extend_run_deadline
+        received = []
+        opts = AnalysisOptions(
+            deadline_at=time.monotonic() + 60,
+            on_deadline_extended=received.append,
+        )
+        with patch(
+            "quodeq.analysis.subagents._pool_launcher.emit_marker"
+        ) as marker:
+            _extend_run_deadline(opts, 7200)
+
+        assert opts.deadline_at >= time.monotonic() + 7000
+        marker.assert_called_once()
+        assert marker.call_args.args[0] == "deadline_extended"
+        iso = marker.call_args.kwargs["deadline_at"]
+        parsed = datetime.fromisoformat(iso)
+        assert parsed.tzinfo is not None
+        assert (parsed - datetime.now(timezone.utc)).total_seconds() > 7000
+        assert received == [iso]
+
+    def test_never_shortens_the_deadline(self):
+        from quodeq.analysis.subagents._pool_launcher import _extend_run_deadline
+        far = time.monotonic() + 99_999
+        opts = AnalysisOptions(deadline_at=far)
+        with patch(
+            "quodeq.analysis.subagents._pool_launcher.emit_marker"
+        ) as marker:
+            _extend_run_deadline(opts, 60)
+        assert opts.deadline_at == far
+        marker.assert_not_called()
+
+    def test_noop_when_run_is_unlimited(self):
+        from quodeq.analysis.subagents._pool_launcher import _extend_run_deadline
+        opts = AnalysisOptions(deadline_at=None)
+        with patch(
+            "quodeq.analysis.subagents._pool_launcher.emit_marker"
+        ) as marker:
+            _extend_run_deadline(opts, 7200)
+        assert opts.deadline_at is None
+        marker.assert_not_called()
+
+    def test_noop_when_pool_budget_unlimited(self):
+        from quodeq.analysis.subagents._pool_launcher import _extend_run_deadline
+        original = time.monotonic() + 60
+        opts = AnalysisOptions(deadline_at=original)
+        with patch(
+            "quodeq.analysis.subagents._pool_launcher.emit_marker"
+        ) as marker:
+            _extend_run_deadline(opts, _UNLIMITED_BUDGET)
+        assert opts.deadline_at == original
+        marker.assert_not_called()
+
+    def test_callback_failure_does_not_raise(self):
+        from quodeq.analysis.subagents._pool_launcher import _extend_run_deadline
+
+        def _boom(_iso: str) -> None:
+            raise RuntimeError("status write failed")
+
+        opts = AnalysisOptions(
+            deadline_at=time.monotonic() + 60,
+            on_deadline_extended=_boom,
+        )
+        with patch("quodeq.analysis.subagents._pool_launcher.emit_marker"):
+            _extend_run_deadline(opts, 7200)
+        # The extension itself must still land even if the notify fails.
+        assert opts.deadline_at >= time.monotonic() + 7000
+
+
+class TestLaunchPoolExtendsDeadline:
+    def test_launch_pool_flows_extended_deadline_into_pool(self, tmp_path):
+        """The AnalysisConfig handed to the pool must carry the EXTENDED
+        deadline, not the stale pre-scale one, so worker drain checks and
+        the run deadline agree on a single number."""
+        from quodeq.analysis.subagents import _pool_launcher
+
+        original = time.monotonic() + 60
+        config = RunConfig(
+            src=tmp_path,
+            language="python",
+            options=AnalysisOptions(deadline_at=original, time_limit=60),
+        )
+        params = _pool_launcher.LaunchPoolParams(
+            evidence_dir=tmp_path,
+            queue_path=tmp_path / "queue.json",
+            prompt="p",
+            all_files=[f"f{i}.py" for i in range(600)],  # scales to 7200s
+        )
+        captured = {}
+
+        def _fake_pool(*, paths, options, config):
+            captured["config"] = config
+            pool = MagicMock()
+            pool.run.return_value = []
+            return pool
+
+        with patch.object(_pool_launcher, "SubagentPool", side_effect=_fake_pool), \
+             patch.object(_pool_launcher, "get_ai_cmd", return_value="ollama"), \
+             patch("quodeq.analysis.subagents._pool_launcher.emit_marker"):
+            _pool_launcher._launch_pool(config, "dim-x", params)
+
+        assert config.options.deadline_at > original
+        assert captured["config"].deadline_at == config.options.deadline_at

--- a/tests/ci/test_cli_lifecycle_integration.py
+++ b/tests/ci/test_cli_lifecycle_integration.py
@@ -367,3 +367,41 @@ def test_pipeline_records_ai_cmd_as_provider(tmp_path: Path, monkeypatch) -> Non
     assert status is not None, "status.json must be written"
     assert status["ai_provider"] == "llamacpp"
     assert status["ai_model"] == "qwen3.6-27b"
+
+
+def test_pool_deadline_extension_reaches_status_json(tmp_path: Path) -> None:
+    """The deadline-extension callback is wired to the lifecycle before the
+    pipeline runs: invoking it (as the pool auto-scale does) must land the
+    new deadline in status.json, where the dashboard countdown and the
+    post-#956 exit-reason labeling read it."""
+    import argparse
+
+    import quodeq._cli_evaluation as cli
+    from quodeq.analysis._types import RunConfig
+
+    evidence_dir = tmp_path / "proj" / "run" / "evidence"
+    evaluation_dir = tmp_path / "proj" / "run" / "evaluation"
+    evidence_dir.mkdir(parents=True)
+    evaluation_dir.mkdir(parents=True)
+
+    config = RunConfig(src=tmp_path, language="python")
+    extended_iso = "2026-08-01T12:00:00+00:00"
+
+    def _fake_pipeline(*_a, **_k):
+        cb = config.options.on_deadline_extended
+        assert cb is not None, "extension callback must be wired before the pipeline runs"
+        cb(extended_iso)
+        return 0
+
+    with patch.object(cli, "_execute_pipeline", side_effect=_fake_pipeline), \
+         patch.object(cli, "_save_manifest"), \
+         patch.object(cli, "_build_run_config", return_value=config), \
+         patch.object(cli, "is_repo_url", return_value=False), \
+         patch.object(cli, "emit_marker"):
+        args = argparse.Namespace(repo="local", pool_budget=60)
+        inputs = type("I", (), {"src": tmp_path, "language": "python", "manifest": None, "dims_data": None})()
+        cli._run_pipeline_with_cleanup(args, inputs, (tmp_path, evidence_dir, evaluation_dir))
+
+    status = read_status(evaluation_dir.parent)
+    assert status is not None
+    assert status["deadline_at"] == extended_iso

--- a/tests/services/test_jobs_deadline_marker.py
+++ b/tests/services/test_jobs_deadline_marker.py
@@ -41,3 +41,24 @@ def test_to_dict_includes_deadline_at():
     job.deadline_at = "2026-05-02T10:00:00+00:00"
     snapshot = job.to_dict()
     assert snapshot.deadline_at == "2026-05-02T10:00:00+00:00"
+
+
+def test_deadline_extended_marker_updates_deadline_on_job():
+    """The pool auto-scale emits deadline_extended mid-run; the watchdog's
+    deadline must follow it, else it kills a healthy run at the ORIGINAL
+    deadline while the pool believes it has hours left."""
+    job = _job()
+    first = (datetime.now(timezone.utc) + timedelta(seconds=60)).isoformat()
+    JobManager._apply_marker(
+        job, json.dumps({"_cc": "analyzing_start", "deadline_at": first, "budget_s": 60})
+    )
+    extended = (datetime.now(timezone.utc) + timedelta(seconds=7200)).isoformat()
+
+    JobManager._apply_marker(
+        job,
+        json.dumps(
+            {"_cc": "deadline_extended", "deadline_at": extended, "budget_s": 7200}
+        ),
+    )
+
+    assert job.deadline_at == extended


### PR DESCRIPTION
## Problem (bug #2 from #956)

The pool auto-scale raises a dimension's working budget for large queues (`_resolve_time_limit`: 60s -> 7200s for 838 files) but the run-level `deadline_at` stayed at the user's original limit. The JobManager watchdog enforces that stale deadline, so it SIGTERMed healthy runs at original-limit+60s while the pool believed it had hours left.

**Evidence:** run `d8f96511` — limit 60s, log shows "Time limit auto-scaled: 60s -> 7200s for 838 files", killed at start+121s (60s limit + 60s watchdog grace).

## Design (approved)

The deadline follows the granted budget. At every pool launch, `_extend_run_deadline` ratchets the run deadline forward to `now + granted_budget` and propagates it to every consumer through one write point:

- **`config.options.deadline_at`** (monotonic) — dim-loop stop checks + worker drain checks; extended *before* the pool snapshots it into its `AnalysisConfig`.
- **`deadline_extended` marker** — `JobManager._apply_marker` now updates `job.deadline_at` from it (same field as `analyzing_start`), so the watchdog follows.
- **`on_deadline_extended` callback** — new `AnalysisOptions` field, wired by the CLI layer to `lifecycle.set_deadline`, so status.json follows; that is what the dashboard countdown and the post-#956 exit-reason labeling read.

Never shortens; unlimited runs (no deadline) untouched; a failing status write logs a warning instead of killing the launch.

## Tests (TDD)

8 new tests, all watched fail first:
- `TestExtendRunDeadline` (5): extends + emits marker + notifies; never shortens; no-op on unlimited run; no-op on unlimited pool budget; callback failure doesn't raise.
- `TestLaunchPoolExtendsDeadline` (1): the `AnalysisConfig` handed to the pool carries the *extended* deadline.
- jobs marker (1): `deadline_extended` updates `job.deadline_at` past `analyzing_start`'s value.
- CLI wiring (1): invoking the callback mid-pipeline lands the new deadline in status.json.

Full suite: **5351 passed, 1 skipped**.

Closes the follow-up declared in #956.