### PR TITLE
refactor(t5): api stops touching the filesystem

### DIFF
--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -23,7 +23,7 @@ from quodeq.api.routes import _reports_dir
 from quodeq.services.base import ActionProvider
 from quodeq.services.score_run import score_completed_evidence
 from quodeq.services.scan_progress import build_scan_progress
-from quodeq.services.run_events import read_dimensions
+from quodeq.services.run_events import read_run_dim_states
 from quodeq.shared.utils import is_repo_url
 
 _logger = logging.getLogger(__name__)
@@ -81,8 +81,7 @@ def _read_dim_states(job: Any) -> dict[str, dict[str, Any]]:
     run_id = getattr(job, "output_run_id", None)
     if not project or not run_id:
         return {}
-    run_dir = Path(_reports_dir()) / project / run_id
-    return read_dimensions(run_dir).get("dimensions", {})
+    return read_run_dim_states(_reports_dir(), project, run_id)
 
 # Cap on /api/evaluations ?limit= so a client cannot ask the server to materialize
 # an unbounded list. limit=0 still means "no client cap" but we clamp the actual

--- a/src/quodeq/api/standards_overrides_routes.py
+++ b/src/quodeq/api/standards_overrides_routes.py
@@ -5,7 +5,6 @@ The override file lives inside the analyzed repository
 """
 from __future__ import annotations
 
-import json
 import logging
 from http import HTTPStatus
 from pathlib import Path
@@ -21,8 +20,11 @@ from quodeq.core.standards.overrides import (
     validate_overrides,
 )
 from quodeq.services.standards_prefs import (
+    clear_project_overrides,
     collect_declared_params,
+    iter_compiled_standards,
     load_project_overrides,
+    save_project_overrides,
 )
 
 logger = logging.getLogger(__name__)
@@ -31,15 +33,11 @@ logger = logging.getLogger(__name__)
 def _counts(overrides: dict, compiled_dir: Path) -> dict[str, int]:
     """Per-dimension count of overridden requirements, keyed by compiled id."""
     dim_by_req: dict[str, str] = {}
-    for path in sorted(compiled_dir.glob("*.json")):
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, ValueError, UnicodeDecodeError):
-            continue
+    for stem, data in iter_compiled_standards(compiled_dir):
         for principle in data.get("principles", []):
             for req in principle.get("requirements", []):
                 if req.get("id"):
-                    dim_by_req[req["id"]] = data.get("id", path.stem)
+                    dim_by_req[req["id"]] = data.get("id", stem)
     counts: dict[str, int] = {}
     for req_id in overrides:
         dim = dim_by_req.get(req_id)
@@ -58,19 +56,18 @@ def _changed_dimensions(compiled_dir: Path, current: dict, proposed: dict) -> li
     only compiled/<dimension>.json), so custom evaluator-dir standards—whose
     cache keys never shift on override change—are symmetrically never reported."""
     changed: list[str] = []
-    for path in sorted(compiled_dir.glob("*.json")):
+    for stem, data in iter_compiled_standards(compiled_dir):
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
             _, before = dimension_params(data, current)
             _, after = dimension_params(data, proposed)
-        except (OSError, ValueError, UnicodeDecodeError, AttributeError, TypeError):
+        except (AttributeError, TypeError):
             # A shape-invalid params block (spec not a dict, "params" not a
             # mapping, etc.) raises AttributeError/TypeError out of
             # dimension_params -- same degrade-and-skip as an unreadable or
             # unparseable compiled file, so a bad file never 500s the PUT.
             continue
         if before != after:
-            changed.append(data.get("id", path.stem))
+            changed.append(data.get("id", stem))
     return changed
 
 
@@ -126,12 +123,10 @@ def register_overrides_routes(app: Flask) -> None:
         dry_run = request.args.get("dryRun", "").lower() in ("1", "true")
         if dry_run:
             return jsonify({"overrides": clean, "changedDimensions": changed})
-        override_path = root / OVERRIDES_RELPATH
         if not clean:
-            override_path.unlink(missing_ok=True)
+            clear_project_overrides(root)
             logger.info("standards.overrides cleared project=%s", project_id)
             return jsonify({"overrides": {}, "changedDimensions": changed})
-        override_path.parent.mkdir(parents=True, exist_ok=True)
-        override_path.write_text(json.dumps({"version": 1, "overrides": clean}, indent=2) + "\n", encoding="utf-8")
+        save_project_overrides(root, clean)
         logger.info("standards.overrides saved project=%s reqs=%d", project_id, len(clean))
         return jsonify({"overrides": clean, "changedDimensions": changed})

--- a/src/quodeq/data/fs/compiled_standards.py
+++ b/src/quodeq/data/fs/compiled_standards.py
@@ -1,0 +1,30 @@
+"""Reads over the compiled-standards directory.
+
+api/standards_overrides_routes globbed this directory and json-parsed each
+file inline; the mechanics live here so the route keeps only its mapping
+logic. Unreadable, unparseable and non-object files are skipped rather
+than raised: a single hand-edited standard must never 500 a request.
+"""
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+
+def iter_compiled_standards(compiled_dir: Path) -> Iterator[tuple[str, dict]]:
+    """Yield ``(file_stem, payload)`` for each readable compiled standard.
+
+    Sorted by path so callers see a stable order. Skips files that fail to
+    read/parse and payloads that are not JSON objects (the recurring
+    non-dict-JSON crash class).
+    """
+    if not compiled_dir.is_dir():
+        return
+    for path in sorted(compiled_dir.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, UnicodeDecodeError):
+            continue
+        if isinstance(data, dict):
+            yield path.stem, data

--- a/src/quodeq/data/fs/standards_prefs.py
+++ b/src/quodeq/data/fs/standards_prefs.py
@@ -70,6 +70,19 @@ def load_project_overrides(project_root: str | Path | None) -> dict[str, dict]:
     return {req_id: vals for req_id, vals in overrides.items() if isinstance(vals, dict)}
 
 
+def save_project_overrides(project_root: str | Path, overrides: dict[str, dict]) -> None:
+    """Write ``{req_id: {param: value}}``, creating ``.quodeq/`` when needed."""
+    path = Path(project_root) / OVERRIDES_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps({"version": 1, "overrides": overrides}, indent=2) + "\n"
+    path.write_text(payload, encoding="utf-8")
+
+
+def clear_project_overrides(project_root: str | Path) -> None:
+    """Remove the overrides file. No-op when it does not exist."""
+    (Path(project_root) / OVERRIDES_RELPATH).unlink(missing_ok=True)
+
+
 def collect_declared_params(compiled_dir: Path) -> dict[str, dict]:
     """Collect ``{req_id: params_spec}`` across every compiled dimension file."""
     declared: dict[str, dict] = {}

--- a/src/quodeq/services/run_events.py
+++ b/src/quodeq/services/run_events.py
@@ -6,3 +6,21 @@ how ``services/grade_formula.py`` fronts the params store.
 """
 from quodeq.data.events.reader import EventLogReader  # noqa: F401 — re-exported API
 from quodeq.data.fs.dimensions_state_store import read_dimensions  # noqa: F401,E402 — re-exported API
+
+
+def read_run_dim_states(reports_dir, project: str, run_id: str) -> dict:
+    """Per-dimension state map for a run, addressed by identifiers.
+
+    The api layer used to compose ``reports_dir / project / run_id`` itself;
+    it now passes identifiers and this facade owns the storage path. Empty
+    dict when the run has no (or an unreadable) dimensions file. Raises
+    ValueError on traversal segments — the join happens here now, so the
+    guard belongs here too.
+    """
+    from pathlib import Path  # noqa: PLC0415
+
+    from quodeq.shared.validation import validate_path_segment  # noqa: PLC0415
+
+    validate_path_segment(project, run_id)
+    run_dir = Path(reports_dir) / project / run_id
+    return read_dimensions(run_dir).get("dimensions", {})

--- a/src/quodeq/services/standards_prefs.py
+++ b/src/quodeq/services/standards_prefs.py
@@ -5,7 +5,12 @@ rules); this facade exposes the per-project standards preference store
 through services. Pure validation/partitioning stays importable from
 ``core/standards/``.
 """
+from quodeq.data.fs.compiled_standards import (  # noqa: F401 — re-exported API
+    iter_compiled_standards,
+)
 from quodeq.data.fs.standards_prefs import (  # noqa: F401 — re-exported API
+    clear_project_overrides,
+    save_project_overrides,
     collect_declared_params,
     load_project_overrides,
     load_visible_standard_ids,

--- a/tests/data/test_compiled_standards.py
+++ b/tests/data/test_compiled_standards.py
@@ -1,0 +1,95 @@
+"""Compiled-standards directory reads belong to the data layer.
+
+api/standards_overrides_routes globbed the compiled dir and json-parsed
+each file inline; the route now keeps only its mapping logic.
+"""
+from __future__ import annotations
+
+import json
+
+
+def _write(d, name: str, payload) -> None:
+    (d / f"{name}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestIterCompiledStandards:
+    def test_yields_parsed_payloads_sorted(self, tmp_path):
+        from quodeq.data.fs.compiled_standards import iter_compiled_standards
+
+        _write(tmp_path, "b-std", {"id": "b-std"})
+        _write(tmp_path, "a-std", {"id": "a-std"})
+
+        out = list(iter_compiled_standards(tmp_path))
+
+        assert [stem for stem, _ in out] == ["a-std", "b-std"]
+        assert [data["id"] for _, data in out] == ["a-std", "b-std"]
+
+    def test_skips_unreadable_and_non_object_files(self, tmp_path):
+        from quodeq.data.fs.compiled_standards import iter_compiled_standards
+
+        _write(tmp_path, "good", {"id": "good"})
+        (tmp_path / "broken.json").write_text("{nope", encoding="utf-8")
+        (tmp_path / "list.json").write_text("[1, 2]", encoding="utf-8")
+
+        assert [stem for stem, _ in iter_compiled_standards(tmp_path)] == ["good"]
+
+    def test_missing_dir_yields_nothing(self, tmp_path):
+        from quodeq.data.fs.compiled_standards import iter_compiled_standards
+
+        assert list(iter_compiled_standards(tmp_path / "nope")) == []
+
+
+class TestRouteDelegation:
+    def test_counts_uses_the_adapter(self, tmp_path):
+        from quodeq.api import standards_overrides_routes as routes
+
+        _write(tmp_path, "sec", {
+            "id": "sec",
+            "principles": [{"requirements": [{"id": "S-1"}, {"id": "S-2"}]}],
+        })
+
+        counts = routes._counts({"S-1": {}, "S-2": {}, "OTHER": {}}, tmp_path)
+
+        assert counts == {"sec": 2}
+
+    def test_api_module_does_no_filesystem_parsing(self):
+        """The route module must not glob or json-parse the compiled dir."""
+        from quodeq.api import standards_overrides_routes as routes
+
+        src = open(routes.__file__).read()
+        assert ".glob(" not in src
+        assert "read_text(" not in src
+
+
+class TestProjectOverridesWriter:
+    def test_save_then_load_round_trip(self, tmp_path):
+        from quodeq.data.fs.standards_prefs import (
+            load_project_overrides, save_project_overrides,
+        )
+
+        save_project_overrides(tmp_path, {"S-1": {"floorMajor": 5.0}})
+
+        assert load_project_overrides(tmp_path) == {"S-1": {"floorMajor": 5.0}}
+
+    def test_clear_removes_the_file(self, tmp_path):
+        from quodeq.data.fs.standards_prefs import (
+            clear_project_overrides, load_project_overrides, save_project_overrides,
+        )
+
+        save_project_overrides(tmp_path, {"S-1": {"floorMajor": 5.0}})
+        clear_project_overrides(tmp_path)
+
+        assert load_project_overrides(tmp_path) == {}
+
+    def test_clear_is_idempotent(self, tmp_path):
+        from quodeq.data.fs.standards_prefs import clear_project_overrides
+
+        clear_project_overrides(tmp_path)  # must not raise
+
+
+def test_overrides_route_does_no_filesystem_writes():
+    from quodeq.api import standards_overrides_routes as routes
+
+    src = open(routes.__file__).read()
+    assert "write_text(" not in src
+    assert "unlink(" not in src

--- a/tests/services/test_run_events_facade.py
+++ b/tests/services/test_run_events_facade.py
@@ -1,0 +1,42 @@
+"""api passes identifiers, not constructed paths, for run dimension states."""
+from __future__ import annotations
+
+import json
+
+
+def test_read_run_dim_states_returns_dimensions_map(tmp_path):
+    from quodeq.services.run_events import read_run_dim_states
+
+    run_dir = tmp_path / "proj" / "run-1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "dimensions.json").write_text(
+        json.dumps({"dimensions": {"security": {"state": "done"}}}), encoding="utf-8",
+    )
+
+    assert read_run_dim_states(tmp_path, "proj", "run-1") == {
+        "security": {"state": "done"},
+    }
+
+
+def test_read_run_dim_states_missing_run_is_empty(tmp_path):
+    from quodeq.services.run_events import read_run_dim_states
+
+    assert read_run_dim_states(tmp_path, "proj", "nope") == {}
+
+
+def test_read_run_dim_states_rejects_traversal(tmp_path):
+    import pytest
+
+    from quodeq.services.run_events import read_run_dim_states
+
+    with pytest.raises(ValueError):
+        read_run_dim_states(tmp_path, "../etc", "run-1")
+
+
+def test_api_builds_no_run_paths():
+    """_read_dim_states hands identifiers to the facade instead of joining
+    a run_dir itself (the api layer must not compose storage paths)."""
+    from quodeq.api import _evaluation_routes as routes
+
+    src = open(routes.__file__).read()
+    assert "_reports_dir()) / project / run_id" not in src


### PR DESCRIPTION
T5 sweep, api slice (live findings CLEA-SEP-03 `_evaluation_routes:84`, `standards_overrides_routes:51`).

The route layer was composing storage paths, globbing the compiled-standards directory, and writing the overrides file itself.

- **`data/fs/compiled_standards.iter_compiled_standards`** — glob + parse in one place, skipping unreadable/unparseable/non-object files so a single hand-edited standard can never 500 a request. `_counts` and `_changed_dimensions` keep only their mapping logic.
- **`data/fs/standards_prefs.save_project_overrides` / `clear_project_overrides`** — siblings of the existing `save_visible_standard_ids`; the PUT route no longer writes or unlinks. (Not in the flagged set — the write side of a module whose read side was flagged; finishing it costs three lines and leaves the module clean.)
- **`services/run_events.read_run_dim_states(reports_dir, project, run_id)`** — the api passes identifiers instead of joining `reports_dir / project / run_id`, so the facade owns the path **and its traversal guard**, which moves with the join.

Both new readers reach the api through the **services facade**, not `data` directly — the import ratchet rejected my first attempt at a direct `data` import from a route, which is exactly the layer rule doing its job.

`standards_overrides_routes.py` now performs zero filesystem operations, test-pinned (no `glob`, `read_text`, `write_text`, `unlink`).

## Tests (TDD)

13 new tests watched fail first. Full suite: **5443 passed, 1 skipped**; import ratchet unchanged at 20 grandfathered.

## Deliberately not in this PR

The core-purity findings (`core/standards/refs.py`, `loader.py` reading JSON via `core/utils/io`) are left alone: WS4 moved those pure IO helpers **inward on purpose**, so "fix" here means deciding whether the standards *loaders* belong in `data/` — a design call with a wide blast radius, not a sweep item.