### PR TITLE
fix(jobs): surface deadline-killed runs as time limit reached, not FAILED

### DIFF
--- a/src/quodeq/services/_job_model.py
+++ b/src/quodeq/services/_job_model.py
@@ -46,6 +46,10 @@ class Job:
     ai_provider: str | None = None
     ai_model: str | None = None
     time_limit_s: int | None = None  # 0 = unlimited, None = unknown
+    # Why the job ended ("deadline", "time_limit", ...); None for clean
+    # completions and plain failures. Lets the UI tell a time-budget kill
+    # apart from a real failure.
+    exit_reason: str | None = None
 
     def complete(self, exit_code: int, ended_at: str) -> None:
         """Transition job to a terminal state based on exit code."""
@@ -89,6 +93,7 @@ class Job:
             ai_provider=self.ai_provider,
             ai_model=self.ai_model,
             time_limit_s=self.time_limit_s,
+            exit_reason=self.exit_reason,
         )
 
 
@@ -193,6 +198,7 @@ def _job_to_json(job: Job) -> dict:
         "ai_provider": job.ai_provider,
         "ai_model": job.ai_model,
         "time_limit_s": job.time_limit_s,
+        "exit_reason": job.exit_reason,
     }
 
 
@@ -216,6 +222,7 @@ def _job_from_json(data: dict) -> Job:
         ai_provider=data.get("ai_provider"),
         ai_model=data.get("ai_model"),
         time_limit_s=data.get("time_limit_s"),
+        exit_reason=data.get("exit_reason"),
     )
 
 

--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -69,6 +69,14 @@ STATUS_CANCELLED = "cancelled"
 STATUS_DONE = "done"
 STATUS_FAILED = "failed"
 
+# status.json exit reasons that mean "the run hit its time budget" — the
+# user's own setting doing its job, not an error. Jobs ending this way are
+# marked cancelled (already in the salvage-scoring trigger list in
+# api/_evaluation_routes.py) with exit_reason set, so the evaluate header
+# renders "time limit reached" instead of FAILED.
+_DEADLINE_EXIT_REASONS = ("deadline", "time_limit")
+_EXIT_REASON_DEADLINE = "deadline"
+
 
 class JobManager:
     """Thread-safe manager for spawning and tracking evaluation subprocesses.
@@ -441,9 +449,34 @@ class JobManager:
             return False
         return now > deadline + _WATCHDOG_DEADLINE_GRACE_S
 
+    def _run_status_exit_reason(self, job: Job | None) -> str | None:
+        """Best-effort read of the run's ``status.json`` ``exit_reason``.
+
+        The analysis loops break out at the deadline without raising, and the
+        lifecycle records ``exit_reason="deadline"`` (see
+        ``_cli_evaluation._record_deadline_if_hit``). When the process then
+        exits nonzero without the job watchdog ever firing, this is the only
+        signal that the exit was a time-limit truncation, not a failure.
+        """
+        if (
+            job is None
+            or not job.output_project
+            or not job.output_run_id
+            or self._reports_root is None
+        ):
+            return None
+        status_path = self._reports_root / job.output_project / job.output_run_id / "status.json"
+        try:
+            data = json.loads(status_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+        reason = data.get("exit_reason")
+        return reason if isinstance(reason, str) else None
+
     def _monitor_process(self, job_id: str, process: subprocess.Popen) -> None:
         started_at = time.time()
         exit_code: int = 0
+        watchdog_killed = False
         while True:
             try:
                 exit_code = process.wait(timeout=_WATCHDOG_POLL_INTERVAL_S)
@@ -461,7 +494,17 @@ class JobManager:
                     # and waits internally.
                     _terminate_process(process)
                     exit_code = _EXIT_CODE_TIMEOUT
+                    watchdog_killed = True
                     break
+        # Resolve a time-limit exit before taking the lock — status.json I/O
+        # must not block API request paths contending on self._lock.
+        deadline_reason: str | None = None
+        if watchdog_killed:
+            deadline_reason = _EXIT_REASON_DEADLINE
+        elif exit_code != 0:
+            reason = self._run_status_exit_reason(self._store.get(job_id))
+            if reason in _DEADLINE_EXIT_REASONS:
+                deadline_reason = reason
         with self._lock:
             self._processes.pop(job_id, None)
             job = self._store.get(job_id)
@@ -469,7 +512,13 @@ class JobManager:
                 return
             job.exit_code = exit_code
             job.ended_at = datetime.now(timezone.utc).isoformat()
-            job.status = STATUS_DONE if exit_code == 0 else STATUS_FAILED
+            if exit_code == 0:
+                job.status = STATUS_DONE
+            elif deadline_reason is not None:
+                job.status = STATUS_CANCELLED
+                job.exit_reason = deadline_reason
+            else:
+                job.status = STATUS_FAILED
             self._store.put(job)
             self._evict_completed_jobs()
         if self._on_job_complete is not None:

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -9,27 +9,38 @@ import { IdentityStrip, IdentityCell } from './IdentityStrip.jsx';
 import { deriveScanMode } from './buildJobStatCells.js';
 import { useEvaluationProgress } from '../hooks/useEvaluationProgress.js';
 import useLiveFeedSettings from '../../settings/hooks/useLiveFeedSettings.js';
+import { exitReasonLabel, isTimeLimitExit } from '../../../models/exitReason.js';
 
 const STATUS = { RUNNING: 'running', DONE: 'done', FAILED: 'failed', LOST: 'lost' };
 const TERMINAL_STATES = new Set(['done', 'completed', 'failed', 'cancelled', 'lost']);
 
-function termNameForStatus(status) {
+// A cancelled/failed job whose run hit its time budget is not an error:
+// the header must agree with the coverage banner below it, which already
+// says "time limit reached" from the run's status.json. Done runs keep
+// their "complete" header; the banner tells the truncation story there.
+function isTimeLimitEnd(status, exitReason) {
+  return (status === 'cancelled' || status === STATUS.FAILED) && isTimeLimitExit(exitReason);
+}
+
+function termNameForStatus(status, exitReason) {
   if (status === STATUS.RUNNING) return 'evaluation_in_progress';
+  if (isTimeLimitEnd(status, exitReason)) return 'evaluation_time_limit';
   if (status === STATUS.DONE)    return 'evaluation_complete';
   if (status === STATUS.FAILED)  return 'evaluation_failed';
   if (status === STATUS.LOST)    return 'evaluation_lost';
   return 'evaluation_cancelled';
 }
 
-function RunPill({ status }) {
+function RunPill({ status, exitReason }) {
+  const timeLimit = isTimeLimitEnd(status, exitReason);
   const mod = status === STATUS.RUNNING ? 'running'
     : status === STATUS.DONE ? 'done'
-    : (status === STATUS.FAILED || status === STATUS.LOST) ? 'failed'
+    : !timeLimit && (status === STATUS.FAILED || status === STATUS.LOST) ? 'failed'
     : 'neutral';
   return (
     <span className={`eval-run-pill eval-run-pill--${mod}`}>
       {status === STATUS.RUNNING && <span className="eval-run-pill__dot" aria-hidden="true" />}
-      {status}
+      {timeLimit ? exitReasonLabel(exitReason) : status}
     </span>
   );
 }
@@ -39,7 +50,10 @@ function JobHeader({ job, onDismiss, onCancel }) {
   const isDone = job.status === STATUS.DONE;
   return (
     <div className="evaluate-panel__top evaluate-panel__top--row">
-      <TermHeader name={termNameForStatus(job.status)} badge={<RunPill status={job.status} />} />
+      <TermHeader
+        name={termNameForStatus(job.status, job.exitReason)}
+        badge={<RunPill status={job.status} exitReason={job.exitReason} />}
+      />
       <div className="evaluate-panel__top-actions">
         {isRunning && (
           <button type="button" className="term-btn term-btn--ghost term-btn--sm" onClick={onCancel}>cancel</button>

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
@@ -82,6 +82,56 @@ describe('JobIdentityStrip', () => {
   });
 });
 
+describe('JobHeader time-limit exit', () => {
+  it('renders a deadline-killed job as time limit reached, not failed', () => {
+    renderWithClient(
+      <EvaluationStatus job={{ ...baseJob, status: 'cancelled', exitReason: 'deadline' }} />
+    );
+    expect(screen.getByText('evaluation_time_limit')).toBeInTheDocument();
+    expect(screen.getByText('time limit reached')).toBeInTheDocument();
+    // Non-error styling, consistent with the coverage banner below.
+    expect(document.querySelector('.eval-run-pill--failed')).toBeNull();
+    expect(document.querySelector('.eval-run-pill--neutral')).not.toBeNull();
+  });
+
+  it('treats a failed status with a time_limit reason the same way', () => {
+    // Defensive: external index rows can end "failed" while status.json
+    // still records the time budget as the cause.
+    renderWithClient(
+      <EvaluationStatus job={{ ...baseJob, status: 'failed', exitReason: 'time_limit' }} />
+    );
+    expect(screen.getByText('evaluation_time_limit')).toBeInTheDocument();
+    expect(screen.getByText('time limit reached')).toBeInTheDocument();
+    expect(document.querySelector('.eval-run-pill--failed')).toBeNull();
+  });
+
+  it('still renders plain failures as failed', () => {
+    renderWithClient(
+      <EvaluationStatus job={{ ...baseJob, status: 'failed' }} />
+    );
+    expect(screen.getByText('evaluation_failed')).toBeInTheDocument();
+    expect(document.querySelector('.eval-run-pill--failed')).not.toBeNull();
+  });
+
+  it('keeps a truncated-but-done run rendered as complete', () => {
+    // rc=0 deadline truncation: results exist and were scored; the banner
+    // below tells the truncation story, the header stays "done".
+    renderWithClient(
+      <EvaluationStatus job={{ ...baseJob, status: 'done', exitReason: 'deadline' }} />
+    );
+    expect(screen.getByText('evaluation_complete')).toBeInTheDocument();
+    expect(screen.queryByText('time limit reached')).toBeNull();
+  });
+
+  it('keeps a user-cancelled job rendered as cancelled', () => {
+    renderWithClient(
+      <EvaluationStatus job={{ ...baseJob, status: 'cancelled' }} />
+    );
+    expect(screen.getByText('evaluation_cancelled')).toBeInTheDocument();
+    expect(screen.queryByText('time limit reached')).toBeNull();
+  });
+});
+
 describe('project label', () => {
   const startedInfo = { id: 'uuid-c', name: 'project-c', displayName: 'Project C' };
   const jobInfo = { id: 'uuid-a', name: 'project-a', displayName: 'Project A' };

--- a/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
@@ -61,12 +61,13 @@ export default function JobStatStrip({ job, liveViolations, hiddenCarriedCount =
     return buildJobStatCells(job.status, {
       overallPct, takenFiles, totalFiles, elapsedS, liveCount, etaHint, suppressedCount,
       carriedCount: hiddenCarriedCount,
+      exitReason: job.exitReason,
       dimCycle: buildDimensionCycle(progress),
       sevCounts: sumSeverities(liveViolations),
       scanMode: deriveScanMode(progress),
     });
     // `elapsedS` advances once per second via useRunElapsed; the sample store is read (not a dep).
-  }, [jobId, job?.status, isTerminal, progress, liveViolations, hiddenCarriedCount, elapsedS]);
+  }, [jobId, job?.status, job?.exitReason, isTerminal, progress, liveViolations, hiddenCarriedCount, elapsedS]);
 
   if (!jobId) return null;
 

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
@@ -5,6 +5,7 @@
 
 import { computeOverallProgress } from './scanProgressTotals.js';
 import { formatDuration } from '../../../utils/formatters.js';
+import { isTimeLimitExit } from '../../../models/exitReason.js';
 
 // Throughput estimate tuning. The eval completes only a few files per MINUTE
 // (one slow LLM call per file), so the rate is shown per minute and measured
@@ -260,14 +261,24 @@ function foundCell(liveCount, label = 'FOUND', hint = 'live violations', suppres
  * @param {number} inputs.liveCount
  * @param {number} [inputs.suppressedCount] — re-found findings already dismissed/deleted
  * @param {number} [inputs.carriedCount] — carried-forward findings the live-feed preference hid
+ * @param {string|null} [inputs.exitReason] — job.exitReason; time-limit reasons soften the status cell
  * @param {object|null} [inputs.dimCycle] — from buildDimensionCycle (running only)
  * @param {object} [inputs.sevCounts] — from sumSeverities (running only)
  * @param {string|null} [inputs.scanMode] — from deriveScanMode (running only)
  * @returns {Array<{label,value,hint,tone,trailing?}>} exactly 4 cells.
  */
 export function buildJobStatCells(status, inputs) {
-  const tone = statusTone(status);
-  const statusCell = { label: 'STATUS', value: status, tone, hint: statusHint(status) };
+  // A run that ended at its time budget is not user-cancelled and not an
+  // error: agree with the header pill ("time limit reached") instead of
+  // showing "user cancelled" / critical "see logs" under it.
+  const timeLimit = isTimeLimitExit(inputs.exitReason);
+  const tone = timeLimit ? 'default' : statusTone(status);
+  const statusCell = {
+    label: 'STATUS',
+    value: status,
+    tone,
+    hint: timeLimit ? 'time limit reached' : statusHint(status),
+  };
 
   if (status === 'done' || status === 'completed') {
     return [

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
@@ -443,3 +443,31 @@ test('deriveScanMode: null when coverage is unknown', () => {
   assert.equal(deriveScanMode(null), null);
   assert.equal(deriveScanMode({ dimensions: [{ id: 'a', state: 'running', files: { taken: 1, total: 10 } }] }), null);
 });
+
+// ---------------------------------------------------------------------------
+// buildJobStatCells: time-limit exits
+// ---------------------------------------------------------------------------
+
+test('buildJobStatCells: deadline-cancelled job reads time limit reached, not user cancelled', () => {
+  const cells = buildJobStatCells('cancelled', { ...baseInputs, exitReason: 'deadline' });
+  assert.equal(cells[0].label, 'STATUS');
+  assert.equal(cells[0].hint, 'time limit reached');
+  assert.equal(cells[0].tone, 'default');
+});
+
+test('buildJobStatCells: failed job with time_limit reason softens tone and hint', () => {
+  const cells = buildJobStatCells('failed', { ...baseInputs, exitReason: 'time_limit' });
+  assert.equal(cells[0].hint, 'time limit reached');
+  assert.equal(cells[0].tone, 'default');
+});
+
+test('buildJobStatCells: plain cancelled still reads user cancelled', () => {
+  const cells = buildJobStatCells('cancelled', baseInputs);
+  assert.equal(cells[0].hint, 'user cancelled');
+});
+
+test('buildJobStatCells: plain failed keeps critical tone and see-logs hint', () => {
+  const cells = buildJobStatCells('failed', baseInputs);
+  assert.equal(cells[0].hint, 'see logs');
+  assert.equal(cells[0].tone, 'critical');
+});

--- a/src/quodeq/ui/src/models/exitReason.js
+++ b/src/quodeq/ui/src/models/exitReason.js
@@ -65,3 +65,12 @@ export function exitReasonHint(code) {
 export function exitReasonWarn(code) {
   return exitReasonInfo(code)?.warn === true;
 }
+
+/**
+ * True when the run ended because it hit its time budget. Not an error:
+ * the user's own limit doing its job, so callers should render it with
+ * neutral styling instead of failure styling.
+ */
+export function isTimeLimitExit(code) {
+  return code === 'deadline' || code === 'time_limit';
+}

--- a/src/quodeq/ui/src/models/exitReason.test.js
+++ b/src/quodeq/ui/src/models/exitReason.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { exitReasonInfo, exitReasonLabel, exitReasonHint, exitReasonWarn } from './exitReason.js';
+import { exitReasonInfo, exitReasonLabel, exitReasonHint, exitReasonWarn, isTimeLimitExit } from './exitReason.js';
 
 test('provider_fatal maps to a label and an actionable hint', () => {
   const info = exitReasonInfo('provider_fatal');
@@ -27,6 +27,15 @@ test('unknown codes pass through verbatim with no hint', () => {
   assert.equal(exitReasonInfo('some_future_code'), null);
   assert.equal(exitReasonLabel('some_future_code'), 'some_future_code');
   assert.equal(exitReasonHint('some_future_code'), null);
+});
+
+test('isTimeLimitExit is true only for time-budget reasons', () => {
+  assert.equal(isTimeLimitExit('deadline'), true);
+  assert.equal(isTimeLimitExit('time_limit'), true);
+  assert.equal(isTimeLimitExit('provider_fatal'), false);
+  assert.equal(isTimeLimitExit('cancelled'), false);
+  assert.equal(isTimeLimitExit(null), false);
+  assert.equal(isTimeLimitExit(undefined), false);
 });
 
 test('provider failures warn on done runs, clean stops do not', () => {

--- a/src/quodeq/ui/src/models/job.js
+++ b/src/quodeq/ui/src/models/job.js
@@ -16,6 +16,7 @@
  * @property {string|null}   deadlineAt     - ISO-8601 wall-clock deadline for the run; null when unlimited or not yet set
  * @property {number|null}   exitCode
  * @property {string|null}   error
+ * @property {string|null}   exitReason     - Why the job ended ('deadline', 'time_limit', ...); null for clean completions and plain failures
  * @property {'internal'|'external'} source  - 'internal' = launched from dashboard; 'external' = CLI/CI
  * @property {string|null}   aiProvider     - Provider this job is actually using (e.g. 'ollama', 'llamacpp')
  * @property {string|null}   aiModel        - Model this job is actually using

--- a/tests/api/test_cluster6_score_offthread.py
+++ b/tests/api/test_cluster6_score_offthread.py
@@ -150,6 +150,48 @@ def test_get_evaluation_scores_only_once_for_same_job(client):
     )
 
 
+class _DeadlineCancelledProvider(_FailedJobProvider):
+    """Deadline-killed job: status 'cancelled' with exit_reason 'deadline'."""
+
+    def get_evaluation_status(self, job_id, reports_dir=None):
+        if job_id != "j1":
+            return None
+        return JobSnapshot(
+            job_id="j1",
+            status="cancelled",
+            exit_reason="deadline",
+            logs=[],
+            output_project="proj",
+            output_run_id="run-1",
+        )
+
+
+def test_deadline_cancelled_job_still_triggers_salvage_scoring(reports_root):
+    """Guards the deadline-exit design in services/jobs.py: watchdog-killed
+    jobs end as status='cancelled' (+ exit_reason='deadline') and rely on
+    'cancelled' staying in this route's salvage-scoring trigger list.
+    """
+    client = create_app(_DeadlineCancelledProvider()).test_client()
+    scoring_started = threading.Event()
+
+    def _score(reports_dir, args):
+        scoring_started.set()
+
+    with patch(
+        "quodeq.api._evaluation_routes.score_completed_evidence",
+        side_effect=_score,
+    ):
+        resp = client.get("/api/evaluations/j1")
+
+    assert resp.status_code == 200
+    # The UI reads exitReason off this payload to render "time limit reached".
+    assert resp.get_json().get("exitReason") == "deadline"
+    assert scoring_started.wait(timeout=budget(2)), (
+        "Deadline-cancelled job never spawned salvage scoring — did "
+        "'cancelled' fall out of the trigger list in _evaluation_routes?"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Unit tests for _claim_scoring (race-closure + bounded-registry guarantees)
 # ---------------------------------------------------------------------------

--- a/tests/services/test_job_manager.py
+++ b/tests/services/test_job_manager.py
@@ -448,7 +448,10 @@ class TestMonitorProcess:
 
         assert proc.killed is True
         assert job.exit_code == _EXIT_CODE_TIMEOUT
-        assert job.status == STATUS_FAILED
+        # Watchdog kills are time-budget exits, not failures: the header
+        # renders them as "time limit reached" via the exit_reason.
+        assert job.status == STATUS_CANCELLED
+        assert job.exit_reason == "deadline"
 
     def test_no_cap_no_deadline_does_not_kill(self, monkeypatch):
         """With no QUODEQ_JOB_TIMEOUT_S and no deadline_at, the watchdog must
@@ -513,7 +516,9 @@ class TestMonitorProcess:
 
         assert proc.killed is True
         assert job.exit_code == _EXIT_CODE_TIMEOUT
-        assert job.status == STATUS_FAILED
+        # Deadline kill = the user's own time budget doing its job.
+        assert job.status == STATUS_CANCELLED
+        assert job.exit_reason == "deadline"
 
     def test_watchdog_kill_terminates_the_process_tree(self, monkeypatch):
         """The watchdog must kill the process GROUP, not just the parent PID.
@@ -546,7 +551,7 @@ class TestMonitorProcess:
 
         assert calls == [proc], "watchdog kill must go through _terminate_process"
         assert job.exit_code == _EXIT_CODE_TIMEOUT
-        assert job.status == STATUS_FAILED
+        assert job.status == STATUS_CANCELLED
 
 
 class _NeverExitsProcess:

--- a/tests/services/test_job_model.py
+++ b/tests/services/test_job_model.py
@@ -207,7 +207,7 @@ class TestSerialization:
             "job_id", "status", "command", "started_at", "ended_at",
             "exit_code", "logs", "output_project", "output_run_id",
             "phase", "deadline_at", "current_dimension", "dimensions",
-            "ai_provider", "ai_model", "time_limit_s",
+            "ai_provider", "ai_model", "time_limit_s", "exit_reason",
         }
         assert set(data.keys()) == expected_keys
 

--- a/tests/services/test_jobs_deadline_exit.py
+++ b/tests/services/test_jobs_deadline_exit.py
@@ -1,0 +1,211 @@
+"""Deadline-killed jobs surface a time-limit terminal state, not FAILED.
+
+When the watchdog kills a run at its deadline (or the run's own status.json
+records exit_reason="deadline"/"time_limit" from PR #956), the job must end
+as status="cancelled" with exit_reason set, so the evaluate header can render
+"time limit reached" (non-error) consistent with the coverage banner below
+it. "cancelled" is already in the salvage-scoring trigger list in
+api/_evaluation_routes.py, so completed dimensions still get scored.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from quodeq.services._job_model import (
+    InMemoryJobStore,
+    Job,
+    _job_from_json,
+    _job_to_json,
+)
+from quodeq.services.jobs import (
+    JobManager,
+    STATUS_CANCELLED,
+    STATUS_DONE,
+    STATUS_FAILED,
+    STATUS_RUNNING,
+    _EXIT_CODE_TIMEOUT,
+)
+
+
+class _NeverExitsProcess:
+    """Subprocess stub: every wait(timeout=...) raises TimeoutExpired until killed."""
+
+    pid = 123
+
+    def __init__(self):
+        self.stdout = io.StringIO("")
+        self.killed = False
+
+    def wait(self, timeout=None):
+        if self.killed:
+            return -9
+        raise subprocess.TimeoutExpired(cmd="cmd", timeout=timeout)
+
+    def kill(self):
+        self.killed = True
+
+
+class _ExitsWith:
+    """Subprocess stub that exits immediately with the given return code."""
+
+    pid = 124
+
+    def __init__(self, returncode: int):
+        self.stdout = io.StringIO("")
+        self._returncode = returncode
+
+    def wait(self, timeout=None):
+        return self._returncode
+
+
+def _running_job(**kwargs) -> Job:
+    return Job(
+        job_id="j1",
+        status=STATUS_RUNNING,
+        command=["quodeq"],
+        started_at=datetime.now(timezone.utc).isoformat(),
+        ended_at=None,
+        exit_code=None,
+        **kwargs,
+    )
+
+
+def _write_status_json(reports_root: Path, project: str, run_id: str, exit_reason) -> None:
+    run_dir = reports_root / project / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "status.json").write_text(
+        json.dumps({"state": "cancelled", "exit_reason": exit_reason}),
+        encoding="utf-8",
+    )
+
+
+class TestWatchdogDeadlineKill:
+    def test_watchdog_kill_marks_job_cancelled_with_deadline_reason(self, monkeypatch):
+        """A watchdog kill is the time budget doing its job, not a failure."""
+        from quodeq.services import jobs as jobs_mod
+
+        monkeypatch.setattr(jobs_mod, "_WATCHDOG_POLL_INTERVAL_S", 0.01)
+        monkeypatch.setattr(jobs_mod, "_WATCHDOG_DEADLINE_GRACE_S", 0.02)
+        monkeypatch.setattr(jobs_mod, "_terminate_process", lambda p: p.kill())
+
+        store = InMemoryJobStore()
+        mgr = JobManager(job_store=store)
+        past = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+        job = _running_job(deadline_at=past)
+        store.put(job)
+        proc = _NeverExitsProcess()
+        mgr._processes["j1"] = proc
+
+        mgr._monitor_process("j1", proc)
+
+        assert proc.killed is True
+        assert job.status == STATUS_CANCELLED
+        assert job.exit_reason == "deadline"
+        assert job.exit_code == _EXIT_CODE_TIMEOUT
+
+
+class TestRunStatusDeadlineFallback:
+    """The analysis side can exit on its own after recording a deadline.
+
+    The loops in analysis/_loops.py break out at the deadline without the
+    watchdog ever firing; if the process then exits nonzero, the run's
+    status.json exit_reason is the only signal that this was a time-limit
+    exit rather than a real failure.
+    """
+
+    def _manager(self, tmp_path: Path) -> tuple[JobManager, Job]:
+        store = InMemoryJobStore()
+        mgr = JobManager(job_store=store, reports_root=tmp_path)
+        job = _running_job(output_project="proj", output_run_id="run1")
+        store.put(job)
+        return mgr, job
+
+    def test_nonzero_exit_with_run_deadline_reason_is_cancelled(self, tmp_path):
+        mgr, job = self._manager(tmp_path)
+        _write_status_json(tmp_path, "proj", "run1", "deadline")
+        proc = _ExitsWith(1)
+        mgr._processes["j1"] = proc
+
+        mgr._monitor_process("j1", proc)
+
+        assert job.status == STATUS_CANCELLED
+        assert job.exit_reason == "deadline"
+        assert job.exit_code == 1
+
+    def test_time_limit_reason_preserved_verbatim(self, tmp_path):
+        mgr, job = self._manager(tmp_path)
+        _write_status_json(tmp_path, "proj", "run1", "time_limit")
+        proc = _ExitsWith(1)
+        mgr._processes["j1"] = proc
+
+        mgr._monitor_process("j1", proc)
+
+        assert job.status == STATUS_CANCELLED
+        assert job.exit_reason == "time_limit"
+
+    def test_other_exit_reason_stays_failed(self, tmp_path):
+        """Only time-budget reasons soften the failure; provider deaths etc.
+        must keep surfacing as FAILED."""
+        mgr, job = self._manager(tmp_path)
+        _write_status_json(tmp_path, "proj", "run1", "provider_fatal")
+        proc = _ExitsWith(1)
+        mgr._processes["j1"] = proc
+
+        mgr._monitor_process("j1", proc)
+
+        assert job.status == STATUS_FAILED
+        assert job.exit_reason is None
+
+    def test_missing_status_json_stays_failed(self, tmp_path):
+        mgr, job = self._manager(tmp_path)
+        proc = _ExitsWith(1)
+        mgr._processes["j1"] = proc
+
+        mgr._monitor_process("j1", proc)
+
+        assert job.status == STATUS_FAILED
+        assert job.exit_reason is None
+
+    def test_corrupt_status_json_stays_failed(self, tmp_path):
+        mgr, job = self._manager(tmp_path)
+        run_dir = tmp_path / "proj" / "run1"
+        run_dir.mkdir(parents=True)
+        (run_dir / "status.json").write_text("not json", encoding="utf-8")
+        proc = _ExitsWith(1)
+        mgr._processes["j1"] = proc
+
+        mgr._monitor_process("j1", proc)
+
+        assert job.status == STATUS_FAILED
+        assert job.exit_reason is None
+
+    def test_clean_exit_stays_done_even_with_deadline_reason(self, tmp_path):
+        """A rc=0 deadline-truncated run keeps DONE; the coverage banner
+        already tells the truncation story from status.json."""
+        mgr, job = self._manager(tmp_path)
+        _write_status_json(tmp_path, "proj", "run1", "deadline")
+        proc = _ExitsWith(0)
+        mgr._processes["j1"] = proc
+
+        mgr._monitor_process("j1", proc)
+
+        assert job.status == STATUS_DONE
+        assert job.exit_reason is None
+
+
+class TestExitReasonSerialization:
+    def test_to_dict_carries_exit_reason(self):
+        job = _running_job()
+        job.exit_reason = "deadline"
+        assert job.to_dict().exit_reason == "deadline"
+
+    def test_json_round_trip_preserves_exit_reason(self):
+        """FileJobStore persistence must not drop the reason across restarts."""
+        job = _running_job()
+        job.exit_reason = "deadline"
+        assert _job_from_json(_job_to_json(job)).exit_reason == "deadline"


### PR DESCRIPTION
## Problem

When an evaluation is watchdog-killed at its deadline, the run's status.json correctly gets `exit_reason="deadline"` (#956) and the coverage banner shows "time limit reached" (non-error). But the evaluate panel header still showed **evaluation_failed / FAILED**, because `_monitor_process` in `services/jobs.py` marked the job FAILED on any nonzero exit without ever consulting the run's exit reason. The header and the banner directly below it contradicted each other.

## Fix

**Backend**
- `Job` gains an `exit_reason` field (persisted by `FileJobStore`, carried into `JobSnapshot`, camelized to `exitReason` on the wire).
- `_monitor_process` now ends a deadline exit as `status="cancelled"` + `exit_reason` set. Two detection paths:
  - the job's own watchdog fired (deadline or the opt-in `QUODEQ_JOB_TIMEOUT_S` cap - both are time budgets), or
  - the process exited nonzero on its own and the run's status.json records `exit_reason` in ("deadline", "time_limit") - the analysis loops break out at the deadline without the watchdog ever firing.
- Reusing "cancelled" (rather than a new status) keeps the salvage-scoring trigger list in `api/_evaluation_routes.py` working untouched, matches what the run's own lifecycle writes, and avoids extending every status whitelist in the UI. A new route test pins the trigger + the `exitReason` wire contract.
- rc=0 deadline-truncated runs keep `done` - results exist and were scored; the banner tells the truncation story.

**UI**
- Header: terminal jobs (cancelled/failed) with a time-limit exit reason render as `evaluation_time_limit` with a neutral **time limit reached** pill instead of the red FAILED pill. Plain failures, user cancels, and done runs are unchanged.
- STATUS stat tile: drops the now-wrong "user cancelled" hint for "time limit reached" (and softens the failed tile's critical tone when the cause was the time budget).
- New `isTimeLimitExit()` helper in `models/exitReason.js`.

## Testing

TDD throughout - every new assertion was watched failing first.
- `tests/services/test_jobs_deadline_exit.py` (new): watchdog kill, status.json fallback ("deadline"/"time_limit"/other/missing/corrupt), rc=0 stays done, serialization round-trip.
- Updated the three existing watchdog-kill tests whose expectations changed.
- Route test: cancelled+deadline job still spawns salvage scoring and serves `exitReason`.
- UI: header cases in `EvaluationStatus.test.jsx`, tile cases in `buildJobStatCells.test.js`, helper cases in `exitReason.test.js`.
- Full suites green: pytest 5363 passed; UI 178 files / 1474 vitest + 404 node tests.
- Verified end to end in the dashboard: a real subprocess job watchdog-killed at its deadline flips the header to `evaluation_time_limit` / neutral "TIME LIMIT REACHED" pill and the STATUS tile to "cancelled - time limit reached".