### PR TITLE
refactor(t5): stream-event parsing moves inward, ratchet 20 -> 17

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 | Layer | Purpose | Dependencies |
 |-------|---------|--------------|
-| `core/` | Domain logic: evidence models, scoring algorithms, standards definitions, type definitions | None (stdlib only) |
+| `core/` | Domain logic: evidence models, scoring algorithms, standards definitions, type definitions, stream-event parsing | None (stdlib only) |
 | `data/` | Data access: filesystem repositories, web API clients, report parsers | core/ |
 | `services/` | Business logic: dashboard, accumulated views, dismissals, standards CRUD | core/, data/ |
 | `assistant/` | Embedded LLM assistant: sessions, tool registry, provider turn adapters, guard | core/, data/, services/, llm_bridge/ |

--- a/src/quodeq/analysis/stream/counters.py
+++ b/src/quodeq/analysis/stream/counters.py
@@ -1,71 +1,17 @@
-"""Stream and JSONL file counting helpers for AI analysis output."""
+"""Stream and JSONL file counting helpers for AI analysis output.
+
+The pure parsers moved to ``core/stream/events.py`` and the file-reading
+counters to ``data/fs/stream_files.py``; this module stays as the
+analysis-side name for both.
+"""
 from __future__ import annotations
 
-import json
-from pathlib import Path
-
-from quodeq.shared.logging import log_debug
-from quodeq.shared.utils import open_text
-
-_TOOL_USE_TYPE = "tool_use"
-_FILE_READ_TOOLS = frozenset({"Read", "Grep"})
-
-
-def extract_files_from_blocks(blocks: list) -> set[str]:
-    """Extract file paths from Read/Grep tool_use blocks."""
-    files: set[str] = set()
-    for block in blocks:
-        if isinstance(block, dict) and block.get("type") == _TOOL_USE_TYPE and block.get("name") in _FILE_READ_TOOLS:
-            fp = (block.get("input") or {}).get("file_path") or (block.get("input") or {}).get("path")
-            if fp:
-                files.add(fp)
-    return files
-
-
-def parse_stream_event(line: str) -> dict | None:
-    """Parse a single stream event line, returning None for empty or invalid lines."""
-    stripped = line.strip()
-    if not stripped:
-        return None
-    try:
-        return json.loads(stripped)
-    except json.JSONDecodeError:
-        return None
-
-
-def extract_files_from_event(data: dict) -> set[str]:
-    """Dispatch to the appropriate file extractor based on event type."""
-    if not isinstance(data, dict):
-        return set()
-    etype = data.get("type", "")
-    if etype == "assistant":
-        return extract_files_from_blocks(data.get("message", {}).get("content", []))
-    if etype == "item.completed":
-        return extract_files_from_blocks(data.get("item", {}).get("content", []))
-    return set()
-
-
-def count_files_in_stream(stream_file: Path) -> set[str]:
-    """Extract unique file paths from Read/Grep tool_use events in the stream."""
-    files: set[str] = set()
-    try:
-        with open_text(stream_file) as f:
-            for line in f:
-                data = parse_stream_event(line)
-                if data is not None:
-                    files.update(extract_files_from_event(data))
-    except (OSError, ValueError) as exc:
-        log_debug(f"Failed to count files from stream {stream_file}: {exc}")
-    return files
-
-
-def count_jsonl_lines(jsonl_file: Path) -> int:
-    """Count evidence lines in the JSONL file written by the MCP server."""
-    try:
-        if not jsonl_file.exists():
-            return 0
-        with open_text(jsonl_file) as f:
-            return sum(1 for line in f if line.strip())
-    except OSError as exc:
-        log_debug(f"Failed to count JSONL lines from {jsonl_file}: {exc}")
-        return 0
+from quodeq.core.stream.events import (  # noqa: F401 — re-exported API
+    extract_files_from_blocks,
+    extract_files_from_event,
+    parse_stream_event,
+)
+from quodeq.data.fs.stream_files import (  # noqa: F401 — re-exported API
+    count_files_in_stream,
+    count_jsonl_lines,
+)

--- a/src/quodeq/analysis/stream/event_text.py
+++ b/src/quodeq/analysis/stream/event_text.py
@@ -1,43 +1,14 @@
 """Shared text extraction from stream-json events.
 
-Used by both ``_fs_violations`` (dashboard live-view) and ``stream_parser``
-(JSONL evidence extraction) to avoid duplicating the event-dispatch logic.
+The implementation moved inward to ``core/stream/events.py`` (pure
+wire-format parsing, reachable from services without a services ->
+analysis arrow). This module stays as the analysis-side name.
 """
 from __future__ import annotations
 
-from typing import Callable
-
-
-def texts_from_assistant(event: dict) -> list[str]:
-    """Extract text blocks from an ``assistant`` stream event."""
-    texts: list[str] = []
-    for block in (event.get("message") or {}).get("content") or []:
-        if block.get("type") == "text" and block.get("text"):
-            texts.append(block["text"])
-    return texts
-
-
-def texts_from_result(event: dict) -> list[str]:
-    """Extract text from a ``result`` stream event."""
-    r = event.get("result")
-    return [r] if r else []
-
-
-def texts_from_item_completed(event: dict) -> list[str]:
-    """Extract text blocks from an ``item.completed`` stream event."""
-    texts: list[str] = []
-    item = event.get("item") or {}
-    if item.get("type") == "agent_message":
-        if item.get("text"):
-            texts.append(item["text"])
-        for block in item.get("content") or []:
-            if block.get("type") in ("text", "output_text") and block.get("text"):
-                texts.append(block["text"])
-    return texts
-
-
-TEXT_EXTRACTORS: dict[str, Callable[[dict], list[str]]] = {
-    "assistant": texts_from_assistant,
-    "result": texts_from_result,
-    "item.completed": texts_from_item_completed,
-}
+from quodeq.core.stream.events import (  # noqa: F401 — re-exported API
+    TEXT_EXTRACTORS,
+    texts_from_assistant,
+    texts_from_item_completed,
+    texts_from_result,
+)

--- a/src/quodeq/core/stream/__init__.py
+++ b/src/quodeq/core/stream/__init__.py
@@ -1,0 +1,1 @@
+"""Pure parsing of AI stream-json events (no I/O, no layer dependencies)."""

--- a/src/quodeq/core/stream/events.py
+++ b/src/quodeq/core/stream/events.py
@@ -1,0 +1,84 @@
+"""Pure parsing of AI stream-json events.
+
+Wire-format logic shared by the analysis pipeline (live progress, evidence
+extraction) and the services layer (dashboard live view). It lives in core
+because it is pure dict/string handling: no filesystem, no configuration,
+no layer dependencies. The file-reading counters that build on it live in
+``data/fs/stream_files.py``.
+"""
+from __future__ import annotations
+
+import json
+from typing import Callable
+
+_TOOL_USE_TYPE = "tool_use"
+_FILE_READ_TOOLS = frozenset({"Read", "Grep"})
+
+
+def texts_from_assistant(event: dict) -> list[str]:
+    """Extract text blocks from an ``assistant`` stream event."""
+    texts: list[str] = []
+    for block in (event.get("message") or {}).get("content") or []:
+        if block.get("type") == "text" and block.get("text"):
+            texts.append(block["text"])
+    return texts
+
+
+def texts_from_result(event: dict) -> list[str]:
+    """Extract text from a ``result`` stream event."""
+    r = event.get("result")
+    return [r] if r else []
+
+
+def texts_from_item_completed(event: dict) -> list[str]:
+    """Extract text blocks from an ``item.completed`` stream event."""
+    texts: list[str] = []
+    item = event.get("item") or {}
+    if item.get("type") == "agent_message":
+        if item.get("text"):
+            texts.append(item["text"])
+        for block in item.get("content") or []:
+            if block.get("type") in ("text", "output_text") and block.get("text"):
+                texts.append(block["text"])
+    return texts
+
+
+TEXT_EXTRACTORS: dict[str, Callable[[dict], list[str]]] = {
+    "assistant": texts_from_assistant,
+    "result": texts_from_result,
+    "item.completed": texts_from_item_completed,
+}
+
+
+def extract_files_from_blocks(blocks: list) -> set[str]:
+    """Extract file paths from Read/Grep tool_use blocks."""
+    files: set[str] = set()
+    for block in blocks:
+        if isinstance(block, dict) and block.get("type") == _TOOL_USE_TYPE and block.get("name") in _FILE_READ_TOOLS:
+            fp = (block.get("input") or {}).get("file_path") or (block.get("input") or {}).get("path")
+            if fp:
+                files.add(fp)
+    return files
+
+
+def parse_stream_event(line: str) -> dict | None:
+    """Parse a single stream event line, returning None for empty or invalid lines."""
+    stripped = line.strip()
+    if not stripped:
+        return None
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+
+
+def extract_files_from_event(data: dict) -> set[str]:
+    """Dispatch to the appropriate file extractor based on event type."""
+    if not isinstance(data, dict):
+        return set()
+    etype = data.get("type", "")
+    if etype == "assistant":
+        return extract_files_from_blocks(data.get("message", {}).get("content", []))
+    if etype == "item.completed":
+        return extract_files_from_blocks(data.get("item", {}).get("content", []))
+    return set()

--- a/src/quodeq/data/fs/stream_files.py
+++ b/src/quodeq/data/fs/stream_files.py
@@ -1,0 +1,41 @@
+"""Counting reads over agent stream/JSONL output files.
+
+The parsing itself is pure and lives in ``core/stream/events.py``; these
+helpers add the file access, so both the analysis pipeline and the
+services layer can reach them without a services -> analysis arrow.
+Both degrade to an empty result on unreadable files: they feed progress
+counters, never correctness.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from quodeq.core.stream.events import extract_files_from_event, parse_stream_event
+from quodeq.shared.logging import log_debug
+from quodeq.shared.utils import open_text
+
+
+def count_files_in_stream(stream_file: Path) -> set[str]:
+    """Extract unique file paths from Read/Grep tool_use events in the stream."""
+    files: set[str] = set()
+    try:
+        with open_text(stream_file) as f:
+            for line in f:
+                data = parse_stream_event(line)
+                if data is not None:
+                    files.update(extract_files_from_event(data))
+    except (OSError, ValueError) as exc:
+        log_debug(f"Failed to count files from stream {stream_file}: {exc}")
+    return files
+
+
+def count_jsonl_lines(jsonl_file: Path) -> int:
+    """Count evidence lines in the JSONL file written by the MCP server."""
+    try:
+        if not jsonl_file.exists():
+            return 0
+        with open_text(jsonl_file) as f:
+            return sum(1 for line in f if line.strip())
+    except OSError as exc:
+        log_debug(f"Failed to count JSONL lines from {jsonl_file}: {exc}")
+        return 0

--- a/src/quodeq/services/_violations_jsonl.py
+++ b/src/quodeq/services/_violations_jsonl.py
@@ -9,7 +9,7 @@ from typing import Iterable
 from quodeq.core.types import Finding, ViolationResponse
 from quodeq.core.evidence._req_mapping import PrincipleResolver, build_principle_resolver
 from quodeq.core.evidence.parser import build_req_refs_lookup
-from quodeq.analysis.stream.counters import count_files_in_stream
+from quodeq.data.fs.stream_files import count_files_in_stream
 from quodeq.services.violation_context import ViolationContext
 from quodeq.services.suppression import SuppressionMatcher, load_req_to_principle
 from quodeq.config.paths import default_paths

--- a/src/quodeq/services/_violations_stream.py
+++ b/src/quodeq/services/_violations_stream.py
@@ -7,8 +7,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 from quodeq.core.types import Finding, ViolationResponse
-from quodeq.analysis.stream.event_text import TEXT_EXTRACTORS
-from quodeq.analysis.stream.counters import extract_files_from_event
+from quodeq.core.stream.events import TEXT_EXTRACTORS, extract_files_from_event
 from quodeq.services.violation_context import ViolationContext
 from quodeq.services.violations_parsing import (
     _build_finding_entry,

--- a/tests/core/test_stream_events.py
+++ b/tests/core/test_stream_events.py
@@ -1,0 +1,103 @@
+"""Stream-event parsing is shared wire-format logic, not analysis logic.
+
+services/_violations_stream and services/_violations_jsonl imported these
+helpers from analysis/ (three grandfathered baseline entries). The pure
+parsers move inward to core/stream/events.py and the file-reading counters
+to data/fs/stream_files.py, so both layers reach them without a
+services -> analysis arrow.
+"""
+from __future__ import annotations
+
+import json
+
+
+class TestPureParsers:
+    def test_parse_stream_event_handles_blank_and_invalid(self):
+        from quodeq.core.stream.events import parse_stream_event
+
+        assert parse_stream_event("") is None
+        assert parse_stream_event("   ") is None
+        assert parse_stream_event("not json") is None
+        assert parse_stream_event('{"type": "assistant"}') == {"type": "assistant"}
+
+    def test_extract_files_from_assistant_event(self):
+        from quodeq.core.stream.events import extract_files_from_event
+
+        event = {
+            "type": "assistant",
+            "message": {"content": [
+                {"type": "tool_use", "name": "Read", "input": {"file_path": "a.py"}},
+                {"type": "tool_use", "name": "Grep", "input": {"path": "b.py"}},
+                {"type": "tool_use", "name": "Write", "input": {"file_path": "skip.py"}},
+            ]},
+        }
+        assert extract_files_from_event(event) == {"a.py", "b.py"}
+
+    def test_extract_files_from_non_dict_is_empty(self):
+        from quodeq.core.stream.events import extract_files_from_event
+
+        assert extract_files_from_event(["nope"]) == set()
+
+    def test_text_extractors_cover_the_event_types(self):
+        from quodeq.core.stream.events import TEXT_EXTRACTORS
+
+        assert set(TEXT_EXTRACTORS) == {"assistant", "result", "item.completed"}
+        assert TEXT_EXTRACTORS["result"]({"result": "done"}) == ["done"]
+
+
+class TestStreamFileCounters:
+    def test_count_files_in_stream(self, tmp_path):
+        from quodeq.data.fs.stream_files import count_files_in_stream
+
+        stream = tmp_path / "s.stream"
+        stream.write_text("\n".join([
+            json.dumps({"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "name": "Read", "input": {"file_path": "x.py"}},
+            ]}}),
+            "",
+            "garbage",
+        ]), encoding="utf-8")
+
+        assert count_files_in_stream(stream) == {"x.py"}
+
+    def test_count_files_missing_stream_is_empty(self, tmp_path):
+        from quodeq.data.fs.stream_files import count_files_in_stream
+
+        assert count_files_in_stream(tmp_path / "nope.stream") == set()
+
+    def test_count_jsonl_lines_skips_blanks(self, tmp_path):
+        from quodeq.data.fs.stream_files import count_jsonl_lines
+
+        f = tmp_path / "e.jsonl"
+        f.write_text('{"a":1}\n\n{"b":2}\n', encoding="utf-8")
+        assert count_jsonl_lines(f) == 2
+
+    def test_count_jsonl_lines_missing_is_zero(self, tmp_path):
+        from quodeq.data.fs.stream_files import count_jsonl_lines
+
+        assert count_jsonl_lines(tmp_path / "nope.jsonl") == 0
+
+
+def test_analysis_shims_keep_their_public_names():
+    """Existing analysis callers and tests import these from analysis/stream;
+    the modules stay as re-export shims so nothing downstream moves."""
+    from quodeq.analysis.stream.counters import (
+        count_files_in_stream, extract_files_from_event, parse_stream_event,
+    )
+    from quodeq.analysis.stream.event_text import TEXT_EXTRACTORS
+    from quodeq.core.stream import events as core_events
+    from quodeq.data.fs import stream_files
+
+    assert extract_files_from_event is core_events.extract_files_from_event
+    assert parse_stream_event is core_events.parse_stream_event
+    assert TEXT_EXTRACTORS is core_events.TEXT_EXTRACTORS
+    assert count_files_in_stream is stream_files.count_files_in_stream
+
+
+def test_violation_services_no_longer_import_analysis():
+    import quodeq.services._violations_jsonl as vj
+    import quodeq.services._violations_stream as vs
+
+    for mod in (vs, vj):
+        src = open(mod.__file__).read()
+        assert "quodeq.analysis" not in src, mod.__name__

--- a/tests/tools/test_import_layers.py
+++ b/tests/tools/test_import_layers.py
@@ -22,7 +22,7 @@ def test_no_new_import_violations():
 
 # Revise DOWNWARD as clean-architecture workstreams burn entries; NEVER raise
 # without a justification reviewed in the PR that raises it.
-BASELINE_CEILING = 20
+BASELINE_CEILING = 17
 
 
 def test_baseline_only_shrinks():

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -13,9 +13,6 @@ src/quodeq/ci/review.py:147:_cli_evaluation
 src/quodeq/data/fs/repo_clone.py:19:context
 src/quodeq/llm_bridge/_providers.py:6:analysis
 src/quodeq/services/_external_jobs.py:21:analysis
-src/quodeq/services/_violations_jsonl.py:12:analysis
-src/quodeq/services/_violations_stream.py:10:analysis
-src/quodeq/services/_violations_stream.py:11:analysis
 src/quodeq/services/evaluation_mixin.py:360:analysis
 src/quodeq/services/jobs.py:20:analysis
 src/quodeq/services/scan_progress.py:23:analysis


### PR DESCRIPTION
T5 sweep, services -> analysis slice (live finding CLEA-DEP-01 `_violations_stream:10`, plus its two sibling baseline entries).

The services layer imported stream helpers from `analysis/` to read live agent output. Those helpers were never analysis logic — they parse the agent **stream-json wire format**, so the fix is an inward move, not a facade:

- **`core/stream/events.py`** — the pure parsers (text extractors, event dispatch, `tool_use` file extraction). No I/O, no config, no layer dependencies.
- **`data/fs/stream_files.py`** — `count_files_in_stream` / `count_jsonl_lines`, which add file access on top (they need `shared`, which core may not import). Both degrade to an empty result on unreadable files: they feed progress counters, never correctness.
- **`analysis/stream/{event_text,counters}.py`** stay as re-export shims, so every existing analysis caller and test keeps its import path unchanged.
- `services/_violations_stream` imports core; `services/_violations_jsonl` imports data.

## Ratchet

Three baseline entries deleted, `BASELINE_CEILING` lowered **20 → 17** — the first shrink since the ratchet was introduced in WS8. `ARCHITECTURE.md`'s core-layer row updated.

## Tests (TDD)

10 new tests watched fail first, covering the moved parsers' edge cases (blank/invalid lines, non-dict events, missing files), the shim identity pins, and a no-`quodeq.analysis` pin on both violation services. Full suite: **5453 passed, 1 skipped**.