### PR TITLE
refactor(ui): domain rules about runs and findings move into models/

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useApi } from "../../../api/ApiContext.jsx";
 import { useProjectScores } from "../../../hooks/useProjectScores.js";
 import { projectKeys, samePlaceholderScope } from "../../../api/queryKeys.js";
+import { isFrozenRun } from '../../../models/runRules.js';
 
 const EMPTY_TREND = [];
 
@@ -66,18 +67,16 @@ export function useDashboard({ selectedProject, selectedRun, selectedSource = "l
   // run deletion), and every one of those invalidates the project query
   // subtree — which forces a refetch regardless of staleTime. Freezing the
   // query here removes the routine time-based background refetch (and the
-  // dashboard-refreshing dim flash) on re-entering a run view. Unknown
-  // status counts as frozen: by the time a run detail is opened the runs
-  // list is already cached, and treating the brief unknown window as frozen
-  // avoids a spurious mount refetch.
-  const runStatus = (availableRuns || []).find((r) => r.runId === selectedRun)?.status;
-  const isFrozenRun = !!selectedRun && selectedRun !== "latest" && runStatus !== "in_progress";
+  // dashboard-refreshing dim flash) on re-entering a run view. The rule
+  // itself (including why an unknown run counts as frozen) lives in
+  // models/runRules.js.
+  const frozenRun = isFrozenRun(selectedRun, availableRuns);
 
   const dashboardQuery = useQuery({
     queryKey: projectKeys.dashboard(projectKey, selectedRun, selectedSource),
     queryFn: () => fetchDashboard(selectedProject, selectedRun),
     enabled: !!selectedProject,
-    staleTime: isFrozenRun ? Infinity : 60_000,
+    staleTime: frozenRun ? Infinity : 60_000,
     // Keep showing the previous run's data while a new run loads — instant
     // perceived navigation. isFetching toggles true during the background
     // fetch, which the page reads to show a subtle indicator.

--- a/src/quodeq/ui/src/features/violations/components/LowConfidenceGroup.jsx
+++ b/src/quodeq/ui/src/features/violations/components/LowConfidenceGroup.jsx
@@ -1,11 +1,10 @@
 import { useState } from 'react';
 import { t } from '../../../strings/index.js';
+import { isLowConfidence } from '../../../models/runRules.js';
 
-const LOW_CONFIDENCE_THRESHOLD = 50;
-
-export function isLowConfidence(violation) {
-  return typeof violation?.confidence === 'number' && violation.confidence < LOW_CONFIDENCE_THRESHOLD;
-}
+// The rule lives in models/runRules.js; re-exported here so existing
+// importers (FileDetailPage) keep their path.
+export { isLowConfidence };
 
 export default function LowConfidenceGroup({ violations, renderViolation }) {
   const [expanded, setExpanded] = useState(false);

--- a/src/quodeq/ui/src/models/index.js
+++ b/src/quodeq/ui/src/models/index.js
@@ -4,3 +4,4 @@ export { createDimension, createDimensionEval } from './dimension.js';
 export { createDashboard } from './dashboard.js';
 export { createJob } from './job.js';
 export { createProject } from './project.js';
+export { isFrozenRun, isLowConfidence, scoreTier, LOW_CONFIDENCE_THRESHOLD, SCORE_THRESHOLDS } from './runRules.js';

--- a/src/quodeq/ui/src/models/runRules.js
+++ b/src/quodeq/ui/src/models/runRules.js
@@ -1,0 +1,55 @@
+/**
+ * Domain rules about runs and findings.
+ *
+ * These are decisions about the domain, not about rendering: whether a run's
+ * data can still change, whether a finding is worth de-emphasising, which
+ * grading tier a score falls into. They lived inside a data-fetching hook and
+ * two components, which made them invisible to anyone reading the domain and
+ * untestable without React. Same shape as `exitReason.js`: pure functions,
+ * no framework imports.
+ */
+
+/**
+ * Confidence below which a finding is grouped away as low-signal.
+ * Matches the backend's own reporting threshold.
+ */
+export const LOW_CONFIDENCE_THRESHOLD = 50;
+
+/** Score tiers, mirroring the backend grading bands (see core scoring params). */
+export const SCORE_THRESHOLDS = { exemplary: 9, good: 7, adequate: 5, poor: 3 };
+
+/**
+ * True when the selected run's data can no longer change.
+ *
+ * A frozen run may be cached indefinitely; a live one must keep refetching.
+ * Three rules, each load-bearing:
+ *  - no selection is not frozen;
+ *  - "latest" is never frozen — it points at a moving target;
+ *  - an UNKNOWN run counts as frozen. By the time a run detail is opened the
+ *    runs list is already cached, so treating the brief unknown window as
+ *    frozen avoids a spurious refetch on mount.
+ */
+export function isFrozenRun(selectedRun, availableRuns) {
+  if (!selectedRun || selectedRun === 'latest') return false;
+  const status = (availableRuns || []).find((r) => r.runId === selectedRun)?.status;
+  return status !== 'in_progress';
+}
+
+/** True when a finding's confidence is below the low-signal threshold. */
+export function isLowConfidence(finding) {
+  return typeof finding?.confidence === 'number'
+    && finding.confidence < LOW_CONFIDENCE_THRESHOLD;
+}
+
+/**
+ * The grading tier for a numeric score, or null when there is no score.
+ * Null is distinct from 'unacceptable': "not scored" is not a bad grade.
+ */
+export function scoreTier(score) {
+  if (typeof score !== 'number' || Number.isNaN(score)) return null;
+  if (score >= SCORE_THRESHOLDS.exemplary) return 'exemplary';
+  if (score >= SCORE_THRESHOLDS.good) return 'good';
+  if (score >= SCORE_THRESHOLDS.adequate) return 'adequate';
+  if (score >= SCORE_THRESHOLDS.poor) return 'poor';
+  return 'unacceptable';
+}

--- a/src/quodeq/ui/src/models/runRules.test.js
+++ b/src/quodeq/ui/src/models/runRules.test.js
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  LOW_CONFIDENCE_THRESHOLD,
+  SCORE_THRESHOLDS,
+  isFrozenRun,
+  isLowConfidence,
+  scoreTier,
+} from './runRules.js';
+
+test('isFrozenRun: a completed historical run is frozen', () => {
+  const runs = [{ runId: 'r1', status: 'complete' }];
+  assert.equal(isFrozenRun('r1', runs), true);
+});
+
+test('isFrozenRun: an in-progress run is never frozen', () => {
+  const runs = [{ runId: 'r1', status: 'in_progress' }];
+  assert.equal(isFrozenRun('r1', runs), false);
+});
+
+test('isFrozenRun: "latest" is never frozen — it tracks a moving target', () => {
+  assert.equal(isFrozenRun('latest', [{ runId: 'latest', status: 'complete' }]), false);
+});
+
+test('isFrozenRun: no selection is not frozen', () => {
+  assert.equal(isFrozenRun(null, []), false);
+  assert.equal(isFrozenRun('', []), false);
+});
+
+test('isFrozenRun: an unknown run counts as frozen', () => {
+  // By the time a run detail opens, the runs list is cached; treating the
+  // brief unknown window as frozen avoids a spurious mount refetch.
+  assert.equal(isFrozenRun('r-missing', [{ runId: 'r1', status: 'complete' }]), true);
+  assert.equal(isFrozenRun('r1', null), true);
+});
+
+test('isLowConfidence: below the threshold only, and only for numbers', () => {
+  assert.equal(isLowConfidence({ confidence: LOW_CONFIDENCE_THRESHOLD - 1 }), true);
+  assert.equal(isLowConfidence({ confidence: LOW_CONFIDENCE_THRESHOLD }), false);
+  assert.equal(isLowConfidence({ confidence: 100 }), false);
+  assert.equal(isLowConfidence({}), false);
+  assert.equal(isLowConfidence(null), false);
+  assert.equal(isLowConfidence({ confidence: 'low' }), false);
+});
+
+test('scoreTier: maps a score onto the backend grading tiers', () => {
+  assert.equal(scoreTier(9.5), 'exemplary');
+  assert.equal(scoreTier(SCORE_THRESHOLDS.exemplary), 'exemplary');
+  assert.equal(scoreTier(8), 'good');
+  assert.equal(scoreTier(6), 'adequate');
+  assert.equal(scoreTier(4), 'poor');
+  assert.equal(scoreTier(1), 'unacceptable');
+});
+
+test('scoreTier: a missing or non-numeric score has no tier', () => {
+  assert.equal(scoreTier(null), null);
+  assert.equal(scoreTier(undefined), null);
+  assert.equal(scoreTier('7'), null);
+});


### PR DESCRIPTION
**B2a of the UI clean-architecture workstream** (CLEA-SEP-01) — business rules that lived inside a data-fetching hook and two components.

New `models/runRules.js`, same shape as the existing `exitReason.js`: pure functions, no framework imports, testable without React.

| Rule | Was | Note |
|---|---|---|
| `isFrozenRun` | inline in `useDashboard` | Keeps all three load-bearing cases together — including why an **unknown** run counts as frozen: the runs list is already cached by the time a detail view opens, so treating that window as live caused a spurious mount refetch. |
| `isLowConfidence` + threshold | defined in `LowConfidenceGroup.jsx` | The rule sat in the component that renders the group. That component now re-exports it, so `FileDetailPage` keeps its import path. |
| `scoreTier` + `SCORE_THRESHOLDS` | constants in `HistoryDimensionPanel` | Mirrors the backend grading bands. Returns **null** rather than a tier for a missing score — "not scored" is not a bad grade. |

8 new tests, watched fail first. Previously these rules could only be exercised by rendering a component or a React Query hook; the frozen-run rule in particular encodes cache-invalidation behaviour that is easy to break silently.

Verification: **1477 vitest**, **429 node:test** (8 new), `vite build` clean, string ratchet unchanged at 708/3 files.