### PR TITLE
refactor(t1): funnel all git subprocess execution through data/git_cli

### DIFF
--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -166,7 +166,7 @@ def _setup_run_dirs(args: argparse.Namespace, src: Path) -> tuple[Path, Path, Pa
     # different local paths share a single project identity.
     remote_url = None
     if location == "local":
-        from quodeq.shared._repo import git_remote_url
+        from quodeq.data.git_cli import git_remote_url
         remote_url = git_remote_url(str(src))
 
     project_uuid = resolve_project_uuid(

--- a/src/quodeq/analysis/subagents/_git_scoring.py
+++ b/src/quodeq/analysis/subagents/_git_scoring.py
@@ -1,9 +1,10 @@
 """Git-based file scoring -- churn and recency signals for file prioritization."""
 from __future__ import annotations
 
-import subprocess
 from datetime import datetime, timedelta
 from pathlib import Path
+
+from quodeq.data.git_cli import stream_log_names
 
 _GIT_LOG_TIMEOUT_S = 10
 _GIT_HASH_LENGTH = 40
@@ -30,48 +31,16 @@ def _has_git(src: Path) -> bool:
     return False
 
 
-def _run_git_log(src: Path, months: int = 3) -> str | None:
-    """Run git log and return raw output, or None if git unavailable.
+def _iter_git_log(src: Path, months: int = 3):
+    """Yield git log lines one at a time (streaming, no full materialization).
 
-    This function (together with ``_iter_git_log``) is the git abstraction
-    layer: all git subprocess calls are funnelled through these two helpers,
-    making it straightforward to swap in a different git backend or mock
-    git access in tests.
+    Process execution lives in ``data/git_cli.stream_log_names``; this
+    wrapper keeps the scoring-local seam that tests patch by name, and the
+    repo pre-check that skips non-git sources without spawning anything.
     """
     if not _has_git(src):
-        return None
-    try:
-        result = subprocess.run(
-            ["git", "log", f"--since={months} months ago", "--name-only", "--format=%H%n%ai"],
-            cwd=str(src), capture_output=True, text=True, encoding="utf-8", timeout=_GIT_LOG_TIMEOUT_S,
-        )
-        return result.stdout if result.returncode == 0 else None
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-
-
-def _iter_git_log(src: Path, months: int = 3):
-    """Yield git log lines one at a time via streaming Popen, avoiding full materialization."""
-    if not _has_git(src):
         return
-    try:
-        proc = subprocess.Popen(
-            ["git", "log", f"--since={months} months ago", "--name-only", "--format=%H%n%ai"],
-            cwd=str(src), stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, encoding="utf-8",
-        )
-    except OSError:
-        return
-    try:
-        assert proc.stdout is not None
-        for line in proc.stdout:
-            yield line
-    finally:
-        proc.stdout.close()  # type: ignore[union-attr]
-        try:
-            proc.wait(timeout=_GIT_LOG_TIMEOUT_S)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait()
+    yield from stream_log_names(src, months=months, timeout=_GIT_LOG_TIMEOUT_S)
 
 
 def compute_git_scores(files: list[str], src: Path, config: dict | None = None) -> dict[str, float]:

--- a/src/quodeq/data/git_cli.py
+++ b/src/quodeq/data/git_cli.py
@@ -1,0 +1,104 @@
+"""Git CLI adapter — the single place that shells out to git.
+
+services/_fs_scan, services/project_registration, shared/_repo and
+analysis/subagents/_git_scoring used to run subprocess directly, coupling
+business flows to process execution. Every helper here is best-effort:
+missing git, non-repo directories, timeouts and failures yield None or
+empty results, matching the callers' long-standing behavior.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+
+from quodeq.shared._repo import normalize_remote_url
+
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT_S = 10
+
+
+def run_git(
+    args: Sequence[str], *, cwd: Path | str | None = None,
+    timeout: float = _DEFAULT_TIMEOUT_S,
+) -> str | None:
+    """Run ``git *args`` and return stdout, or None on any failure."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd) if cwd is not None else None,
+            capture_output=True, text=True, encoding="utf-8", timeout=timeout,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def list_branches(repo_dir: Path, *, timeout: float = _DEFAULT_TIMEOUT_S) -> list[str]:
+    """Local branch names of *repo_dir*; empty when not a git repo."""
+    if not (repo_dir / ".git").exists():
+        return []
+    out = run_git(
+        ["-C", str(repo_dir), "branch", "--format=%(refname:short)"],
+        timeout=timeout,
+    )
+    if out is None:
+        _logger.debug("Failed to list git branches for %s", repo_dir)
+        return []
+    return [b.strip() for b in out.splitlines() if b.strip()]
+
+
+def remote_origin_url_raw(repo_dir: Path | str, *, timeout: float = _DEFAULT_TIMEOUT_S) -> str | None:
+    """``git remote get-url origin`` verbatim, or None when absent/unreadable."""
+    out = run_git(["-C", str(repo_dir), "remote", "get-url", "origin"], timeout=timeout)
+    if out is None:
+        return None
+    origin = out.strip()
+    return origin or None
+
+
+def git_remote_url(repo_path: str, *, timeout: float = _DEFAULT_TIMEOUT_S) -> str | None:
+    """Normalized canonical URL of the git 'origin' remote, if any.
+
+    Reads ``git config --get remote.origin.url`` and folds equivalent forms
+    (https / ssh:// / git@host:path, with or without ``.git``) into
+    ``host/owner/repo`` via ``shared._repo.normalize_remote_url``.
+    """
+    out = run_git(
+        ["-C", repo_path, "config", "--get", "remote.origin.url"], timeout=timeout,
+    )
+    if out is None:
+        return None
+    return normalize_remote_url(out)
+
+
+def stream_log_names(
+    repo_dir: Path, *, months: int = 3, timeout: float = _DEFAULT_TIMEOUT_S,
+) -> Iterator[str]:
+    """Yield ``git log --name-only`` lines one at a time (streaming Popen).
+
+    Avoids materializing the full log for large repositories. Yields
+    nothing when git is unavailable or the command cannot start.
+    """
+    try:
+        proc = subprocess.Popen(
+            ["git", "log", f"--since={months} months ago", "--name-only", "--format=%H%n%ai"],
+            cwd=str(repo_dir), stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            text=True, encoding="utf-8",
+        )
+    except OSError:
+        return
+    try:
+        assert proc.stdout is not None
+        yield from proc.stdout
+    finally:
+        proc.stdout.close()  # type: ignore[union-attr]
+        try:
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()

--- a/src/quodeq/services/_fs_scan.py
+++ b/src/quodeq/services/_fs_scan.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import dataclasses
 import json
 import logging
-import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
 from quodeq.core.types.scan import ScanData
+from quodeq.data.git_cli import list_branches
 
 _logger = logging.getLogger(__name__)
 
@@ -96,19 +96,7 @@ def _walk_files(root: Path):
 
 def _list_branches(project_dir: Path) -> list[str]:
     """List local git branches, returning empty list if not a git repo."""
-    if not (project_dir / ".git").exists():
-        return []
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(project_dir), "branch", "--format=%(refname:short)"],
-            capture_output=True, text=True, encoding="utf-8", timeout=_GIT_TIMEOUT_S,
-        )
-        if result.returncode != 0:
-            return []
-        return [b.strip() for b in result.stdout.splitlines() if b.strip()]
-    except (subprocess.TimeoutExpired, OSError):
-        _logger.debug("Failed to list git branches for %s", project_dir)
-        return []
+    return list_branches(project_dir, timeout=_GIT_TIMEOUT_S)
 
 
 def _list_modules(project_dir: Path) -> list[str]:

--- a/src/quodeq/services/project_registration.py
+++ b/src/quodeq/services/project_registration.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 
 import json
 import re
-import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
+from quodeq.data.git_cli import remote_origin_url_raw
 from quodeq.data.fs.project_resolver import ProjectIdentity, resolve_project_uuid
 from quodeq.data.fs.repo_validation import validate_remote_url
 from quodeq.services._fs_clone import run_git_clone
@@ -54,15 +54,8 @@ def _scan_parent_project(project_dir: Path, reports_path: Path, repo_path: Path)
 
 def _read_origin_remote(repo_dir: Path) -> str | None:
     """Best-effort ``git remote get-url origin`` for a local working copy."""
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(repo_dir), "remote", "get-url", "origin"],
-            capture_output=True, text=True, encoding="utf-8", timeout=10,
-        )
-    except (subprocess.SubprocessError, OSError):
-        return None
-    origin = result.stdout.strip()
-    if result.returncode != 0 or not origin:
+    origin = remote_origin_url_raw(repo_dir)
+    if not origin:
         return None
     return _strip_credentials(origin)
 

--- a/src/quodeq/shared/_repo.py
+++ b/src/quodeq/shared/_repo.py
@@ -1,7 +1,10 @@
-"""Repository URL helpers."""
+"""Repository URL helpers — pure string/path logic only.
+
+Anything that shells out to git lives in ``data/git_cli.py``; this module
+stays importable from the core-only ``shared`` layer.
+"""
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 
 
@@ -26,15 +29,8 @@ def project_name_from_repo(repo: str) -> str:
     return Path(repo).resolve().name
 
 
-def git_remote_url(repo_path: str) -> str | None:
-    """Return the normalized canonical URL of the git 'origin' remote, if any.
-
-    Reads the origin remote URL via ``git config`` from *repo_path*.
-    Returns ``None`` if:
-    - path is not a git repo
-    - no 'origin' remote configured
-    - git is not installed
-    - remote URL is malformed / empty
+def normalize_remote_url(url: str) -> str | None:
+    """Fold equivalent git remote URL forms into one canonical form.
 
     Normalization maps these equivalent forms to a single canonical form:
       - ``git@github.com:owner/repo.git`` -> ``github.com/owner/repo``
@@ -45,18 +41,9 @@ def git_remote_url(repo_path: str) -> str | None:
     Trailing ``.git`` is stripped. Leading ``https://`` / ``ssh://`` / ``git@``
     is stripped. The colon in ``git@host:path`` form is converted to ``/``.
     Non-standard ports (e.g. ``host:22/path``) are not supported.
+    Returns ``None`` for an empty/blank input.
     """
-    try:
-        result = subprocess.run(
-            ["git", "-C", repo_path, "config", "--get", "remote.origin.url"],
-            capture_output=True,
-            text=True, encoding="utf-8",
-            check=True,
-        )
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        return None
-
-    url = result.stdout.strip()
+    url = (url or "").strip()
     if not url:
         return None
 

--- a/tests/data/test_git_cli.py
+++ b/tests/data/test_git_cli.py
@@ -1,0 +1,115 @@
+"""The git CLI adapter is the single place that shells out to git.
+
+services/_fs_scan, services/project_registration, shared/_repo and
+analysis/subagents/_git_scoring used to run subprocess directly. The
+process execution now lives in ``data/git_cli.py``; the callers keep only
+their domain logic (and shared keeps the pure URL normalizer).
+"""
+from __future__ import annotations
+
+import subprocess as sp
+from pathlib import Path
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    sp.run(["git", "init", "-q", "-b", "main", str(tmp_path)], check=True)
+    return tmp_path
+
+
+def _commit(repo: Path, name: str = "f.txt") -> None:
+    (repo / name).write_text("x")
+    sp.run(["git", "-C", str(repo), "add", "."], check=True)
+    sp.run(
+        ["git", "-C", str(repo), "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-q", "-m", "c"],
+        check=True,
+    )
+
+
+class TestRunGit:
+    def test_returns_stdout_on_success(self, tmp_path):
+        from quodeq.data.git_cli import run_git
+
+        repo = _init_repo(tmp_path)
+        out = run_git(["rev-parse", "--is-inside-work-tree"], cwd=repo)
+        assert out is not None and out.strip() == "true"
+
+    def test_returns_none_outside_a_repo(self, tmp_path):
+        from quodeq.data.git_cli import run_git
+
+        assert run_git(["rev-parse", "--is-inside-work-tree"], cwd=tmp_path) is None
+
+
+class TestListBranches:
+    def test_lists_local_branches(self, tmp_path):
+        from quodeq.data.git_cli import list_branches
+
+        repo = _init_repo(tmp_path)
+        _commit(repo)
+        assert list_branches(repo) == ["main"]
+
+    def test_non_repo_returns_empty(self, tmp_path):
+        from quodeq.data.git_cli import list_branches
+
+        assert list_branches(tmp_path) == []
+
+
+class TestRemoteOrigin:
+    def test_raw_url(self, tmp_path):
+        from quodeq.data.git_cli import remote_origin_url_raw
+
+        repo = _init_repo(tmp_path)
+        sp.run(
+            ["git", "-C", str(repo), "remote", "add", "origin",
+             "https://github.com/x/y.git"],
+            check=True,
+        )
+        assert remote_origin_url_raw(repo) == "https://github.com/x/y.git"
+
+    def test_none_without_remote(self, tmp_path):
+        from quodeq.data.git_cli import remote_origin_url_raw
+
+        assert remote_origin_url_raw(_init_repo(tmp_path)) is None
+
+    def test_normalized_remote_url(self, tmp_path):
+        from quodeq.data.git_cli import git_remote_url
+
+        repo = _init_repo(tmp_path)
+        sp.run(
+            ["git", "-C", str(repo), "remote", "add", "origin",
+             "git@github.com:quodeq/quodeq.git"],
+            check=True,
+        )
+        assert git_remote_url(str(repo)) == "github.com/quodeq/quodeq"
+
+    def test_normalized_none_for_non_repo(self, tmp_path):
+        from quodeq.data.git_cli import git_remote_url
+
+        assert git_remote_url(str(tmp_path)) is None
+
+
+class TestStreamLogNames:
+    def test_yields_log_lines(self, tmp_path):
+        from quodeq.data.git_cli import stream_log_names
+
+        repo = _init_repo(tmp_path)
+        _commit(repo, "a.txt")
+        lines = list(stream_log_names(repo, months=1))
+        assert any("a.txt" in line for line in lines)
+
+    def test_non_repo_yields_nothing(self, tmp_path):
+        from quodeq.data.git_cli import stream_log_names
+
+        assert list(stream_log_names(tmp_path, months=3)) == []
+
+
+def test_callers_carry_no_subprocess_dependency():
+    """Process execution is an adapter-layer detail: none of the former
+    call sites may import subprocess at runtime."""
+    import quodeq.analysis.subagents._git_scoring as git_scoring
+    import quodeq.services._fs_scan as fs_scan
+    import quodeq.services.project_registration as project_registration
+    import quodeq.shared._repo as repo
+
+    for mod in (fs_scan, project_registration, repo, git_scoring):
+        assert "subprocess" not in vars(mod), mod.__name__

--- a/tests/services/test_fs_scan_coverage.py
+++ b/tests/services/test_fs_scan_coverage.py
@@ -103,30 +103,30 @@ class TestListBranches:
 
     def test_git_failure(self, tmp_path):
         (tmp_path / ".git").mkdir()
-        with patch("quodeq.services._fs_scan.subprocess.run") as mock_run:
+        with patch("quodeq.data.git_cli.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stdout="")
             assert _list_branches(tmp_path) == []
 
     def test_timeout(self, tmp_path):
         (tmp_path / ".git").mkdir()
-        with patch("quodeq.services._fs_scan.subprocess.run", side_effect=subprocess.TimeoutExpired("git", 10)):
+        with patch("quodeq.data.git_cli.subprocess.run", side_effect=subprocess.TimeoutExpired("git", 10)):
             assert _list_branches(tmp_path) == []
 
     def test_os_error(self, tmp_path):
         (tmp_path / ".git").mkdir()
-        with patch("quodeq.services._fs_scan.subprocess.run", side_effect=OSError("fail")):
+        with patch("quodeq.data.git_cli.subprocess.run", side_effect=OSError("fail")):
             assert _list_branches(tmp_path) == []
 
     def test_parses_branches(self, tmp_path):
         (tmp_path / ".git").mkdir()
-        with patch("quodeq.services._fs_scan.subprocess.run") as mock_run:
+        with patch("quodeq.data.git_cli.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="main\nfeature/x\n  develop  \n")
             branches = _list_branches(tmp_path)
             assert branches == ["main", "feature/x", "develop"]
 
     def test_empty_lines_filtered(self, tmp_path):
         (tmp_path / ".git").mkdir()
-        with patch("quodeq.services._fs_scan.subprocess.run") as mock_run:
+        with patch("quodeq.data.git_cli.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="\n\n  \n")
             assert _list_branches(tmp_path) == []
 

--- a/tests/shared/test_repo_remote_url.py
+++ b/tests/shared/test_repo_remote_url.py
@@ -1,8 +1,10 @@
-"""Tests for git_remote_url and project_name_from_repo edge cases."""
-from __future__ import annotations
+"""Tests for the pure repo-URL helpers in shared/_repo.
 
-import subprocess
-from unittest.mock import patch
+``normalize_remote_url`` is a pure string function (no git, no patching);
+the process side lives in ``data/git_cli.py`` and is covered by
+``tests/data/test_git_cli.py`` against real repositories.
+"""
+from __future__ import annotations
 
 
 def test_project_name_resolves_dot_to_basename(tmp_path, monkeypatch):
@@ -19,51 +21,27 @@ def test_project_name_url_unchanged():
     assert project_name_from_repo("https://github.com/quodeq/quodeq.git") == "quodeq"
 
 
-def test_git_remote_url_normalizes_https():
-    from quodeq.shared._repo import git_remote_url
-    mock = subprocess.CompletedProcess(["git"], 0, stdout="https://github.com/quodeq/quodeq.git\n", stderr="")
-    with patch("subprocess.run", return_value=mock):
-        assert git_remote_url("/any/path") == "github.com/quodeq/quodeq"
+def test_normalize_https():
+    from quodeq.shared._repo import normalize_remote_url
+    assert normalize_remote_url("https://github.com/quodeq/quodeq.git") == "github.com/quodeq/quodeq"
 
 
-def test_git_remote_url_normalizes_ssh():
-    from quodeq.shared._repo import git_remote_url
-    mock = subprocess.CompletedProcess(["git"], 0, stdout="git@github.com:quodeq/quodeq.git\n", stderr="")
-    with patch("subprocess.run", return_value=mock):
-        assert git_remote_url("/any/path") == "github.com/quodeq/quodeq"
+def test_normalize_ssh_colon_form():
+    from quodeq.shared._repo import normalize_remote_url
+    assert normalize_remote_url("git@github.com:quodeq/quodeq.git") == "github.com/quodeq/quodeq"
 
 
-def test_git_remote_url_normalizes_ssh_scheme():
-    from quodeq.shared._repo import git_remote_url
-    mock = subprocess.CompletedProcess(
-        ["git"], 0, stdout="ssh://git@github.com/quodeq/quodeq.git\n", stderr=""
-    )
-    with patch("subprocess.run", return_value=mock):
-        assert git_remote_url("/any/path") == "github.com/quodeq/quodeq"
+def test_normalize_ssh_scheme():
+    from quodeq.shared._repo import normalize_remote_url
+    assert normalize_remote_url("ssh://git@github.com/quodeq/quodeq.git") == "github.com/quodeq/quodeq"
 
 
-def test_git_remote_url_strips_trailing_slash_and_git():
-    from quodeq.shared._repo import git_remote_url
-    mock = subprocess.CompletedProcess(["git"], 0, stdout="https://github.com/quodeq/quodeq/\n", stderr="")
-    with patch("subprocess.run", return_value=mock):
-        assert git_remote_url("/any/path") == "github.com/quodeq/quodeq"
+def test_normalize_strips_trailing_slash_and_git():
+    from quodeq.shared._repo import normalize_remote_url
+    assert normalize_remote_url("https://github.com/quodeq/quodeq/") == "github.com/quodeq/quodeq"
 
 
-def test_git_remote_url_returns_none_when_not_a_repo():
-    from quodeq.shared._repo import git_remote_url
-    error = subprocess.CalledProcessError(128, ["git"], stderr="not a git repo")
-    with patch("subprocess.run", side_effect=error):
-        assert git_remote_url("/any/path") is None
-
-
-def test_git_remote_url_returns_none_when_git_missing():
-    from quodeq.shared._repo import git_remote_url
-    with patch("subprocess.run", side_effect=FileNotFoundError):
-        assert git_remote_url("/any/path") is None
-
-
-def test_git_remote_url_returns_none_on_empty_output():
-    from quodeq.shared._repo import git_remote_url
-    mock = subprocess.CompletedProcess(["git"], 0, stdout="\n", stderr="")
-    with patch("subprocess.run", return_value=mock):
-        assert git_remote_url("/any/path") is None
+def test_normalize_empty_returns_none():
+    from quodeq.shared._repo import normalize_remote_url
+    assert normalize_remote_url("") is None
+    assert normalize_remote_url("   ") is None


### PR DESCRIPTION
Third fix batch from the clean-architecture keep-list — theme **T1 group B: git process execution in services/shared/analysis** (findings CLEA-TES-02 `_fs_scan:103`, CLEA-SEP-03 `project_registration:58` / `shared/_repo:50` / `_git_scoring:58`).

New `data/git_cli.py` is the single place that shells out to git: `run_git` core plus `list_branches`, `remote_origin_url_raw`, `git_remote_url` (normalized) and `stream_log_names` (streaming Popen with the same close/kill semantics).

- `shared/_repo` keeps only pure logic — the normalization half of `git_remote_url` is now `normalize_remote_url` (directly testable, no subprocess patching), the process half lives in the adapter. `shared` stays compatible with its core-only layer rule; the one production caller (`_cli_evaluation`) imports from the adapter.
- `_git_scoring._iter_git_log` delegates but keeps its name (the seam tests patch) and the `_has_git` pre-check; dead `_run_git_log` (zero callers anywhere) deleted rather than migrated.
- Credential stripping and timeouts stay with their owners.

## Tests (TDD)

16 new/rewritten tests watched fail first: real-repository adapter tests (init/commit/remote fixtures), pure normalizer tests (replacing the old subprocess-patching ones), and the no-subprocess decoupling pin over all four caller modules. `TestListBranches` behavior tests retargeted to the adapter namespace. Full suite: **5394 passed, 1 skipped**.

## Expected dogfood effect

`_fs_scan:103` was the LAST occupant of CLEA-TES-02 — this batch should empty that principle entirely, plus three CLEA-SEP-03 instances.