### PR TITLE
docs(readme): document Homebrew + desktop apps, surface privacy and contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ pipx install quodeq    # isolated, recommended
 # or: pip install quodeq
 ```
 
-Prefer a desktop app to the CLI? See [Desktop apps](#desktop-apps) below.
+Prefer a desktop app to the CLI? See [Desktop apps](#desktop-apps-beta) below.
 
 ### 3. Pick an AI provider
 
@@ -103,6 +103,9 @@ ollama serve    # runs in the background
 - [Codex CLI](https://developers.openai.com/codex/quickstart) — `npm install -g @openai/codex`
 - [Gemini CLI](https://geminicli.com/docs/get-started/installation/) — `npm install -g @google/gemini-cli`
 
+[llama.cpp](#ai-providers) is also supported. See [AI Providers](#ai-providers) for the
+full list and how to choose.
+
 ### 4. Launch the dashboard
 
 ```bash
@@ -112,8 +115,6 @@ quodeq
 The dashboard opens at `http://127.0.0.1:7863`. Use **Settings → AI Provider** to select the one you installed in step 3, then **Evaluate** to point at a project and start your first scan.
 
 If the native window doesn't show up (common on Linux without GTK), run `quodeq --browser` instead.
-
-<a id="desktop-apps"></a>
 
 ### Desktop apps (beta)
 
@@ -214,19 +215,6 @@ Upload to GitHub code scanning:
 
 ---
 
-## Updates
-
-Quodeq checks for new versions once a day in the background (PyPI for
-`pip`/`pipx`/`uv` installs, GitHub Releases for the macOS/Windows apps) and
-shows a dismissible notice with the right upgrade step. It never auto-replaces
-itself and sends no telemetry — the only network call is an unauthenticated
-request to PyPI/GitHub.
-
-Disable it by setting `QUODEQ_NO_UPDATE_NOTIFIER=1`, or toggle "Automatic
-checks" off under Settings → Updates.
-
----
-
 ## AI Providers
 
 Choose what fits your workflow. Configure in **Settings** from the dashboard.
@@ -280,6 +268,20 @@ Numeric thresholds on the built-in standards (max function lines, max parameters
 
 ---
 
+## Privacy
+
+There is no Quodeq account, no Quodeq server, and no telemetry. Your source code is read
+locally and evaluation results are written to `~/.quodeq/evaluations/` as plain JSON. If
+you run a local provider, nothing about your code leaves the machine at all. If you pick a
+cloud provider, your code goes to that provider under your own API key and nowhere else.
+
+Quodeq makes exactly one network call of its own: a daily unauthenticated version check
+(PyPI for `pip`/`pipx`/`uv` installs, GitHub Releases for the desktop apps). It shows a
+dismissible notice with the right upgrade step and never replaces itself. Turn it off with
+`QUODEQ_NO_UPDATE_NOTIFIER=1`, or under **Settings → Updates**.
+
+---
+
 ## Development
 
 Run from a fresh checkout:
@@ -295,9 +297,25 @@ Same OS prerequisites as the pipx install (Python 3.12+), plus Node 20+ and npm 
 
 If the dashboard window doesn't appear on Linux, run `uv run quodeq --browser` (the native window needs `python3-gi` + `gir1.2-webkit2-4.1`, which aren't pulled in by the pip wheel).
 
+---
+
+## Contributing
+
+Issues and pull requests are welcome. [CONTRIBUTING.md](CONTRIBUTING.md) covers the
+development setup, the test suite, and how changes get reviewed. Everyone taking part is
+expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+- **Found a bug or want a feature?** [Open an issue](https://github.com/quodeq/quodeq/issues).
+- **Want to ask something, or show what you built?** [Discussions](https://github.com/quodeq/quodeq/discussions).
+- **Found a security problem?** Please don't open a public issue. [SECURITY.md](SECURITY.md) has the disclosure process.
+
+If Quodeq is useful to you, starring the repo genuinely helps other people find it.
+
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for release history.
+See [CHANGELOG.md](CHANGELOG.md) for release history, or the
+[release announcements](https://github.com/quodeq/quodeq/discussions/categories/announcements)
+for the readable version.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 </p>
 
 <h2 align="center">AI-powered code quality and security scanner</h2>
-<p align="center"><strong>v1.8.1</strong></p>
 <p align="center">
   <a href="https://github.com/quodeq/quodeq/actions/workflows/test.yml"><img src="https://github.com/quodeq/quodeq/actions/workflows/test.yml/badge.svg" alt="Tests" /></a>
   <a href="https://github.com/quodeq/quodeq/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
@@ -14,7 +13,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.youtube.com/watch?v=Ie7rAiPBDQE&list=PLJjpl8sE7W-U1HMePWdGis7w834NPYD3R&index=1">Watch the demo</a> · <a href="https://quodeq.ai">Website</a> · <a href="https://quodeq.ai/blog/">Blog</a> · <a href="https://github.com/quodeq/quodeq/releases/latest">Releases</a>
+  <a href="https://www.youtube.com/watch?v=Ie7rAiPBDQE&list=PLJjpl8sE7W-U1HMePWdGis7w834NPYD3R&index=1">Watch the demo</a> · <a href="https://quodeq.ai">Website</a> · <a href="https://quodeq.ai/blog/">Blog</a> · <a href="https://github.com/quodeq/quodeq/discussions">Discussions</a> · <a href="https://github.com/quodeq/quodeq/releases/latest">Releases</a>
 </p>
 
 ---
@@ -54,6 +53,9 @@ Each finding includes a reason, the offending code, and a fix plan. Results are 
 
 ### 1. Prerequisites
 
+> **On macOS you can skip this step** by installing through Homebrew (see step 2). The
+> formula pulls in its own Python.
+
 | OS | Command |
 |---|---|
 | **macOS** | `brew install python pipx` |
@@ -70,10 +72,20 @@ Minimum versions: Python 3.12+. (The dashboard UI ships pre-built inside the whe
 
 ### 2. Install quodeq
 
+**Homebrew** (macOS, and the shortest path):
+
+```bash
+brew install quodeq/tap/quodeq
+```
+
+**pipx / pip** (every platform):
+
 ```bash
 pipx install quodeq    # isolated, recommended
 # or: pip install quodeq
 ```
+
+Prefer a desktop app to the CLI? See [Desktop apps](#desktop-apps) below.
 
 ### 3. Pick an AI provider
 
@@ -101,15 +113,29 @@ The dashboard opens at `http://127.0.0.1:7863`. Use **Settings → AI Provider**
 
 If the native window doesn't show up (common on Linux without GTK), run `quodeq --browser` instead.
 
-### macOS App (beta)
+<a id="desktop-apps"></a>
 
-Download the `.dmg` from [Releases](https://github.com/quodeq/quodeq/releases/latest), open it, and drag `Quodeq.app` to Applications. On first launch:
+### Desktop apps (beta)
+
+Every release attaches three prebuilt apps to [Releases](https://github.com/quodeq/quodeq/releases/latest). They bundle their own Python, so none of the prerequisites above apply.
+
+| Download | Platform | What it is |
+|---|---|---|
+| `Quodeq-<version>-macOS.dmg` | macOS | The dashboard in a native window |
+| `QuodeqBar-<version>-macOS.dmg` | macOS | Menu bar app that starts and stops the dashboard, with an icon that reflects whether a scan is running |
+| `Quodeq-<version>-Windows.zip` | Windows | The dashboard in a native window (WebView2) |
+
+**macOS.** Open the `.dmg` and drag the app to Applications. The apps are unsigned, so
+the first launch needs one of:
 
 ```bash
-xattr -cr /Applications/Quodeq.app    # Required for unsigned apps
+xattr -cr /Applications/Quodeq.app       # or /Applications/QuodeqBar.app
 ```
 
 Or right-click the app, select Open, then click Open in the dialog.
+
+**Windows.** Unzip anywhere and run `Quodeq.exe`. SmartScreen will warn about an
+unrecognized publisher on first launch: choose **More info** then **Run anyway**.
 
 ---
 


### PR DESCRIPTION
Two commits, separable if you only want the first.

## 1. Install paths that were shipping but undocumented

**Homebrew.** The tap has published a current formula for every release and has its own release workflow plus a manual-fix runbook, but the README only mentioned pipx. macOS users were told to `brew install python pipx` as a *prerequisite* and never told `brew install quodeq/tap/quodeq` installs quodeq itself. Verified against the live formula (currently 1.8.1, `depends_on "python@3.12"`, so it needs no prerequisites of its own).

**Desktop apps.** Each release attaches three (`Quodeq-macOS.dmg`, `QuodeqBar-macOS.dmg`, `Quodeq-Windows.zip`); the README documented one. Windows users got no app instructions and the menu bar app was invisible. Replaced the macOS-only section with a table covering all three, plus the SmartScreen note for Windows.

**Version banner dropped.** `<p align="center"><strong>v1.8.1</strong></p>` was a manual bump in the release flow, sitting directly above a PyPI badge that already reports the version. It could only ever be correct or stale.

**Discussions** added to the header nav.

## 2. Structure

**Privacy section.** The update-checker disclosure was in position five, between Dashboard and AI Providers and above How It Works. Folded it into a new Privacy section near the bottom, together with the local-first story that previously got one bold line in the intro.

**Contributing section.** `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` and `SECURITY.md` all existed with no section linking them. The security disclosure process was the worst case: findable only by browsing the file tree.

**Deduplicated** Getting Started step 3 against the AI Providers table, which lists the same three CLIs with more detail and also covers llama.cpp.

## Checks

- Both internal anchors (`#desktop-apps-beta`, `#ai-providers`) resolve against real headings.
- Every referenced file exists.
- No em dashes in added prose.
- Homebrew formula and release asset names verified against the live tap and `gh release view v1.8.1`, not assumed.

## Follow-up

The release skill step that bumps the README version banner is now conditional on the banner still being present, so it is correct both before and after this merges. Once merged it becomes a no-op and can be deleted.