### PR TITLE
feat(scoring): fold near-miss requirement IDs instead of quarantining them

### DIFF
--- a/src/quodeq/core/evidence/_req_mapping.py
+++ b/src/quodeq/core/evidence/_req_mapping.py
@@ -77,6 +77,48 @@ def _resolve_req_to_principle_map(
     return mapping
 
 
+def _id_shape(req_id: str) -> tuple[str, str] | None:
+    """The trailing ``(category, number)`` of a requirement ID, upper-cased.
+
+    ``CLEA-DEP-05`` and ``DEP-05`` both shape to ``("DEP", "05")``. Returns
+    None for anything without at least two dash-separated segments ending in
+    a number, which is the only form we are willing to guess about.
+    """
+    parts = [p for p in (req_id or "").strip().split("-") if p]
+    if len(parts) < 2 or not parts[-1].isdigit():
+        return None
+    return parts[-2].upper(), parts[-1].lstrip("0") or "0"
+
+
+def normalize_req_id(raw: str, canonical_ids) -> str | None:
+    """Fold a near-miss requirement ID onto the standard's real ID.
+
+    Local models emit IDs the standard does not define -- wrong case
+    (``CLEa-DEP-05``), a truncated prefix (``CLE-TES-02``) or no prefix at all
+    (``SEP-03``). Each is a real finding that would otherwise be quarantined
+    over a typo.
+
+    The match is on the trailing ``(category, number)`` pair, so two genuinely
+    different requirements can never merge: ``CLEA-DEP-01`` and ``CLEA-DEP-02``
+    differ in the number and stay distinct despite being one character apart.
+    An ambiguous shape (two canonical IDs sharing the pair) refuses to fold --
+    guessing between real requirements is worse than quarantining.
+    """
+    ids = tuple(canonical_ids or ())
+    if not raw or not ids:
+        return None
+    for candidate in ids:
+        if candidate == raw:
+            return candidate
+    shape = _id_shape(raw)
+    if shape is None:
+        return None
+    matches = [c for c in ids if _id_shape(c) == shape]
+    if len(matches) != 1:
+        return None  # unknown, or ambiguous between real requirements
+    return matches[0]
+
+
 @dataclass(frozen=True)
 class PrincipleResolver:
     """Resolves a finding's raw principle/requirement ID to a canonical principle.
@@ -100,7 +142,17 @@ class PrincipleResolver:
         """
         if not practice_id:
             return None
-        principle = self.req_to_principle.get(practice_id, practice_id)
+        principle = self.req_to_principle.get(practice_id)
+        if principle is None:
+            # Second chance before quarantine: fold a near-miss ID (wrong case,
+            # truncated or missing prefix) onto the standard's real one.
+            folded = normalize_req_id(practice_id, tuple(self.req_to_principle))
+            if folded is not None:
+                principle = self.req_to_principle[folded]
+        if principle is None:
+            # Not a requirement ID: findings may name the principle directly,
+            # and with no standard at all every id passes through unchanged.
+            principle = practice_id
         if self.canonical and principle not in self.canonical:
             return None
         return principle

--- a/tests/core/test_req_id_normalizer.py
+++ b/tests/core/test_req_id_normalizer.py
@@ -1,0 +1,79 @@
+"""Near-miss requirement IDs fold onto the standard's real IDs.
+
+Local models emit IDs the standard does not define — the 2026-08-01
+clean-architecture run alone quarantined ``CLEa-DEP-05`` (wrong case),
+``CLE-TES-02``/``CLE-ENT-02`` (truncated prefix) and bare ``SEP-03``
+(missing prefix). Each was a real finding thrown away over a typo.
+
+The fold matches on the trailing ``(category, number)`` segments, so it can
+never merge two genuinely different requirements: ``CLEA-DEP-01`` and
+``CLEA-DEP-02`` differ in the number and stay distinct, even though they are
+one character apart.
+"""
+from __future__ import annotations
+
+from quodeq.core.evidence._req_mapping import PrincipleResolver, normalize_req_id
+
+CANONICAL = ("CLEA-DEP-01", "CLEA-DEP-05", "CLEA-TES-02", "CLEA-SEP-03", "CLEA-ENT-02")
+
+
+class TestNormalizeReqId:
+    def test_exact_id_is_returned_unchanged(self):
+        assert normalize_req_id("CLEA-DEP-05", CANONICAL) == "CLEA-DEP-05"
+
+    def test_wrong_case_folds(self):
+        assert normalize_req_id("CLEa-DEP-05", CANONICAL) == "CLEA-DEP-05"
+        assert normalize_req_id("clea-dep-05", CANONICAL) == "CLEA-DEP-05"
+
+    def test_truncated_prefix_folds(self):
+        assert normalize_req_id("CLE-TES-02", CANONICAL) == "CLEA-TES-02"
+        assert normalize_req_id("CLE-ENT-02", CANONICAL) == "CLEA-ENT-02"
+
+    def test_missing_prefix_folds(self):
+        assert normalize_req_id("SEP-03", CANONICAL) == "CLEA-SEP-03"
+
+    def test_neighbouring_requirements_never_merge(self):
+        """One edit apart, but a different requirement: must NOT fold."""
+        assert normalize_req_id("CLEA-DEP-02", CANONICAL) is None
+        assert normalize_req_id("CLEA-DEP-99", CANONICAL) is None
+
+    def test_unknown_category_does_not_fold(self):
+        assert normalize_req_id("CLEA-XXX-01", CANONICAL) is None
+
+    def test_ambiguous_trailing_pair_refuses_to_fold(self):
+        """Two standards sharing a category+number is not a typo we can resolve."""
+        ambiguous = ("CLEA-SEP-03", "DDD-SEP-03")
+        assert normalize_req_id("SEP-03", ambiguous) is None
+
+    def test_blank_and_shapeless_inputs(self):
+        assert normalize_req_id("", CANONICAL) is None
+        assert normalize_req_id("nonsense", CANONICAL) is None
+        assert normalize_req_id("CLEA-DEP-05", ()) is None
+
+
+class TestResolverUsesTheFold:
+    def _resolver(self):
+        return PrincipleResolver(
+            req_to_principle={"CLEA-DEP-05": "Dependency Rule",
+                              "CLEA-SEP-03": "Separation of Concerns"},
+            canonical=frozenset({"Dependency Rule", "Separation of Concerns"}),
+        )
+
+    def test_near_miss_id_resolves_instead_of_quarantining(self):
+        assert self._resolver().resolve("CLEa-DEP-05") == "Dependency Rule"
+        assert self._resolver().resolve("SEP-03") == "Separation of Concerns"
+
+    def test_exact_ids_still_resolve(self):
+        assert self._resolver().resolve("CLEA-DEP-05") == "Dependency Rule"
+
+    def test_a_principle_name_still_resolves_directly(self):
+        """Findings may name the principle rather than a requirement."""
+        assert self._resolver().resolve("Dependency Rule") == "Dependency Rule"
+
+    def test_genuinely_foreign_ids_still_quarantine(self):
+        assert self._resolver().resolve("SEC-CON-1") is None
+        assert self._resolver().resolve(None) is None
+
+    def test_no_standard_stays_permissive(self):
+        permissive = PrincipleResolver(req_to_principle={}, canonical=frozenset())
+        assert permissive.resolve("ANYTHING-1") == "ANYTHING-1"


### PR DESCRIPTION
Track 3 of the roadmap. Local models emit requirement IDs the standard does not define; each one is a **real finding discarded over a typo**.

From the 2026-08-01 clean-architecture run's own log:

| Emitted | Should be | Defect |
|---|---|---|
| `CLEa-DEP-05` | `CLEA-DEP-05` | wrong case |
| `CLE-TES-02`, `CLE-ENT-02` | `CLEA-...` | truncated prefix |
| `SEP-03` | `CLEA-SEP-03` | no prefix |

## The fold rule, and why it is safe

Matching on the trailing **(category, number)** pair rather than edit distance. That distinction matters: `CLEA-DEP-01` and `CLEA-DEP-02` are one character apart, so any edit-distance fold would merge two genuinely different requirements. Under this rule they differ in the number and stay distinct.

When two canonical IDs share a shape, the fold **refuses** — guessing between real requirements is worse than quarantining.

## Placement

`PrincipleResolver.resolve` is the single membership predicate that both the report path and the live scan counters go through, so the fold lands in exactly one place. It runs only after an exact lookup misses and before quarantine, so exact IDs, findings that name a principle directly, and the permissive no-standard path are all untouched.

13 new tests, watched fail first, including the neighbour-merge case and the ambiguity refusal. Full suite: **5510 passed**.
