### PR TITLE
refactor(t1): move findings-table SQL out of services into a data-layer query module

### DIFF
--- a/src/quodeq/data/sqlite/findings_queries.py
+++ b/src/quodeq/data/sqlite/findings_queries.py
@@ -1,0 +1,111 @@
+"""Read-only queries over a run's ``findings`` table.
+
+The services layer (dismissed/deleted/run_keys) used to inline this SQL,
+which coupled business flows to the schema and pulled sqlite3 into the
+service layer. All three reads live here so the schema stays an
+adapter-layer detail. Every function is best-effort: an absent or
+unreadable database yields empty results, matching the callers'
+long-standing behavior.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+
+from quodeq.data.sqlite.connection import open_evaluation_db
+
+_logger = logging.getLogger(__name__)
+
+
+def read_finding_details(run_dir: Path, keys: set[tuple]) -> dict[tuple, dict]:
+    """Return finding-detail dicts for the ``(requirement, file, line)``
+    *keys* present in *run_dir*'s findings table.
+
+    Keys not present are simply absent from the result. The SQL ``verdict``
+    column is ignored on purpose: actions.jsonl is the source of truth for
+    *which* findings are dismissed; the row only supplies *what* the finding
+    was. A corrupt database returns whatever was read before the error.
+    """
+    db_path = run_dir / "evaluation.db"
+    if not db_path.is_file():
+        return {}
+    out: dict[tuple, dict] = {}
+    try:
+        with open_evaluation_db(run_dir) as conn:
+            cursor = conn.execute(
+                "SELECT requirement, file, line, dimension, practice_id, severity, "
+                "title, reason, snippet, context, scope, end_line, req_refs_json "
+                "FROM findings"
+            )
+            for row in cursor:
+                key = (str(row[0] or ""), str(row[1] or ""), int(row[2] or 0))
+                if key not in keys or key in out:
+                    continue
+                req_refs_raw = row[12]
+                try:
+                    req_refs = json.loads(req_refs_raw) if req_refs_raw else []
+                except (json.JSONDecodeError, TypeError):
+                    req_refs = []
+                out[key] = {
+                    "req": row[0] or "", "file": row[1] or "", "line": row[2] or 0,
+                    "dimension": row[3] or "", "principle": row[4] or "",
+                    "severity": row[5] or "", "title": row[6] or "", "reason": row[7] or "",
+                    "snippet": row[8] or "", "context": row[9] or "", "scope": row[10] or "",
+                    "endLine": row[11] or 0, "reqRefs": req_refs,
+                }
+    except sqlite3.DatabaseError:
+        return out
+    return out
+
+
+def read_run_key_sets(run_dir: Path) -> tuple[set[tuple], set[tuple]]:
+    """Return ``(dismiss_keys, class_keys)`` present in *run_dir*'s findings.
+
+    ``dismiss_keys``: ``{(requirement, file, line)}``.
+    ``class_keys``: ``{(dimension, practice_id, file)}``.
+    Keys come from ALL findings regardless of verdict, so a dismiss (which
+    only flips a verdict) never changes a run's key set.
+    """
+    db_path = run_dir / "evaluation.db"
+    if not db_path.is_file():
+        return set(), set()
+    dismiss: set[tuple] = set()
+    cls: set[tuple] = set()
+    try:
+        with open_evaluation_db(run_dir) as conn:
+            for req, file, line, dim, pid in conn.execute(
+                "SELECT requirement, file, line, dimension, practice_id FROM findings"
+            ):
+                dismiss.add((str(req or ""), str(file or ""), int(line or 0)))
+                cls.add((str(dim or ""), str(pid or ""), str(file or "")))
+    except sqlite3.DatabaseError:
+        return set(), set()
+    return dismiss, cls
+
+
+def find_dismissed_matching(
+    run_dir: Path, *, dimension: str, practice_id: str, file: str,
+) -> list[tuple[str, str, int]]:
+    """Return ``(requirement, file, line)`` for every DISMISSED finding in
+    *run_dir* matching the ``(dimension, practice_id, file)`` deletion key."""
+    db_path = run_dir / "evaluation.db"
+    if not db_path.is_file():
+        return []
+    try:
+        with open_evaluation_db(run_dir) as conn:
+            return [
+                (row[0] or "", row[1] or "", int(row[2] or 0))
+                for row in conn.execute(
+                    "SELECT requirement, file, line FROM findings "
+                    "WHERE verdict = 'dismissed' AND dimension = ? "
+                    "AND practice_id = ? AND file = ?",
+                    (dimension, practice_id, file),
+                )
+            ]
+    except (sqlite3.Error, OSError):
+        _logger.warning(
+            "Skipping unreadable evaluation.db in %s", run_dir, exc_info=True,
+        )
+        return []

--- a/src/quodeq/services/deleted.py
+++ b/src/quodeq/services/deleted.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import sqlite3
 from contextlib import contextmanager
 from dataclasses import replace
 from datetime import datetime, timezone
@@ -154,10 +153,11 @@ def delete_all_dismissed(project_dir: Path) -> int:
 def _sweep_dismissed_matching(project_dir: Path, key: tuple) -> int:
     """Undismiss every dismissed finding whose ``(dimension, principle, file)`` matches *key*.
 
-    Reads from each run's evaluation.db to find dismissed findings that match
-    the deletion key, then appends FindingUndismissedEvent to actions.jsonl for each.
+    Reads from each run's evaluation.db (via the data layer's
+    ``find_dismissed_matching``) to find dismissed findings that match the
+    deletion key, then appends FindingUndismissedEvent to actions.jsonl for each.
     """
-    from quodeq.data.sqlite.connection import open_evaluation_db  # noqa: PLC0415
+    from quodeq.data.sqlite.findings_queries import find_dismissed_matching  # noqa: PLC0415
 
     dimension, principle, file = key
     if not project_dir.is_dir():
@@ -167,24 +167,11 @@ def _sweep_dismissed_matching(project_dir: Path, key: tuple) -> int:
     for run_dir in project_dir.iterdir():
         if not run_dir.is_dir():
             continue
-        db_path = run_dir / "evaluation.db"
-        if not db_path.is_file():
-            continue
-        try:
-            with open_evaluation_db(run_dir) as conn:
-                for row in conn.execute(
-                    "SELECT requirement, file, line FROM findings "
-                    "WHERE verdict = 'dismissed' AND dimension = ? "
-                    "AND practice_id = ? AND file = ?",
-                    (dimension, principle, file),
-                ):
-                    matching.append((row[0] or "", row[1] or "", int(row[2] or 0)))
-        except (sqlite3.Error, OSError):
-            _logger.warning(
-                "Skipping unreadable evaluation.db while undismissing in %s",
-                run_dir, exc_info=True,
+        matching.extend(
+            find_dismissed_matching(
+                run_dir, dimension=dimension, practice_id=principle, file=file,
             )
-            continue
+        )
 
     if not matching:
         return 0

--- a/src/quodeq/services/dismissed.py
+++ b/src/quodeq/services/dismissed.py
@@ -7,7 +7,6 @@ evaluation.db (aggregated across runs).
 from __future__ import annotations
 
 import json
-import sqlite3
 from dataclasses import replace
 from pathlib import Path
 
@@ -22,7 +21,7 @@ from quodeq.core.events.models import (
 from quodeq.core.types.finding import Finding, SeverityTally, Totals
 from quodeq.data.actions_log import ActionLogWriter, read_action_events
 from quodeq.data.migrations.dismissed_json_to_actions_log import migrate_if_needed
-from quodeq.data.sqlite.connection import open_evaluation_db
+from quodeq.data.sqlite.findings_queries import read_finding_details
 
 
 def dismiss_finding(project_dir: Path, finding: dict) -> None:
@@ -92,40 +91,12 @@ def _enrich_from_sql(run_dir: Path, keys: set[tuple], out: dict[tuple, dict]) ->
     """Add finding detail from a run's SQL findings table for any dismissed key not yet enriched.
 
     Modern runs (those with an ``events.jsonl`` projected into ``findings``)
-    expose the full Judgment row here. We look up by the canonical (req,
-    file, line) tuple — the SQL ``verdict`` column is ignored because we
-    treat ``actions.jsonl`` as the source of truth for *which* findings
-    are dismissed, and the SQL row only for *what* the finding was.
+    expose the full Judgment row here. The lookup and its schema knowledge
+    live in the data layer (``findings_queries``); ``setdefault`` preserves
+    the first-run-wins merge across runs.
     """
-    db_path = run_dir / "evaluation.db"
-    if not db_path.is_file():
-        return
-    try:
-        with open_evaluation_db(run_dir) as conn:
-            cursor = conn.execute(
-                "SELECT requirement, file, line, dimension, practice_id, severity, "
-                "title, reason, snippet, context, scope, end_line, req_refs_json "
-                "FROM findings"
-            )
-            for row in cursor:
-                key = (str(row[0] or ""), str(row[1] or ""), int(row[2] or 0))
-                if key not in keys or key in out:
-                    continue
-                req_refs_raw = row[12]
-                try:
-                    req_refs = json.loads(req_refs_raw) if req_refs_raw else []
-                except (json.JSONDecodeError, TypeError):
-                    req_refs = []
-                out[key] = {
-                    "req": row[0] or "", "file": row[1] or "", "line": row[2] or 0,
-                    "dimension": row[3] or "", "principle": row[4] or "",
-                    "severity": row[5] or "", "title": row[6] or "", "reason": row[7] or "",
-                    "snippet": row[8] or "", "context": row[9] or "", "scope": row[10] or "",
-                    "endLine": row[11] or 0, "reqRefs": req_refs,
-                }
-    except sqlite3.DatabaseError:
-        # Corrupt evaluation.db — skip rather than fail the whole list.
-        return
+    for key, detail in read_finding_details(run_dir, keys).items():
+        out.setdefault(key, detail)
 
 
 def _enrich_from_json_eval(run_dir: Path, keys: set[tuple], out: dict[tuple, dict]) -> None:

--- a/src/quodeq/services/run_keys.py
+++ b/src/quodeq/services/run_keys.py
@@ -5,32 +5,12 @@ run, so the score cache versions each run by (dismissed âˆ© these) + (deleted âˆ
 these). Keys come from ALL findings regardless of verdict, so a dismiss (which
 only flips a verdict) never changes a run's key set. Best-effort: an
 unreadable/absent db yields empty sets.
+
+The SQL itself lives in the data layer (``findings_queries``); this module
+is the service-facing facade.
 """
 from __future__ import annotations
 
-import sqlite3
-from pathlib import Path
+from quodeq.data.sqlite.findings_queries import read_run_key_sets
 
-
-def read_run_key_sets(run_dir: Path) -> tuple[set[tuple], set[tuple]]:
-    """Return ``(dismiss_keys, class_keys)`` present in *run_dir*'s findings.
-
-    ``dismiss_keys``: ``{(requirement, file, line)}`` (matches ``dismissed_keys``).
-    ``class_keys``: ``{(dimension, practice_id, file)}`` (matches ``deleted_keys``).
-    """
-    db_path = run_dir / "evaluation.db"
-    if not db_path.is_file():
-        return set(), set()
-    dismiss: set[tuple] = set()
-    cls: set[tuple] = set()
-    try:
-        from quodeq.data.sqlite.connection import open_evaluation_db  # noqa: PLC0415
-        with open_evaluation_db(run_dir) as conn:
-            for req, file, line, dim, pid in conn.execute(
-                "SELECT requirement, file, line, dimension, practice_id FROM findings"
-            ):
-                dismiss.add((str(req or ""), str(file or ""), int(line or 0)))
-                cls.add((str(dim or ""), str(pid or ""), str(file or "")))
-    except sqlite3.DatabaseError:
-        return set(), set()
-    return dismiss, cls
+__all__ = ["read_run_key_sets"]

--- a/tests/data/test_findings_queries.py
+++ b/tests/data/test_findings_queries.py
@@ -1,0 +1,94 @@
+"""Read-only findings-table queries live in the data layer, not in services.
+
+dismissed.py, deleted.py and run_keys.py used to inline this SQL, coupling
+service flows to the schema (and importing sqlite3 into the service layer).
+The queries now live in ``data/sqlite/findings_queries.py``; services call
+them and no longer carry any database dependency at runtime.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from quodeq.core.events.models import Judgment
+from quodeq.data.sqlite.state_store import SQLiteStateStore
+
+
+def _seed(run_dir: Path, **kw) -> None:
+    defaults = dict(
+        practice_id="P1", verdict="violation", dimension="clean-architecture",
+        file="src/a.py", line=10, reason="r", req="X-1", severity="major",
+        title="t", snippet="s",
+    )
+    SQLiteStateStore(run_dir).record_finding(Judgment(**{**defaults, **kw}))
+
+
+class TestReadFindingDetails:
+    def test_returns_details_for_matching_keys_only(self, tmp_path):
+        from quodeq.data.sqlite.findings_queries import read_finding_details
+
+        _seed(tmp_path, req="X-1", file="src/a.py", line=10)
+        _seed(tmp_path, req="X-2", file="src/b.py", line=20, practice_id="P2")
+
+        out = read_finding_details(tmp_path, {("X-1", "src/a.py", 10)})
+
+        assert set(out) == {("X-1", "src/a.py", 10)}
+        detail = out[("X-1", "src/a.py", 10)]
+        assert detail["req"] == "X-1"
+        assert detail["principle"] == "P1"
+        assert detail["severity"] == "major"
+
+    def test_missing_db_returns_empty(self, tmp_path):
+        from quodeq.data.sqlite.findings_queries import read_finding_details
+
+        assert read_finding_details(tmp_path, {("X", "f", 1)}) == {}
+
+
+class TestReadRunKeySets:
+    def test_returns_dismiss_and_class_keys(self, tmp_path):
+        from quodeq.data.sqlite.findings_queries import read_run_key_sets
+
+        _seed(tmp_path)
+        dismiss, cls = read_run_key_sets(tmp_path)
+
+        assert dismiss == {("X-1", "src/a.py", 10)}
+        assert cls == {("clean-architecture", "P1", "src/a.py")}
+
+    def test_missing_db_returns_empty_sets(self, tmp_path):
+        from quodeq.data.sqlite.findings_queries import read_run_key_sets
+
+        assert read_run_key_sets(tmp_path) == (set(), set())
+
+
+class TestFindDismissedMatching:
+    def test_returns_only_dismissed_rows_matching_key(self, tmp_path):
+        from quodeq.data.sqlite.findings_queries import find_dismissed_matching
+
+        _seed(tmp_path, req="X-1", file="src/a.py", line=10)
+        _seed(tmp_path, req="X-2", file="src/a.py", line=30, practice_id="P2")
+        store = SQLiteStateStore(tmp_path)
+        store.update_verdict(req="X-1", file="src/a.py", line=10, verdict="dismissed")
+
+        rows = find_dismissed_matching(
+            tmp_path, dimension="clean-architecture", practice_id="P1", file="src/a.py",
+        )
+
+        assert rows == [("X-1", "src/a.py", 10)]
+
+    def test_missing_db_returns_empty(self, tmp_path):
+        from quodeq.data.sqlite.findings_queries import find_dismissed_matching
+
+        assert find_dismissed_matching(
+            tmp_path, dimension="d", practice_id="p", file="f",
+        ) == []
+
+
+def test_services_carry_no_database_dependency():
+    """The service modules must not import sqlite3 or the connection helper
+    at runtime — the schema is an adapter-layer detail now."""
+    import quodeq.services.deleted as deleted
+    import quodeq.services.dismissed as dismissed
+    import quodeq.services.run_keys as run_keys
+
+    for mod in (dismissed, deleted, run_keys):
+        assert "sqlite3" not in vars(mod), mod.__name__
+        assert "open_evaluation_db" not in vars(mod), mod.__name__


### PR DESCRIPTION
Second fix batch from the clean-architecture keep-list — theme **T1: services implementing persistence themselves**, sub-group "raw SQL in services" (findings CLEA-DB-02 on `dismissed.py:105`, `deleted.py:160`, `run_keys.py:30` + CLEA-FRM-01 on `dismissed.py:10`).

New `data/sqlite/findings_queries.py` owns the three read paths over a run's `findings` table:

- `read_finding_details(run_dir, keys)` — the Dismissed-tab enrichment lookup (verdict column deliberately ignored: actions.jsonl stays the source of truth for *which*, SQL only for *what*).
- `read_run_key_sets(run_dir)` — cache-version key sets; `services/run_keys.py` is now a facade.
- `find_dismissed_matching(run_dir, ...)` — the delete-sweep query; per-run unreadable-db warning preserved, logged by the adapter.

Behavior parity preserved everywhere: first-run-wins merge, corrupt-db partials, best-effort empties on absent DBs. No service module imports `sqlite3` or `open_evaluation_db` at runtime anymore — pinned by test.

## Tests (TDD)

7 new tests in `tests/data/test_findings_queries.py`, all watched fail first, including the decoupling pin over all three service modules. Full suite: **5385 passed, 1 skipped**.