### PR TITLE
refactor(t2): DI seams for projection stack, run scores, mutation rescore, pool cache

### DIFF
--- a/src/quodeq/analysis/subagents/_pool_scaling.py
+++ b/src/quodeq/analysis/subagents/_pool_scaling.py
@@ -44,24 +44,35 @@ _QUEUE_CACHE_MAX_SIZE = 64
 _cached_file_queues: OrderedDict[Path, WorkQueue] = OrderedDict()
 
 
-def get_queue(queue: WorkQueue | None, queue_path: Path) -> WorkQueue:
+def clear_cached_queues() -> None:
+    """Empty the process-wide FileQueue cache (test isolation hook)."""
+    _cached_file_queues.clear()
+
+
+def get_queue(
+    queue: WorkQueue | None, queue_path: Path,
+    *, cache: OrderedDict[Path, WorkQueue] | None = None,
+) -> WorkQueue:
     """Return the injected queue or construct a FileQueue from the path.
 
     When *queue* is None a ``FileQueue`` is constructed from *queue_path*.
     The result is cached by path so repeated calls avoid rebuilding the queue.
     The cache is bounded (LRU): in long-running sessions that touch many
     distinct queue paths, the oldest entry is evicted once the cap is hit.
+    *cache* defaults to the process-wide cache; tests inject their own so
+    cached queues never leak between them.
     """
     if queue is not None:
         return queue
-    cached = _cached_file_queues.get(queue_path)
+    c = cache if cache is not None else _cached_file_queues
+    cached = c.get(queue_path)
     if cached is not None:
-        _cached_file_queues.move_to_end(queue_path)
+        c.move_to_end(queue_path)
         return cached
     fq: WorkQueue = FileQueue(queue_path)
-    _cached_file_queues[queue_path] = fq
-    if len(_cached_file_queues) > _QUEUE_CACHE_MAX_SIZE:
-        _cached_file_queues.popitem(last=False)
+    c[queue_path] = fq
+    if len(c) > _QUEUE_CACHE_MAX_SIZE:
+        c.popitem(last=False)
     return fq
 
 

--- a/src/quodeq/data/projection/engine.py
+++ b/src/quodeq/data/projection/engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -15,15 +16,20 @@ _logger = logging.getLogger(__name__)
 class ProjectionEngine:
     """Projects the JSONL event log into evaluation.db."""
 
+    def __init__(
+        self, store_factory: Callable[[Path], SQLiteStateStore] | None = None,
+    ) -> None:
+        self._store_factory = store_factory or SQLiteStateStore
+
     def rebuild(self, event_log: Path, run_dir: Path) -> int:
         """Full rebuild: clear all state and replay every event."""
-        store = SQLiteStateStore(run_dir)
+        store = self._store_factory(run_dir)
         store.clear_all()
         return self._project(event_log, store, since=None)
 
     def update(self, event_log: Path, run_dir: Path) -> int:
         """Incremental: replay only events after the stored checkpoint."""
-        store = SQLiteStateStore(run_dir)
+        store = self._store_factory(run_dir)
         return self._project(event_log, store, since=store.get_checkpoint())
 
     def update_actions(self, actions_log: Path, run_dir: Path, *, force: bool = False) -> int:
@@ -41,7 +47,7 @@ class ProjectionEngine:
         """
         from quodeq.data.actions_log import read_action_events  # noqa: PLC0415
 
-        store = SQLiteStateStore(run_dir)
+        store = self._store_factory(run_dir)
         last_size = store.get_actions_projected_size() or 0
         current_size = actions_log.stat().st_size if actions_log.is_file() else 0
 

--- a/src/quodeq/data/projection/handlers.py
+++ b/src/quodeq/data/projection/handlers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Callable
+from typing import Any, Callable, Protocol
 
 from quodeq.core.events.models import (
     BaseEvent,
@@ -10,21 +10,32 @@ from quodeq.core.events.models import (
     FindingUndismissedEvent,
     JudgmentCreatedEvent,
 )
-from quodeq.data.sqlite.state_store import SQLiteStateStore
 
 _logger = logging.getLogger(__name__)
 
 
-def _handle_judgment_created(event: JudgmentCreatedEvent, store: SQLiteStateStore) -> None:
+class StateStoreWriter(Protocol):
+    """The slice of the state store the event handlers write through.
+
+    ``SQLiteStateStore`` satisfies it in production; tests hand in fakes so
+    handler logic runs without a database file.
+    """
+
+    def record_finding(self, payload: Any) -> None: ...
+
+    def update_verdict(self, *, req: str, file: str, line: int, verdict: str) -> None: ...
+
+
+def _handle_judgment_created(event: JudgmentCreatedEvent, store: StateStoreWriter) -> None:
     store.record_finding(event.payload)
 
 
-def _handle_finding_dismissed(event: FindingDismissedEvent, store: SQLiteStateStore) -> None:
+def _handle_finding_dismissed(event: FindingDismissedEvent, store: StateStoreWriter) -> None:
     payload = event.payload
     store.update_verdict(req=payload.req, file=payload.file, line=payload.line, verdict="dismissed")
 
 
-def _handle_finding_undismissed(event: FindingUndismissedEvent, store: SQLiteStateStore) -> None:
+def _handle_finding_undismissed(event: FindingUndismissedEvent, store: StateStoreWriter) -> None:
     payload = event.payload
     # Restore the original violation verdict. (Compliance findings can't be dismissed
     # in the UI today, so 'violation' is the correct restore target.)
@@ -38,7 +49,7 @@ _HANDLERS: dict[EventType, Callable] = {
 }
 
 
-def handle(event: BaseEvent, store: SQLiteStateStore) -> None:
+def handle(event: BaseEvent, store: StateStoreWriter) -> None:
     """Dispatch an event to its registered handler. Unknown types are skipped."""
     handler = _HANDLERS.get(event.event_type)
     if handler is None:

--- a/src/quodeq/data/projection/projector.py
+++ b/src/quodeq/data/projection/projector.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import threading
 from collections import defaultdict
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -15,7 +16,25 @@ class ProjectionResult:
     rebuilt: bool
 
 
-_ensure_locks: dict[Path, threading.Lock] = defaultdict(threading.Lock)
+class EnsureLockRegistry:
+    """Per-run-dir locks serializing ``ensure_projected``.
+
+    The default registry below is process-wide on purpose — concurrent
+    callers projecting the same run must share one lock. Tests inject a
+    fresh registry so lock state never leaks between them.
+    """
+
+    def __init__(self) -> None:
+        self._locks: dict[Path, threading.Lock] = defaultdict(threading.Lock)
+
+    def lock_for(self, run_dir: Path) -> threading.Lock:
+        return self._locks[run_dir]
+
+    def clear(self) -> None:
+        self._locks.clear()
+
+
+_DEFAULT_LOCKS = EnsureLockRegistry()
 
 
 class Projector:
@@ -26,8 +45,15 @@ class Projector:
     surface it.
     """
 
-    def __init__(self, engine: ProjectionEngine | None = None) -> None:
+    def __init__(
+        self,
+        engine: ProjectionEngine | None = None,
+        store_factory: Callable[[Path], SQLiteStateStore] | None = None,
+        locks: EnsureLockRegistry | None = None,
+    ) -> None:
         self._engine = engine or ProjectionEngine()
+        self._store_factory = store_factory or SQLiteStateStore
+        self._locks = locks or _DEFAULT_LOCKS
 
     def project(
         self,
@@ -44,7 +70,7 @@ class Projector:
         if not events_path.is_file():
             raise FileNotFoundError(f"Event log not found: {events_path}")
 
-        do_rebuild = force_rebuild or SQLiteStateStore(run_dir).get_checkpoint() is None
+        do_rebuild = force_rebuild or self._store_factory(run_dir).get_checkpoint() is None
 
         if do_rebuild:
             count = self._engine.rebuild(events_path, run_dir)
@@ -64,13 +90,13 @@ class Projector:
         if not events_path.is_file():
             raise FileNotFoundError(f"Event log not found: {events_path}")
 
-        with _ensure_locks[run_dir]:
+        with self._locks.lock_for(run_dir):
             if project_dir is not None:
                 from quodeq.data.migrations.dismissed_json_to_actions_log import (  # noqa: PLC0415
                     migrate_if_needed,
                 )
                 migrate_if_needed(project_dir)
-            store = SQLiteStateStore(run_dir)
+            store = self._store_factory(run_dir)
 
             # Events.jsonl branch (today's behavior)
             projected_size = store.get_projected_size()

--- a/src/quodeq/services/mutation_rescore.py
+++ b/src/quodeq/services/mutation_rescore.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -17,26 +18,42 @@ from quodeq.shared.validation import validate_path_segment
 
 _logger = logging.getLogger(__name__)
 
-# Per-project locks for background projection.  A module-level guard lock
-# protects creation of per-project entries; after creation each project's Lock
-# is accessed without the guard.
-#
-# Intentionally unbounded: one tiny Lock object per distinct project name that
-# has ever triggered a background projection on this host.  In practice this
-# mirrors the number of projects on disk, which is small and naturally bounded
-# by real usage.  Contrast with _scored_jobs (bounded LRU) — scored jobs can
-# accumulate many run-ids per project, so a size cap there is meaningful;
-# here there is one entry per project, not per run.
-_projection_locks: dict[str, threading.Lock] = {}
-_projection_locks_guard = threading.Lock()
+class ProjectLockRegistry:
+    """Per-project locks for background projection.
+
+    Intentionally unbounded: one tiny Lock object per distinct project name
+    that has ever triggered a background projection on this host.  In practice
+    this mirrors the number of projects on disk, which is small and naturally
+    bounded by real usage.  Contrast with _scored_jobs (bounded LRU) — scored
+    jobs can accumulate many run-ids per project, so a size cap there is
+    meaningful; here there is one entry per project, not per run.
+
+    The default registry below is process-wide on purpose; tests inject a
+    fresh one so lock state never leaks between them.
+    """
+
+    def __init__(self) -> None:
+        self._locks: dict[str, threading.Lock] = {}
+        self._guard = threading.Lock()
+
+    def get(self, project: str) -> threading.Lock:
+        """Return (and lazily create) the Lock for *project*."""
+        with self._guard:
+            if project not in self._locks:
+                self._locks[project] = threading.Lock()
+            return self._locks[project]
+
+    def clear(self) -> None:
+        with self._guard:
+            self._locks.clear()
 
 
-def _get_projection_lock(project: str) -> threading.Lock:
-    """Return (and lazily create) the Lock for *project*."""
-    with _projection_locks_guard:
-        if project not in _projection_locks:
-            _projection_locks[project] = threading.Lock()
-        return _projection_locks[project]
+_DEFAULT_PROJECT_LOCKS = ProjectLockRegistry()
+
+
+def _get_projection_lock(project: str, registry: ProjectLockRegistry | None = None) -> threading.Lock:
+    """Return the Lock for *project* from *registry* (default: process-wide)."""
+    return (registry or _DEFAULT_PROJECT_LOCKS).get(project)
 
 
 def _resolve_project_dir(evaluations_dir: str, project: str) -> Path:
@@ -85,7 +102,10 @@ def _slim_scores(scores: dict[str, Any]) -> dict[str, Any]:
     return {"dimensions": slim_dims, "summary": scores.get("summary", {})}
 
 
-def _project_all_runs(project_dir: Path) -> None:
+def _project_all_runs(
+    project_dir: Path,
+    repo_factory: Callable[[Path], Any] | None = None,
+) -> None:
     """Trigger projection across every run dir of the project.
 
     Used as a safety net when the dismiss POST didn't carry a usable
@@ -102,15 +122,15 @@ def _project_all_runs(project_dir: Path) -> None:
     """
     if not project_dir.is_dir():
         return
-    from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository  # noqa: PLC0415
+    if repo_factory is None:
+        from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository  # noqa: PLC0415
+        repo_factory = SqliteFindingsRepository
 
-    for run_dir in project_dir.iterdir():
-        if not run_dir.is_dir():
-            continue
+    for run_dir in sorted(p for p in project_dir.iterdir() if p.is_dir()):
         if not (run_dir / "events.jsonl").is_file():
             continue
         try:
-            SqliteFindingsRepository(run_dir).ensure_projected()
+            repo_factory(run_dir).ensure_projected()
         except Exception:
             _logger.warning("Projection after mutation failed for %s", run_dir, exc_info=True)
 

--- a/src/quodeq/services/scoring/_run_scores.py
+++ b/src/quodeq/services/scoring/_run_scores.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from quodeq.core.types import DimensionResult
 from quodeq.services._cache import make_lru_dimension_fetcher
 
-_DEFAULT_CACHE_MAX = int(os.environ.get("QUODEQ_DEFAULT_CACHE_MAX", "256"))
+_FALLBACK_CACHE_MAX = 256
 
 # Module-level cache shared across callers in the same process. Quodeq's
 # server is single-process, so this is intentional. Multi-process setups
@@ -18,14 +18,26 @@ _cache: OrderedDict[tuple, list[DimensionResult]] = OrderedDict()
 _cache_lock = threading.Lock()
 
 
+def _resolve_cache_max(env: dict[str, str] | None = None) -> int:
+    """LRU ceiling from QUODEQ_DEFAULT_CACHE_MAX, resolved per call.
+
+    Env-injection seam (not an import-time constant) so tests and callers
+    can vary the ceiling without reloading the module.
+    """
+    raw = (env if env is not None else os.environ).get("QUODEQ_DEFAULT_CACHE_MAX", "")
+    return int(raw) if raw.isdigit() and int(raw) > 0 else _FALLBACK_CACHE_MAX
+
+
 def get_run_dimensions(
     reports_root: Path, project: str, run_id: str,
     *, cache: OrderedDict | None = None,
     cache_lock: threading.Lock | None = None,
-    cache_max: int = _DEFAULT_CACHE_MAX,
+    cache_max: int | None = None,
+    env: dict[str, str] | None = None,
 ) -> list[DimensionResult]:
     """Return dimension data for a single run, using the shared LRU cache."""
     c = cache if cache is not None else _cache
     lk = cache_lock if cache_lock is not None else _cache_lock
-    fetcher = make_lru_dimension_fetcher(reports_root, project, c, lk, cache_max)
+    ceiling = cache_max if cache_max is not None else _resolve_cache_max(env)
+    fetcher = make_lru_dimension_fetcher(reports_root, project, c, lk, ceiling)
     return fetcher(run_id)

--- a/tests/analysis/test_pool_scaling_cache_seam.py
+++ b/tests/analysis/test_pool_scaling_cache_seam.py
@@ -1,0 +1,38 @@
+"""Seam for the pool-scaling FileQueue cache: injectable and clearable."""
+from __future__ import annotations
+
+import json
+from collections import OrderedDict
+from pathlib import Path
+
+from quodeq.analysis.subagents import _pool_scaling
+
+
+def _queue_file(tmp_path: Path) -> Path:
+    p = tmp_path / "q.json"
+    p.write_text(json.dumps(
+        {"version": 1, "pending": [], "taken": [], "max_files_per_agent": 10}
+    ))
+    return p
+
+
+def test_get_queue_uses_injected_cache(tmp_path):
+    cache: OrderedDict = OrderedDict()
+    p = _queue_file(tmp_path)
+
+    q1 = _pool_scaling.get_queue(None, p, cache=cache)
+    q2 = _pool_scaling.get_queue(None, p, cache=cache)
+
+    assert q1 is q2
+    assert list(cache) == [p]
+    assert p not in _pool_scaling._cached_file_queues
+
+
+def test_clear_cached_queues(tmp_path):
+    p = _queue_file(tmp_path)
+    _pool_scaling.get_queue(None, p)
+    assert p in _pool_scaling._cached_file_queues
+
+    _pool_scaling.clear_cached_queues()
+
+    assert len(_pool_scaling._cached_file_queues) == 0

--- a/tests/api/test_cluster6_projection_offthread.py
+++ b/tests/api/test_cluster6_projection_offthread.py
@@ -14,7 +14,7 @@ import pytest
 from flask import Flask
 
 from quodeq.api.routes_findings import register_findings_routes
-from quodeq.services.mutation_rescore import _projection_locks
+from quodeq.services.mutation_rescore import _DEFAULT_PROJECT_LOCKS
 from tests._timeouts import budget
 
 
@@ -75,7 +75,7 @@ def test_concurrent_dismisses_same_project_call_project_all_runs_once(
     skip projection when the first is still running.
     """
     # Clear any leftover lock state from previous tests.
-    _projection_locks.clear()
+    _DEFAULT_PROJECT_LOCKS.clear()
 
     (tmp_path / "proj").mkdir()
 

--- a/tests/data/test_projection_di_seams.py
+++ b/tests/data/test_projection_di_seams.py
@@ -1,0 +1,142 @@
+"""DI seams for the projection stack: injected stores, engines, and locks.
+
+The projection stack hardcoded ``SQLiteStateStore(run_dir)`` at every layer
+and serialized ``ensure_projected`` through a module-global lock dict, so no
+test could exercise projection logic without a real SQLite file, and global
+lock state leaked between tests. Each collaborator is now injectable with
+the concrete default preserved.
+"""
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+from quodeq.data.projection.engine import ProjectionEngine
+from quodeq.data.projection.projector import Projector, ProjectionResult
+
+
+class _FakeStore:
+    def __init__(self):
+        self.cleared = False
+        self.findings = []
+        self.checkpoint = None
+        self.projected_size = None
+
+    def clear_all(self):
+        self.cleared = True
+
+    def get_checkpoint(self):
+        return self.checkpoint
+
+    def save_checkpoint(self, ts):
+        self.checkpoint = ts
+
+    def save_projected_size(self, n):
+        self.projected_size = n
+
+    def get_projected_size(self):
+        return self.projected_size
+
+    def record_finding(self, payload):
+        self.findings.append(payload)
+
+
+class _FakeEngine:
+    def __init__(self):
+        self.calls = []
+
+    def rebuild(self, path, run_dir):
+        self.calls.append(("rebuild", path, run_dir))
+        return 3
+
+    def update(self, path, run_dir):
+        self.calls.append(("update", path, run_dir))
+        return 1
+
+
+def test_engine_uses_injected_store_factory(tmp_path):
+    log = tmp_path / "events.jsonl"
+    log.write_text("")
+    made = []
+
+    def factory(run_dir):
+        s = _FakeStore()
+        made.append((run_dir, s))
+        return s
+
+    ProjectionEngine(store_factory=factory).rebuild(log, tmp_path)
+
+    assert made and made[0][0] == tmp_path
+    assert made[0][1].cleared is True
+    assert not (tmp_path / "evaluation.db").exists()
+
+
+def test_projector_rebuild_decision_via_injected_store(tmp_path):
+    log = tmp_path / "events.jsonl"
+    log.write_text("")
+
+    fresh = _FakeStore()  # checkpoint None -> rebuild
+    engine = _FakeEngine()
+    res = Projector(engine=engine, store_factory=lambda d: fresh).project(log, tmp_path)
+    assert res == ProjectionResult(events_projected=3, rebuilt=True)
+
+    seen = _FakeStore()
+    seen.checkpoint = "2026-01-01T00:00:00"
+    res2 = Projector(engine=engine, store_factory=lambda d: seen).project(log, tmp_path)
+    assert res2 == ProjectionResult(events_projected=1, rebuilt=False)
+    assert [c[0] for c in engine.calls] == ["rebuild", "update"]
+
+
+def test_ensure_lock_registry_shares_and_clears(tmp_path):
+    from quodeq.data.projection.projector import EnsureLockRegistry
+
+    reg = EnsureLockRegistry()
+    a = reg.lock_for(tmp_path)
+    assert reg.lock_for(tmp_path) is a
+    assert isinstance(a, type(threading.Lock()))
+    reg.clear()
+    assert reg.lock_for(tmp_path) is not a
+
+
+def test_ensure_projected_uses_injected_locks_and_store(tmp_path):
+    from quodeq.data.projection.projector import EnsureLockRegistry
+
+    log = tmp_path / "events.jsonl"
+    log.write_text("x\n")
+
+    class _SpyRegistry(EnsureLockRegistry):
+        def __init__(self):
+            super().__init__()
+            self.asked = []
+
+        def lock_for(self, run_dir):
+            self.asked.append(run_dir)
+            return super().lock_for(run_dir)
+
+    store = _FakeStore()
+    store.projected_size = log.stat().st_size  # fresh -> early no-op return
+    reg = _SpyRegistry()
+    proj = Projector(engine=_FakeEngine(), store_factory=lambda d: store, locks=reg)
+
+    res = proj.ensure_projected(log, tmp_path)
+
+    assert res == ProjectionResult(events_projected=0, rebuilt=False)
+    assert reg.asked == [tmp_path]
+
+
+def test_handlers_do_not_depend_on_concrete_store():
+    """Handlers write through the StateStoreWriter protocol; the concrete
+    SQLite class must not be a runtime dependency of the handler module."""
+    import quodeq.data.projection.handlers as handlers
+
+    assert "SQLiteStateStore" not in vars(handlers)
+
+
+def test_handle_dispatches_to_duck_typed_store():
+    from quodeq.core.events.models import EventType
+    from quodeq.data.projection.handlers import handle
+
+    store = _FakeStore()
+    ev = SimpleNamespace(event_type=EventType.JUDGMENT_CREATED, payload={"req": "X-1"})
+    handle(ev, store)
+    assert store.findings == [{"req": "X-1"}]

--- a/tests/services/test_mutation_rescore_seams.py
+++ b/tests/services/test_mutation_rescore_seams.py
@@ -1,0 +1,35 @@
+"""DI seams for mutation_rescore: injectable project locks and repo factory."""
+from __future__ import annotations
+
+
+def test_project_lock_registry_shares_per_project_and_clears():
+    from quodeq.services.mutation_rescore import ProjectLockRegistry
+
+    reg = ProjectLockRegistry()
+    a = reg.get("proj-a")
+    assert reg.get("proj-a") is a
+    assert reg.get("proj-b") is not a
+    reg.clear()
+    assert reg.get("proj-a") is not a
+
+
+def test_project_all_runs_uses_injected_repo_factory(tmp_path):
+    from quodeq.services.mutation_rescore import _project_all_runs
+
+    (tmp_path / "r1").mkdir()
+    (tmp_path / "r1" / "events.jsonl").write_text("")
+    (tmp_path / "r2").mkdir()  # no events.jsonl -> skipped
+
+    seen = []
+
+    class _FakeRepo:
+        def __init__(self, run_dir):
+            self._run_dir = run_dir
+
+        def ensure_projected(self):
+            seen.append(self._run_dir)
+
+    _project_all_runs(tmp_path, repo_factory=_FakeRepo)
+
+    assert seen == [tmp_path / "r1"]
+    assert not (tmp_path / "r1" / "evaluation.db").exists()

--- a/tests/services/test_run_scores_seams.py
+++ b/tests/services/test_run_scores_seams.py
@@ -1,0 +1,22 @@
+"""Seams for _run_scores: env-injected cache ceiling, no import-time env read."""
+from __future__ import annotations
+
+import quodeq.services.scoring._run_scores as run_scores
+
+
+def test_resolve_cache_max_honors_injected_env():
+    assert run_scores._resolve_cache_max({"QUODEQ_DEFAULT_CACHE_MAX": "7"}) == 7
+
+
+def test_resolve_cache_max_defaults_without_env():
+    assert run_scores._resolve_cache_max({}) == 256
+
+
+def test_resolve_cache_max_ignores_garbage():
+    assert run_scores._resolve_cache_max({"QUODEQ_DEFAULT_CACHE_MAX": "soon"}) == 256
+
+
+def test_no_import_time_env_read():
+    """The ceiling is resolved per call via the env-injection seam, not
+    frozen into a module constant at import time."""
+    assert not hasattr(run_scores, "_DEFAULT_CACHE_MAX")


### PR DESCRIPTION
First fix batch from the clean-architecture dogfood keep-list ([triage 2026-08-01]: 67 real findings, theme **T2 = missing DI seams / module-global state**, 14 findings; 11 Python ones addressed here, 3 UI ones deferred to the T3 UI workstream).

All seams follow the codebase's established injection-with-default pattern. Behavior unchanged; every construction site keeps working with no-arg defaults.

| Finding(s) | Seam |
|---|---|
| `engine.py` TES-02 x3, `projector.py` DB-02 | `store_factory: Callable[[Path], SQLiteStateStore]` on both; rebuild decision + all projection paths go through it |
| `projector.py` TES-03 (`_ensure_locks` global) | `EnsureLockRegistry` — process-wide default preserved, injectable + clearable |
| `handlers.py` DEP-05 (concrete store dep) | `StateStoreWriter` Protocol; SQLite class no longer a runtime dep of the module |
| `_run_scores.py` DEP-07 + TES-03 | `QUODEQ_DEFAULT_CACHE_MAX` resolved per call via env-injection seam; no import-time env read |
| `mutation_rescore.py` TES-03 + DEP-08 | `ProjectLockRegistry` (clearable) + `repo_factory` param on `_project_all_runs` |
| `_pool_scaling.py` TES-03 (queue cache) | `cache` param on `get_queue` + `clear_cached_queues()` hook |

## Tests (TDD)

14 new tests across 4 files, 13 watched fail first (the 14th documents the pre-existing duck-typing contract). One existing test migrated from reaching into the removed `_projection_locks` dict to `_DEFAULT_PROJECT_LOCKS.clear()` — exactly the leak the registry fixes.

Full suite: **5378 passed, 1 skipped**.

## Expected dogfood effect

These were the kept instances under CLEA-TES-02, CLEA-TES-03, CLEA-DB-02, CLEA-DEP-05 (Python side) — the next incremental evaluation re-analyzes the changed files and should clear those principles, which is the fastest path to moving the 5.0 pinned by `floorMajor`.