### PR TITLE
refactor(t1): run-dir reads and standards file mechanics move into data/fs

### DIFF
--- a/src/quodeq/data/fs/run_files.py
+++ b/src/quodeq/data/fs/run_files.py
@@ -1,0 +1,78 @@
+"""Run-directory read mechanics: evaluation counts, status state, fingerprints.
+
+services/_cache and services/_accumulated_data used to do these reads
+inline. The mechanics live here; the services keep the guard decisions
+(terminal-state sets, staleness rules). Every read is best-effort and
+never raises — these functions sit under cache guards where an error must
+degrade to "no signal", not break the caller.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+_FINGERPRINT_DIRS = ("evaluation", "evidence")
+_FINGERPRINT_FILES = ("evaluation.db", "evaluation.db-wal", "events.jsonl")
+
+
+def count_eval_files(run_dir: Path) -> int | None:
+    """Number of ``evaluation/*.json`` files, or None when the dir is absent.
+
+    None vs 0 matters: callers anchored on the directory existing (unit
+    tests that pre-seed caches) must treat "no directory" as "no signal".
+    """
+    eval_dir = run_dir / "evaluation"
+    if not eval_dir.is_dir():
+        return None
+    try:
+        return sum(1 for p in eval_dir.iterdir() if p.suffix == ".json")
+    except OSError:
+        return None
+
+
+def read_run_state(run_dir: Path) -> str | None:
+    """The ``state`` string from ``status.json``, or None when absent,
+    corrupt, non-dict, or non-string.
+
+    Unlike ``run_status_store.read_status`` this never raises (no schema
+    check): it feeds cache guards, where any read problem must degrade to
+    "no signal".
+    """
+    path = run_dir / "status.json"
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    state = data.get("state") if isinstance(data, dict) else None
+    return state if isinstance(state, str) else None
+
+
+def run_fingerprint(run_dir: Path) -> str:
+    """Cheap content fingerprint for the inputs ``read_run_data`` reads.
+
+    Stat-based rather than hash-based: the point is to be far cheaper than
+    the read it guards, while still changing whenever a run's data is
+    rewritten in place (see :data:`_FINGERPRINT_FILES`).
+    """
+    parts: list[str] = []
+    for sub in _FINGERPRINT_DIRS:
+        try:
+            entries = sorted((run_dir / sub).iterdir())
+        except OSError:
+            continue
+        for path in entries:
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            parts.append(f"{sub}/{path.name}:{stat.st_mtime_ns}:{stat.st_size}")
+    for name in _FINGERPRINT_FILES:
+        try:
+            stat = (run_dir / name).stat()
+        except OSError:
+            continue
+        parts.append(f"{name}:{stat.st_mtime_ns}:{stat.st_size}")
+    return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()

--- a/src/quodeq/data/fs/standards_store.py
+++ b/src/quodeq/data/fs/standards_store.py
@@ -1,0 +1,63 @@
+"""Custom-standard file mechanics for the evaluators directory.
+
+services/_standards_crud composed paths, checked existence, mkdir'd and
+unlinked inline; services/standards_library wrote payloads with
+write_text. The path/file mechanics live here; validation and permission
+decisions (managed/builtin/collision rules) stay in the services, and the
+CRUD service keeps its injected JsonIO for the payload contents.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def standard_path(evaluators_dir: Path, standard_id: str) -> Path:
+    """The on-disk path for *standard_id* in *evaluators_dir*."""
+    return evaluators_dir / f"{standard_id}.json"
+
+
+def standard_exists(evaluators_dir: Path, standard_id: str) -> bool:
+    """True when the standard's file exists."""
+    return standard_path(evaluators_dir, standard_id).is_file()
+
+
+def compiled_exists(compiled_dir: Path, standard_id: str) -> bool:
+    """True when a compiled (built-in) standard file exists."""
+    return (compiled_dir / f"{standard_id}.json").is_file()
+
+
+def ensure_evaluators_dir(evaluators_dir: Path) -> None:
+    """Create the evaluators directory (and parents) if absent."""
+    evaluators_dir.mkdir(parents=True, exist_ok=True)
+
+
+def remove_standard(evaluators_dir: Path, standard_id: str) -> None:
+    """Delete the standard's file. Raises FileNotFoundError when absent."""
+    standard_path(evaluators_dir, standard_id).unlink()
+
+
+def resolve_jailed_standard_path(evaluators_dir: Path, standard_id: str) -> Path:
+    """Resolved path for *standard_id*, guaranteed inside *evaluators_dir*.
+
+    Raises ValueError when the id would escape the directory (defense in
+    depth behind the services' own id validation).
+    """
+    dest = (evaluators_dir / f"{standard_id}.json").resolve()
+    if not dest.is_relative_to(evaluators_dir.resolve()):
+        raise ValueError(f"Invalid standard ID: {standard_id}")
+    return dest
+
+
+def read_standard_payload(path: Path) -> dict | None:
+    """Parsed standard JSON at *path*, or None when the file is absent."""
+    if not path.is_file():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_standard_payload(path: Path, data: dict) -> None:
+    """Write a standard payload, creating the parent directory if needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(data, indent=2)
+    path.write_text(payload, encoding="utf-8")

--- a/src/quodeq/services/_accumulated_data.py
+++ b/src/quodeq/services/_accumulated_data.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Callable
 
+from quodeq.data.fs.run_files import run_fingerprint  # noqa: F401 — facade re-export
 from quodeq.data.fs.report_parser.runs import RunInfo, read_run_data
 from quodeq.core.types import DimensionResult
 
@@ -16,8 +17,6 @@ from quodeq.core.types import DimensionResult
 # SQL grade tables that overlay_sql_grades reads back, so the fingerprint has
 # to cover the database (and its write-ahead log, which absorbs writes long
 # before a checkpoint touches the main file) alongside the JSON.
-_FINGERPRINT_DIRS = ("evaluation", "evidence")
-_FINGERPRINT_FILES = ("evaluation.db", "evaluation.db-wal", "events.jsonl")
 
 
 @dataclass
@@ -67,32 +66,6 @@ def _classify_dimension(
         buckets.prev_run_latest_map[dim_name] = dim
 
 
-def run_fingerprint(run_dir: Path) -> str:
-    """Cheap content fingerprint for the inputs ``read_run_data`` reads.
-
-    Stat-based rather than hash-based: the point is to be far cheaper than the
-    read it guards, while still changing whenever a run's data is rewritten in
-    place (see :data:`_FINGERPRINT_FILES`).
-    """
-    parts: list[str] = []
-    for sub in _FINGERPRINT_DIRS:
-        try:
-            entries = sorted((run_dir / sub).iterdir())
-        except OSError:
-            continue
-        for path in entries:
-            try:
-                stat = path.stat()
-            except OSError:
-                continue
-            parts.append(f"{sub}/{path.name}:{stat.st_mtime_ns}:{stat.st_size}")
-    for name in _FINGERPRINT_FILES:
-        try:
-            stat = (run_dir / name).stat()
-        except OSError:
-            continue
-        parts.append(f"{name}:{stat.st_mtime_ns}:{stat.st_size}")
-    return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
 
 
 def _strip_findings(dimensions: list[DimensionResult]) -> list[DimensionResult]:

--- a/src/quodeq/services/_cache.py
+++ b/src/quodeq/services/_cache.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Callable
 
 from quodeq.data.fs.report_parser.runs import read_run_data
+from quodeq.data.fs.run_files import count_eval_files, read_run_state
 from quodeq.core.types import DimensionResult
 
 _logger = logging.getLogger(__name__)
@@ -47,15 +48,10 @@ def _count_eval_files(reports_root: Path, project: str, run_id: str) -> int:
 
     Used to detect a stale cache: if the cached dim list has a different
     count from what's currently on disk, the cache is wrong and must be
-    evicted. One ``listdir`` per cached lookup -- cheap.
+    evicted. One ``listdir`` per cached lookup -- cheap. The read itself
+    lives in the data layer; a missing directory counts as 0 here.
     """
-    eval_dir = reports_root / project / run_id / "evaluation"
-    if not eval_dir.is_dir():
-        return 0
-    try:
-        return sum(1 for p in eval_dir.iterdir() if p.suffix == ".json")
-    except OSError:
-        return 0
+    return count_eval_files(reports_root / project / run_id) or 0
 
 
 def _run_is_in_progress(reports_root: Path, project: str, run_id: str) -> bool:
@@ -67,15 +63,8 @@ def _run_is_in_progress(reports_root: Path, project: str, run_id: str) -> bool:
     run that crashed without flipping its state reads fresh forever, which is
     the safe direction for a cache guard.
     """
-    status_path = reports_root / project / run_id / "status.json"
-    if not status_path.is_file():
-        return False
-    try:
-        data = json.loads(status_path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return False
-    state = data.get("state") if isinstance(data, dict) else None
-    return isinstance(state, str) and state not in _TERMINAL_RUN_STATES
+    state = read_run_state(reports_root / project / run_id)
+    return state is not None and state not in _TERMINAL_RUN_STATES
 
 
 def _cached_entry_is_stale(
@@ -86,10 +75,10 @@ def _cached_entry_is_stale(
     Anchored on the evaluation/ directory existing: without disk state to
     compare against (unit tests that pre-seed the cache), the entry is trusted.
     """
-    eval_dir = reports_root / project / run_id / "evaluation"
-    if not eval_dir.is_dir():
+    on_disk = count_eval_files(reports_root / project / run_id)
+    if on_disk is None:
         return False
-    return len(cached) != _count_eval_files(reports_root, project, run_id)
+    return len(cached) != on_disk
 
 
 def _fetch_dimensions_from_disk(

--- a/src/quodeq/services/_standards_crud.py
+++ b/src/quodeq/services/_standards_crud.py
@@ -6,6 +6,10 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+from quodeq.data.fs.standards_store import (
+    compiled_exists, ensure_evaluators_dir, remove_standard,
+    standard_exists, standard_path,
+)
 from quodeq.core.types.standard import StandardDetail
 from quodeq.services._standards_io import (
     _TYPE_CUSTOM, build_custom_meta, build_detail, count_principles_and_requirements,
@@ -32,10 +36,10 @@ def create(data: dict, evaluators_dir: Path, io: JsonIO) -> StandardDetail:
     """Create a new custom standard and persist it to disk."""
     standard_id = data["id"]
     _validate_id(standard_id)
-    path = evaluators_dir / f"{standard_id}.json"
-    if path.exists():
+    path = standard_path(evaluators_dir, standard_id)
+    if standard_exists(evaluators_dir, standard_id):
         raise ValueError(f"Standard '{standard_id}' already exists")
-    evaluators_dir.mkdir(parents=True, exist_ok=True)
+    ensure_evaluators_dir(evaluators_dir)
     io.write(path, {**data, **_CUSTOM_DEFAULTS})
     return build_detail(io.read(path))
 
@@ -43,8 +47,8 @@ def create(data: dict, evaluators_dir: Path, io: JsonIO) -> StandardDetail:
 def update(standard_id: str, data: dict, evaluators_dir: Path, io: JsonIO) -> StandardDetail:
     """Update an existing custom standard with new *data*."""
     _validate_id(standard_id)
-    path = evaluators_dir / f"{standard_id}.json"
-    if not path.is_file():
+    path = standard_path(evaluators_dir, standard_id)
+    if not standard_exists(evaluators_dir, standard_id):
         raise FileNotFoundError(f"Standard not found: {standard_id}")
     if io.read(path).get("managed", False):
         raise PermissionError(f"Cannot edit managed standard '{standard_id}'")
@@ -57,24 +61,24 @@ def delete(standard_id: str, evaluators_dir: Path, compiled_dir: Path,
            io: JsonIO, is_builtin: Callable[[str], bool]) -> None:
     """Delete a custom standard. Raises for built-in or managed standards."""
     _validate_id(standard_id)
-    path = evaluators_dir / f"{standard_id}.json"
-    if not path.is_file():
-        if (compiled_dir / f"{standard_id}.json").is_file() or is_builtin(standard_id):
+    path = standard_path(evaluators_dir, standard_id)
+    if not standard_exists(evaluators_dir, standard_id):
+        if compiled_exists(compiled_dir, standard_id) or is_builtin(standard_id):
             raise PermissionError(f"Cannot delete built-in standard '{standard_id}'")
         raise FileNotFoundError(f"Standard not found: {standard_id}")
     if io.read(path).get("managed", False):
         raise PermissionError(f"Cannot delete managed standard '{standard_id}'")
-    path.unlink()
+    remove_standard(evaluators_dir, standard_id)
 
 
 def duplicate(standard_id: str, new_id: str, source_detail: StandardDetail,
               evaluators_dir: Path, io: JsonIO) -> StandardDetail:
     """Duplicate an existing standard under *new_id* as a custom copy."""
     _validate_id(new_id)
-    new_path = evaluators_dir / f"{new_id}.json"
-    if new_path.exists():
+    new_path = standard_path(evaluators_dir, new_id)
+    if standard_exists(evaluators_dir, new_id):
         raise ValueError(f"Standard '{new_id}' already exists")
-    evaluators_dir.mkdir(parents=True, exist_ok=True)
+    ensure_evaluators_dir(evaluators_dir)
     s = source_detail
     payload = {"id": new_id, "name": s.name, "description": s.description,
                "weight": s.weight, "source": s.source, "principles": s.principles,
@@ -91,15 +95,15 @@ def import_from_file(data: dict, force: bool, evaluators_dir: Path, io: JsonIO) 
     cleaned = validation["data"]
     warnings = scan_injection(cleaned)
     standard_id = cleaned["id"]
-    path = evaluators_dir / f"{standard_id}.json"
-    if path.is_file() and not force:
+    path = standard_path(evaluators_dir, standard_id)
+    if standard_exists(evaluators_dir, standard_id) and not force:
         existing = io.read(path)
         p, r = count_principles_and_requirements(existing)
         return {"status": "conflict", "detail": None,
                 "existing": build_custom_meta(existing, p, r), "warnings": warnings}
-    if path.is_file() and force and io.read(path).get("managed", False):
+    if standard_exists(evaluators_dir, standard_id) and force and io.read(path).get("managed", False):
         raise PermissionError(f"Cannot overwrite managed standard '{standard_id}'")
-    evaluators_dir.mkdir(parents=True, exist_ok=True)
+    ensure_evaluators_dir(evaluators_dir)
     io.write(path, {**cleaned, **_CUSTOM_DEFAULTS})
     return {"status": "imported", "detail": build_detail(io.read(path)),
             "existing": None, "warnings": warnings}

--- a/src/quodeq/services/standards_library.py
+++ b/src/quodeq/services/standards_library.py
@@ -8,6 +8,10 @@ import urllib.request
 from pathlib import Path
 from typing import Any, Protocol
 
+from quodeq.data.fs.standards_store import (
+    read_standard_payload, resolve_jailed_standard_path, write_standard_payload,
+)
+
 # NOTE: logging in inner layer — tracked for middleware extraction
 logger = logging.getLogger(__name__)
 
@@ -59,13 +63,13 @@ class StandardsLibraryClient:
         data = self.fetch_standard(file_path)
         self._validate_id(data.get("id", ""))
         content_hash = hashlib.sha256(json.dumps(data, sort_keys=True).encode()).hexdigest()[:_HASH_PREFIX_LEN]
-        evaluators_dir.mkdir(parents=True, exist_ok=True)
-        dest = (evaluators_dir / f"{data['id']}.json").resolve()
-        if not dest.is_relative_to(evaluators_dir.resolve()):
-            raise ValueError(f"Invalid standard ID from library: {data['id']}")
+        try:
+            dest = resolve_jailed_standard_path(evaluators_dir, data["id"])
+        except ValueError:
+            raise ValueError(f"Invalid standard ID from library: {data['id']}") from None
         # Check for collision with existing standard
-        if dest.is_file():
-            existing = json.loads(dest.read_text(encoding="utf-8"))
+        existing = read_standard_payload(dest)
+        if existing is not None:
             if existing.get("origin") == file_path:
                 # Same origin — update in place
                 pass
@@ -79,5 +83,5 @@ class StandardsLibraryClient:
         data["managed"] = True
         data["origin"] = file_path
         data["origin_hash"] = content_hash
-        dest.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        write_standard_payload(dest, data)
         return dest

--- a/tests/data/test_run_files.py
+++ b/tests/data/test_run_files.py
@@ -1,0 +1,84 @@
+"""Run-directory read mechanics live in the data layer (T1 group C2).
+
+services/_cache counted evaluation/*.json and parsed status.json inline;
+services/_accumulated_data walked run dirs for its stat fingerprint. The
+mechanics now live in data/fs/run_files.py; the services keep the guard
+decisions (terminal-state sets, staleness rules) and delegate the I/O.
+"""
+from __future__ import annotations
+
+import json
+
+
+class TestCountEvalFiles:
+    def test_missing_dir_returns_none(self, tmp_path):
+        from quodeq.data.fs.run_files import count_eval_files
+
+        assert count_eval_files(tmp_path) is None
+
+    def test_empty_dir_returns_zero(self, tmp_path):
+        from quodeq.data.fs.run_files import count_eval_files
+
+        (tmp_path / "evaluation").mkdir()
+        assert count_eval_files(tmp_path) == 0
+
+    def test_counts_only_json(self, tmp_path):
+        from quodeq.data.fs.run_files import count_eval_files
+
+        d = tmp_path / "evaluation"
+        d.mkdir()
+        (d / "a.json").write_text("{}")
+        (d / "b.json").write_text("{}")
+        (d / "notes.txt").write_text("x")
+        assert count_eval_files(tmp_path) == 2
+
+
+class TestReadRunState:
+    def test_missing_returns_none(self, tmp_path):
+        from quodeq.data.fs.run_files import read_run_state
+
+        assert read_run_state(tmp_path) is None
+
+    def test_corrupt_returns_none(self, tmp_path):
+        from quodeq.data.fs.run_files import read_run_state
+
+        (tmp_path / "status.json").write_text("{nope")
+        assert read_run_state(tmp_path) is None
+
+    def test_non_dict_returns_none(self, tmp_path):
+        from quodeq.data.fs.run_files import read_run_state
+
+        (tmp_path / "status.json").write_text("[1]")
+        assert read_run_state(tmp_path) is None
+
+    def test_returns_state_string(self, tmp_path):
+        from quodeq.data.fs.run_files import read_run_state
+
+        (tmp_path / "status.json").write_text(json.dumps({"state": "running"}))
+        assert read_run_state(tmp_path) == "running"
+
+
+class TestRunFingerprint:
+    def test_changes_when_inputs_change(self, tmp_path):
+        from quodeq.data.fs.run_files import run_fingerprint
+
+        (tmp_path / "evaluation").mkdir()
+        (tmp_path / "evaluation" / "a.json").write_text("{}")
+        before = run_fingerprint(tmp_path)
+        assert before == run_fingerprint(tmp_path)  # stable
+
+        (tmp_path / "evaluation" / "a.json").write_text('{"changed": true}')
+        assert run_fingerprint(tmp_path) != before
+
+    def test_empty_run_dir_is_stable(self, tmp_path):
+        from quodeq.data.fs.run_files import run_fingerprint
+
+        assert run_fingerprint(tmp_path) == run_fingerprint(tmp_path)
+
+
+def test_accumulated_data_reexports_run_fingerprint():
+    """Facade compat: the service module keeps exposing run_fingerprint."""
+    from quodeq.data.fs.run_files import run_fingerprint as data_fn
+    from quodeq.services._accumulated_data import run_fingerprint as svc_fn
+
+    assert svc_fn is data_fn

--- a/tests/data/test_standards_store.py
+++ b/tests/data/test_standards_store.py
@@ -1,0 +1,64 @@
+"""Custom-standard file mechanics live in the data layer (T1 group C2).
+
+services/_standards_crud composed paths, checked existence, mkdir'd and
+unlinked inline (its JsonIO read/write was already injected); the library
+importer wrote payloads with write_text. The path mechanics now live in
+data/fs/standards_store.py; validation and permission decisions stay in
+the services.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+class TestPathsAndExistence:
+    def test_standard_path_composes(self, tmp_path):
+        from quodeq.data.fs.standards_store import standard_path
+
+        assert standard_path(tmp_path, "my-std") == tmp_path / "my-std.json"
+
+    def test_exists_is_file_based(self, tmp_path):
+        from quodeq.data.fs.standards_store import standard_exists
+
+        assert standard_exists(tmp_path, "x") is False
+        (tmp_path / "x.json").write_text("{}")
+        assert standard_exists(tmp_path, "x") is True
+
+    def test_ensure_evaluators_dir(self, tmp_path):
+        from quodeq.data.fs.standards_store import ensure_evaluators_dir
+
+        target = tmp_path / "nested" / "evaluators"
+        ensure_evaluators_dir(target)
+        assert target.is_dir()
+
+    def test_remove_standard(self, tmp_path):
+        from quodeq.data.fs.standards_store import remove_standard, standard_exists
+
+        (tmp_path / "x.json").write_text("{}")
+        remove_standard(tmp_path, "x")
+        assert standard_exists(tmp_path, "x") is False
+
+
+class TestJailedPayloadIo:
+    def test_round_trip(self, tmp_path):
+        from quodeq.data.fs.standards_store import (
+            read_standard_payload, resolve_jailed_standard_path, write_standard_payload,
+        )
+
+        dest = resolve_jailed_standard_path(tmp_path, "lib-std")
+        write_standard_payload(dest, {"id": "lib-std", "managed": True})
+        assert json.loads(dest.read_text())["id"] == "lib-std"
+        assert read_standard_payload(dest) == {"id": "lib-std", "managed": True}
+
+    def test_read_missing_returns_none(self, tmp_path):
+        from quodeq.data.fs.standards_store import read_standard_payload
+
+        assert read_standard_payload(tmp_path / "nope.json") is None
+
+    def test_jail_rejects_escape(self, tmp_path):
+        from quodeq.data.fs.standards_store import resolve_jailed_standard_path
+
+        with pytest.raises(ValueError):
+            resolve_jailed_standard_path(tmp_path, "../escape")


### PR DESCRIPTION
Fifth fix batch from the clean-architecture keep-list — theme **T1 group C2** (live findings CLEA-SEP-03 `_cache:52`-family, `standards_library:82`, `_standards_crud:35`; SEP-01 `_accumulated_data:70`).

Two new adapters:

- **`data/fs/run_files.py`** — `count_eval_files` (None = directory absent, preserving the stale-guard anchor), `read_run_state` (never raises, non-dict safe — deliberately laxer than `run_status_store.read_status`, which schema-checks; this one feeds cache guards where errors must degrade to no-signal), and `run_fingerprint` moved verbatim (service re-exports as facade).
- **`data/fs/standards_store.py`** — path/existence/mkdir/unlink mechanics for the CRUD service (its `JsonIO` was already an injected seam; only path mechanics moved) plus jailed payload IO for the library importer (the `is_relative_to` jail stays as defense-in-depth, now in the adapter).

All permission/validation/staleness decisions stay in the services. One noted parity nuance: create/duplicate collision checks moved from `.exists()` to `.is_file()`.

**Not fixed, dismissed with rationale**: `evidence_rescore:69` — its `normpath+startswith` path-jail is the exact barrier shape CodeQL models; relocating recognized guard code regresses the scanner for no structural gain (per the CodeQL triage notes).

## Tests (TDD)

17 new tests watched fail first (adapter behaviors incl. the None-vs-0 anchor, jail rejection, fingerprint stability, and the facade re-export pin). Full suite: **5421 passed, 1 skipped**.

This empties the services contingent of CLEA-SEP-03.