### PR TITLE
refactor(t1): project-file writes move from services into data/fs/project_files

### DIFF
--- a/src/quodeq/data/fs/project_files.py
+++ b/src/quodeq/data/fs/project_files.py
@@ -1,0 +1,50 @@
+"""Per-project JSON artifacts: ``repository_info.json`` and ``scan.json``.
+
+Services used to read/modify/write these files directly (json.loads +
+read_text/write_text inline), scattering the on-disk format across the
+service layer. The mechanics live here; services keep the decision logic
+and delegate the I/O. Reads are best-effort (None on absent/corrupt/
+non-dict payloads — the recurring non-dict-JSON crash class), writes are
+best-effort too (False on failure) so callers keep their long-standing
+swallow semantics explicitly.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+from quodeq.core.types.scan import ScanData
+
+REPOSITORY_INFO_FILENAME = "repository_info.json"
+SCAN_FILENAME = "scan.json"
+
+
+def read_repository_info(project_dir: Path) -> dict | None:
+    """Parsed ``repository_info.json``, or None when absent, corrupt, or
+    not a JSON object."""
+    path = project_dir / REPOSITORY_INFO_FILENAME
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def write_repository_info(project_dir: Path, data: dict) -> bool:
+    """Write ``repository_info.json``; False when the write fails."""
+    payload = json.dumps(data, indent=2)
+    try:
+        (project_dir / REPOSITORY_INFO_FILENAME).write_text(payload, encoding="utf-8")
+    except OSError:
+        return False
+    return True
+
+
+def write_scan_json(scan: ScanData, output_dir: Path) -> None:
+    """Persist scan data as ``scan.json``, creating *output_dir* if needed."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(dataclasses.asdict(scan), indent=2)
+    (output_dir / SCAN_FILENAME).write_text(payload, encoding="utf-8")

--- a/src/quodeq/services/_fs_project_helpers.py
+++ b/src/quodeq/services/_fs_project_helpers.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from quodeq.core.types import ProjectEntry
+from quodeq.data.fs.project_files import read_repository_info, write_repository_info
 from quodeq.services._fs_metadata import (
     _check_path_exists,
     _extract_project_metadata,
@@ -34,26 +35,16 @@ def _backfill_onboarding_field(
     evaluation runs — running an evaluation IS completing setup, so a null
     left behind by a pre-stamp wizard must not show 'Resume setup' forever.
     """
-    info_path = project_dir / "repository_info.json"
-    if not info_path.exists():
-        return None
-    try:
-        data = json.loads(info_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
+    data = read_repository_info(project_dir)
+    if data is None:
         return None
     if "onboardingCompletedAt" in data:
         if data["onboardingCompletedAt"] is None and heal_completed_at:
             data["onboardingCompletedAt"] = heal_completed_at
-            try:
-                info_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
-            except OSError:
-                pass
+            write_repository_info(project_dir, data)
         return data
     data["onboardingCompletedAt"] = data.get("createdAt") or datetime.now(timezone.utc).isoformat()
-    try:
-        info_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
-    except OSError:
-        pass
+    write_repository_info(project_dir, data)
     return data
 
 

--- a/src/quodeq/services/_fs_scan.py
+++ b/src/quodeq/services/_fs_scan.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from quodeq.core.types.scan import ScanData
+from quodeq.data.fs.project_files import write_scan_json
 from quodeq.data.git_cli import list_branches
 
 _logger = logging.getLogger(__name__)
@@ -108,7 +109,5 @@ def _list_modules(project_dir: Path) -> list[str]:
 
 
 def _write_scan_json(scan: ScanData, output_dir: Path) -> None:
-    """Persist scan data as JSON."""
-    output_dir.mkdir(parents=True, exist_ok=True)
-    payload = dataclasses.asdict(scan)
-    (output_dir / "scan.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    """Persist scan data as JSON (delegates to the data layer)."""
+    write_scan_json(scan, output_dir)

--- a/src/quodeq/services/project_registration.py
+++ b/src/quodeq/services/project_registration.py
@@ -10,6 +10,7 @@ import re
 from datetime import datetime, timezone
 from pathlib import Path
 
+from quodeq.data.fs.project_files import read_repository_info, write_repository_info
 from quodeq.data.git_cli import remote_origin_url_raw
 from quodeq.data.fs.project_resolver import ProjectIdentity, resolve_project_uuid
 from quodeq.data.fs.repo_validation import validate_remote_url
@@ -123,8 +124,9 @@ def register_project(
             raise FileNotFoundError(f"Repo path does not exist: {target_path}")
 
     # Persist the resolved path + ephemeral flag in repository_info.json.
-    info_path = project_dir / "repository_info.json"
-    info = json.loads(info_path.read_text(encoding="utf-8")) if info_path.exists() else {}
+    # A corrupt existing file is treated as empty and rewritten (self-heal);
+    # registration is the flow that owns this file's creation.
+    info = read_repository_info(project_dir) or {}
     info["path"] = str(target_path.resolve())
     info["location"] = _LOCATION_LOCAL
     info["ephemeral"] = bool(ephemeral)
@@ -135,7 +137,7 @@ def register_project(
         # URL-registration branch (raw *repo*) is covered too, and so this
         # call site stays safe even if the helper's behavior changes.
         info["originUrl"] = _strip_credentials(origin_url)
-    info_path.write_text(json.dumps(info, indent=2), encoding="utf-8")
+    write_repository_info(project_dir, info)
 
     # Scan now that files are guaranteed on disk.
     scan_project(target_path, output_dir=project_dir)
@@ -152,17 +154,11 @@ def _ensure_onboarding_field(project_dir: Path) -> None:
     field set to null. Existing projects without the field get a backfill on
     read (see `_backfill_onboarding_field` in _fs_project_helpers.py).
     """
-    info_path = project_dir / "repository_info.json"
-    if not info_path.exists():
-        return
-    try:
-        data = json.loads(info_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return
-    if "onboardingCompletedAt" in data:
+    data = read_repository_info(project_dir)
+    if data is None or "onboardingCompletedAt" in data:
         return
     data["onboardingCompletedAt"] = None
-    info_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    write_repository_info(project_dir, data)
 
 
 def mark_onboarding_complete(project_dir: Path) -> None:
@@ -171,17 +167,8 @@ def mark_onboarding_complete(project_dir: Path) -> None:
     An existing timestamp is left untouched so re-evaluations don't move the
     original completion time.
     """
-    info_path = project_dir / "repository_info.json"
-    if not info_path.exists():
-        return
-    try:
-        data = json.loads(info_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return
-    if data.get("onboardingCompletedAt"):
+    data = read_repository_info(project_dir)
+    if data is None or data.get("onboardingCompletedAt"):
         return
     data["onboardingCompletedAt"] = datetime.now(timezone.utc).isoformat()
-    try:
-        info_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
-    except OSError:
-        pass
+    write_repository_info(project_dir, data)

--- a/tests/data/test_project_files.py
+++ b/tests/data/test_project_files.py
@@ -1,0 +1,102 @@
+"""Per-project JSON artifacts (repository_info.json, scan.json) are owned
+by the data layer; services delegate instead of calling write_text/read_text.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from quodeq.core.types.scan import ScanData
+
+
+class TestReadRepositoryInfo:
+    def test_missing_returns_none(self, tmp_path):
+        from quodeq.data.fs.project_files import read_repository_info
+
+        assert read_repository_info(tmp_path) is None
+
+    def test_corrupt_returns_none(self, tmp_path):
+        from quodeq.data.fs.project_files import read_repository_info
+
+        (tmp_path / "repository_info.json").write_text("{nope")
+        assert read_repository_info(tmp_path) is None
+
+    def test_non_dict_json_returns_none(self, tmp_path):
+        from quodeq.data.fs.project_files import read_repository_info
+
+        (tmp_path / "repository_info.json").write_text("[1, 2]")
+        assert read_repository_info(tmp_path) is None
+
+    def test_valid_returns_dict(self, tmp_path):
+        from quodeq.data.fs.project_files import read_repository_info
+
+        (tmp_path / "repository_info.json").write_text('{"path": "/x"}')
+        assert read_repository_info(tmp_path) == {"path": "/x"}
+
+
+class TestWriteRepositoryInfo:
+    def test_round_trip(self, tmp_path):
+        from quodeq.data.fs.project_files import (
+            read_repository_info, write_repository_info,
+        )
+
+        assert write_repository_info(tmp_path, {"a": 1}) is True
+        assert read_repository_info(tmp_path) == {"a": 1}
+
+    def test_unwritable_returns_false(self, tmp_path):
+        from quodeq.data.fs.project_files import write_repository_info
+
+        assert write_repository_info(tmp_path / "no-such-dir", {"a": 1}) is False
+
+
+class TestWriteScanJson:
+    def test_creates_dir_and_writes(self, tmp_path):
+        from quodeq.data.fs.project_files import write_scan_json
+
+        scan = ScanData(
+            file_tree=["a.py"], languages={"python": 1},
+            scanned_at="2026-08-01T00:00:00Z", total_files=1, code_files=1,
+        )
+        out = tmp_path / "nested" / "dir"
+        write_scan_json(scan, out)
+
+        data = json.loads((out / "scan.json").read_text())
+        assert data["total_files"] == 1
+        assert data["file_tree"] == ["a.py"]
+
+
+class TestServiceDelegation:
+    def test_mark_onboarding_complete_writes_through_adapter(self, tmp_path):
+        from quodeq.services.project_registration import mark_onboarding_complete
+
+        (tmp_path / "repository_info.json").write_text("{}")
+        with patch(
+            "quodeq.services.project_registration.write_repository_info",
+            return_value=True,
+        ) as spy:
+            mark_onboarding_complete(tmp_path)
+
+        assert spy.call_count == 1
+        assert spy.call_args.args[1].get("onboardingCompletedAt")
+
+    def test_backfill_heal_writes_through_adapter(self, tmp_path):
+        from quodeq.services._fs_project_helpers import _backfill_onboarding_field
+
+        (tmp_path / "repository_info.json").write_text('{"createdAt": "2026-01-01"}')
+        with patch(
+            "quodeq.services._fs_project_helpers.write_repository_info",
+            return_value=True,
+        ) as spy:
+            data = _backfill_onboarding_field(tmp_path)
+
+        assert spy.call_count == 1
+        assert data["onboardingCompletedAt"] == "2026-01-01"
+
+    def test_scan_write_delegates_to_adapter(self, tmp_path):
+        from quodeq.services import _fs_scan
+
+        scan = ScanData(scanned_at="2026-08-01T00:00:00Z")
+        with patch("quodeq.services._fs_scan.write_scan_json") as spy:
+            _fs_scan._write_scan_json(scan, tmp_path)
+
+        spy.assert_called_once_with(scan, tmp_path)


### PR DESCRIPTION
Fourth fix batch from the clean-architecture keep-list — theme **T1 group C (write side)**: services performing file persistence themselves (live findings CLEA-SEP-03 `_fs_scan:102`, `project_registration:138`, `_fs_project_helpers:48`).

New `data/fs/project_files.py` owns the two per-project JSON artifacts:

- `read_repository_info` — None on absent, corrupt, or non-dict payloads (the recurring non-dict-JSON `.get()` crash class, now guarded at the boundary).
- `write_repository_info` — best-effort bool, so callers' long-standing swallow semantics stay explicit.
- `write_scan_json` — creates the output dir, persists the ScanData.

Rewired: `_fs_scan._write_scan_json` (name kept — tests import it), `project_registration` (register flow + both onboarding helpers), `_fs_project_helpers._backfill_onboarding_field`.

**One deliberate behavior change**: a corrupt existing `repository_info.json` encountered during registration is treated as empty and rewritten (self-heal) instead of crashing the registration — consistent with how every other consumer of this file already degrades.

## Tests (TDD)

10 new tests watched fail first: adapter read/write edge cases (corrupt, non-dict, unwritable) plus three delegation spies proving each service writes through the adapter. Full suite: **5404 passed, 1 skipped** (also satisfies the repo's Windows-encoding guard).

## Expected dogfood effect

Clears three of the eleven live CLEA-SEP-03 instances.