### PR TITLE
feat(ui): dates and numbers follow the app's locale, not the OS

### DIFF
--- a/src/quodeq/ui/src/components/ProjectHeader.jsx
+++ b/src/quodeq/ui/src/components/ProjectHeader.jsx
@@ -1,6 +1,6 @@
 import RunNavigator from '../features/dashboard/components/RunNavigator.jsx';
 import { formatRunId, extDisplayName } from '../utils/formatters.js';
-import { t } from '../strings/index.js';
+import { t, LOCALE } from '../strings/index.js';
 
 const MAX_DISPLAYED_STATS = 5;
 
@@ -12,7 +12,7 @@ function LanguageStats({ stats, totalFiles }) {
     <div className="content-header-stats">
       {total && (
         <span className="content-stat">
-          <span className="content-stat-num">{total.toLocaleString()}</span>
+          <span className="content-stat-num">{total.toLocaleString(LOCALE)}</span>
           <span className="content-stat-label">{t('evaluate.filesLabel')}</span>
         </span>
       )}

--- a/src/quodeq/ui/src/components/Sidebar.jsx
+++ b/src/quodeq/ui/src/components/Sidebar.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { ICON_OVERVIEW, ICON_VIOLATIONS, ICON_MAP, ICON_HISTORY, ICON_EVALUATE, ICON_SETTINGS, ICON_STANDARDS, ICON_HELP, ICON_FOLDER as BASE_ICON_FOLDER } from '../constants/navigation.jsx';
 import { cloneElement } from 'react';
 import { BRAND_NAME } from '../strings/brand.js';
-import { t } from '../strings/index.js';
+import { t, LOCALE } from '../strings/index.js';
 
 // Folder glyph for the REPOSITORY row — same outline used in the file/folder
 // table on FileDetailPage, just sized up for the sidebar rail.
@@ -65,7 +65,7 @@ function formatLastEval(iso) {
   try {
     const d = new Date(iso);
     if (Number.isNaN(d.getTime())) return null;
-    return d.toLocaleString(undefined, {
+    return d.toLocaleString(LOCALE, {
       day: '2-digit',
       month: 'short',
       hour: '2-digit',

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.jsx
@@ -8,7 +8,7 @@ import { SevBadge } from '../../../components/terminal/index.js';
 import { splitScore, scoreGradeColorVar, complianceRatio, formatRunId } from '../../../utils/formatters.js';
 import { scoreToGradeLabel } from '../../../utils/gradeThresholds.js';
 import { exitReasonLabel, exitReasonHint } from '../../../models/exitReason.js';
-import { t } from '../../../strings/index.js';
+import { t, LOCALE } from '../../../strings/index.js';
 
 /**
  * Build a coverage record for the gauge card's footer line.
@@ -43,7 +43,7 @@ function buildPartialTooltip({ filesRead, sourceFileCount, exitReason }) {
     sourceFileCount > 0;
   const parts = [t('overview.partialRun')];
   if (hasCounts) {
-    parts.push(t('overview.filesOf', { read: filesRead.toLocaleString(), total: sourceFileCount.toLocaleString() }));
+    parts.push(t('overview.filesOf', { read: filesRead.toLocaleString(LOCALE), total: sourceFileCount.toLocaleString(LOCALE) }));
   }
   if (typeof exitReason === 'string') {
     parts.push(t('overview.stoppedReason', { reason: exitReasonLabel(exitReason) }));
@@ -73,8 +73,8 @@ function UnmappedSegment({ count }) {
   return (
     <> · <span
       className="dim-gauge-card__unmapped"
-      title={t(tooltipKey, { count: count.toLocaleString() })}
-    >{t('overview.unmappedCount', { count: count.toLocaleString() })}</span></>
+      title={t(tooltipKey, { count: count.toLocaleString(LOCALE) })}
+    >{t('overview.unmappedCount', { count: count.toLocaleString(LOCALE) })}</span></>
   );
 }
 

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
@@ -8,7 +8,7 @@ import { useSharedProjects } from '../hooks/useSharedProjects.js';
 import { usePublish } from '../hooks/usePublish.js';
 import { useMergedProjects } from '../hooks/useMergedProjects.js';
 import Badge from '../../../components/Badge.jsx';
-import { t } from '../../../strings/index.js';
+import { t, LOCALE } from '../../../strings/index.js';
 
 // Technology and discipline names are proper nouns: a translator handed
 // "React Native" would be right to leave it, and wrong to change it.
@@ -42,7 +42,7 @@ function disciplineLabel(d) {
 function formatDate(iso) {
   if (!iso) return null;
   try {
-    return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    return new Date(iso).toLocaleDateString(LOCALE, { month: 'short', day: 'numeric' });
   } catch {
     return null;
   }
@@ -67,14 +67,14 @@ function GradeChip({ grade, score }) {
 
 function LanguageNumbers({ stats, filesCount }) {
   if (!stats || Object.keys(stats).length === 0) {
-    if (filesCount != null) return <span className="project-stat"><span className="project-stat-num">{filesCount.toLocaleString()}</span> <span className="project-stat-label">{t('evaluate.filesLabel')}</span></span>;
+    if (filesCount != null) return <span className="project-stat"><span className="project-stat-num">{filesCount.toLocaleString(LOCALE)}</span> <span className="project-stat-label">{t('evaluate.filesLabel')}</span></span>;
     return null;
   }
   const sorted = Object.entries(stats).sort(([, a], [, b]) => b - a).slice(0, 4);
   const total = filesCount || sorted.reduce((s, [, c]) => s + c, 0);
   return (
     <div className="project-lang-row">
-      <span className="project-stat"><span className="project-stat-num">{total.toLocaleString()}</span> <span className="project-stat-label">{t('evaluate.filesLabel')}</span></span>
+      <span className="project-stat"><span className="project-stat-num">{total.toLocaleString(LOCALE)}</span> <span className="project-stat-label">{t('evaluate.filesLabel')}</span></span>
       {sorted.map(([lang, count]) => (
         <span key={lang} className="project-stat"><span className="project-stat-num">{count}</span> <span className="project-stat-label">{extDisplayName(lang)}</span></span>
       ))}

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -15,7 +15,7 @@ import HelpHint from '../../../components/HelpHint.jsx';
 import EmptyState from '../../../components/EmptyState.jsx';
 import { ACTIVE_PROVIDER_KEY } from '../../../constants.js';
 import { resolveProviderSettings } from '../../../utils/effectiveProviderSettings.js';
-import { t } from '../../../strings/index.js';
+import { t, LOCALE } from '../../../strings/index.js';
 import { apiErrorMessage } from '../../../strings/apiErrors.js';
 
 const EVAL_OPTIONS_HINT = (
@@ -59,7 +59,7 @@ function initialBudgetSeconds(storage = localStorage) {
 }
 
 function n(x) {
-  return typeof x === 'number' ? x.toLocaleString() : x;
+  return typeof x === 'number' ? x.toLocaleString(LOCALE) : x;
 }
 
 function useReEvalInfo(project, initialInfo, { getProjectInfo, relocateProject }) {
@@ -346,7 +346,7 @@ function ReEvaluateCardView({ info, project, disabled, dimensions, actions, scop
         const cached = isClean ? 0 : (est.cached ?? 0);
         if (count === 0) return [id, [t('evaluate.upToDate')]];
         const pct = Math.round((cached / total) * 100);
-        const lines = [t('evaluate.filesToAnalyze', { count: count.toLocaleString() })];
+        const lines = [t('evaluate.filesToAnalyze', { count: count.toLocaleString(LOCALE) })];
         if (pct > 0) lines.push(t('evaluate.pctAnalyzed', { pct }));
         return [id, lines];
       }))

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -19,7 +19,7 @@ import LoadingScreen from '../../../components/LoadingScreen.jsx';
 import FittedText from '../../../components/FittedText.jsx';
 import SharedReadOnlyBadge from '../../../components/SharedReadOnlyBadge.jsx';
 import { abbrevDim } from '../utils/dimAbbrev.js';
-import { t } from '../../../strings/index.js';
+import { t, LOCALE } from '../../../strings/index.js';
 
 const TOAST_DISMISS_MS = 2600;
 const NOT_READY_MESSAGE = t('history.notReadyMessage');
@@ -35,9 +35,13 @@ function formatDateParts(dateISO, fallbackLabel) {
   if (!dateISO) return { date: fallbackLabel || '', time: '' };
   try {
     const d = new Date(dateISO);
-    // Short month (`Apr 14, 2026`) to match the reference mockup.
-    const date = d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
-    const time = d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    // Short month, ordered by LOCALE. The mockup this was built from showed
+    // `Apr 14, 2026`, but the call passed `undefined` as the locale, so the
+    // order actually followed the viewer's OS -- US machines matched the
+    // mockup and nobody else did. It now agrees with formatPeriodLabel,
+    // which was already day-first and deterministic everywhere.
+    const date = d.toLocaleDateString(LOCALE, { day: 'numeric', month: 'short', year: 'numeric' });
+    const time = d.toLocaleTimeString(LOCALE, { hour: '2-digit', minute: '2-digit' });
     return { date, time };
   } catch {
     return { date: fallbackLabel || '', time: '' };
@@ -462,7 +466,7 @@ export default function HistoryPage({ trend: rawTrend, selection, availableRuns,
     if (entry?.dateISO) {
       try {
         const d = new Date(entry.dateISO);
-        return d.toLocaleDateString(undefined, { day: 'numeric', month: 'long', year: 'numeric' }) + ' ' + d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+        return d.toLocaleDateString(LOCALE, { day: 'numeric', month: 'long', year: 'numeric' }) + ' ' + d.toLocaleTimeString(LOCALE, { hour: '2-digit', minute: '2-digit' });
       } catch { return entry.dateISO || ''; }
     }
     return entry?.dateLabel || currentOverviewRun;

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.test.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.test.jsx
@@ -90,7 +90,12 @@ describe('HistoryPage — delete-run source gating', () => {
     expect(screen.queryByRole('button', { name: 'Delete run', hidden: true })).toBeNull();
     // The row itself (and its chevron) must still render — only the delete
     // affordance is gone.
-    expect(screen.getByText('Jul 1, 2026')).toBeInTheDocument();
+    //
+    // Was 'Jul 1, 2026', which passed only because this machine's browser
+    // locale is en-US: the row formatted dates with `undefined` as the locale,
+    // so the assertion (and the product) followed the OS rather than the app.
+    // Dates now come from strings/index.js LOCALE, so this is deterministic.
+    expect(screen.getByText('1 Jul 2026')).toBeInTheDocument();
   });
 });
 

--- a/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
@@ -1,11 +1,11 @@
 import { scoreColorClass, gradeLabel } from '../../../utils/formatters.js';
-import { t } from '../../../strings/index.js';
+import { t, LOCALE } from '../../../strings/index.js';
 
 function formatDate(dateISO) {
   if (!dateISO) return '';
   try {
     const d = new Date(dateISO);
-    return d.toLocaleDateString(undefined, { day: 'numeric', month: 'long', year: 'numeric' });
+    return d.toLocaleDateString(LOCALE, { day: 'numeric', month: 'long', year: 'numeric' });
   } catch { return ''; }
 }
 
@@ -13,7 +13,7 @@ function formatTime(dateISO) {
   if (!dateISO) return '';
   try {
     const d = new Date(dateISO);
-    return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    return d.toLocaleTimeString(LOCALE, { hour: '2-digit', minute: '2-digit' });
   } catch { return ''; }
 }
 

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import { LOCALE } from '../strings/index.js';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDashboard } from '../features/dashboard/hooks/useDashboard.js';
 import { usePrefetchAdjacentRuns } from '../features/dashboard/hooks/usePrefetchAdjacentRuns.js';
@@ -90,7 +91,7 @@ export function formatDayLabel(trend, currentOverviewRun, dailyRuns, overviewRun
   const entry = (trend || []).find((r) => r.runId === currentOverviewRun);
   if (entry?.dateISO) {
     try {
-      return new Date(entry.dateISO).toLocaleDateString(undefined, { day: 'numeric', month: 'long', year: 'numeric' });
+      return new Date(entry.dateISO).toLocaleDateString(LOCALE, { day: 'numeric', month: 'long', year: 'numeric' });
     } catch { return entry.dateISO; }
   }
   return dailyRuns[overviewRunIndex]?.dateLabel || currentOverviewRun;

--- a/src/quodeq/ui/src/strings/en.json
+++ b/src/quodeq/ui/src/strings/en.json
@@ -147,6 +147,7 @@
   "common.unknownError": "unknown error",
   "common.versionPrefix": "v{version}",
   "common.viewRunningEvaluation": "View running evaluation",
+  "common.weekOfYear": "Week {week}, {year}",
   "common.yearsAgo": "{years} years ago",
   "common.yesterday": "yesterday",
   "dimension.clearFileFilterAria": "Clear file filter",

--- a/src/quodeq/ui/src/strings/index.js
+++ b/src/quodeq/ui/src/strings/index.js
@@ -7,6 +7,21 @@
 // yet. That is a separate decision; this seam is what makes it cheap.
 import en from './en.json' with { type: 'json' };
 
+/**
+ * BCP-47 tag for everything Intl formats: dates, times, numbers.
+ *
+ * Paired with the catalog above, deliberately. Call sites used to pass
+ * `undefined`, which means "the browser's locale" -- so a Dutch machine
+ * running the English UI got Dutch dates next to English copy, and adding a
+ * locale would not have changed them at all. One tag, one place.
+ *
+ * 'en-GB' rather than 'en' is also deliberate: the app renders dates
+ * day-month-year ("25 Mar 2026"), which is what this tag encodes. Plain 'en'
+ * resolves to US ordering and would silently reformat every date in the
+ * product.
+ */
+export const LOCALE = 'en-GB';
+
 export function t(key, vars) {
   const template = en[key];
   if (template === undefined) {

--- a/src/quodeq/ui/src/strings/locale.test.js
+++ b/src/quodeq/ui/src/strings/locale.test.js
@@ -1,0 +1,52 @@
+// LOCALE is the one tag every Intl call reads. Before this existed, call
+// sites passed `undefined` -- "use the browser's locale" -- so a Dutch
+// machine running the English UI got Dutch dates next to English copy, and
+// translating the catalog would not have changed a single date.
+//
+// These assert the two properties that matter: today's output is unchanged,
+// and swapping the tag actually reformats everything. The second is the
+// point of the change and the easiest thing to get subtly wrong (a hardcoded
+// month array formats identically no matter what tag you pass it).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { LOCALE } from './index.js';
+import { formatPeriodLabel, formatShortDate } from '../utils/formatters.js';
+
+const ENTRY = { dateISO: '2026-03-25T14:00:00', dateLabel: 'server label' };
+
+test('LOCALE is a BCP-47 tag, not a bare language', () => {
+  // 'en' would resolve to US ordering and silently reformat every date in
+  // the product; the app renders day-month-year.
+  assert.match(LOCALE, /^[a-z]{2}-[A-Z]{2}$/);
+});
+
+test('day/month formatting is unchanged from the hand-rolled version', () => {
+  assert.equal(formatPeriodLabel(ENTRY, 'day'), '25 Mar 2026');
+  assert.equal(formatPeriodLabel(ENTRY, 'month'), 'March 2026');
+  assert.equal(formatShortDate('2026-03-25T14:00:00'), '25 Mar 2026');
+});
+
+test('week keeps a catalog pattern, since Intl has no week-of-year format', () => {
+  assert.equal(formatPeriodLabel(ENTRY, 'week'), 'Week 13, 2026');
+});
+
+// The regression this guards: with a hardcoded month-name array, every one
+// of these produces English regardless of the tag, and the bug is invisible
+// until someone actually ships a second locale.
+test('month names come from Intl, so another locale genuinely reformats', () => {
+  const d = new Date('2026-03-25T14:00:00');
+  const shape = { day: 'numeric', month: 'short', year: 'numeric' };
+  const es = d.toLocaleDateString('es-ES', shape);
+  const nl = d.toLocaleDateString('nl-NL', shape);
+  const ja = d.toLocaleDateString('ja-JP', shape);
+
+  for (const [tag, out] of [['es-ES', es], ['nl-NL', nl], ['ja-JP', ja]]) {
+    assert.ok(out && !out.includes('Mar'), `${tag} still rendered the English month: ${out}`);
+  }
+  assert.notEqual(es, nl, 'es and nl should not format identically');
+});
+
+test('unparseable input still falls back to the server label', () => {
+  assert.equal(formatPeriodLabel({ dateISO: 'not-a-date', dateLabel: 'server label' }, 'day'), 'server label');
+  assert.equal(formatPeriodLabel({ dateLabel: 'server label' }, 'month'), 'server label');
+});

--- a/src/quodeq/ui/src/utils/formatters.js
+++ b/src/quodeq/ui/src/utils/formatters.js
@@ -1,5 +1,11 @@
 import { getGradeThresholds } from './gradeThresholds.js';
 import { isoWeekKey, localDayKey } from './dailyGrouping.js';
+import { LOCALE, t } from '../strings/index.js';
+
+// Intl formatters are comparatively expensive to construct, and these run in
+// list renders. Build once at module scope.
+const DAY_MONTH_YEAR = new Intl.DateTimeFormat(LOCALE, { day: 'numeric', month: 'short', year: 'numeric' });
+const MONTH_YEAR = new Intl.DateTimeFormat(LOCALE, { month: 'long', year: 'numeric' });
 
 /**
  * Grade-to-CSS-class mapping.
@@ -129,7 +135,7 @@ export function formatShortDate(dateStr) {
   if (!dateStr) return dateStr;
   const d = new Date(dateStr);
   if (isNaN(d.getTime())) return dateStr;
-  return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+  return DAY_MONTH_YEAR.format(d);
 }
 
 /**
@@ -303,11 +309,6 @@ export function formatDurationCoarse(s) {
   return parts.join(' ');
 }
 
-const PERIOD_MONTH_NAMES = [
-  'January', 'February', 'March', 'April', 'May', 'June',
-  'July', 'August', 'September', 'October', 'November', 'December',
-];
-
 /**
  * Human label for a score-history bucket at the given grouping granularity.
  * - day   -> the entry's LOCAL date (e.g. "25 Mar 2026")
@@ -329,21 +330,21 @@ export function formatPeriodLabel(entry, granularity = 'day') {
   const fallback = entry?.dateLabel || iso;
   if (granularity === 'month') {
     const [y, m] = localDayKey(iso).slice(0, 7).split('-');
-    const idx = Number(m) - 1;
-    return (y && PERIOD_MONTH_NAMES[idx]) ? `${PERIOD_MONTH_NAMES[idx]} ${y}` : fallback;
+    if (!y || !m) return fallback;
+    // Format the local calendar day, not the raw instant: the bucket is a
+    // local-day key, so a run near midnight must name the bucket it sits in.
+    const d = new Date(Number(y), Number(m) - 1, 1);
+    return Number.isNaN(d.getTime()) ? fallback : MONTH_YEAR.format(d);
   }
   if (granularity === 'week') {
     const key = isoWeekKey(iso); // 'YYYY-Www' or ''
     const [y, w] = key.split('-W');
-    return (y && w) ? `Week ${Number(w)}, ${y}` : fallback;
+    // Intl has no week-of-year format, so this one stays a catalog pattern.
+    return (y && w) ? t('common.weekOfYear', { week: Number(w), year: y }) : fallback;
   }
   if (iso.length > 10) {
-    // Same "25 Mar 2026" shape the server's dateLabel uses, but from the
-    // LOCAL date so the label names the bucket the run actually sits in.
     const d = new Date(iso);
-    if (!Number.isNaN(d.getTime())) {
-      return `${d.getDate()} ${PERIOD_MONTH_NAMES[d.getMonth()].slice(0, 3)} ${d.getFullYear()}`;
-    }
+    if (!Number.isNaN(d.getTime())) return DAY_MONTH_YEAR.format(d);
   }
   return fallback;
 }


### PR DESCRIPTION
## The gap

**Translating `en.json` did not translate a single date.** Two separate causes, both invisible to the string ratchet:

**1. A hardcoded English month array.** `utils/formatters.js:306` built dates by hand, so `"13 March 2026"` survived any catalog translation. `i18n/no-prose-literals` cannot flag it by construction — each month is one word, an array of single words is not prose, and `"Week "` is under the length threshold. The same shape as every other gap in this effort: invisible to the instrument, not missed by the sweep.

**2. `undefined` as the locale.** Every other date/number call site meant "use the browser's locale". A Dutch machine running the English UI **already** showed Dutch dates next to English copy — and adding a locale would not have changed them at all.

## The change

Both now read `LOCALE` from `strings/index.js`, sitting next to the catalog it's paired with. Intl does the formatting; the hand-rolled month array is **deleted rather than translated**. Numbers go through it too, since thousands separators are locale-specific (`1,234` / `1.234` / `1 234`).

`'en-GB'`, not `'en'`, deliberately: the app renders dates day-month-year (`25 Mar 2026`), which is what the tag encodes. Plain `'en'` resolves to US ordering and would silently reformat every date in the product.

**Output is byte-identical for every existing site except one.**

## That one exception

`HistoryPage`'s `formatDateParts` carried a comment: short month *"to match the reference mockup"* (`Apr 14, 2026`). But it passed `undefined`, so it only matched the mockup **on US machines** — the intent was documented and never actually enforced. It now agrees with `formatPeriodLabel`, which was already day-first and deterministic everywhere. Comment corrected to say what the code does.

Relatedly: a test asserted `'Jul 1, 2026'` and passed **only because this machine is en-US**. It would have failed on a Dutch laptop. Updated, with the reason recorded inline.

## Verification

Tests pin both directions, and the second one is the point:

- today's output is unchanged (`25 Mar 2026`, `March 2026`, `Week 13, 2026`)
- **swapping the tag genuinely reformats** — verified against `es-ES` / `nl-NL` / `ja-JP`, which a hardcoded month array would have passed identically

Proof it works end to end — one line changed to `es-ES`:

```
day  : 25 mar 2026
month: marzo de 2026
```

Week-of-year stays a catalog pattern (`common.weekOfYear`) because Intl has no week format.

181 test files / 1493 vitest tests, 447 node tests, gate at 0, build clean.