### PR TITLE
refactor(ui): reset hooks for the module-scoped caches

### DIFF
--- a/src/quodeq/ui/src/utils/moduleCacheReset.test.jsx
+++ b/src/quodeq/ui/src/utils/moduleCacheReset.test.jsx
@@ -1,0 +1,50 @@
+import { expect, test } from 'vitest';
+
+import {
+  clearAllCachedState, readCachedState, resetCachedScope, writeCachedState,
+} from './pageStateCache.js';
+import { resetWriteGeneration, writeVisibleStandardIds } from './visibleStandards.js';
+
+/** Thin asserts so the body reads like the node:test siblings. */
+const expect_deep = (actual, expected) => expect(actual).toEqual(expected);
+const expect_eq = (actual, expected) => expect(actual).toBe(expected);
+
+const fakeStorage = () => ({
+  data: {},
+  getItem(k) { return k in this.data ? this.data[k] : null; },
+  setItem(k, v) { this.data[k] = String(v); },
+  removeItem(k) { delete this.data[k]; },
+});
+
+test('pageStateCache: clearAllCachedState empties every namespace', () => {
+  writeCachedState('map', 'proj-1', { tab: 'files' });
+  writeCachedState('violations', 'proj-1', { filter: 'major' });
+  expect_deep(readCachedState('map', 'proj-1', {}), { tab: 'files' });
+
+  clearAllCachedState();
+
+  expect_deep(readCachedState('map', 'proj-1', { tab: 'default' }), { tab: 'default' });
+  expect_deep(readCachedState('violations', 'proj-1', {}), {});
+});
+
+test('pageStateCache: clearing all is broader than resetting one scope', () => {
+  writeCachedState('map', 'proj-1', { tab: 'files' });
+  writeCachedState('map', 'proj-2', { tab: 'folders' });
+
+  resetCachedScope('map', 'proj-1');
+  expect_deep(readCachedState('map', 'proj-2', {}), { tab: 'folders' });
+
+  clearAllCachedState();
+  expect_deep(readCachedState('map', 'proj-2', {}), {});
+});
+
+test('visibleStandards: the write generation is resettable', () => {
+  const s = fakeStorage();
+  writeVisibleStandardIds(['a'], s);
+  writeVisibleStandardIds(['b'], s);
+
+  // The module's own note asks for this hook: without it, a promise left
+  // dangling across a test boundary trips the next caller's staleness check.
+  expect_eq(resetWriteGeneration(), 0);
+  expect_deep(JSON.parse(s.data['quodeq-visible-standards']), ['b']);
+});

--- a/src/quodeq/ui/src/utils/pageStateCache.js
+++ b/src/quodeq/ui/src/utils/pageStateCache.js
@@ -44,3 +44,14 @@ export function writeCachedState(namespace, scope, patch) {
 export function resetCachedScope(namespace, scope) {
   storeFor(namespace).delete(scope || '__global__');
 }
+
+/**
+ * Drop every namespace and scope.
+ *
+ * Test-isolation hook: the store is module-scoped, so without this a page's
+ * cached state leaks into the next test in the same process. Production code
+ * uses `resetCachedScope` for the narrower "user clicked the tab" reset.
+ */
+export function clearAllCachedState() {
+  STORES.clear();
+}

--- a/src/quodeq/ui/src/utils/visibleStandards.js
+++ b/src/quodeq/ui/src/utils/visibleStandards.js
@@ -47,14 +47,18 @@ export function readVisibleStandardIds(storage = localStorage) {
 // already landed a newer value, and this response is discarded instead of
 // clobbering it.
 //
-// The counter is module state, so it is only safe across tests because each
-// call compares against its own sample rather than an absolute value, AND
-// every caller awaits its in-flight hydrate before the next one starts. A
-// promise left dangling across a test boundary WOULD trip a later call's
-// check. That invariant is not enforced structurally; if a second caller of
-// hydrateVisibleStandardIds ever appears, or a test stops awaiting, export a
-// test-only reset rather than relying on it.
+// The counter is module state: each call compares against its own sample
+// rather than an absolute value, and every caller awaits its in-flight
+// hydrate before the next one starts. A promise left dangling across a test
+// boundary would otherwise trip a later call's check, so `resetWriteGeneration`
+// below exists as the structural escape hatch that note used to only ask for.
 let writeGeneration = 0;
+
+/** Reset the write generation. Test-isolation hook; returns the new value. */
+export function resetWriteGeneration() {
+  writeGeneration = 0;
+  return writeGeneration;
+}
 
 /** Write the selection to the local cache. The server is the source of truth. */
 export function writeVisibleStandardIds(ids, storage = localStorage) {


### PR DESCRIPTION
**B3 of the UI clean-architecture workstream** — module-level caches with no way to clear them (CLEA-TES-03). This is the UI tail of the T2 seam work, using the same registry-and-clear pattern.

- **`utils/pageStateCache`** — `clearAllCachedState()` drops every namespace. Production code keeps using the narrower `resetCachedScope` for the "user clicked the tab" reset; this is purely the test-isolation hook.
- **`utils/visibleStandards`** — `resetWriteGeneration()`. The module's own comment asked for exactly this: *"if a second caller ever appears, or a test stops awaiting, export a test-only reset rather than relying on it"*, because a promise left dangling across a test boundary trips the next caller's staleness check. The comment now documents the hook instead of requesting it.

**One finding needed no work**: `usePluginDimensions` already exported `invalidateDimensionCache`. Worth stating plainly rather than manufacturing a change — the evaluator flagged the module-level cache, but the escape hatch was already there.

## Note on test placement

The new test runs under **vitest**, not `node:test` like its `utils/` siblings: `visibleStandards` transitively reads `import.meta.env`, which the node runner cannot provide.

Verification: **1477 vitest** (3 new), **421 node:test**, string ratchet unchanged at 708/3 files.