### PR TITLE
refactor(t5): ProjectsCache holds entities, the route serializes

### DIFF
--- a/src/quodeq/analysis/_types.py
+++ b/src/quodeq/analysis/_types.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from quodeq.analysis import dispatch_policy
 from quodeq.analysis._dimensions import DimensionsConfig
 from quodeq.analysis.manifest import AnalysisTarget, SourceManifest
 from quodeq.analysis.subprocess import HeartbeatCallback
@@ -103,8 +104,6 @@ class RunConfig:
             files, total = self.manifest.source_files, self.manifest.total_files
         else:
             return 0
-        # Late import: dispatch_policy reads provider config; keep _types a leaf.
-        from quodeq.analysis import dispatch_policy  # noqa: PLC0415
         if not files or not dispatch_policy.provider_is_api():
             return total
         dispatchable, _excluded = dispatch_policy.split_api_dispatchable(self.src, files)

--- a/src/quodeq/api/routes_project_list.py
+++ b/src/quodeq/api/routes_project_list.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from flask import Flask, Response, jsonify, request
 
 from quodeq.api.helpers import error_response, scan_target_error as _scan_target_error
+from quodeq.core.types import to_camel_dict
 from quodeq.api.import_project import import_project as _import_project
 from quodeq.api.routes_common import reports_dir
 from quodeq.api.zip import export_project_zip
@@ -136,7 +137,10 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
             projects = projects[offset:]
         if limit > 0:
             projects = projects[:limit]
-        return jsonify({**result, "projects": projects})
+        # Serialize at the boundary: providers hand back ProjectEntry
+        # entities (or already-serialized dicts from remote providers).
+        wire = [p if isinstance(p, dict) else to_camel_dict(p) for p in projects]
+        return jsonify({**result, "projects": wire})
 
     @app.patch("/api/projects/<project>/path")
     def update_project_path(project: str) -> Response | tuple[Response, int]:

--- a/src/quodeq/services/_projects_cache.py
+++ b/src/quodeq/services/_projects_cache.py
@@ -2,7 +2,8 @@
 
 The project list is read from disk on every dashboard refresh; caching it
 for a few seconds collapses bursts of identical requests without making
-edits feel stale.
+edits feel stale. The cache holds ``ProjectEntry`` entities — serialization
+to the camelCase wire shape happens at the route.
 """
 from __future__ import annotations
 
@@ -10,7 +11,6 @@ import time
 from pathlib import Path
 from typing import Any
 
-from quodeq.core.types import to_camel_dict
 from quodeq.services import _fs_projects
 
 _DEFAULT_TTL_S = 5
@@ -32,7 +32,10 @@ class ProjectsCache:
         if self._is_fresh():
             return self._payload  # type: ignore[return-value]
         projects = _fs_projects.build_project_list(Path(reports_dir))
-        self._payload = {"projects": [to_camel_dict(p) for p in projects]}
+        # Entities, not wire dicts: the route serializes per request (WS6).
+        # The cached part is the expensive disk walk; camelCase mapping is
+        # cheap and belongs at the boundary.
+        self._payload = {"projects": projects}
         self._stamp = time.monotonic()
         return self._payload
 

--- a/tests/services/test_action_provider_fs_evaluations.py
+++ b/tests/services/test_action_provider_fs_evaluations.py
@@ -56,11 +56,13 @@ def test_list_projects_returns_latest_run(tmp_path: Path) -> None:
     result = provider.list_projects(str(reports))
 
     assert result["projects"], "expected projects to be listed"
+    # The provider hands back ProjectEntry entities; the route serializes
+    # them to the camelCase wire shape (WS6 boundary).
     project = result["projects"][0]
-    assert project["name"] == "proj"
-    assert project["runsCount"] == 2
-    assert project["latestRunId"] == "20260102"
-    assert project["latestDate"] == "2026-01-02"
+    assert project.name == "proj"
+    assert project.runs_count == 2
+    assert project.latest_run_id == "20260102"
+    assert project.latest_date == "2026-01-02"
 
 
 def test_get_dimension_eval_from_json(tmp_path: Path) -> None:

--- a/tests/services/test_projects_cache_entities.py
+++ b/tests/services/test_projects_cache_entities.py
@@ -1,0 +1,81 @@
+"""ProjectsCache caches entities; the route owns serialization (WS6).
+
+The cache used to store the camelCase wire payload, a declared
+serialization-ratchet entry. It now caches ``ProjectEntry`` objects — the
+expensive part (the disk walk) stays cached, and the cheap camelCase
+mapping happens per request at the route boundary.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from quodeq.core.types import ProjectEntry
+from quodeq.services._projects_cache import ProjectsCache
+
+
+def _entry(pid: str = "p1") -> ProjectEntry:
+    return ProjectEntry(id=pid, name="proj", runs_count=2, latest_run_id="r2")
+
+
+def test_cache_returns_entities_not_wire_dicts(tmp_path):
+    with patch(
+        "quodeq.services._projects_cache._fs_projects.build_project_list",
+        return_value=[_entry()],
+    ):
+        out = ProjectsCache().list(str(tmp_path))
+
+    assert out["projects"] == [_entry()]
+    assert isinstance(out["projects"][0], ProjectEntry)
+
+
+def test_cache_still_collapses_repeat_reads(tmp_path):
+    with patch(
+        "quodeq.services._projects_cache._fs_projects.build_project_list",
+        return_value=[_entry()],
+    ) as spy:
+        cache = ProjectsCache()
+        cache.list(str(tmp_path))
+        cache.list(str(tmp_path))
+
+    assert spy.call_count == 1, "the TTL window must still collapse the disk walk"
+
+
+def test_invalidate_forces_a_reread(tmp_path):
+    with patch(
+        "quodeq.services._projects_cache._fs_projects.build_project_list",
+        return_value=[_entry()],
+    ) as spy:
+        cache = ProjectsCache()
+        cache.list(str(tmp_path))
+        cache.invalidate()
+        cache.list(str(tmp_path))
+
+    assert spy.call_count == 2
+
+
+def test_service_module_does_no_serialization():
+    """The declared WS6 wire-boundary entry is retired: no to_camel_dict here."""
+    import quodeq.services._projects_cache as mod
+
+    assert "to_camel_dict" not in open(mod.__file__).read()
+
+
+def test_route_serializes_entities_to_camel_case(tmp_path):
+    """End-to-end: the /api/projects payload keeps its camelCase shape."""
+    from flask import Flask
+
+    from quodeq.api.routes_project_list import register_project_list_routes
+
+    class _Provider:
+        def list_projects(self, reports_dir):
+            return {"projects": [_entry()]}
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["EVALUATIONS_DIR"] = str(tmp_path)
+    register_project_list_routes(app, _Provider())
+
+    body = app.test_client().get("/api/projects").get_json()
+
+    assert body["projects"][0]["runsCount"] == 2
+    assert body["projects"][0]["latestRunId"] == "r2"

--- a/tests/tools/test_serialization_boundary.py
+++ b/tests/tools/test_serialization_boundary.py
@@ -22,7 +22,6 @@ DECLARED_WIRE_BOUNDARIES: dict[str, str] = {
     "data/fs/report_parser/_eval_parsing.py": "parses stored camelCase findings back out (stored contract)",
     "services/accumulated.py": "payload feeds both routes and the persisted score cache — burn-down: WS5/scoring reader",
     "services/rescore.py": "envelope consumed by routes AND services/scoring — burn-down: WS5/scoring reader",
-    "services/_projects_cache.py": "cache stores the final wire payload it serves",
     "services/dashboard.py": "run-dim LRU stores wire payloads — burn-down: WS5/scoring reader",
     "services/_fs_reports.py": "violation responses cached in wire shape — burn-down: WS5",
     "services/scoring/_response_builders.py": "scoring payloads flow into SSE + caches in wire shape — burn-down: WS5/scoring reader",

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -7,7 +7,7 @@ src/quodeq/api/import_project.py:31:data
 src/quodeq/api/import_project.py:32:data
 src/quodeq/api/import_project.py:33:data
 src/quodeq/api/llm_bridge_routes.py:8:llm_bridge
-src/quodeq/api/routes_project_list.py:275:analysis
+src/quodeq/api/routes_project_list.py:279:analysis
 src/quodeq/ci/review.py:129:cli_parser
 src/quodeq/ci/review.py:147:_cli_evaluation
 src/quodeq/data/fs/repo_clone.py:19:context


### PR DESCRIPTION
Closes the last two T5 items, both per your calls.

## ProjectsCache → entities (retires a declared WS6 entry)

The cache stored the camelCase wire payload — a declared serialization-boundary entry. It now caches `list[ProjectEntry]`:

- The **expensive** part (the project-dir walk) is still collapsed by the TTL; only the cheap camelCase mapping repeats per request.
- The provider contract hands entities to the route. The route serializes at the boundary and **passes already-serialized dicts through untouched**, so remote/shared providers that return wire shape keep working.
- The one provider-level test that asserted `project["runsCount"]` now asserts `project.runs_count` — the contract changed deliberately, so the test says so.

## Stale cycle dodge in analysis/_types

`source_file_count` late-imported `dispatch_policy` to "keep _types a leaf". But `_types` already imports `analysis.subprocess`, which imports `dispatch_policy` at module level — so the cycle was already being taken transitively at import time. Hoisted; one fewer function-body import (roadmap Track 2.3's target class).

## Ratchets

Both guards flagged their own maintenance: the import baseline needed regeneration for a **line shift** (count unchanged at **17** — the checker's message predicted exactly this case), and the now-stale `_projects_cache` serialization declaration was deleted (that list only shrinks).

5 new tests watched fail first, including an end-to-end assertion that `/api/projects` still returns camelCase. Full suite: **5458 passed, 1 skipped**.