### PR TITLE
fix(analysis): explicit time limit is a hard cap, watchdog never cuts a drain

### DIFF
--- a/src/quodeq/analysis/subagents/_pool_launcher.py
+++ b/src/quodeq/analysis/subagents/_pool_launcher.py
@@ -20,12 +20,13 @@ _MAX_FILES_PER_AGENT = 30
 _MAX_FILES_PER_AGENT_CAP = 50
 _NON_SCOUT_PROVIDERS = tuple(os.environ.get("QUODEQ_NON_SCOUT_PROVIDERS", "codex,gemini").split(","))
 
-# Auto-scale the time limit so large queues don't get killed mid-run.
-# A fixed 600s cap chokes any dim with a queue larger than ~80 files
-# (observed throughput ≈ 7-12 s/file with 8 agents); the surviving
-# pending files keep haunting the next run via the not_analyzed sweep
-# and the dim never converges. The user's explicit time_limit is a
-# FLOOR — we only ever extend it upward, never shrink it.
+# Auto-scale the IMPLICIT default time limit so large queues don't get
+# killed mid-run: a fixed 600s budget chokes any dim with a queue larger
+# than ~80 files (observed throughput ≈ 7-12 s/file with 8 agents) and
+# the surviving pending files keep haunting the next run via the
+# not_analyzed sweep. An EXPLICITLY chosen time_limit is a HARD CAP and
+# is never scaled: the run stops dispatching at the cap, loaded agents
+# drain, and the remainder carries over to the next run.
 _SECONDS_PER_FILE_AUTOSCALE = 12
 # Hard upper bound so a runaway queue can't lock up the run for days.
 _MAX_AUTO_POOL_BUDGET = 7200  # 2 hours
@@ -36,18 +37,19 @@ _UNLIMITED_BUDGET = 0
 def _resolve_time_limit(user_budget: int | None, queue_size: int) -> int:
     """Compute the effective time limit for a queue of *queue_size* files.
 
-    The user's `time_limit` (or `DEFAULT_TIME_LIMIT` if unset) is treated
-    as a floor. For large queues we extend it to give each file a fair
-    slice of wallclock time, capped at `_MAX_AUTO_POOL_BUDGET`. A user-set
-    limit of 0 means "unlimited" and is preserved verbatim.
+    An explicitly set `time_limit` is a HARD CAP and is returned verbatim
+    (0 means "unlimited"): the user asked for that number, so the run
+    dispatches until the cap and carries the remainder forward. Only when
+    no limit was chosen (`None`) do we auto-scale the `DEFAULT_TIME_LIMIT`
+    to give each file a fair slice of wallclock time, capped at
+    `_MAX_AUTO_POOL_BUDGET`.
     """
-    base = user_budget if user_budget is not None else DEFAULT_TIME_LIMIT
-    if base == _UNLIMITED_BUDGET:
-        return _UNLIMITED_BUDGET
+    if user_budget is not None:
+        return user_budget
     if queue_size <= 0:
-        return base
+        return DEFAULT_TIME_LIMIT
     needed = queue_size * _SECONDS_PER_FILE_AUTOSCALE
-    return min(_MAX_AUTO_POOL_BUDGET, max(base, needed))
+    return min(_MAX_AUTO_POOL_BUDGET, max(DEFAULT_TIME_LIMIT, needed))
 
 
 def _extend_run_deadline(options: AnalysisOptions, time_limit: int) -> None:

--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -55,9 +55,13 @@ _DEFAULT_LIST_LIMIT = 100
 # which only lands in job state after the analyzing_start marker — so a
 # blocking wait(timeout=full_budget) at spawn time can't see it.
 _WATCHDOG_POLL_INTERVAL_S = 1.0
-# Grace window past deadline_at before SIGKILL — gives the analysis side's
-# graceful-cancel path time to score completed dimensions.
-_WATCHDOG_DEADLINE_GRACE_S = 60
+# Grace window past deadline_at before the kill. The watchdog exists to
+# reap HUNG runs, never to cut loaded agents: past the deadline the pool
+# stops dispatching and in-flight model calls drain. The longest
+# legitimate in-flight call is one scaled local read timeout (500s per
+# subagent, realistically up to 3), so the grace must exceed that or a
+# healthy drain gets SIGTERMed and the batch's work is lost.
+_WATCHDOG_DEADLINE_GRACE_S = 1800
 
 # Canonical job status strings.
 STATUS_RUNNING = "running"

--- a/tests/analysis/test_time_limit_autoscale.py
+++ b/tests/analysis/test_time_limit_autoscale.py
@@ -39,11 +39,14 @@ class TestResolveTimeLimit:
         # the 7200s ceiling → return the proportional value.
         assert _resolve_time_limit(None, 200) == 200 * _SECONDS_PER_FILE_AUTOSCALE
 
-    def test_explicit_user_budget_is_floor_not_cap(self) -> None:
-        # User wants at least 1800s; queue would only need 600s → keep 1800.
+    def test_explicit_user_budget_is_a_hard_cap(self) -> None:
+        # An explicitly chosen limit is respected verbatim: the run stops
+        # dispatching at the cap and carries the remainder forward. Only
+        # the implicit default is auto-scaled. (A 60s limit that silently
+        # became a 2h run was the opposite of what the user asked for.)
         assert _resolve_time_limit(1800, 30) == 1800
-        # User wants 1800s but queue needs 3600s → extend to 3600.
-        assert _resolve_time_limit(1800, 300) == 300 * _SECONDS_PER_FILE_AUTOSCALE
+        assert _resolve_time_limit(1800, 300) == 1800
+        assert _resolve_time_limit(60, 837) == 60
 
     def test_unlimited_budget_is_preserved(self) -> None:
         # time_limit=0 means "no cap"; auto-scaling must not turn that
@@ -59,7 +62,8 @@ class TestResolveTimeLimit:
 
     def test_runaway_queue_capped_at_max(self) -> None:
         assert _resolve_time_limit(None, 100_000) == _MAX_AUTO_POOL_BUDGET
-        assert _resolve_time_limit(900, 100_000) == _MAX_AUTO_POOL_BUDGET
+        # Explicit budgets are never scaled, not even for runaway queues.
+        assert _resolve_time_limit(900, 100_000) == 900
 
 
 class TestExtendRunDeadline:

--- a/tests/services/test_jobs_deadline_marker.py
+++ b/tests/services/test_jobs_deadline_marker.py
@@ -62,3 +62,15 @@ def test_deadline_extended_marker_updates_deadline_on_job():
     )
 
     assert job.deadline_at == extended
+
+
+def test_watchdog_grace_covers_a_full_drain():
+    """The watchdog exists to reap HUNG runs, never to cut loaded agents.
+    Past the deadline the pool stops dispatching and in-flight calls drain;
+    the longest legitimate in-flight call is one scaled local read timeout
+    (500s x subagents, realistically up to 3). The grace must exceed that,
+    or the watchdog SIGTERMs a healthy drain and the batch's work is lost."""
+    from quodeq.analysis._api_runner import _LOCAL_TIMEOUT
+    from quodeq.services import jobs as jobs_mod
+
+    assert jobs_mod._WATCHDOG_DEADLINE_GRACE_S >= _LOCAL_TIMEOUT.read * 3


### PR DESCRIPTION
## Problem

An explicitly chosen time limit was treated as a FLOOR by the pool auto-scale: a 60s limit on an 837-file queue silently became a 2h run. #958 made the whole system coherently follow that scaled number — which surfaced that the semantic itself was wrong for explicit choices ("1 minute" must not mean "2 hours").

## Semantics (approved by Victor)

- **Explicit limit = hard cap**: `_resolve_time_limit` returns it verbatim (0 = unlimited). The run dispatches until the cap, **loaded agents are never cut** — the pool's existing drain lets in-flight calls finish — and the remainder carries over to the next run.
- **Implicit default only** (no limit chosen): the 600s default still auto-scales to 12s/file, capped at 2h, so bare runs on big queues stay useful.
- **Watchdog grace 60s -> 1800s**: past the deadline the pool drains; the longest legitimate in-flight call is one scaled local read timeout (500s x up to 3 subagents), and a 60s grace SIGTERMed healthy drains mid-call, losing the batch's work. The watchdog reverts to its real job: reaping hung processes.

## Tests (TDD)

- Flipped `test_explicit_user_budget_is_floor_not_cap` -> `test_explicit_user_budget_is_a_hard_cap` (incl. the exact 60s/837-file case), updated the runaway-queue case, and added a contract test pinning `_WATCHDOG_DEADLINE_GRACE_S >= _LOCAL_TIMEOUT.read * 3`. All watched fail first.
- Full suite: **5354 passed, 1 skipped**.

## Notes

- `_extend_run_deadline` (#958) still ratchets the run deadline to the granted budget — for explicit caps that is the cap itself, for scaled defaults the scaled value.
- Known nuance, unchanged tonight: multi-dimension runs grant each dim its own budget slice (pre-existing pool semantics); the cap is per-dim, not per-run-total. Single-dimension runs (the dogfood case) are exact.