### PR TITLE
refactor(t4): env-dependent config resolves per call, not at import

### DIFF
--- a/src/quodeq/analysis/_config.py
+++ b/src/quodeq/analysis/_config.py
@@ -1,7 +1,7 @@
 """Analysis configuration dataclasses and type aliases."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -15,8 +15,14 @@ HeartbeatCallback = Callable[[int, dict], None]
 
 _DEFAULT_MAX_FILES_PER_AGENT = 30
 
-_DEFAULT_MAX_TURNS = _env_int("QUODEQ_DEFAULT_MAX_TURNS", 200)
-_DEFAULT_MAX_DURATION = _env_int("QUODEQ_DEFAULT_MAX_DURATION", 1800)  # 30 minutes
+def _default_max_turns(env: dict[str, str] | None = None) -> int:
+    """Turn ceiling per agent, resolved per construction (not at import)."""
+    return _env_int("QUODEQ_DEFAULT_MAX_TURNS", 200, env=env)
+
+
+def _default_max_duration(env: dict[str, str] | None = None) -> int:
+    """Wall-clock ceiling per agent in seconds (30 min), resolved per construction."""
+    return _env_int("QUODEQ_DEFAULT_MAX_DURATION", 1800, env=env)
 _MCP_TOOL_REPORT_FINDING = "mcp__findings__report_finding"
 _MCP_TOOL_GET_NEXT_FILES = "mcp__findings__get_next_files"
 _MCP_TOOL_MARK_FILE_DONE = "mcp__findings__mark_file_done"
@@ -31,8 +37,8 @@ class AnalysisConfig:
     heartbeat_callback: HeartbeatCallback | None = None
     ai_cmd: str | None = None
     ai_model: str | None = None
-    max_turns: int | None = _DEFAULT_MAX_TURNS
-    max_duration: int | None = _DEFAULT_MAX_DURATION
+    max_turns: int | None = field(default_factory=_default_max_turns)
+    max_duration: int | None = field(default_factory=_default_max_duration)
     time_limit: int = DEFAULT_TIME_LIMIT
     deadline_at: float | None = None
     """Absolute monotonic-clock deadline for the whole run. None = unlimited."""

--- a/src/quodeq/analysis/_provider_cache.py
+++ b/src/quodeq/analysis/_provider_cache.py
@@ -2,11 +2,9 @@
 from __future__ import annotations
 
 import json
-import os
 import threading
-from pathlib import Path
 
-_AI_PROVIDERS_PATH = Path(os.environ.get("QUODEQ_AI_PROVIDERS_PATH", str(Path(__file__).resolve().parent.parent / "data" / "config" / "ai_providers.json")))
+from quodeq.shared.provider_env import _providers_path
 
 # Fallback provider configs used when the primary JSON file
 # (data/config/ai_providers.json) cannot be loaded.
@@ -56,7 +54,7 @@ class _ProviderConfigCache:
             with self._lock:
                 if self._configs is None:
                     try:
-                        self._configs = json.loads(_AI_PROVIDERS_PATH.read_text(encoding="utf-8"))
+                        self._configs = json.loads(_providers_path().read_text(encoding="utf-8"))
                     except (OSError, json.JSONDecodeError):
                         self._configs = _PROVIDER_CONFIGS_FALLBACK
         return self._configs

--- a/src/quodeq/analysis/dispatch_policy.py
+++ b/src/quodeq/analysis/dispatch_policy.py
@@ -22,9 +22,9 @@ from quodeq.shared.utils import get_ai_cmd
 _DEFAULT_MAX_API_FILE_SIZE = 15000
 
 
-def api_file_size_cap() -> int:
+def api_file_size_cap(env: dict[str, str] | None = None) -> int:
     """Max file size (bytes, exclusive) an API provider will dispatch."""
-    raw = os.environ.get("QUODEQ_MAX_API_FILE_SIZE", "")
+    raw = (env if env is not None else os.environ).get("QUODEQ_MAX_API_FILE_SIZE", "")
     try:
         return int(raw) if raw else _DEFAULT_MAX_API_FILE_SIZE
     except ValueError:

--- a/src/quodeq/analysis/mcp/handlers.py
+++ b/src/quodeq/analysis/mcp/handlers.py
@@ -33,9 +33,9 @@ _SERVER_VERSION = __version__ or "0.0.0"
 _DEFAULT_MAX_FILE_BATCH_SIZE = 1000
 
 
-def _max_file_batch_size() -> int:
+def _max_file_batch_size(env: dict[str, str] | None = None) -> int:
     """Return the per-call file-batch ceiling, honouring QUODEQ_MCP_MAX_BATCH."""
-    raw = os.environ.get("QUODEQ_MCP_MAX_BATCH")
+    raw = (env if env is not None else os.environ).get("QUODEQ_MCP_MAX_BATCH")
     if not raw:
         return _DEFAULT_MAX_FILE_BATCH_SIZE
     try:

--- a/src/quodeq/analysis/subagents/_pool_launcher.py
+++ b/src/quodeq/analysis/subagents/_pool_launcher.py
@@ -18,8 +18,6 @@ from quodeq.shared.utils import get_ai_cmd
 
 _MAX_FILES_PER_AGENT = 30
 _MAX_FILES_PER_AGENT_CAP = 50
-_NON_SCOUT_PROVIDERS = tuple(os.environ.get("QUODEQ_NON_SCOUT_PROVIDERS", "codex,gemini").split(","))
-
 # Auto-scale the IMPLICIT default time limit so large queues don't get
 # killed mid-run: a fixed 600s budget chokes any dim with a queue larger
 # than ~80 files (observed throughput ≈ 7-12 s/file with 8 agents) and
@@ -32,6 +30,13 @@ _SECONDS_PER_FILE_AUTOSCALE = 12
 _MAX_AUTO_POOL_BUDGET = 7200  # 2 hours
 # time_limit = 0 means "unlimited"; respect that and never scale it.
 _UNLIMITED_BUDGET = 0
+
+
+def _non_scout_providers(env: dict[str, str] | None = None) -> tuple[str, ...]:
+    """Providers that skip scout mode (no per-token billing), read per call."""
+    raw = (env if env is not None else os.environ).get(
+        "QUODEQ_NON_SCOUT_PROVIDERS", "codex,gemini")
+    return tuple(p.strip() for p in raw.split(",") if p.strip())
 
 
 def _resolve_time_limit(user_budget: int | None, queue_size: int) -> int:
@@ -142,7 +147,7 @@ def _launch_pool(
     # Skip scout mode for providers without per-token billing (e.g. Codex with
     # ChatGPT subscription).  Launch all agents immediately for faster results.
     ai_cmd = get_ai_cmd()
-    use_scout = ai_cmd not in _NON_SCOUT_PROVIDERS
+    use_scout = ai_cmd not in _non_scout_providers()
 
     pool = SubagentPool(
         paths=PoolPaths(work_dir=config.src, evidence_dir=params.evidence_dir, queue_path=params.queue_path,

--- a/src/quodeq/analysis/subagents/_pool_scaling.py
+++ b/src/quodeq/analysis/subagents/_pool_scaling.py
@@ -123,12 +123,12 @@ def should_respawn(
 _DEFAULT_AGENT_FAILURE_STREAK = 5
 
 
-def _agent_failure_streak_limit() -> int:
+def _agent_failure_streak_limit(env: dict[str, str] | None = None) -> int:
     """Consecutive whole-agent failures tolerated before the run is cancelled.
 
     Env override QUODEQ_AGENT_FAILURE_STREAK; 0 disables the backstop.
     """
-    raw = os.environ.get("QUODEQ_AGENT_FAILURE_STREAK", "").strip()
+    raw = (env if env is not None else os.environ).get("QUODEQ_AGENT_FAILURE_STREAK", "").strip()
     try:
         return int(raw) if raw else _DEFAULT_AGENT_FAILURE_STREAK
     except ValueError:

--- a/src/quodeq/context/online_cache.py
+++ b/src/quodeq/context/online_cache.py
@@ -31,22 +31,22 @@ _DISABLE_ENV = "QUODEQ_DISABLE_ONLINE_CACHE"
 _DEFAULT_CLONE_TIMEOUT_S = 300
 
 
-def cache_root() -> Path:
+def cache_root(env: dict[str, str] | None = None) -> Path:
     """Return the cache root, creating it if needed.
 
     Defaults to ``~/.quodeq/cache``; override with ``QUODEQ_CACHE_ROOT``
     so tests can point at a sandbox without touching the user's real cache.
     """
-    raw = os.environ.get(_CACHE_ENV, "").strip()
+    raw = (env if env is not None else os.environ).get(_CACHE_ENV, "").strip()
     base = Path(raw) if raw else Path.home() / ".quodeq" / "cache"
     online = base / "online"
     online.mkdir(parents=True, exist_ok=True)
     return online
 
 
-def cache_disabled() -> bool:
+def cache_disabled(env: dict[str, str] | None = None) -> bool:
     """True when the user has flipped the kill switch."""
-    return os.environ.get(_DISABLE_ENV, "").strip() in {"1", "true", "yes"}
+    return (env if env is not None else os.environ).get(_DISABLE_ENV, "").strip() in {"1", "true", "yes"}
 
 
 def _url_hash(url: str) -> str:

--- a/src/quodeq/services/plugin_discovery.py
+++ b/src/quodeq/services/plugin_discovery.py
@@ -14,17 +14,23 @@ from quodeq.shared.utils import read_json
 
 _logger = logging.getLogger(__name__)
 
-_PLUGIN_CACHE_TTL = int(os.environ.get("QUODEQ_PLUGIN_CACHE_TTL", "60"))  # seconds; allows runtime plugin changes to propagate
+_DEFAULT_PLUGIN_CACHE_TTL = 60  # seconds; allows runtime plugin changes to propagate
+
+
+def _plugin_cache_ttl(env: dict[str, str] | None = None) -> int:
+    """Cache TTL, resolved per construction so runtime changes are seen."""
+    raw = (env if env is not None else os.environ).get("QUODEQ_PLUGIN_CACHE_TTL", "")
+    return int(raw) if raw.isdigit() and int(raw) > 0 else _DEFAULT_PLUGIN_CACHE_TTL
 
 
 class _PluginCache:
     """Thread-safe TTL cache for plugin metadata."""
 
-    def __init__(self, ttl: float = _PLUGIN_CACHE_TTL) -> None:
+    def __init__(self, ttl: float | None = None) -> None:
         self._lock = threading.Lock()
         self._cache: list[PluginInfo] | None = None
         self._ts: float = 0.0
-        self._ttl = ttl
+        self._ttl = _plugin_cache_ttl() if ttl is None else ttl
 
     def get(self) -> list[PluginInfo] | None:
         with self._lock:
@@ -97,7 +103,7 @@ def _discover_from_detection(detection_file: Path, dimensions_file: Path) -> lis
 def discover_plugins(*, cache: _PluginCache | None = None, paths: object | None = None) -> list[PluginInfo]:
     """Return available plugin metadata from detection.json + dimensions.json.
 
-    Results are cached for _PLUGIN_CACHE_TTL seconds so that configuration
+    Results are cached for _plugin_cache_ttl() seconds so that configuration
     changes are picked up on the next request after the TTL expires.
 
     Pass *cache* to override the module-level cache (useful for testing).

--- a/tests/analysis/test_config.py
+++ b/tests/analysis/test_config.py
@@ -1,12 +1,27 @@
-import importlib
+"""Defensive env parsing for the analysis config defaults.
+
+These used to be import-time constants, so this test had to reload the
+module with the env var set and reload again to restore it. The defaults
+now resolve per construction, so the seam is exercised directly.
+"""
 
 
 def test_invalid_max_turns_env_falls_back_to_default(monkeypatch):
+    from quodeq.analysis._config import AnalysisConfig
+
     monkeypatch.setenv("QUODEQ_DEFAULT_MAX_TURNS", "not-a-number")
-    import quodeq.analysis._config as config_mod
-    importlib.reload(config_mod)
-    try:
-        assert config_mod._DEFAULT_MAX_TURNS == 200
-    finally:
-        monkeypatch.delenv("QUODEQ_DEFAULT_MAX_TURNS", raising=False)
-        importlib.reload(config_mod)  # restore real env for subsequent tests
+    assert AnalysisConfig().max_turns == 200
+
+
+def test_invalid_max_duration_env_falls_back_to_default(monkeypatch):
+    from quodeq.analysis._config import AnalysisConfig
+
+    monkeypatch.setenv("QUODEQ_DEFAULT_MAX_DURATION", "")
+    assert AnalysisConfig().max_duration == 1800
+
+
+def test_injected_env_is_honoured():
+    from quodeq.analysis._config import _default_max_duration, _default_max_turns
+
+    assert _default_max_turns({"QUODEQ_DEFAULT_MAX_TURNS": "11"}) == 11
+    assert _default_max_duration({"QUODEQ_DEFAULT_MAX_DURATION": "22"}) == 22

--- a/tests/analysis/test_provider_cache.py
+++ b/tests/analysis/test_provider_cache.py
@@ -40,22 +40,22 @@ class TestProviderConfigType:
         assert configs["custom"]["type"] == "api"
         assert "${AI_MODEL}" in configs["custom"]["model"]
 
-    def test_cache_loads_from_file(self, tmp_path):
+    def test_cache_loads_from_file(self, tmp_path, monkeypatch):
         cfg_file = tmp_path / "providers.json"
         cfg_file.write_text(json.dumps({
             "test-cli": {"type": "cli", "cmd": "test", "base_args": "--print"},
             "test-api": {"type": "api", "model": "gpt-4o", "api_base": "http://localhost:8000/v1"},
         }))
-        cache = _ProviderConfigCache()
-        with patch("quodeq.analysis._provider_cache._AI_PROVIDERS_PATH", cfg_file):
-            result = cache.get()
+        # The path resolves per read via the shared env seam, so the test
+        # sets the real env var instead of patching a module constant.
+        monkeypatch.setenv("QUODEQ_AI_PROVIDERS_PATH", str(cfg_file))
+        result = _ProviderConfigCache().get()
         assert result["test-cli"]["type"] == "cli"
         assert result["test-api"]["type"] == "api"
 
-    def test_fallback_configs_have_type(self):
+    def test_fallback_configs_have_type(self, monkeypatch):
         """Fallback configs used when JSON is unreadable must also have type."""
-        cache = _ProviderConfigCache()
-        with patch("quodeq.analysis._provider_cache._AI_PROVIDERS_PATH", Path("/nonexistent")):
-            result = cache.get()
+        monkeypatch.setenv("QUODEQ_AI_PROVIDERS_PATH", "/nonexistent/providers.json")
+        result = _ProviderConfigCache().get()
         for name, cfg in result.items():
             assert "type" in cfg, f"Fallback provider '{name}' missing 'type'"

--- a/tests/test_env_seams_t4.py
+++ b/tests/test_env_seams_t4.py
@@ -1,0 +1,119 @@
+"""Env-dependent configuration resolves per call, not at import time.
+
+Four settings were frozen into module constants when their module was first
+imported, so a test (or a runtime settings change) could only move them via
+importlib.reload — the workaround tests/services/test_env_fallbacks.py still
+carries. They now resolve lazily through the codebase's env-injection seam
+(``env: dict | None = None``).
+"""
+from __future__ import annotations
+
+
+class TestAnalysisConfigDefaults:
+    def test_max_turns_reads_env_at_construction(self, monkeypatch):
+        from quodeq.analysis._config import AnalysisConfig
+
+        monkeypatch.setenv("QUODEQ_DEFAULT_MAX_TURNS", "42")
+        assert AnalysisConfig().max_turns == 42
+
+    def test_max_duration_reads_env_at_construction(self, monkeypatch):
+        from quodeq.analysis._config import AnalysisConfig
+
+        monkeypatch.setenv("QUODEQ_DEFAULT_MAX_DURATION", "77")
+        assert AnalysisConfig().max_duration == 77
+
+    def test_defaults_without_env(self, monkeypatch):
+        from quodeq.analysis._config import AnalysisConfig
+
+        monkeypatch.delenv("QUODEQ_DEFAULT_MAX_TURNS", raising=False)
+        monkeypatch.delenv("QUODEQ_DEFAULT_MAX_DURATION", raising=False)
+        cfg = AnalysisConfig()
+        assert (cfg.max_turns, cfg.max_duration) == (200, 1800)
+
+    def test_malformed_env_falls_back(self, monkeypatch):
+        from quodeq.analysis._config import AnalysisConfig
+
+        monkeypatch.setenv("QUODEQ_DEFAULT_MAX_TURNS", "not-a-number")
+        assert AnalysisConfig().max_turns == 200
+
+
+class TestProvidersPath:
+    def test_analysis_reuses_the_shared_resolver(self):
+        """One lazy resolver for QUODEQ_AI_PROVIDERS_PATH, not two."""
+        from quodeq.analysis import _provider_cache
+        from quodeq.shared.provider_env import _providers_path
+
+        assert _provider_cache._providers_path is _providers_path
+        assert not hasattr(_provider_cache, "_AI_PROVIDERS_PATH")
+
+    def test_env_override_is_seen_without_reload(self, monkeypatch, tmp_path):
+        from quodeq.shared.provider_env import _providers_path
+
+        target = tmp_path / "providers.json"
+        monkeypatch.setenv("QUODEQ_AI_PROVIDERS_PATH", str(target))
+        assert _providers_path() == target
+
+
+class TestNonScoutProviders:
+    def test_reads_env_at_call_time(self, monkeypatch):
+        from quodeq.analysis.subagents._pool_launcher import _non_scout_providers
+
+        monkeypatch.setenv("QUODEQ_NON_SCOUT_PROVIDERS", "alpha,beta")
+        assert _non_scout_providers() == ("alpha", "beta")
+
+    def test_default_when_unset(self, monkeypatch):
+        from quodeq.analysis.subagents._pool_launcher import _non_scout_providers
+
+        monkeypatch.delenv("QUODEQ_NON_SCOUT_PROVIDERS", raising=False)
+        assert _non_scout_providers() == ("codex", "gemini")
+
+    def test_injected_env_wins(self):
+        from quodeq.analysis.subagents._pool_launcher import _non_scout_providers
+
+        assert _non_scout_providers({"QUODEQ_NON_SCOUT_PROVIDERS": "solo"}) == ("solo",)
+
+
+class TestPluginCacheTtl:
+    def test_reads_env_at_construction(self, monkeypatch):
+        from quodeq.services.plugin_discovery import _PluginCache
+
+        monkeypatch.setenv("QUODEQ_PLUGIN_CACHE_TTL", "5")
+        assert _PluginCache()._ttl == 5
+
+    def test_default_and_malformed_fall_back(self, monkeypatch):
+        from quodeq.services.plugin_discovery import _PluginCache
+
+        monkeypatch.setenv("QUODEQ_PLUGIN_CACHE_TTL", "soon")
+        assert _PluginCache()._ttl == 60
+        monkeypatch.delenv("QUODEQ_PLUGIN_CACHE_TTL", raising=False)
+        assert _PluginCache()._ttl == 60
+
+    def test_explicit_ttl_still_wins(self, monkeypatch):
+        from quodeq.services.plugin_discovery import _PluginCache
+
+        monkeypatch.setenv("QUODEQ_PLUGIN_CACHE_TTL", "5")
+        assert _PluginCache(ttl=99)._ttl == 99
+
+
+class TestCallTimeEnvSeams:
+    """Readers that already resolved per call gain the injection parameter."""
+
+    def test_api_file_size_cap(self):
+        from quodeq.analysis.dispatch_policy import api_file_size_cap
+
+        assert api_file_size_cap(env={"QUODEQ_MAX_API_FILE_SIZE": "123"}) == 123
+
+    def test_agent_failure_streak_limit(self):
+        from quodeq.analysis.subagents._pool_scaling import _agent_failure_streak_limit
+
+        assert _agent_failure_streak_limit(env={"QUODEQ_AGENT_FAILURE_STREAK": "7"}) == 7
+
+    def test_mcp_max_batch(self):
+        from quodeq.analysis.mcp.handlers import _max_file_batch_size
+
+        assert _max_file_batch_size(env={"QUODEQ_MCP_MAX_BATCH": "9"}) == 9
+
+    def test_online_cache_root(self, tmp_path):
+        from quodeq.context.online_cache import cache_root
+
+        assert cache_root(env={"QUODEQ_CACHE_ROOT": str(tmp_path)}) == tmp_path / "online"


### PR DESCRIPTION
T4 sweep — the env-sprawl findings (CLEA-DEP-07 family). Sorting them showed two distinct problems, only one of which was real debt.

## Frozen at import (the actual bug class)

Four settings were baked into module constants when the module was first imported, so neither a test nor a runtime settings change could move them without `importlib.reload`:

- **`analysis/_config`** — `max_turns` / `max_duration` become dataclass `default_factory` calls, so every `AnalysisConfig()` reads current env.
- **`analysis/_provider_cache`** — drops its own frozen `_AI_PROVIDERS_PATH` and reuses `shared.provider_env._providers_path`. The same env var had **two resolvers, one lazy and one frozen**; now there is one.
- **`_pool_launcher`** — `_NON_SCOUT_PROVIDERS` becomes `_non_scout_providers(env=None)` (and now trims whitespace per entry).
- **`services/plugin_discovery`** — TTL resolves per construction; an explicit `ttl=` still wins.

## Already lazy, missing the seam

`api_file_size_cap`, `_agent_failure_streak_limit`, `_max_file_batch_size`, `cache_root`, `cache_disabled` gain the codebase's standard `env: dict | None = None` parameter.

## Tests that got to drop their workarounds

Three existing tests were compensating for the frozen constants: two patched the module-level provider path, one reloaded `_config` twice per assertion (and reloaded again in a `finally` to restore global state). All three now set the env var directly — the reload dance is gone, which is the clearest evidence the seam was worth adding.

16 new tests, watched fail first. Full suite: **5476 passed, 1 skipped**; import ratchet unchanged at 17.