### PR TITLE
refactor(t1): precedent SQL moves into the findings-queries adapter

### DIFF
--- a/src/quodeq/context/precedent.py
+++ b/src/quodeq/context/precedent.py
@@ -69,27 +69,16 @@ def load_precedent_fingerprints(project_dir: Path) -> set[str]:
     if not project_dir or not project_dir.is_dir():
         return set()
 
+    from quodeq.data.sqlite.findings_queries import read_dismissed_snippets  # noqa: PLC0415
+
     out: set[str] = set()
     for run_dir in project_dir.iterdir():
         if not run_dir.is_dir():
             continue
-        db_path = run_dir / "evaluation.db"
-        if not db_path.is_file():
-            continue
-        try:
-            from quodeq.data.sqlite.connection import open_evaluation_db  # noqa: PLC0415
-            with open_evaluation_db(run_dir) as conn:
-                for row in conn.execute(
-                    "SELECT requirement, snippet FROM findings WHERE verdict = 'dismissed'"
-                ):
-                    fp = fingerprint(row[0], row[1])
-                    if fp is not None:
-                        out.add(fp)
-        except Exception as exc:
-            _logger.warning(
-                "Could not read precedent corpus from %s: %s", db_path, exc
-            )
-            continue
+        for req, snippet in read_dismissed_snippets(run_dir):
+            fp = fingerprint(req, snippet)
+            if fp is not None:
+                out.add(fp)
     return out
 
 
@@ -177,14 +166,6 @@ class PrecedentCorpus:
             return None
 
 
-_SEMANTIC_ELIGIBLE_SQL = (
-    "SELECT requirement, snippet FROM findings WHERE verdict = 'dismissed' "
-    "AND (scope IS NULL OR scope = '') "
-    "AND line > 0 "
-    "AND snippet IS NOT NULL AND TRIM(snippet) <> ''"
-)
-
-
 def _collect_dismissed_texts(project_dir: Path) -> dict[str, str]:
     """Map fingerprint -> canonical text for every dismissed finding.
 
@@ -195,23 +176,21 @@ def _collect_dismissed_texts(project_dir: Path) -> dict[str, str]:
     future finding filed under that requirement, and corpus/match-side
     eligibility would be asymmetric.
     """
+    from quodeq.data.sqlite.findings_queries import (  # noqa: PLC0415
+        read_semantic_eligible_dismissals,
+    )
+
     out: dict[str, str] = {}
     if not project_dir or not project_dir.is_dir():
         return out
     for run_dir in project_dir.iterdir():
-        if not run_dir.is_dir() or not (run_dir / "evaluation.db").is_file():
+        if not run_dir.is_dir():
             continue
-        try:
-            from quodeq.data.sqlite.connection import open_evaluation_db  # noqa: PLC0415
-            with open_evaluation_db(run_dir) as conn:
-                for req, snippet in conn.execute(_SEMANTIC_ELIGIBLE_SQL):
-                    fp = fingerprint(req, snippet)
-                    text = precedent_text(req, snippet)
-                    if fp is not None and text is not None:
-                        out[fp] = text
-        except Exception as exc:
-            _logger.warning("Could not read dismissed texts from %s: %s", run_dir, exc)
-            continue
+        for req, snippet in read_semantic_eligible_dismissals(run_dir):
+            fp = fingerprint(req, snippet)
+            text = precedent_text(req, snippet)
+            if fp is not None and text is not None:
+                out[fp] = text
     return out
 
 

--- a/src/quodeq/data/sqlite/findings_queries.py
+++ b/src/quodeq/data/sqlite/findings_queries.py
@@ -85,6 +85,54 @@ def read_run_key_sets(run_dir: Path) -> tuple[set[tuple], set[tuple]]:
     return dismiss, cls
 
 
+_SEMANTIC_ELIGIBLE_SQL = (
+    "SELECT requirement, snippet FROM findings WHERE verdict = 'dismissed' "
+    "AND (scope IS NULL OR scope = '') "
+    "AND line > 0 "
+    "AND snippet IS NOT NULL AND TRIM(snippet) <> ''"
+)
+
+
+def read_dismissed_snippets(run_dir: Path) -> list[tuple[str | None, str | None]]:
+    """``(requirement, snippet)`` for every dismissed finding in *run_dir*.
+
+    Feeds precedent fingerprinting. Any read failure yields an empty list:
+    precedent matching degrades gracefully and never breaks a scan.
+    """
+    if not (run_dir / "evaluation.db").is_file():
+        return []
+    try:
+        with open_evaluation_db(run_dir) as conn:
+            return [
+                (row[0], row[1])
+                for row in conn.execute(
+                    "SELECT requirement, snippet FROM findings "
+                    "WHERE verdict = 'dismissed'"
+                )
+            ]
+    except Exception as exc:  # noqa: BLE001 — precedent must never break a scan
+        _logger.warning("Could not read dismissed snippets from %s: %s", run_dir, exc)
+        return []
+
+
+def read_semantic_eligible_dismissals(run_dir: Path) -> list[tuple[str | None, str | None]]:
+    """``(requirement, snippet)`` for dismissals eligible as semantic precedents.
+
+    Excludes scope-level dismissals and empty-snippet/line<=0 rows, mirroring
+    ``_semantic_eligible`` in ``analysis/mcp/enricher.py`` on the match side:
+    without the filter a single empty-snippet dismissal would cosine-match
+    every future finding under that requirement.
+    """
+    if not (run_dir / "evaluation.db").is_file():
+        return []
+    try:
+        with open_evaluation_db(run_dir) as conn:
+            return [(req, snippet) for req, snippet in conn.execute(_SEMANTIC_ELIGIBLE_SQL)]
+    except Exception as exc:  # noqa: BLE001 — precedent must never break a scan
+        _logger.warning("Could not read dismissed texts from %s: %s", run_dir, exc)
+        return []
+
+
 def find_dismissed_matching(
     run_dir: Path, *, dimension: str, practice_id: str, file: str,
 ) -> list[tuple[str, str, int]]:

--- a/tests/data/test_findings_queries.py
+++ b/tests/data/test_findings_queries.py
@@ -92,3 +92,51 @@ def test_services_carry_no_database_dependency():
     for mod in (dismissed, deleted, run_keys):
         assert "sqlite3" not in vars(mod), mod.__name__
         assert "open_evaluation_db" not in vars(mod), mod.__name__
+
+
+class TestDismissedSnippetReaders:
+    """Precedent matching (context/precedent.py) used to inline these SELECTs."""
+
+    def test_read_dismissed_snippets_returns_pairs(self, tmp_path):
+        from quodeq.data.sqlite.findings_queries import read_dismissed_snippets
+
+        _seed(tmp_path, req="X-1", file="src/a.py", line=10, snippet="bad()")
+        _seed(tmp_path, req="X-2", file="src/b.py", line=20, practice_id="P2")
+        store = SQLiteStateStore(tmp_path)
+        store.update_verdict(req="X-1", file="src/a.py", line=10, verdict="dismissed")
+
+        assert read_dismissed_snippets(tmp_path) == [("X-1", "bad()")]
+
+    def test_read_dismissed_snippets_missing_db(self, tmp_path):
+        from quodeq.data.sqlite.findings_queries import read_dismissed_snippets
+
+        assert read_dismissed_snippets(tmp_path) == []
+
+    def test_semantic_eligible_excludes_scoped_and_empty(self, tmp_path):
+        from quodeq.data.sqlite.findings_queries import read_semantic_eligible_dismissals
+
+        # eligible: line > 0, non-empty snippet, no scope
+        _seed(tmp_path, req="OK-1", file="a.py", line=5, snippet="real()")
+        # excluded: empty snippet
+        _seed(tmp_path, req="NO-1", file="b.py", line=5, snippet="   ", practice_id="P2")
+        # excluded: scope-level finding
+        _seed(tmp_path, req="NO-2", file="c.py", line=5, snippet="x()", scope="module", practice_id="P3")
+        store = SQLiteStateStore(tmp_path)
+        for req, f in [("OK-1", "a.py"), ("NO-1", "b.py"), ("NO-2", "c.py")]:
+            store.update_verdict(req=req, file=f, line=5, verdict="dismissed")
+
+        assert read_semantic_eligible_dismissals(tmp_path) == [("OK-1", "real()")]
+
+    def test_semantic_eligible_missing_db(self, tmp_path):
+        from quodeq.data.sqlite.findings_queries import read_semantic_eligible_dismissals
+
+        assert read_semantic_eligible_dismissals(tmp_path) == []
+
+
+def test_precedent_carries_no_database_dependency():
+    """context/precedent.py must not import the sqlite connection helper."""
+    import quodeq.context.precedent as precedent
+
+    src = open(precedent.__file__).read()
+    assert "open_evaluation_db" not in src
+    assert "FROM findings" not in src


### PR DESCRIPTION
Group D of the clean-architecture keep-list (live findings CLEA-SEP-03 `precedent.py:207`, CLEA-DEP-01 `precedent.py:80`).

`context/precedent.py` ran its own `SELECT ... FROM findings` per run dir, including a module-level `_SEMANTIC_ELIGIBLE_SQL` constant. Two readers join the existing adapter:

- `read_dismissed_snippets(run_dir)` — `(requirement, snippet)` for every dismissed finding (fingerprint precedent).
- `read_semantic_eligible_dismissals(run_dir)` — the same, minus scope-level and empty-snippet/`line<=0` rows. That filter mirrors `_semantic_eligible` in `analysis/mcp/enricher.py` so corpus and match sides stay symmetric; without it one empty-snippet dismissal cosine-matches every future finding under that requirement.

Both preserve the load-bearing invariant that **precedent matching degrades gracefully and never breaks a scan**: read failures become an empty list, with the per-run skip and warning moved into the adapter. `precedent.py` keeps all fingerprinting/text logic and no longer names a table or a connection (test-pinned).

## Tests (TDD)

5 new tests watched fail first, including the eligibility filter's exclusions (scoped, blank-snippet) and the decoupling pin. Full suite: **5430 passed, 1 skipped**; import ratchet unchanged at 20 grandfathered.