### PR TITLE
refactor(ui): single storage adapter replaces per-call-site localStorage guards

### DIFF
--- a/src/quodeq/ui/src/adapters/storage.js
+++ b/src/quodeq/ui/src/adapters/storage.js
@@ -1,0 +1,80 @@
+/**
+ * Browser-storage adapter — the single place the UI touches `localStorage`.
+ *
+ * Every call site used to re-implement the same guard: a try/catch around
+ * `getItem`/`setItem` (private mode and quota errors throw), plus a
+ * `JSON.parse` fallback for structured values. That guard is here now, so
+ * components and hooks state *what* they persist, not *how*.
+ *
+ * `storage` stays injectable with a `localStorage` default, matching the
+ * pattern already used across the UI: tests pass a plain in-memory object
+ * instead of leaning on a jsdom global.
+ */
+
+/** Resolve the backend, tolerating a missing/blocked `localStorage`. */
+function backend(storage) {
+  if (storage !== undefined) return storage;
+  try {
+    return typeof localStorage === 'undefined' ? null : localStorage;
+  } catch {
+    return null; // access itself can throw when cookies/storage are blocked
+  }
+}
+
+/** Read a raw string. Returns `fallback` when absent or unreadable. */
+export function readString(key, fallback = null, storage) {
+  const s = backend(storage);
+  if (!s) return fallback;
+  try {
+    const raw = s.getItem(key);
+    return raw === null ? fallback : raw;
+  } catch {
+    return fallback;
+  }
+}
+
+/** Persist a raw string. Returns false when storage rejected the write. */
+export function writeString(key, value, storage) {
+  const s = backend(storage);
+  if (!s) return false;
+  try {
+    s.setItem(key, String(value));
+    return true;
+  } catch {
+    return false; // private mode, quota exceeded — non-fatal by design
+  }
+}
+
+/** Read and parse JSON. Returns `fallback` when absent, unreadable or malformed. */
+export function readJSON(key, fallback = null, storage) {
+  const raw = readString(key, null, storage);
+  if (raw === null) return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+/** Serialize and persist JSON. Returns false when it could not be stored. */
+export function writeJSON(key, value, storage) {
+  let raw;
+  try {
+    raw = JSON.stringify(value);
+  } catch {
+    return false; // cyclic or otherwise unserializable
+  }
+  if (raw === undefined) return false;
+  return writeString(key, raw, storage);
+}
+
+/** Remove a key. Never throws. */
+export function removeKey(key, storage) {
+  const s = backend(storage);
+  if (!s) return;
+  try {
+    s.removeItem(key);
+  } catch {
+    /* storage unavailable — nothing to clean up */
+  }
+}

--- a/src/quodeq/ui/src/adapters/storage.test.js
+++ b/src/quodeq/ui/src/adapters/storage.test.js
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readJSON, readString, removeKey, writeJSON, writeString } from './storage.js';
+
+/** Minimal in-memory backend matching the Storage interface we use. */
+const fake = (entries = {}) => ({
+  data: { ...entries },
+  getItem(key) { return key in this.data ? this.data[key] : null; },
+  setItem(key, value) { this.data[key] = String(value); },
+  removeItem(key) { delete this.data[key]; },
+});
+
+/** A backend that throws on every operation (private mode, quota exceeded). */
+const hostile = () => ({
+  getItem() { throw new Error('SecurityError'); },
+  setItem() { throw new Error('QuotaExceededError'); },
+  removeItem() { throw new Error('SecurityError'); },
+});
+
+test('readString returns the stored value', () => {
+  assert.equal(readString('k', null, fake({ k: 'v' })), 'v');
+});
+
+test('readString returns the fallback when the key is absent', () => {
+  assert.equal(readString('missing', 'dflt', fake()), 'dflt');
+});
+
+test('readString returns the fallback when the backend throws', () => {
+  assert.equal(readString('k', 'dflt', hostile()), 'dflt');
+});
+
+test('writeString persists and reports success', () => {
+  const s = fake();
+  assert.equal(writeString('k', 'v', s), true);
+  assert.equal(s.data.k, 'v');
+});
+
+test('writeString reports failure instead of throwing', () => {
+  assert.equal(writeString('k', 'v', hostile()), false);
+});
+
+test('readJSON parses objects and arrays', () => {
+  const s = fake({ obj: '{"a":1}', arr: '[1,2]' });
+  assert.deepEqual(readJSON('obj', null, s), { a: 1 });
+  assert.deepEqual(readJSON('arr', null, s), [1, 2]);
+});
+
+test('readJSON returns the fallback on malformed JSON', () => {
+  assert.deepEqual(readJSON('k', { safe: true }, fake({ k: '{nope' })), { safe: true });
+});
+
+test('readJSON returns the fallback when absent or when the backend throws', () => {
+  assert.equal(readJSON('missing', null, fake()), null);
+  assert.equal(readJSON('k', null, hostile()), null);
+});
+
+test('writeJSON round-trips through readJSON', () => {
+  const s = fake();
+  assert.equal(writeJSON('k', { a: [1, 2] }, s), true);
+  assert.deepEqual(readJSON('k', null, s), { a: [1, 2] });
+});
+
+test('writeJSON reports failure on an unserializable value', () => {
+  const cyclic = {};
+  cyclic.self = cyclic;
+  assert.equal(writeJSON('k', cyclic, fake()), false);
+});
+
+test('removeKey deletes and never throws', () => {
+  const s = fake({ k: 'v' });
+  removeKey('k', s);
+  assert.equal(s.getItem('k'), null);
+  removeKey('k', hostile()); // must not throw
+});
+
+test('a null backend degrades to fallbacks instead of crashing', () => {
+  assert.equal(readString('k', 'dflt', null), 'dflt');
+  assert.equal(writeString('k', 'v', null), false);
+  assert.equal(readJSON('k', null, null), null);
+  removeKey('k', null);
+});

--- a/src/quodeq/ui/src/features/dashboard/components/IncompleteSetupCard.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/IncompleteSetupCard.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import CloneTargetStep from '../../onboarding/components/steps/CloneTargetStep.jsx';
 import { registerProject } from '../../../api/index.js';
 import { t } from '../../../strings/index.js';
+import { writeString } from '../../../adapters/storage.js';
 
 /**
  * Surfaces a "Complete setup" CTA on the project view for legacy projects
@@ -24,9 +25,7 @@ export default function IncompleteSetupCard({ projectInfo, onComplete }) {
     try {
       const result = await registerProject({ repo: repoUrl, cloneDest, ephemeral });
       if (cloneDest) {
-        try { localStorage.setItem('quodeq.lastCloneRoot', cloneDest); } catch (_) {
-          // ignore (private mode, disabled storage, etc.)
-        }
+        writeString('quodeq.lastCloneRoot', cloneDest);
       }
       onComplete?.(result);
     } catch (err) {

--- a/src/quodeq/ui/src/features/evaluation/components/CleanScanToggle.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/CleanScanToggle.jsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import { t } from '../../../strings/index.js';
+import { readString, removeKey, writeString } from '../../../adapters/storage.js';
 
 const STORAGE_KEY = 'quodeq.cleanScan.permanent';
 
 function readPermanent() {
   try {
-    return localStorage.getItem(STORAGE_KEY) === '1';
+    return readString(STORAGE_KEY) === '1';
   } catch {
     return false;
   }

--- a/src/quodeq/ui/src/features/evaluation/components/ScanModeCards.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanModeCards.jsx
@@ -2,24 +2,17 @@ import { useEffect } from 'react';
 import HelpHint from '../../../components/HelpHint.jsx';
 import { useSidePane } from '../../side-pane/SidePaneContext.jsx';
 import { t } from '../../../strings/index.js';
+import { readString, removeKey, writeString } from '../../../adapters/storage.js';
 
 const STORAGE_KEY = 'quodeq.cleanScan.permanent';
 
 function readPermanent() {
-  try {
-    return localStorage.getItem(STORAGE_KEY) === '1';
-  } catch {
-    return false;
-  }
+  return readString(STORAGE_KEY) === '1';
 }
 
 function writePermanent(on) {
-  try {
-    if (on) localStorage.setItem(STORAGE_KEY, '1');
-    else localStorage.removeItem(STORAGE_KEY);
-  } catch {
-    /* ignore quota / disabled storage */
-  }
+  if (on) writeString(STORAGE_KEY, '1');
+  else removeKey(STORAGE_KEY);
 }
 
 function ModeCard({ id, checked, onPick, disabled, title, tag, children }) {

--- a/src/quodeq/ui/src/features/onboarding/components/steps/CloneTargetStep.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/steps/CloneTargetStep.jsx
@@ -1,19 +1,12 @@
 import { useState } from 'react';
 import { TermHeader } from '../../../../components/terminal/index.js';
 import { t } from '../../../../strings/index.js';
+import { readString } from '../../../../adapters/storage.js';
 
 const STORAGE_KEY = 'quodeq.lastCloneRoot';
 
 function readInitialDest() {
-  try {
-    if (typeof localStorage !== 'undefined') {
-      const stored = localStorage.getItem(STORAGE_KEY);
-      if (stored) return stored;
-    }
-  } catch {
-    // ignore (private mode, disabled storage, etc.)
-  }
-  return '~';
+  return readString(STORAGE_KEY) || '~';
 }
 
 export default function CloneTargetStep({

--- a/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
@@ -6,6 +6,7 @@ import { STORAGE_KEY as POWER_KEY } from '../../evaluation/components/powerLevel
 import { TimeLimitSetting, AdvancedAnalysisSettings, SUBAGENTS_HINT_REMOTE } from './ProviderSettings.jsx';
 import { t } from '../../../strings/index.js';
 import { tRich } from '../../../strings/rich.jsx';
+import { readString, writeString } from '../../../adapters/storage.js';
 
 const DEFAULT_POWER_LEVEL = 2;
 
@@ -45,12 +46,12 @@ function ModelTextInput({ label, value, placeholder, onChange, required }) {
 
 export default function CliProviderTab({ providerId, state, update }) {
   const [power, setPower] = useState(() => {
-    try { return Number(localStorage.getItem(POWER_KEY)) || DEFAULT_POWER_LEVEL; } catch { return DEFAULT_POWER_LEVEL; }
+    return Number(readString(POWER_KEY)) || DEFAULT_POWER_LEVEL;
   });
 
   function persistPower(level) {
     setPower(level);
-    try { localStorage.setItem(POWER_KEY, String(level)); } catch (e) { console.warn('localStorage unavailable:', e); }
+    writeString(POWER_KEY, String(level));
   }
 
   const hint = MODEL_HINTS[providerId];

--- a/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
@@ -12,6 +12,7 @@ import HelpHint from '../../../components/HelpHint.jsx';
 import SectionLabel from '../../../components/terminal/SectionLabel.jsx';
 import { t } from '../../../strings/index.js';
 import { tRich } from '../../../strings/rich.jsx';
+import { readString, removeKey, writeString } from '../../../adapters/storage.js';
 
 const PROVIDER_HINT = (
   <>
@@ -88,16 +89,16 @@ function TabContent({ provider, providerConfig }) {
 function useMigrateLegacySettings(clients) {
   useEffect(() => {
     if (clients.length === 0) return;
-    if (localStorage.getItem(MIGRATION_DONE_KEY)) return;
-    const targetId = localStorage.getItem(LEGACY_AI_CMD_KEY) || clients[0].id;
+    if (readString(MIGRATION_DONE_KEY)) return;
+    const targetId = readString(LEGACY_AI_CMD_KEY) || clients[0].id;
     for (const [oldKey, newSuffix] of Object.entries(LEGACY_SETTING_MIGRATIONS)) {
-      const oldVal = localStorage.getItem(oldKey);
+      const oldVal = readString(oldKey);
       if (oldVal !== null) {
-        localStorage.setItem(`cc-${targetId}-${newSuffix}`, oldVal);
-        localStorage.removeItem(oldKey);
+        writeString(`cc-${targetId}-${newSuffix}`, oldVal);
+        removeKey(oldKey);
       }
     }
-    localStorage.setItem(MIGRATION_DONE_KEY, '1');
+    writeString(MIGRATION_DONE_KEY, '1');
   }, [clients]);
 }
 
@@ -105,7 +106,7 @@ export default function ProviderTabs({ providerConfigs }) {
   const { getAiClients } = useApi();
   const [clients, setClients] = useState([]);
   const [clientsError, setClientsError] = useState(null);
-  const [activeTab, setActiveTab] = useState(() => localStorage.getItem(ACTIVE_PROVIDER_KEY) || '');
+  const [activeTab, setActiveTab] = useState(() => readString(ACTIVE_PROVIDER_KEY) || '');
 
   useMigrateLegacySettings(clients);
 
@@ -122,7 +123,7 @@ export default function ProviderTabs({ providerConfigs }) {
       if (!activeTab && list.length > 0) {
         const firstInstalled = list.find((c) => c.installed !== false) || list[0];
         setActiveTab(firstInstalled.id);
-        localStorage.setItem(ACTIVE_PROVIDER_KEY, firstInstalled.id);
+        writeString(ACTIVE_PROVIDER_KEY, firstInstalled.id);
       }
       setClientsError(null);
     }).catch(() => { setClients([]); setClientsError(t('settings.providersLoadFailed')); });
@@ -130,7 +131,7 @@ export default function ProviderTabs({ providerConfigs }) {
 
   const selectTab = (id) => {
     setActiveTab(id);
-    localStorage.setItem(ACTIVE_PROVIDER_KEY, id);
+    writeString(ACTIVE_PROVIDER_KEY, id);
     // The assistant's Default mode follows the analysis provider — tell it to
     // re-read so its displayed provider/model updates live.
     notifyProviderSettingsChanged();

--- a/src/quodeq/ui/src/features/side-pane/SidePaneProvider.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePaneProvider.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { SidePaneContext } from './SidePaneContext.jsx';
 import { clampSidePaneWidth } from './paneWidthMath.js';
+import { readString, removeKey, writeString } from '../../adapters/storage.js';
 
 const STORAGE_KEY = 'quodeq.sidePaneWidth';
 const LEGACY_STORAGE_KEY = 'quodeq.reportPaneWidth';
@@ -29,31 +30,22 @@ function SidePaneToast({ notice, onDismiss }) {
 }
 
 function readStoredWidth() {
-  try {
-    if (typeof localStorage === 'undefined') return DEFAULT_WIDTH_PX;
-    let raw = localStorage.getItem(STORAGE_KEY);
-    if (raw == null) {
-      // One-time migration from the pre-rename key.
-      const legacy = localStorage.getItem(LEGACY_STORAGE_KEY);
-      if (legacy != null) {
-        localStorage.setItem(STORAGE_KEY, legacy);
-        localStorage.removeItem(LEGACY_STORAGE_KEY);
-        raw = legacy;
-      }
+  let raw = readString(STORAGE_KEY);
+  if (raw == null) {
+    // One-time migration from the pre-rename key.
+    const legacy = readString(LEGACY_STORAGE_KEY);
+    if (legacy != null) {
+      writeString(STORAGE_KEY, legacy);
+      removeKey(LEGACY_STORAGE_KEY);
+      raw = legacy;
     }
-    const n = raw ? parseInt(raw, 10) : NaN;
-    return Number.isFinite(n) && n > 0 ? n : DEFAULT_WIDTH_PX;
-  } catch {
-    return DEFAULT_WIDTH_PX;
   }
+  const n = raw ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_WIDTH_PX;
 }
 
 function writeStoredWidth(px) {
-  try {
-    if (typeof localStorage !== 'undefined') localStorage.setItem(STORAGE_KEY, String(px));
-  } catch {
-    /* quota / disabled — ignore */
-  }
+  writeString(STORAGE_KEY, String(px));
 }
 
 export function SidePaneProvider({ children }) {

--- a/src/quodeq/ui/src/features/terminal/useTerminalSessions.js
+++ b/src/quodeq/ui/src/features/terminal/useTerminalSessions.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { listTerminalSessions, createTerminalSession, killTerminalSession } from '../../api/terminal.js';
+import { readString, writeString } from '../../adapters/storage.js';
 
 // Closing the drawer unmounts the pane (and this hook), so the selected tab
 // must survive outside React state or reopening always lands on the newest
@@ -9,7 +10,7 @@ import { listTerminalSessions, createTerminalSession, killTerminalSession } from
 const ACTIVE_SESSION_KEY = 'quodeq.terminal.activeSession';
 
 function readStoredActive() {
-  try { return window.localStorage.getItem(ACTIVE_SESSION_KEY); } catch { return null; }
+  return readString(ACTIVE_SESSION_KEY);
 }
 
 /**
@@ -68,7 +69,7 @@ export function useTerminalSessions({ enabled }) {
   // so the next mount of this hook starts from the same tab.
   useEffect(() => {
     if (!activeId) return;
-    try { window.localStorage.setItem(ACTIVE_SESSION_KEY, activeId); } catch { /* noop */ }
+    writeString(ACTIVE_SESSION_KEY, activeId);
   }, [activeId]);
 
   const openSession = useCallback(async () => {

--- a/src/quodeq/ui/src/hooks/useAppSettings.js
+++ b/src/quodeq/ui/src/hooks/useAppSettings.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { resolveDataTheme } from '../utils/themeResolver.js';
+import { readString, removeKey, writeString } from '../adapters/storage.js';
 
 const MODE_KEY = 'cc-theme-mode';
 const FAMILY_KEY = 'cc-theme-family';
@@ -23,19 +24,19 @@ const MIGRATION_MAP = {
 
 function migrateOldTheme() {
   try {
-    const old = localStorage.getItem(OLD_THEME_KEY);
+    const old = readString(OLD_THEME_KEY);
     if (old === null) {
       // Migrate old family names to character names
-      const currentFamily = localStorage.getItem(FAMILY_KEY);
+      const currentFamily = readString(FAMILY_KEY);
       if (currentFamily && FAMILY_RENAMES[currentFamily]) {
-        localStorage.setItem(FAMILY_KEY, FAMILY_RENAMES[currentFamily]);
+        writeString(FAMILY_KEY, FAMILY_RENAMES[currentFamily]);
       }
       return;
     }
     const mapped = MIGRATION_MAP[old] || { mode: 'system', family: 'daruma' };
-    localStorage.setItem(MODE_KEY, mapped.mode);
-    localStorage.setItem(FAMILY_KEY, mapped.family);
-    localStorage.removeItem(OLD_THEME_KEY);
+    writeString(MODE_KEY, mapped.mode);
+    writeString(FAMILY_KEY, mapped.family);
+    removeKey(OLD_THEME_KEY);
   } catch (e) {
     console.warn('Theme migration failed:', e);
   }
@@ -53,7 +54,7 @@ function applyDataTheme(value) {
 
 export function useAppSettings() {
   function safeGet(key, fallback = '') {
-    try { return localStorage.getItem(key) || fallback; } catch (e) { console.warn('localStorage unavailable:', e); return fallback; }
+    return readString(key) || fallback;
   }
 
   // Run migration once before reading new keys


### PR DESCRIPTION
**B1 of the UI clean-architecture workstream** ([plan](docs/superpowers/plans/2026-08-01-ui-clean-arch-workstream.md)) — the largest and lowest-risk cluster: CLEA-SEP-03 / DB-02 / DEP-05 findings for persistence inline in components and hooks.

## The duplication this removes

107 `localStorage` references across 37 files, and 28 of those files hand-roll the same guard: a try/catch (private mode **and** quota exceeded both throw), frequently with a `JSON.parse` fallback around it. `src/adapters/storage.js` owns that guard once:

- `readString` / `readJSON` fall back instead of throwing; `writeString` / `writeJSON` return a boolean instead of throwing; `removeKey` never throws.
- A missing or blocked backend degrades cleanly — note that *accessing* `localStorage` can itself throw when storage is blocked, which several call sites did not guard.
- The backend stays injectable with a `localStorage` default, matching the pattern already used in `scoreHistoryPrefs`, `useTerminalSettings` and `useProjectState`. Tests pass a plain in-memory object rather than leaning on a jsdom global.

## Migrated (9 flagged sites)

`ScanModeCards`, `CleanScanToggle`, `IncompleteSetupCard`, `CloneTargetStep`, `CliProviderTab`, `ProviderTabs`, `useTerminalSessions`, `useAppSettings`, `SidePaneProvider`.

The remaining call sites already use the injectable-`storage` pattern and can follow in a later pass; this PR takes the ones that reached for the global directly.

## Verification

12 new adapter tests (TDD, watched fail), **421 node:test**, **1474 vitest**, `vite build` clean, and the **i18n string ratchet unchanged** at 708 grandfathered across 3 files — the plan's inherited constraint was that moved code must not reintroduce JSX literals, and it did not.