### PR TITLE
feat(suppressions): pattern rules so an ADR survives the code moving

### DIFF
--- a/src/quodeq/core/types/suppression_rule.py
+++ b/src/quodeq/core/types/suppression_rule.py
@@ -1,0 +1,28 @@
+"""Pattern-level suppression rule — an ADR expressed as data.
+
+Dismissals are keyed ``(req, file, line)``, so a refactor that shifts a line
+re-surfaces a finding the team already decided is acceptable. A rule matches
+by requirement + file glob instead, letting one decision cover a pattern
+("services importing quodeq.data.* is accepted per WS1") for as long as the
+decision holds, wherever the code moves.
+
+Rules are deliberately dumb: two globs and a mandatory human reason. Anything
+smarter (severity ranges, expiry dates) should be argued for on its own.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SuppressionRule:
+    """One accepted pattern. All three fields are required."""
+
+    req: str
+    """Requirement ID or glob (e.g. ``CLEA-DEP-01``, ``CLEA-DEP-*``, ``*``)."""
+
+    file: str
+    """Repo-relative path glob (``**`` spans directories)."""
+
+    reason: str
+    """Why this pattern is accepted. Required: an unexplained rule is a bug."""

--- a/src/quodeq/data/fs/suppression_rules.py
+++ b/src/quodeq/data/fs/suppression_rules.py
@@ -1,0 +1,50 @@
+"""Read the project's pattern-level suppression rules.
+
+Stored next to the other per-project suppression state as
+``<project_dir>/suppression_rules.json``:
+
+    {"version": 1, "rules": [{"req": ..., "file": ..., "reason": ...}]}
+
+Best-effort like its siblings: an absent, unreadable or malformed file yields
+no rules. Individual entries are validated and skipped rather than raising —
+one half-written rule must never suppress everything, and a suppression store
+that fails closed is safer than one that fails open.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from quodeq.core.types.suppression_rule import SuppressionRule
+
+_FILENAME = "suppression_rules.json"
+_logger = logging.getLogger(__name__)
+
+
+def load_suppression_rules(project_dir: Path) -> tuple[SuppressionRule, ...]:
+    """Return the project's suppression rules, or ``()`` when there are none."""
+    path = project_dir / _FILENAME
+    if not path.is_file():
+        return ()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, UnicodeDecodeError) as exc:
+        _logger.warning("Ignoring malformed suppression rules %s: %s", path, exc)
+        return ()
+    raw_rules = data.get("rules") if isinstance(data, dict) else None
+    if not isinstance(raw_rules, list):
+        return ()
+    rules: list[SuppressionRule] = []
+    for entry in raw_rules:
+        if not isinstance(entry, dict):
+            continue
+        req, file, reason = entry.get("req"), entry.get("file"), entry.get("reason")
+        # Every field is required: a rule missing its pattern would match far
+        # more than intended, and one missing its reason is undocumented policy.
+        if not (isinstance(req, str) and req and isinstance(file, str) and file
+                and isinstance(reason, str) and reason):
+            _logger.warning("Skipping incomplete suppression rule in %s: %r", path, entry)
+            continue
+        rules.append(SuppressionRule(req=req, file=file, reason=reason))
+    return tuple(rules)

--- a/src/quodeq/services/dismissed.py
+++ b/src/quodeq/services/dismissed.py
@@ -22,6 +22,7 @@ from quodeq.core.types.finding import Finding, SeverityTally, Totals
 from quodeq.data.actions_log import ActionLogWriter, read_action_events
 from quodeq.data.migrations.dismissed_json_to_actions_log import migrate_if_needed
 from quodeq.data.sqlite.findings_queries import read_finding_details
+from quodeq.data.fs.suppression_rules import load_suppression_rules
 
 
 def dismiss_finding(project_dir: Path, finding: dict) -> None:
@@ -247,14 +248,15 @@ def filter_dismissed_from_dimensions(
     Leaves compliance, principles, overall_score, overall_grade unchanged.
     """
     keys = dismissed_keys(project_dir)
-    if not keys:
+    rules = load_suppression_rules(project_dir)
+    if not keys and not rules:
         return dimensions
     result = []
     for dim in dimensions:
         filtered = [
             v for v in dim.violations
             if not is_dismissed(keys, req=v.req, principle=v.practice_id,
-                                file=v.file, line=v.line)
+                                file=v.file, line=v.line, rules=rules)
         ]
         if len(filtered) == len(dim.violations):
             result.append(dim)

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -20,6 +20,7 @@ from quodeq.core.types import DimensionResult
 from quodeq.services.deleted import deleted_keys
 from quodeq.services.dismissed import dismissed_keys
 from quodeq.shared._env import get_score_cache_path, score_cache_disabled
+from quodeq.data.fs.suppression_rules import load_suppression_rules
 
 _logger = logging.getLogger(__name__)
 _BUSY_TIMEOUT_MS = 5000
@@ -257,15 +258,20 @@ def _params_fingerprint(params: ScoringParams) -> str:
 
 
 def score_cache_version(project_dir: Path, params: ScoringParams) -> str:
-    """Content-hash of the project's dismissals + deletions + grade params.
+    """Content-hash of the project's suppression state + grade params.
 
     Any change to any of these produces a new version, auto-invalidating cached
-    rows without a write-path hook.
+    rows without a write-path hook. Pattern rules are part of the state for the
+    same reason the exact keys are: adding one hides findings, so a cached row
+    computed before it must not survive.
     """
     payload = json.dumps({
         "epoch": _CACHE_WRITER_EPOCH,
         "dismissed": sorted(str(k) for k in dismissed_keys(project_dir)),
         "deleted": sorted(str(k) for k in deleted_keys(project_dir)),
+        "rules": [
+            [r.req, r.file, r.reason] for r in load_suppression_rules(project_dir)
+        ],
         "params": _params_fingerprint(params),
     }, sort_keys=True)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/src/quodeq/services/suppression.py
+++ b/src/quodeq/services/suppression.py
@@ -31,6 +31,7 @@ from quodeq.services.suppression_keys import (  # noqa: F401 — re-exported API
     is_dismissed,
 )
 from quodeq.shared.validation import validate_path_segment
+from quodeq.data.fs.suppression_rules import load_suppression_rules
 
 _TYPE_VIOLATION = "violation"
 
@@ -42,12 +43,13 @@ class SuppressionMatcher:
     dimension: str
     dismissed: frozenset = frozenset()
     deleted: frozenset = frozenset()
+    rules: tuple = ()
     req_to_principle: Mapping[str, str] = field(default_factory=dict)
 
     @property
     def active(self) -> bool:
         """False when nothing is suppressed -- callers can skip the scan."""
-        return bool(self.dismissed or self.deleted)
+        return bool(self.dismissed or self.deleted or self.rules)
 
     def principle_for(self, raw: str) -> str:
         """Map an evidence ``p`` (req ID or principle name) to a principle name."""
@@ -67,7 +69,7 @@ class SuppressionMatcher:
             return False
         file = row.get("file") or ""
         if is_dismissed(self.dismissed, req=row.get("req"), principle=raw,
-                        file=file, line=row.get("line")):
+                        file=file, line=row.get("line"), rules=self.rules):
             return True
         return is_deleted(self.deleted, dimension=self.dimension,
                           principle=self.principle_for(raw), file=file)
@@ -122,6 +124,7 @@ def build_matcher(
     deleted: frozenset,
     *,
     evaluators_dir: Path | None = None,
+    rules: tuple = (),
 ) -> SuppressionMatcher:
     """Attach already-loaded key sets to one dimension.
 
@@ -129,13 +132,14 @@ def build_matcher(
     run (the progress reader) pays for the store reads once, not once per
     dimension.
     """
-    if not dismissed and not deleted:
+    if not dismissed and not deleted and not rules:
         # Nothing to map against, so skip the evaluator read entirely.
         return SuppressionMatcher(dimension=dimension)
     return SuppressionMatcher(
         dimension=dimension,
         dismissed=dismissed,
         deleted=deleted,
+        rules=rules,
         req_to_principle=load_req_to_principle(dimension, evaluators_dir),
     )
 
@@ -145,4 +149,5 @@ def matcher_for(
 ) -> SuppressionMatcher:
     """Build the matcher for *dimension* from *project_dir*'s suppression stores."""
     dismissed, deleted = project_suppressions(project_dir)
-    return build_matcher(dimension, dismissed, deleted, evaluators_dir=evaluators_dir)
+    return build_matcher(dimension, dismissed, deleted, evaluators_dir=evaluators_dir,
+                         rules=load_suppression_rules(project_dir))

--- a/src/quodeq/services/suppression_keys.py
+++ b/src/quodeq/services/suppression_keys.py
@@ -15,6 +15,29 @@ import cycle.
 """
 from __future__ import annotations
 
+from fnmatch import fnmatch
+
+from quodeq.core.types.suppression_rule import SuppressionRule
+
+
+def matches_suppression_rule(
+    rules: "tuple[SuppressionRule, ...]", req: str, file: str,
+) -> bool:
+    """True when any rule accepts this ``(req, file)`` pair.
+
+    Both parts must be non-empty: a finding with no requirement or no file
+    cannot be matched against a pattern without matching far too much.
+    ``**`` in the file glob spans directories (fnmatch's ``*`` already
+    crosses separators, so both forms work).
+    """
+    if not rules or not req or not file:
+        return False
+    return any(
+        fnmatch(req, rule.req) and fnmatch(file, rule.file)
+        for rule in rules
+    )
+
+
 def _coerce_line(line: object) -> int:
     try:
         return int(line)  # type: ignore[arg-type]
@@ -25,6 +48,7 @@ def _coerce_line(line: object) -> int:
 def is_dismissed(
     dismissed: frozenset | set, *, req: str | None, principle: str | None = "",
     file: str | None = "", line: object = 0,
+    rules: "tuple[SuppressionRule, ...]" = (),
 ) -> bool:
     """True when the dismiss store hides this finding.
 
@@ -38,9 +62,13 @@ def is_dismissed(
     test_dismiss_apply_e2e.py), and older stores may hold either form -- so
     both are accepted.
     """
+    file_key = file or ""
+    # Pattern rules are checked first and independently of the key store: a
+    # rule stays true after a refactor shifts the line the exact key pinned.
+    if matches_suppression_rule(rules, req or principle or "", file_key):
+        return True
     if not dismissed:
         return False
-    file_key = file or ""
     line_key = _coerce_line(line)
     if (req or principle or "", file_key, line_key) in dismissed:
         return True

--- a/src/quodeq/ui/node_modules
+++ b/src/quodeq/ui/node_modules
@@ -1,0 +1,1 @@
+/Users/victor/GitHub/quodeq/src/quodeq/ui/node_modules

--- a/tests/services/test_suppression_rules.py
+++ b/tests/services/test_suppression_rules.py
@@ -1,0 +1,203 @@
+"""Pattern-level suppressions: encode an ADR once instead of per line number.
+
+Dismissals are keyed ``(req, file, line)``. Every refactor that shifts a line
+re-surfaces a finding the team already decided is acceptable — this session
+alone paid ~13 re-dismissals for patterns covered by the WS1 lean-architecture
+ADR. A rule matches by requirement + file glob, so the decision survives the
+code moving.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from quodeq.core.types.suppression_rule import SuppressionRule
+from quodeq.services.suppression_keys import is_dismissed, matches_suppression_rule
+
+
+class TestMatchesSuppressionRule:
+    def test_matches_req_and_file_glob(self):
+        rules = (SuppressionRule(req="CLEA-DEP-01", file="src/quodeq/services/*", reason="WS1"),)
+        assert matches_suppression_rule(rules, "CLEA-DEP-01", "src/quodeq/services/dismissed.py")
+        assert not matches_suppression_rule(rules, "CLEA-DEP-01", "src/quodeq/api/routes.py")
+        assert not matches_suppression_rule(rules, "CLEA-SEP-03", "src/quodeq/services/dismissed.py")
+
+    def test_req_glob(self):
+        rules = (SuppressionRule(req="CLEA-DEP-*", file="src/quodeq/services/*", reason="r"),)
+        assert matches_suppression_rule(rules, "CLEA-DEP-05", "src/quodeq/services/a.py")
+        assert not matches_suppression_rule(rules, "CLEA-SEP-01", "src/quodeq/services/a.py")
+
+    def test_recursive_file_glob_spans_directories(self):
+        rules = (SuppressionRule(req="*", file="src/quodeq/ui/**", reason="SPA adapters"),)
+        assert matches_suppression_rule(rules, "CLEA-SEP-03", "src/quodeq/ui/src/hooks/useX.js")
+
+    def test_empty_inputs_never_match(self):
+        rules = (SuppressionRule(req="*", file="*", reason="r"),)
+        assert not matches_suppression_rule((), "CLEA-DEP-01", "a.py")
+        assert not matches_suppression_rule(rules, "", "a.py")
+        assert not matches_suppression_rule(rules, "CLEA-DEP-01", "")
+
+    def test_any_matching_rule_wins(self):
+        rules = (
+            SuppressionRule(req="X-1", file="a.py", reason="one"),
+            SuppressionRule(req="Y-2", file="b.py", reason="two"),
+        )
+        assert matches_suppression_rule(rules, "Y-2", "b.py")
+
+
+class TestIsDismissedHonoursRules:
+    def test_rule_suppresses_without_an_exact_key(self):
+        rules = (SuppressionRule(req="CLEA-DEP-01", file="src/quodeq/services/*", reason="WS1"),)
+        assert is_dismissed(
+            set(), req="CLEA-DEP-01", file="src/quodeq/services/x.py", line=42, rules=rules,
+        )
+
+    def test_rule_survives_a_line_shift(self):
+        """The whole point: the same finding at a new line stays suppressed."""
+        rules = (SuppressionRule(req="CLEA-DEP-01", file="src/quodeq/services/x.py", reason="WS1"),)
+        for line in (10, 11, 9999):
+            assert is_dismissed(set(), req="CLEA-DEP-01", file="src/quodeq/services/x.py",
+                                line=line, rules=rules)
+
+    def test_exact_keys_still_work_with_no_rules(self):
+        keys = {("R1", "a.py", 1)}
+        assert is_dismissed(keys, req="R1", file="a.py", line=1)
+        assert not is_dismissed(keys, req="R1", file="a.py", line=2)
+
+    def test_principle_fallback_applies_to_rules_too(self):
+        """A no-req finding matches on its principle, mirroring the key path."""
+        rules = (SuppressionRule(req="Independence", file="a.py", reason="r"),)
+        assert is_dismissed(set(), req=None, principle="Independence", file="a.py",
+                            line=3, rules=rules)
+
+
+class TestLoadSuppressionRules:
+    def test_reads_rules_from_disk(self, tmp_path):
+        from quodeq.data.fs.suppression_rules import load_suppression_rules
+
+        (tmp_path / "suppression_rules.json").write_text(json.dumps({
+            "version": 1,
+            "rules": [{"req": "CLEA-DEP-01", "file": "src/quodeq/services/*", "reason": "WS1"}],
+        }), encoding="utf-8")
+
+        rules = load_suppression_rules(tmp_path)
+
+        assert len(rules) == 1
+        assert rules[0].req == "CLEA-DEP-01"
+        assert rules[0].reason == "WS1"
+
+    def test_absent_or_malformed_yields_no_rules(self, tmp_path):
+        from quodeq.data.fs.suppression_rules import load_suppression_rules
+
+        assert load_suppression_rules(tmp_path) == ()
+        (tmp_path / "suppression_rules.json").write_text("{nope", encoding="utf-8")
+        assert load_suppression_rules(tmp_path) == ()
+
+    def test_entries_missing_a_required_field_are_skipped(self, tmp_path):
+        """A half-written rule must not silently suppress everything."""
+        from quodeq.data.fs.suppression_rules import load_suppression_rules
+
+        (tmp_path / "suppression_rules.json").write_text(json.dumps({
+            "rules": [
+                {"file": "a.py", "reason": "no req"},
+                {"req": "X-1", "reason": "no file"},
+                {"req": "X-2", "file": "b.py", "reason": "complete"},
+                "not-a-dict",
+            ],
+        }), encoding="utf-8")
+
+        rules = load_suppression_rules(tmp_path)
+
+        assert [r.req for r in rules] == ["X-2"]
+
+    def test_a_rule_requires_a_reason(self, tmp_path):
+        """Reasons are the point: an unexplained blanket rule is rejected."""
+        from quodeq.data.fs.suppression_rules import load_suppression_rules
+
+        (tmp_path / "suppression_rules.json").write_text(json.dumps({
+            "rules": [{"req": "*", "file": "*"}],
+        }), encoding="utf-8")
+
+        assert load_suppression_rules(tmp_path) == ()
+
+
+def test_suppression_rule_is_frozen():
+    rule = SuppressionRule(req="X", file="a.py", reason="r")
+    with pytest.raises(Exception):
+        rule.req = "Y"
+
+
+class TestRulesParticipateInInvalidation:
+    """A rule change must invalidate cached scores.
+
+    The cache version is a content hash of the suppression state. If rules
+    were left out, adding one would hide findings while the cache kept
+    serving the pre-rule payload — the stale-row failure class from the
+    2026-07-29 incident.
+    """
+
+    def test_adding_a_rule_changes_the_cache_version(self, tmp_path):
+        from quodeq.core.scoring.params import DEFAULT_PARAMS
+        from quodeq.services.score_cache import score_cache_version
+
+        before = score_cache_version(tmp_path, DEFAULT_PARAMS)
+        (tmp_path / "suppression_rules.json").write_text(json.dumps({
+            "rules": [{"req": "X-1", "file": "a.py", "reason": "accepted"}],
+        }), encoding="utf-8")
+        after = score_cache_version(tmp_path, DEFAULT_PARAMS)
+
+        assert before != after
+
+    def test_editing_a_rule_changes_the_version_too(self, tmp_path):
+        from quodeq.core.scoring.params import DEFAULT_PARAMS
+        from quodeq.services.score_cache import score_cache_version
+
+        path = tmp_path / "suppression_rules.json"
+        path.write_text(json.dumps({"rules": [
+            {"req": "X-1", "file": "a.py", "reason": "accepted"}]}), encoding="utf-8")
+        before = score_cache_version(tmp_path, DEFAULT_PARAMS)
+        path.write_text(json.dumps({"rules": [
+            {"req": "X-1", "file": "b.py", "reason": "accepted"}]}), encoding="utf-8")
+
+        assert score_cache_version(tmp_path, DEFAULT_PARAMS) != before
+
+
+class TestReadPathsHonourRules:
+    def test_dimension_filter_drops_a_rule_matched_violation(self, tmp_path):
+        from quodeq.core.types.dimension import DimensionResult
+        from quodeq.core.types.finding import Finding
+        from quodeq.services.dismissed import filter_dismissed_from_dimensions
+
+        (tmp_path / "suppression_rules.json").write_text(json.dumps({
+            "rules": [{"req": "CLEA-DEP-01", "file": "src/quodeq/services/*",
+                       "reason": "WS1 lean architecture"}],
+        }), encoding="utf-8")
+        dim = DimensionResult(
+            dimension="clean-architecture",
+            violations=[
+                Finding(req="CLEA-DEP-01", practice_id="P1",
+                        file="src/quodeq/services/dismissed.py", line=23, severity="major"),
+                Finding(req="CLEA-DEP-01", practice_id="P1",
+                        file="src/quodeq/api/routes.py", line=5, severity="major"),
+            ],
+        )
+
+        out = filter_dismissed_from_dimensions([dim], tmp_path)
+
+        assert [v.file for v in out[0].violations] == ["src/quodeq/api/routes.py"]
+
+    def test_matcher_suppresses_a_rule_matched_row(self, tmp_path):
+        from quodeq.services.suppression import matcher_for
+
+        (tmp_path / "suppression_rules.json").write_text(json.dumps({
+            "rules": [{"req": "X-1", "file": "a.py", "reason": "accepted"}],
+        }), encoding="utf-8")
+
+        matcher = matcher_for(tmp_path, "clean-architecture")
+
+        assert matcher.active is True
+        assert matcher.is_suppressed(
+            {"t": "violation", "req": "X-1", "p": "X-1", "file": "a.py", "line": 7})
+        assert not matcher.is_suppressed(
+            {"t": "violation", "req": "X-1", "p": "X-1", "file": "b.py", "line": 7})


### PR DESCRIPTION
Track 3 of the [Phase 2 roadmap](docs/superpowers/plans/2026-08-01-clean-arch-phase2-roadmap.md) — the evaluator improvement with a measurable cost today.

## The problem, measured

Dismissal keys are `(req, file, line)`. Every refactor that shifts a line re-surfaces a finding the team already decided is acceptable. **This session alone paid ~13 re-dismissals** for patterns covered by the WS1 lean-architecture ADR — the same decision, re-entered by hand, at new line numbers.

## The rule

```json
{"req": "CLEA-DEP-01", "file": "src/quodeq/services/*",
 "reason": "WS1: services call data adapters directly"}
```

Two globs and a **mandatory reason**. Deliberately dumb — no severity ranges, no expiry dates; those should be argued for on their own.

## Safety properties

- **Fails closed.** Malformed files and incomplete entries are skipped with a warning, never applied. A half-written rule must not suppress everything.
- **A reason is required.** An unexplained blanket suppression is a bug, not a policy, so the loader rejects it.
- **Participates in cache invalidation.** `score_cache_version` now hashes the rules alongside the keys. Without that, adding a rule would hide findings while the cache kept serving the pre-rule payload — precisely the stale-row failure class from the 2026-07-29 incident.

## Integration

`is_dismissed` is the single predicate every reader funnels through, so it gained an optional `rules=` parameter and **no call-site signatures changed**. Wired into the two read paths that load their own keys: `filter_dismissed_from_dimensions` and `matcher_for`.

**Scope boundary, stated plainly:** the rescore path receives key sets as parameters rather than loading them, so threading rules there is a separate change. Until it lands, rules clean the lists and counters; **grades still move only on exact dismissals**.

18 new tests (TDD), including the line-shift case that motivated the feature. Full suite: **5494 passed**; import ratchet 17.
