### PR TITLE
feat(suppressions): pattern rules reach the scoring path

### DIFF
--- a/src/quodeq/api/routes_rescore.py
+++ b/src/quodeq/api/routes_rescore.py
@@ -13,6 +13,7 @@ from quodeq.services.dismissed import dismissed_keys as load_dismissed_keys
 from quodeq.services.rescore import rescore_dimensions
 from quodeq.shared.utils import get_evaluations_dir
 from quodeq.shared.validation import validate_path_segment
+from quodeq.services.suppression import load_suppression_rules
 
 
 def _eval_dir_from_app(app: Flask) -> str:
@@ -59,5 +60,6 @@ def register_rescore_routes(app: Flask) -> None:
         # *dimensions* were read from this one run, so its directory is the
         # evidence basis for the rescore.
         result = rescore_dimensions(
-            dimensions, dismissed, deleted, run_dir=project_dir / run_id)
+            dimensions, dismissed, deleted, run_dir=project_dir / run_id,
+            rules=load_suppression_rules(project_dir))
         return jsonify(result)

--- a/src/quodeq/services/_trend_fetcher.py
+++ b/src/quodeq/services/_trend_fetcher.py
@@ -33,6 +33,7 @@ from quodeq.data.fs.report_parser.runs import read_run_scalars as _default_read_
 from quodeq.services.rescore import _rescore_dimension
 from quodeq.services.score_cache import make_cache_backed_fetcher
 from quodeq.shared.validation import validate_path_segment
+from quodeq.data.fs.suppression_rules import load_suppression_rules
 
 _logger = logging.getLogger(__name__)
 
@@ -58,7 +59,9 @@ def make_rescoring_fetcher(
     project_dir = reports_root / project
     dismissed = dismissed_keys(project_dir)
     deleted = deleted_keys(project_dir)
-    if not dismissed and not deleted:
+    rules = load_suppression_rules(project_dir)
+    # Rules count as suppression state; see scored_run_dimensions.
+    if not dismissed and not deleted and not rules:
         return base_fetcher
 
     def rescoring_fetcher(run_id: str) -> list[DimensionResult]:
@@ -68,7 +71,8 @@ def make_rescoring_fetcher(
         validate_path_segment(run_id)
         run_dir = project_dir / run_id
         return [
-            _rescore_dimension(d, dismissed, deleted, params=params, run_dir=run_dir)
+            _rescore_dimension(d, dismissed, deleted, params=params, run_dir=run_dir,
+                               rules=rules)
             for d in dims
         ]
 

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -21,6 +21,7 @@ from quodeq.services._trend_fetcher import make_trend_fetcher
 from quodeq.services.scoring_view import is_eligible_for_default_view, select_trend_runs
 from quodeq.services.dismissed import filter_dismissed_from_dimensions
 from quodeq.shared.validation import validate_path_segment
+from quodeq.data.fs.suppression_rules import load_suppression_rules
 
 _logger = logging.getLogger(__name__)
 
@@ -186,12 +187,15 @@ def _rescore_run_dimensions(
     project_dir = reports_root / project
     dismissed = dismissed_keys(project_dir)
     deleted = deleted_keys(project_dir)
-    if not dismissed and not deleted:
+    rules = load_suppression_rules(project_dir)
+    # Rules count as suppression state; see scored_run_dimensions.
+    if not dismissed and not deleted and not rules:
         return dims
     validate_path_segment(run_id)
     run_dir = project_dir / run_id
     return [
-        _rescore_dimension(d, dismissed, deleted, params=params, run_dir=run_dir)
+        _rescore_dimension(d, dismissed, deleted, params=params, run_dir=run_dir,
+                           rules=rules)
         for d in dims
     ]
 

--- a/src/quodeq/services/rescore.py
+++ b/src/quodeq/services/rescore.py
@@ -131,6 +131,7 @@ def _rescore_dimension(
     params: ScoringParams = DEFAULT_PARAMS,
     *,
     run_dir: Path | None = None,
+    rules: tuple = (),
 ) -> DimensionResult:
     """Rescore a single dimension after filtering dismissed and deleted findings.
 
@@ -143,7 +144,7 @@ def _rescore_dimension(
     dim_id = dim.dimension or ""
     filtered_violations = [
         v for v in dim.violations
-        if not is_dismissed(dismissed, req=v.req, principle=v.practice_id,
+        if not is_dismissed(dismissed, req=v.req, principle=v.practice_id, rules=rules,
                             file=v.file, line=v.line)
         and not is_deleted(deleted, dimension=dim_id, principle=v.practice_id,
                            file=v.file)
@@ -212,6 +213,7 @@ def rescore_dimensions(
     params: ScoringParams | None = None,
     *,
     run_dir: Path | None = None,
+    rules: tuple = (),
 ) -> dict[str, Any]:
     """Rescore all dimensions after filtering dismissed and deleted findings.
 
@@ -224,7 +226,8 @@ def rescore_dimensions(
         from quodeq.services import grade_formula  # noqa: PLC0415
         params = grade_formula.load_params()
     rescored = [
-        _rescore_dimension(dim, dismissed_keys, deleted_keys, params=params, run_dir=run_dir)
+        _rescore_dimension(dim, dismissed_keys, deleted_keys, params=params,
+                           run_dir=run_dir, rules=rules)
         for dim in dimensions
     ]
     summary = summarize_dimensions(rescored, params=params)

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -59,6 +59,7 @@ from quodeq.services.scoring._response_builders import (  # noqa: F401
     _build_totals_from_findings,
     _severity_bucket,
 )
+from quodeq.data.fs.suppression_rules import load_suppression_rules
 from quodeq.services.scoring._rescoring import (  # noqa: F401
     _dims_expecting_rescore,
     _merge_rescored_dims,
@@ -205,12 +206,16 @@ def scored_run_dimensions(
     dismissed = (d.dismissed_keys or dismissed_keys)(project_dir)
     deleted = (d.deleted_keys or deleted_keys)(project_dir)
     dims = (d.read_run_data or read_run_data)(reports_root, project, run_id)
-    if not dismissed and not deleted:
+    rules = load_suppression_rules(project_dir)
+    # Rules are suppression state too: skipping the rescore when only rules
+    # exist would silently return raw scores for a project whose ADRs are
+    # expressed as patterns rather than per-line dismissals.
+    if not dismissed and not deleted and not rules:
         return dims
     run_dir = project_dir / run_id
     rescore = d.rescore_dimension or _rescore_dimension
     return [
-        rescore(dim, dismissed, deleted, params=params, run_dir=run_dir)
+        rescore(dim, dismissed, deleted, params=params, run_dir=run_dir, rules=rules)
         for dim in dims
     ]
 

--- a/src/quodeq/services/scoring/_rescoring.py
+++ b/src/quodeq/services/scoring/_rescoring.py
@@ -20,6 +20,7 @@ from quodeq.services.rescore import rescore_dimensions
 from quodeq.services.scoring._deps import ScoringDeps, _NO_DEPS
 from quodeq.services.scoring._summary import recompute_summary
 from quodeq.shared.validation import validate_path_segment
+from quodeq.data.fs.suppression_rules import load_suppression_rules
 
 _logger = logging.getLogger(__name__)
 
@@ -49,7 +50,8 @@ def _rescore_runs_by_dimension(
             # basis for every dimension sourced from it.
             result = rescore_dimensions(
                 run_dims, dismissed, deleted, params=params,
-                run_dir=reports_root / project / run_id)
+                run_dir=reports_root / project / run_id,
+                rules=load_suppression_rules(reports_root / project))
             seen_runs[run_id] = {
                 (rd.get("dimension") or "").lower(): rd
                 for rd in result.get("dimensions", [])

--- a/src/quodeq/services/scoring/_response_builders.py
+++ b/src/quodeq/services/scoring/_response_builders.py
@@ -22,6 +22,7 @@ from quodeq.services.dismissed import dismissed_keys
 from quodeq.services.rescore import rescore_dimensions
 from quodeq.services.scoring._deps import ScoringDeps, _NO_DEPS
 from quodeq.shared.validation import validate_path_segment
+from quodeq.data.fs.suppression_rules import load_suppression_rules
 
 
 def _severity_bucket(severity: str) -> str:
@@ -234,7 +235,8 @@ def _build_response_from_eval_files(
 
     dims = base_fetcher(run_id)
     rescored = rescore_dimensions(
-        dims, dismissed, deleted, params=params, run_dir=project_dir / run_id)
+        dims, dismissed, deleted, params=params, run_dir=project_dir / run_id,
+        rules=load_suppression_rules(project_dir))
     return {
         "dimensions": rescored.get("dimensions", []),
         "summary": rescored.get("summary", {}),

--- a/src/quodeq/services/suppression.py
+++ b/src/quodeq/services/suppression.py
@@ -31,7 +31,9 @@ from quodeq.services.suppression_keys import (  # noqa: F401 — re-exported API
     is_dismissed,
 )
 from quodeq.shared.validation import validate_path_segment
-from quodeq.data.fs.suppression_rules import load_suppression_rules
+from quodeq.data.fs.suppression_rules import (  # noqa: F401 — re-exported API
+    load_suppression_rules,
+)
 
 _TYPE_VIOLATION = "violation"
 

--- a/tests/services/scoring/test_scored_run_dimensions.py
+++ b/tests/services/scoring/test_scored_run_dimensions.py
@@ -107,7 +107,7 @@ def test_scored_run_dimensions_passes_the_run_dir_to_rescore():
     raw_dim = _make_dimension([_make_violation()], [_make_compliance()])
     seen: list[Path | None] = []
 
-    def fake_rescore(dim, dismissed, deleted=None, params=None, *, run_dir=None):
+    def fake_rescore(dim, dismissed, deleted=None, params=None, *, run_dir=None, rules=()):
         seen.append(run_dir)
         return dim
 

--- a/tests/services/scoring/test_scoring_deps_seam.py
+++ b/tests/services/scoring/test_scoring_deps_seam.py
@@ -31,7 +31,7 @@ def test_scored_run_dimensions_uses_injected_deps(tmp_path):
     rescored = replace(raw, overall_score="9.0/10")
     calls = {}
 
-    def fake_rescore(d, dismissed, deleted, *, params, run_dir):
+    def fake_rescore(d, dismissed, deleted, *, params, run_dir, rules=()):
         calls["args"] = (d, dismissed, deleted, run_dir)
         return rescored
 

--- a/tests/services/test_suppression_rules.py
+++ b/tests/services/test_suppression_rules.py
@@ -201,3 +201,56 @@ class TestReadPathsHonourRules:
             {"t": "violation", "req": "X-1", "p": "X-1", "file": "a.py", "line": 7})
         assert not matcher.is_suppressed(
             {"t": "violation", "req": "X-1", "p": "X-1", "file": "b.py", "line": 7})
+
+
+class TestRulesMoveTheGrade:
+    """The point of the feature: a rule must change the score, not just lists."""
+
+    def _dim(self):
+        from quodeq.core.types.dimension import DimensionResult
+        from quodeq.core.types.finding import Finding
+        return DimensionResult(
+            dimension="clean-architecture",
+            overall_score="5.0/10",
+            violations=[
+                Finding(req="CLEA-DEP-01", practice_id="Independence",
+                        file="src/quodeq/services/a.py", line=3, severity="major"),
+            ],
+        )
+
+    def test_rescore_drops_a_rule_matched_violation(self):
+        from quodeq.core.types.suppression_rule import SuppressionRule
+        from quodeq.services.rescore import rescore_dimensions
+
+        rules = (SuppressionRule(req="CLEA-DEP-01", file="src/quodeq/services/*",
+                                 reason="WS1"),)
+        out = rescore_dimensions([self._dim()], set(), set(), rules=rules)
+
+        assert out["dimensions"][0]["violations"] == []
+
+    def test_without_the_rule_the_violation_survives(self):
+        from quodeq.services.rescore import rescore_dimensions
+
+        out = rescore_dimensions([self._dim()], set(), set())
+
+        assert len(out["dimensions"][0]["violations"]) == 1
+
+    def test_scored_run_dimensions_loads_rules_from_the_project(self, tmp_path):
+        """End-to-end: the entry point reads the rules file itself."""
+        from quodeq.services.scoring import ScoringDeps, scored_run_dimensions
+
+        (tmp_path / "proj").mkdir()
+        (tmp_path / "proj" / "suppression_rules.json").write_text(json.dumps({
+            "rules": [{"req": "CLEA-DEP-01", "file": "src/quodeq/services/*",
+                       "reason": "WS1"}],
+        }), encoding="utf-8")
+        dim = self._dim()
+        deps = ScoringDeps(
+            read_run_data=lambda root, p, r: [dim],
+            dismissed_keys=lambda pd: set(),
+            deleted_keys=lambda pd: set(),
+        )
+
+        out = scored_run_dimensions(tmp_path, "proj", "run-1", deps=deps)
+
+        assert out[0].violations == [], "a project rule must reach the scoring path"


### PR DESCRIPTION
Completes #1008 — the scope boundary that PR called out. **Rules now move grades, not just lists.**

## Threading

`rescore_dimensions` / `_rescore_dimension` take `rules` and pass them to `is_dismissed`, so a rule-matched violation is filtered before scoring. Every entry point that loads dismiss keys now loads rules from the same project dir: `scored_run_dimensions`, the eval-file response builder, the accumulated rescore, the rescore route, and the dashboard + trend fetchers.

## The bug this surfaced

Three early-return guards read `if not dismissed and not deleted: return raw`. For a project whose ADRs are expressed as **patterns** rather than per-line dismissals, that skipped the rescore entirely — the lists would show findings hidden while the grade was computed from the raw set. All three now count rules as suppression state, and the test that caught it asserts the end-to-end path (rules file on disk → scored dimensions).

## Layer rule, again

The api layer reaches the loader through `services/suppression` rather than importing `data` directly — the import ratchet rejected my first attempt. That is the third time today a guard caught a layering slip mid-refactor.

Full suite: **5497 passed**; ratchet 17.