### PR TITLE
refactor(scoring): ScoringDeps seam retires namespace-patch coupling

### DIFF
--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -51,6 +51,32 @@ from quodeq.shared._env import env_int
 from quodeq.shared.validation import validate_path_segment
 from quodeq.services.scoring._summary import recompute_summary
 
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ScoringDeps:
+    """Injectable dependency bundle for the scoring reader.
+
+    A ``None`` field resolves to the production callable at call time, so
+    the seam is purely additive: existing callers pass nothing and see no
+    change. Tests construct a ``ScoringDeps`` with fakes instead of
+    patching this module's attributes — the namespace-patch coupling is
+    what made the previous decomposition attempt revert.
+    """
+
+    read_run_data: Callable | None = None
+    read_run_scalars: Callable | None = None
+    dismissed_keys: Callable | None = None
+    deleted_keys: Callable | None = None
+    cached_accumulated: Callable | None = None
+    rescore_dimension: Callable | None = None
+    rescore_runs_by_dimension: Callable | None = None
+    recompute_summary: Callable | None = None
+
+
+_NO_DEPS = ScoringDeps()
+
 
 def _max_history_runs() -> int:
     """Read max history runs from env at call time for lazy configuration."""
@@ -248,6 +274,7 @@ def _build_response_from_grade_tables(
 def _build_response_from_eval_files(
     reports_root: Path, project: str, run_id: str,
     params: ScoringParams = DEFAULT_PARAMS,
+    deps: ScoringDeps | None = None,
 ) -> dict:
     """Read eval JSON files for a run and apply rescore (legacy path).
 
@@ -262,10 +289,11 @@ def _build_response_from_eval_files(
     path, so callers (UI dismiss handlers) don't need to branch.
     """
     validate_path_segment(project, run_id)
+    d = deps or _NO_DEPS
     base_fetcher = _make_run_dimension_fetcher(reports_root, project)
     project_dir = reports_root / project
-    dismissed = dismissed_keys(project_dir)
-    deleted = deleted_keys(project_dir)
+    dismissed = (d.dismissed_keys or dismissed_keys)(project_dir)
+    deleted = (d.deleted_keys or deleted_keys)(project_dir)
 
     dims = base_fetcher(run_id)
     rescored = rescore_dimensions(
@@ -278,6 +306,7 @@ def _build_response_from_eval_files(
 
 def get_scores_raw(
     reports_root: Path, project: str, run_id: str,
+    deps: ScoringDeps | None = None,
 ) -> dict:
     """Return raw rescore dict for a single run (explorer detail compat).
 
@@ -290,6 +319,7 @@ def get_scores_raw(
     POST returned no scores, the UI had nothing to apply.
     """
     validate_path_segment(project, run_id)
+    d = deps or _NO_DEPS
     run_dir = reports_root / project / run_id
     if not run_dir.is_dir():
         raise FileNotFoundError(f"Run directory not found: {run_dir}")
@@ -310,7 +340,10 @@ def get_scores_raw(
     # rescored that way; they keep the SQL path, whose ``_ensure_fresh``
     # re-projection applies the dismissals directly to the findings table.
     project_dir = reports_root / project
-    has_project_wide_filters = bool(dismissed_keys(project_dir) or deleted_keys(project_dir))
+    has_project_wide_filters = bool(
+        (d.dismissed_keys or dismissed_keys)(project_dir)
+        or (d.deleted_keys or deleted_keys)(project_dir)
+    )
     eval_dir = run_dir / "evaluation"
     prefer_eval_rescore = (
         has_project_wide_filters
@@ -341,11 +374,14 @@ def get_scores_raw(
                 project, run_id,
             )
 
-    return _build_response_from_eval_files(reports_root, project, run_id, params=params)
+    return _build_response_from_eval_files(
+        reports_root, project, run_id, params=params, deps=deps,
+    )
 
 
 def get_scores_slim(
     reports_root: Path, project: str, run_id: str,
+    deps: ScoringDeps | None = None,
 ) -> dict:
     """``get_scores_raw`` with finding bodies stripped for the run-scores route.
 
@@ -358,7 +394,7 @@ def get_scores_slim(
     the merge needs at a fraction of the size. Compliance bodies are never
     read from this payload, so the list is emptied (counts live in totals).
     """
-    raw = get_scores_raw(reports_root, project, run_id)
+    raw = get_scores_raw(reports_root, project, run_id, deps=deps)
     slim_dims = []
     for dim in raw.get("dimensions", []) or []:
         slim_violations = [
@@ -372,6 +408,7 @@ def get_scores_slim(
 def scored_run_dimensions(
     reports_root: Path, project: str, run_id: str,
     params: ScoringParams | None = None,
+    deps: ScoringDeps | None = None,
 ) -> list[DimensionResult]:
     """Return a run's dimensions with the project-wide dismiss/delete rescore applied.
 
@@ -389,35 +426,40 @@ def scored_run_dimensions(
     ``get_scores_raw`` / ``build_dashboard``.
     """
     validate_path_segment(project, run_id)
+    d = deps or _NO_DEPS
     if params is None:
         params = load_params()
     project_dir = reports_root / project
-    dismissed = dismissed_keys(project_dir)
-    deleted = deleted_keys(project_dir)
-    dims = read_run_data(reports_root, project, run_id)
+    dismissed = (d.dismissed_keys or dismissed_keys)(project_dir)
+    deleted = (d.deleted_keys or deleted_keys)(project_dir)
+    dims = (d.read_run_data or read_run_data)(reports_root, project, run_id)
     if not dismissed and not deleted:
         return dims
     run_dir = project_dir / run_id
+    rescore = d.rescore_dimension or _rescore_dimension
     return [
-        _rescore_dimension(d, dismissed, deleted, params=params, run_dir=run_dir)
-        for d in dims
+        rescore(dim, dismissed, deleted, params=params, run_dir=run_dir)
+        for dim in dims
     ]
 
 
 def _make_rescoring_fetcher(
     reports_root: Path, project: str,
     params: ScoringParams = DEFAULT_PARAMS,
+    deps: ScoringDeps | None = None,
 ) -> Callable[[str], list[DimensionResult]]:
     """Return a dimension fetcher that applies rescore (dismissals) to results.
 
-    Thin seam over the shared :func:`make_rescoring_fetcher` factory. Passes the
-    scoring module's own ``dismissed_keys`` / ``deleted_keys`` references so
-    monkeypatch-based tests keep working, and the full-data base fetcher.
+    Thin seam over the shared :func:`make_rescoring_fetcher` factory. The
+    suppression readers come from *deps* (production defaults when None),
+    plus the full-data base fetcher.
     """
+    d = deps or _NO_DEPS
     return make_rescoring_fetcher(
         reports_root, project, params=params,
         base_fetcher=_make_run_dimension_fetcher(reports_root, project),
-        dismissed_keys=dismissed_keys, deleted_keys=deleted_keys,
+        dismissed_keys=d.dismissed_keys or dismissed_keys,
+        deleted_keys=d.deleted_keys or deleted_keys,
     )
 
 
@@ -425,21 +467,23 @@ def _make_trend_fetcher(
     reports_root: Path, project: str,
     params: ScoringParams = DEFAULT_PARAMS,
     cacheable_run_ids: set[str] | None = None,
+    deps: ScoringDeps | None = None,
 ) -> Callable[[str], list[DimensionResult]]:
     """Return the dimension fetcher for the trend chart.
 
-    Thin seam over the shared :func:`make_trend_fetcher` factory, passing the
-    scoring module's own ``read_run_scalars`` / ``dismissed_keys`` /
-    ``deleted_keys`` references (so this module's monkeypatch-based tests keep
-    working) and the shared full-data base-fetcher factory. See
+    Thin seam over the shared :func:`make_trend_fetcher` factory. The scalar
+    reader and suppression readers come from *deps* (production defaults
+    when None), plus the shared full-data base-fetcher factory. See
     :func:`make_trend_fetcher` for the fast/heavy path and caching semantics.
     """
+    d = deps or _NO_DEPS
     return make_trend_fetcher(
         reports_root, project, params=params, cacheable_run_ids=cacheable_run_ids,
         max_history=_max_history_runs(),
         base_fetcher_factory=_make_run_dimension_fetcher,
-        read_run_scalars=read_run_scalars,
-        dismissed_keys=dismissed_keys, deleted_keys=deleted_keys,
+        read_run_scalars=d.read_run_scalars or read_run_scalars,
+        dismissed_keys=d.dismissed_keys or dismissed_keys,
+        deleted_keys=d.deleted_keys or deleted_keys,
     )
 
 
@@ -514,6 +558,7 @@ def _rescore_accumulated_with_coverage(
     reports_root: Path,
     project: str,
     params: ScoringParams = DEFAULT_PARAMS,
+    deps: ScoringDeps | None = None,
 ) -> tuple[dict[str, Any], bool]:
     """Apply rescore to an accumulated response dict (in-place compatible shape).
 
@@ -526,9 +571,10 @@ def _rescore_accumulated_with_coverage(
     keep their raw baked scores and the payload MUST NOT be persisted: its
     version hash cannot tell it apart from a fully rescored one.
     """
+    d = deps or _NO_DEPS
     project_dir = reports_root / project
-    dismissed = dismissed_keys(project_dir)
-    deleted = deleted_keys(project_dir)
+    dismissed = (d.dismissed_keys or dismissed_keys)(project_dir)
+    deleted = (d.deleted_keys or deleted_keys)(project_dir)
     if (not dismissed and not deleted) or not accumulated:
         return accumulated, True
 
@@ -536,7 +582,7 @@ def _rescore_accumulated_with_coverage(
     if not dims:
         return accumulated, True
 
-    rescored_by_dim = _rescore_runs_by_dimension(
+    rescored_by_dim = (d.rescore_runs_by_dimension or _rescore_runs_by_dimension)(
         dims, reports_root, project, dismissed, deleted, params=params,
     )
     missing = _dims_expecting_rescore(dims) - set(rescored_by_dim)
@@ -548,7 +594,9 @@ def _rescore_accumulated_with_coverage(
         )
     new_dims = _merge_rescored_dims(dims, rescored_by_dim)
 
-    new_summary = recompute_summary(new_dims, accumulated.get("summary", {}), params=params)
+    new_summary = (d.recompute_summary or recompute_summary)(
+        new_dims, accumulated.get("summary", {}), params=params,
+    )
     return {**accumulated, "dimensions": new_dims, "summary": new_summary}, not missing
 
 
@@ -557,10 +605,11 @@ def _rescore_accumulated_response(
     reports_root: Path,
     project: str,
     params: ScoringParams = DEFAULT_PARAMS,
+    deps: ScoringDeps | None = None,
 ) -> dict[str, Any]:
     """`_rescore_accumulated_with_coverage` for callers that don't persist."""
     payload, _complete = _rescore_accumulated_with_coverage(
-        accumulated, reports_root, project, params=params,
+        accumulated, reports_root, project, params=params, deps=deps,
     )
     return payload
 
@@ -569,6 +618,7 @@ def rescore_accumulated(
     accumulated: dict[str, Any] | None,
     reports_root: Path, project: str,
     params: ScoringParams | None = None,
+    deps: ScoringDeps | None = None,
 ) -> dict[str, Any] | None:
     """Public seam: project-wide dismiss/delete rescore for an accumulated payload.
 
@@ -586,11 +636,14 @@ def rescore_accumulated(
         return accumulated
     if params is None:
         params = load_params()
-    return _rescore_accumulated_response(accumulated, reports_root, project, params=params)
+    return _rescore_accumulated_response(
+        accumulated, reports_root, project, params=params, deps=deps,
+    )
 
 
 def get_project_scores(
     reports_root: Path, project: str, as_of: str | None = None,
+    deps: ScoringDeps | None = None,
 ) -> dict[str, Any] | None:
     """Return the full scores payload for the dashboard.
 
@@ -604,6 +657,7 @@ def get_project_scores(
     if not (reports_root / project).exists():
         return None
 
+    d = deps or _NO_DEPS
     params = load_params()
 
     all_runs = list_runs(reports_root, project)
@@ -625,7 +679,7 @@ def get_project_scores(
         if acc is None:
             acc = {"dimensions": [], "summary": {}}
         payload, complete = _rescore_accumulated_with_coverage(
-            acc, reports_root, project, params=params,
+            acc, reports_root, project, params=params, deps=deps,
         )
         rescore_complete[0] = complete
         return payload
@@ -642,7 +696,7 @@ def get_project_scores(
                              [(r.run_id, r.status) for r in all_runs]),
             as_of,
         )
-        accumulated = cached_accumulated(
+        accumulated = (d.cached_accumulated or cached_accumulated)(
             project, acc_version, _compute_accumulated_payload,
             cacheable=lambda _payload: rescore_complete[0],
         )
@@ -662,6 +716,7 @@ def get_project_scores(
     cacheable_run_ids = {r.run_id for r in history_runs if r.status == "complete"}
     trend_fetcher = _make_trend_fetcher(
         reports_root, project, params=params, cacheable_run_ids=cacheable_run_ids,
+        deps=deps,
     )
     trend = build_accumulated_trend(history_runs, trend_fetcher, params=params)
 

--- a/tests/services/scoring/test_rescore_coverage.py
+++ b/tests/services/scoring/test_rescore_coverage.py
@@ -36,52 +36,47 @@ def test_dims_expecting_rescore_needs_a_source_run():
     assert _dims_expecting_rescore(dims) == {"security"}
 
 
-def test_no_suppressions_is_complete(monkeypatch):
-    monkeypatch.setattr(scoring, "dismissed_keys", lambda pdir: set())
-    monkeypatch.setattr(scoring, "deleted_keys", lambda pdir: set())
+def test_no_suppressions_is_complete():
+    deps = scoring.ScoringDeps(
+        dismissed_keys=lambda pdir: set(), deleted_keys=lambda pdir: set(),
+    )
     payload, complete = _rescore_accumulated_with_coverage(
-        _acc([_dim("security")]), Path("/reports"), "proj",
+        _acc([_dim("security")]), Path("/reports"), "proj", deps=deps,
     )
     assert complete is True
     assert payload["dimensions"] == [_dim("security")]
 
 
-def test_full_coverage_is_complete(monkeypatch):
-    monkeypatch.setattr(scoring, "dismissed_keys", lambda pdir: {("R1", "a.py", 1)})
-    monkeypatch.setattr(scoring, "deleted_keys", lambda pdir: set())
-    monkeypatch.setattr(
-        scoring, "_rescore_runs_by_dimension",
-        lambda dims, root, project, dismissed, deleted=None, params=None: {
+def test_full_coverage_is_complete():
+    deps = scoring.ScoringDeps(
+        dismissed_keys=lambda pdir: {("R1", "a.py", 1)},
+        deleted_keys=lambda pdir: set(),
+        rescore_runs_by_dimension=lambda dims, root, project, dismissed, deleted=None, params=None: {
             "security": {"overallScore": "7.5/10", "overallGrade": "Good"},
             "performance": {"overallScore": "8.2/10", "overallGrade": "Good"},
         },
-    )
-    monkeypatch.setattr(
-        scoring, "recompute_summary", lambda dims, summary, params=None: summary,
+        recompute_summary=lambda dims, summary, params=None: summary,
     )
     payload, complete = _rescore_accumulated_with_coverage(
-        _acc([_dim("security"), _dim("performance")]), Path("/reports"), "proj",
+        _acc([_dim("security"), _dim("performance")]), Path("/reports"), "proj", deps=deps,
     )
     assert complete is True
     assert payload["dimensions"][0]["overallScore"] == "7.5/10"
     assert payload["dimensions"][1]["overallScore"] == "8.2/10"
 
 
-def test_partial_coverage_is_flagged_incomplete(monkeypatch):
+def test_partial_coverage_is_flagged_incomplete():
     """Rescore came back for security only: serve it, but flag it uncacheable."""
-    monkeypatch.setattr(scoring, "dismissed_keys", lambda pdir: {("R1", "a.py", 1)})
-    monkeypatch.setattr(scoring, "deleted_keys", lambda pdir: set())
-    monkeypatch.setattr(
-        scoring, "_rescore_runs_by_dimension",
-        lambda dims, root, project, dismissed, deleted=None, params=None: {
+    deps = scoring.ScoringDeps(
+        dismissed_keys=lambda pdir: {("R1", "a.py", 1)},
+        deleted_keys=lambda pdir: set(),
+        rescore_runs_by_dimension=lambda dims, root, project, dismissed, deleted=None, params=None: {
             "security": {"overallScore": "7.5/10", "overallGrade": "Good"},
         },
-    )
-    monkeypatch.setattr(
-        scoring, "recompute_summary", lambda dims, summary, params=None: summary,
+        recompute_summary=lambda dims, summary, params=None: summary,
     )
     payload, complete = _rescore_accumulated_with_coverage(
-        _acc([_dim("security"), _dim("performance")]), Path("/reports"), "proj",
+        _acc([_dim("security"), _dim("performance")]), Path("/reports"), "proj", deps=deps,
     )
     assert complete is False
     # The payload is still the best available answer for THIS request.

--- a/tests/services/scoring/test_scored_run_dimensions.py
+++ b/tests/services/scoring/test_scored_run_dimensions.py
@@ -49,7 +49,7 @@ def _make_dimension(violations, compliance):
     )
 
 
-def test_scored_run_dimensions_applies_project_wide_dismissal(monkeypatch):
+def test_scored_run_dimensions_applies_project_wide_dismissal():
     """A dismissed violation must move the returned dimension score.
 
     Mirrors the real-data disparity: raw read_run_data reports one score,
@@ -64,11 +64,12 @@ def test_scored_run_dimensions_applies_project_wide_dismissal(monkeypatch):
     compliance = [_make_compliance(req=f"C{i}", file=f"c{i}.py", line=20) for i in range(5)]
     raw_dim = _make_dimension([crit, *extras], compliance)
 
-    monkeypatch.setattr(scoring, "read_run_data", lambda root, p, r: [raw_dim])
-    monkeypatch.setattr(scoring, "dismissed_keys", lambda pdir: {("R1", "a.py", 1)})
-    monkeypatch.setattr(scoring, "deleted_keys", lambda pdir: set())
-
-    result = scoring.scored_run_dimensions(Path("/reports"), "proj", "run1")
+    deps = scoring.ScoringDeps(
+        read_run_data=lambda root, p, r: [raw_dim],
+        dismissed_keys=lambda pdir: {("R1", "a.py", 1)},
+        deleted_keys=lambda pdir: set(),
+    )
+    result = scoring.scored_run_dimensions(Path("/reports"), "proj", "run1", deps=deps)
 
     assert len(result) == 1
     dim = result[0]
@@ -83,19 +84,20 @@ def test_scored_run_dimensions_applies_project_wide_dismissal(monkeypatch):
     assert new_num > raw_num, f"dismissing the critical should raise the score; {raw_num} -> {new_num}"
 
 
-def test_scored_run_dimensions_no_dismissals_returns_unchanged(monkeypatch):
+def test_scored_run_dimensions_no_dismissals_returns_unchanged():
     """With no dismissals/deletions, the raw dimensions pass through untouched."""
     raw_dim = _make_dimension([_make_violation()], [_make_compliance()])
-    monkeypatch.setattr(scoring, "read_run_data", lambda root, p, r: [raw_dim])
-    monkeypatch.setattr(scoring, "dismissed_keys", lambda pdir: set())
-    monkeypatch.setattr(scoring, "deleted_keys", lambda pdir: set())
-
-    result = scoring.scored_run_dimensions(Path("/reports"), "proj", "run1")
+    deps = scoring.ScoringDeps(
+        read_run_data=lambda root, p, r: [raw_dim],
+        dismissed_keys=lambda pdir: set(),
+        deleted_keys=lambda pdir: set(),
+    )
+    result = scoring.scored_run_dimensions(Path("/reports"), "proj", "run1", deps=deps)
 
     assert [d.overall_score for d in result] == [raw_dim.overall_score]
 
 
-def test_scored_run_dimensions_passes_the_run_dir_to_rescore(monkeypatch):
+def test_scored_run_dimensions_passes_the_run_dir_to_rescore():
     """The rescore must receive THIS run's directory as its evidence basis.
 
     ``_rescore_dimension`` scores from ``<run_dir>/evidence/<dim>_evidence.jsonl``
@@ -109,21 +111,19 @@ def test_scored_run_dimensions_passes_the_run_dir_to_rescore(monkeypatch):
         seen.append(run_dir)
         return dim
 
-    monkeypatch.setattr(scoring, "_rescore_dimension", fake_rescore)
-    monkeypatch.setattr(scoring, "read_run_data", lambda root, p, r: [raw_dim])
-    monkeypatch.setattr(scoring, "dismissed_keys", lambda pdir: {("R1", "a.py", 1)})
-    monkeypatch.setattr(scoring, "deleted_keys", lambda pdir: set())
-
-    scoring.scored_run_dimensions(Path("/reports"), "proj", "run1")
+    deps = scoring.ScoringDeps(
+        rescore_dimension=fake_rescore,
+        read_run_data=lambda root, p, r: [raw_dim],
+        dismissed_keys=lambda pdir: {("R1", "a.py", 1)},
+        deleted_keys=lambda pdir: set(),
+    )
+    scoring.scored_run_dimensions(Path("/reports"), "proj", "run1", deps=deps)
 
     assert seen == [Path("/reports/proj/run1")]
 
 
-def test_scored_run_dimensions_validates_path_segments(monkeypatch):
+def test_scored_run_dimensions_validates_path_segments():
     """Path-traversal segments are rejected like read_run_data does."""
-    monkeypatch.setattr(scoring, "read_run_data", lambda root, p, r: [])
-    monkeypatch.setattr(scoring, "dismissed_keys", lambda pdir: set())
-    monkeypatch.setattr(scoring, "deleted_keys", lambda pdir: set())
     with pytest.raises(ValueError):
         scoring.scored_run_dimensions(Path("/reports"), "../etc", "run1")
 

--- a/tests/services/scoring/test_scoring_deps_seam.py
+++ b/tests/services/scoring/test_scoring_deps_seam.py
@@ -1,0 +1,98 @@
+"""ScoringDeps: injectable dependency bundle for the scoring reader.
+
+The scoring module's tests patched its namespace attributes (read_run_data,
+dismissed_keys, ...), which welded every caller to the module layout and
+made the previous decomposition attempt revert. Public entry points now
+accept a ``deps`` bundle; a None field resolves to the production callable
+at call time, so the seam is purely additive.
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+
+from quodeq.core.types.dimension import DimensionResult
+from quodeq.core.types.finding import Finding
+
+
+def _dim(name: str = "security") -> DimensionResult:
+    return DimensionResult(
+        dimension=name, overall_score="7.0/10", overall_grade="Good",
+        principles=[], violations=[
+            Finding(req="R1", file="a.py", line=1, severity="major"),
+        ], compliance=[], totals=None,
+    )
+
+
+def test_scored_run_dimensions_uses_injected_deps(tmp_path):
+    from quodeq.services.scoring import ScoringDeps, scored_run_dimensions
+
+    (tmp_path / "proj" / "run-1").mkdir(parents=True)
+    raw = _dim()
+    rescored = replace(raw, overall_score="9.0/10")
+    calls = {}
+
+    def fake_rescore(d, dismissed, deleted, *, params, run_dir):
+        calls["args"] = (d, dismissed, deleted, run_dir)
+        return rescored
+
+    deps = ScoringDeps(
+        read_run_data=lambda root, p, r: [raw],
+        dismissed_keys=lambda pd: {("R1", "a.py", 1)},
+        deleted_keys=lambda pd: set(),
+        rescore_dimension=fake_rescore,
+    )
+    out = scored_run_dimensions(tmp_path, "proj", "run-1", deps=deps)
+
+    assert out == [rescored]
+    assert calls["args"][0] is raw
+    assert calls["args"][3] == tmp_path / "proj" / "run-1"
+
+
+def test_scored_run_dimensions_skips_rescore_without_suppressions(tmp_path):
+    from quodeq.services.scoring import ScoringDeps, scored_run_dimensions
+
+    raw = _dim()
+    deps = ScoringDeps(
+        read_run_data=lambda root, p, r: [raw],
+        dismissed_keys=lambda pd: set(),
+        deleted_keys=lambda pd: set(),
+        rescore_dimension=lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not rescore")),
+    )
+    assert scored_run_dimensions(tmp_path, "proj", "run-1", deps=deps) == [raw]
+
+
+def test_rescore_accumulated_uses_injected_rescorer(tmp_path):
+    from quodeq.services.scoring import ScoringDeps, rescore_accumulated
+
+    accumulated = {
+        "dimensions": [{"dimension": "security", "fromRunId": "run-1",
+                        "overallScore": "5.0/10", "violations": []}],
+        "summary": {"dimensionsCount": 1},
+    }
+    seen = {}
+
+    def fake_runs_rescore(dims, root, project, dismissed, deleted, *, params):
+        seen["dims"] = dims
+        return {"security": {"overallScore": "8.0/10", "overallGrade": "Good"}}
+
+    deps = ScoringDeps(
+        dismissed_keys=lambda pd: {("R1", "a.py", 1)},
+        deleted_keys=lambda pd: set(),
+        rescore_runs_by_dimension=fake_runs_rescore,
+    )
+    out = rescore_accumulated(accumulated, tmp_path, "proj", deps=deps)
+
+    assert seen["dims"] == accumulated["dimensions"]
+    assert out["dimensions"][0]["overallScore"] == "8.0/10"
+
+
+def test_none_deps_defaults_to_production_behavior(tmp_path):
+    """deps=None resolves every field to the module's production callable,
+    so existing callers and (transitionally) namespace patches see no change."""
+    from quodeq.services import scoring
+
+    (tmp_path / "proj").mkdir()
+    import pytest
+
+    with pytest.raises(FileNotFoundError):
+        scoring.get_scores_raw(tmp_path, "proj", "missing-run")

--- a/tests/services/test_accumulated_partial_not_persisted.py
+++ b/tests/services/test_accumulated_partial_not_persisted.py
@@ -55,17 +55,16 @@ def persist_spy(monkeypatch):
     return calls
 
 
-def test_partial_rescore_is_served_but_not_persisted(project, monkeypatch, persist_spy):
+def test_partial_rescore_is_served_but_not_persisted(project, persist_spy):
     real = scoring._rescore_runs_by_dimension
 
-    def partial(dims, reports_root, project_name, dismissed, deleted=None, params=None):
+    def partial(dims, reports_root, project_name, dismissed, deleted=None, *, params=None):
         full = real(dims, reports_root, project_name, dismissed, deleted, params=params)
         # Simulate the incident: only the first-finished dimension came back.
         return {k: v for k, v in full.items() if k == "security"}
 
-    monkeypatch.setattr(scoring, "_rescore_runs_by_dimension", partial)
-
-    payload = get_project_scores(project, "proj")
+    deps = scoring.ScoringDeps(rescore_runs_by_dimension=partial)
+    payload = get_project_scores(project, "proj", deps=deps)
 
     assert payload is not None, "partial coverage must degrade to serving, not erroring"
     assert persist_spy == [], (

--- a/tests/services/test_score_cache_accumulated_parity.py
+++ b/tests/services/test_score_cache_accumulated_parity.py
@@ -57,7 +57,7 @@ def test_parent_project_bypasses_cache(tmp_path, monkeypatch):
     import quodeq.services.scoring as scoring
     def boom(*a, **k):
         raise AssertionError("accumulated cache used for a parent project")
-    monkeypatch.setattr(scoring, "cached_accumulated", boom)
+    deps = scoring.ScoringDeps(cached_accumulated=boom)
 
-    result = get_project_scores(reports, "parent")   # must NOT raise (bypasses cache)
+    result = get_project_scores(reports, "parent", deps=deps)   # must NOT raise (bypasses cache)
     assert result is not None

--- a/tests/services/test_scoring_scalar_parity.py
+++ b/tests/services/test_scoring_scalar_parity.py
@@ -30,8 +30,8 @@ def test_trend_identical_between_fast_and_heavy_paths(tmp_path: Path, monkeypatc
     import quodeq.services.scoring as scoring
     monkeypatch.setattr(
         scoring, "_make_trend_fetcher",
-        lambda rr, p, params=scoring.DEFAULT_PARAMS, cacheable_run_ids=None: (
-            scoring._make_rescoring_fetcher(rr, p, params=params)
+        lambda rr, p, params=scoring.DEFAULT_PARAMS, cacheable_run_ids=None, deps=None: (
+            scoring._make_rescoring_fetcher(rr, p, params=params, deps=deps)
         ),
     )
     heavy = get_project_scores(reports, "proj")

--- a/tests/services/test_scoring_trend_fetcher.py
+++ b/tests/services/test_scoring_trend_fetcher.py
@@ -5,7 +5,7 @@ import pytest
 
 from quodeq.core.types import DimensionResult
 from quodeq.services._trend_fetcher import make_rescoring_fetcher
-from quodeq.services.scoring import _make_trend_fetcher
+from quodeq.services.scoring import ScoringDeps, _make_trend_fetcher
 
 
 def _make_project(tmp_path: Path) -> tuple[Path, str]:
@@ -14,7 +14,7 @@ def _make_project(tmp_path: Path) -> tuple[Path, str]:
     return reports, "proj"
 
 
-def test_no_dismissals_uses_scalar_reader(tmp_path: Path, monkeypatch) -> None:
+def test_no_dismissals_uses_scalar_reader(tmp_path: Path) -> None:
     reports, project = _make_project(tmp_path)  # fresh project -> no dismissals
 
     calls: list[str] = []
@@ -23,11 +23,8 @@ def test_no_dismissals_uses_scalar_reader(tmp_path: Path, monkeypatch) -> None:
         calls.append(rid)
         return [DimensionResult(dimension="security", overall_score="8.0/10", overall_grade="Good")]
 
-    # _make_trend_fetcher passes the module-global read_run_scalars as the
-    # reader (an explicit arg, so patching the module global takes effect).
-    monkeypatch.setattr("quodeq.services.scoring.read_run_scalars", fake_scalar)
-
-    fetcher = _make_trend_fetcher(reports, project)
+    deps = ScoringDeps(read_run_scalars=fake_scalar)
+    fetcher = _make_trend_fetcher(reports, project, deps=deps)
     result = fetcher("r1")
 
     assert [d.overall_score for d in result] == ["8.0/10"]
@@ -36,9 +33,6 @@ def test_no_dismissals_uses_scalar_reader(tmp_path: Path, monkeypatch) -> None:
 
 def test_active_dismissal_uses_heavy_path(tmp_path: Path, monkeypatch) -> None:
     reports, project = _make_project(tmp_path)
-    # Force a non-empty dismissed set so the scalar fast path is bypassed.
-    monkeypatch.setattr("quodeq.services.scoring.dismissed_keys", lambda _pd: {("R1", "a.py", 1)})
-    monkeypatch.setattr("quodeq.services.scoring.deleted_keys", lambda _pd: set())
     # Use a tmp score cache so the test stays isolated.
     monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
 
@@ -56,9 +50,14 @@ def test_active_dismissal_uses_heavy_path(tmp_path: Path, monkeypatch) -> None:
 
     def boom(*_a):
         raise AssertionError("scalar reader used despite active dismissals")
-    monkeypatch.setattr("quodeq.services.scoring.read_run_scalars", boom)
 
-    fetcher = _make_trend_fetcher(reports, project)
+    # A non-empty dismissed set forces the heavy path past the scalar reader.
+    deps = ScoringDeps(
+        read_run_scalars=boom,
+        dismissed_keys=lambda _pd: {("R1", "a.py", 1)},
+        deleted_keys=lambda _pd: set(),
+    )
+    fetcher = _make_trend_fetcher(reports, project, deps=deps)
 
     # Heavy path: the cache-wrapper is returned (not the raw rescoring fetcher).
     # Calling it must invoke the rescoring fetcher (not the scalar reader).
@@ -69,8 +68,6 @@ def test_active_dismissal_uses_heavy_path(tmp_path: Path, monkeypatch) -> None:
 
 def test_active_deletion_uses_heavy_path(tmp_path: Path, monkeypatch) -> None:
     reports, project = _make_project(tmp_path)
-    monkeypatch.setattr("quodeq.services.scoring.dismissed_keys", lambda _pd: set())
-    monkeypatch.setattr("quodeq.services.scoring.deleted_keys", lambda _pd: {("sec", "prin", "a.py")})
     monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
 
     rescoring_calls: list[str] = []
@@ -85,9 +82,13 @@ def test_active_deletion_uses_heavy_path(tmp_path: Path, monkeypatch) -> None:
 
     def boom(*_a):
         raise AssertionError("scalar reader used despite active deletions")
-    monkeypatch.setattr("quodeq.services.scoring.read_run_scalars", boom)
 
-    fetcher = _make_trend_fetcher(reports, project)
+    deps = ScoringDeps(
+        read_run_scalars=boom,
+        dismissed_keys=lambda _pd: set(),
+        deleted_keys=lambda _pd: {("sec", "prin", "a.py")},
+    )
+    fetcher = _make_trend_fetcher(reports, project, deps=deps)
 
     # Heavy path: rescoring fetcher is wrapped in the cache; scalar reader must NOT be called.
     result = fetcher("r2")


### PR DESCRIPTION
Phase 1 of the ScoringReader decomposition ([roadmap] Track 2.2, the last 686-line god module).

## Why a seam first

The previous decomposition attempt reverted on namespace-patch whack-a-mole: 28 test sites patched `quodeq.services.scoring.<dep>` attributes, so any function that moved broke its patch targets. This PR removes that coupling *before* moving anything.

## The seam

`ScoringDeps` — a frozen dataclass whose `None` fields resolve to the production callables **at call time**, making it purely additive: existing callers pass nothing and see identical behavior (transitionally, even namespace patches kept working). Threaded through `scored_run_dimensions`, `get_scores_raw/slim`, the `rescore_accumulated` chain, both fetcher factories, and `get_project_scores`.

Bundled deps: `read_run_data`, `read_run_scalars`, `dismissed_keys`, `deleted_keys`, `cached_accumulated`, `rescore_dimension`, `rescore_runs_by_dimension`, `recompute_summary`.

## Test conversion

All five namespace-patching files converted to deps injection (`test_scored_run_dimensions`, `test_rescore_coverage`, `test_scoring_trend_fetcher`, `test_score_cache_accumulated_parity`, `test_accumulated_partial_not_persisted` — including the #955 persist-gate mutation cover, which now injects its partial rescorer). Zero `setattr` patches on scoring dependency names remain. One deliberate exception documented in the commit: the scalar-parity test patches `_make_trend_fetcher` itself — orchestration glue that stays in `__init__` post-split.

4 new seam tests (TDD, watched fail). Full suite: **5425 passed, 1 skipped**.

## Next

Phase 2 (separate PR): move the response builders + rescore machinery into `_response_builders.py` / `_rescoring.py`, keeping `__init__` as the public facade — now mechanical since nothing patches the old locations.