### PR TITLE
feat(analysis): deterministic requirement checkers, starting with framework imports

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -136,6 +136,40 @@ Dashboard
   └─► opens  GET /api/jobs/<id>/logs/stream   (SSE: replay + tail; `event: done` on terminal)
 ```
 
+## Deterministic Requirement Checkers
+
+Some requirements are properties of the whole codebase rather than of any one
+file — "no transitive framework dependencies in core layers" cannot be judged
+by reading a single file, which is why they never produced a judgment at all.
+A requirement opts into a deterministic checker by naming it in the compiled
+standard:
+
+```json
+{ "id": "CLEA-DEP-06", "text": "...", "check": "framework-imports" }
+```
+
+At run time `analysis/checks/runner.py` resolves the named checkers, runs each
+once, filters the judgments back to the requirements that declared it, and
+folds the results into the dimension's evidence — as ordinary violations and
+compliances, so scoring, dismissal, the dashboard and the SQL projection need
+no special case. A checker that runs clean emits **one** compliance, because
+"no violations" and "never checked" must not look the same.
+
+Three rules hold everywhere in this path:
+
+- **Fail-soft.** A checker that raises, a standard that will not parse, a JSONL
+  that will not open — each costs the deterministic findings and nothing else.
+- **Forward compatible.** A `check` name this build does not know is skipped,
+  not an error: standards ship as data and outlive binaries.
+- **Never cached.** These are graph properties, and the per-file content cache
+  has no key that could express "the graph changed". They recompute per run.
+
+| Piece | File |
+|---|---|
+| Pure judgment logic | `src/quodeq/core/checks/` |
+| Import graph (the only I/O) | `src/quodeq/data/fs/import_graph.py` |
+| Registry + run wiring | `src/quodeq/analysis/checks/` |
+
 ## Key Design Rules
 
 1. **`status.json` is authoritative.** The index never holds state not derivable from `status.json` + filesystem signals. Delete `index.db` → next read rebuilds.

--- a/src/quodeq/analysis/checks/__init__.py
+++ b/src/quodeq/analysis/checks/__init__.py
@@ -1,0 +1,7 @@
+"""Deterministic checkers, wired into an evaluation run.
+
+``core/checks`` holds the pure judgment logic and ``data/fs/import_graph``
+reads the facts off disk. This package is the seam between them and the
+pipeline: it resolves which checkers a dimension's standard asked for, runs
+them, and merges the results into the run's evidence.
+"""

--- a/src/quodeq/analysis/checks/registry.py
+++ b/src/quodeq/analysis/checks/registry.py
@@ -1,0 +1,42 @@
+"""Name -> checker lookup.
+
+A requirement opts into a checker by naming it in the compiled standard
+(``"check": "framework-imports"``). Standards ship as data and outlive the
+binaries that read them, so a name this build does not recognise is ignored
+rather than treated as an error: an older quodeq reading a newer standard
+loses that check and keeps everything else.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from quodeq.core.checks.framework_deps import check_framework_dependencies
+from quodeq.core.checks.frameworks import FRAMEWORK_PACKAGES
+from quodeq.core.events.models import Judgment
+from quodeq.data.fs.import_graph import build_import_graph
+
+
+@dataclass(frozen=True)
+class CheckContext:
+    """What every checker gets: the project, its sources, and the dimension."""
+    root: Path
+    source_files: Sequence[str]
+    dimension: str
+
+
+def _framework_imports(context: CheckContext) -> list[Judgment]:
+    graph = build_import_graph(
+        context.root, [Path(f) for f in context.source_files],
+    )
+    return check_framework_dependencies(
+        graph,
+        framework_packages=FRAMEWORK_PACKAGES,
+        dimension=context.dimension,
+    )
+
+
+CHECKERS: dict[str, Callable[[CheckContext], list[Judgment]]] = {
+    "framework-imports": _framework_imports,
+}

--- a/src/quodeq/analysis/checks/runner.py
+++ b/src/quodeq/analysis/checks/runner.py
@@ -1,0 +1,218 @@
+"""Run a dimension's deterministic checkers and fold the results into its evidence.
+
+Every step here is fail-soft. A checker that raises, a standard that will not
+load, a JSONL that will not open -- each costs the deterministic findings and
+nothing else. The LLM's findings, the score and the run itself carry on. A
+check that can take a run down is worse than a check that does not exist.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Sequence
+from pathlib import Path
+
+from quodeq.analysis.checks.registry import CHECKERS, CheckContext
+from quodeq.core.events.models import Judgment, JudgmentCreatedEvent
+from quodeq.core.evidence._jsonl import judgment_to_dict
+from quodeq.core.evidence._req_mapping import build_principle_resolver
+from quodeq.core.evidence.model import Evidence, PrincipleEvidence
+from quodeq.data.fs.standards_loader import load_requirement_checks
+
+_logger = logging.getLogger(__name__)
+
+
+def deterministic_judgments(
+    *,
+    root: Path,
+    source_files: Sequence[str],
+    dimension: str,
+    compiled_dir: Path | None,
+    evaluators_dir: Path | None = None,
+) -> list[Judgment]:
+    """Judgments from every checker *dimension*'s standard asks for.
+
+    Each named checker runs once regardless of how many requirements name it,
+    and its judgments are filtered back to those requirements -- a standard
+    that declares the checker on only one of the two requirements it can
+    answer gets findings for that one only.
+    """
+    if not source_files:
+        return []
+    try:
+        declared = load_requirement_checks(compiled_dir, dimension, evaluators_dir)
+    except Exception:  # a broken standard must not stop the run
+        _logger.warning("checks: could not read %s's standard", dimension, exc_info=True)
+        return []
+    if not declared:
+        return []
+
+    context = CheckContext(root=Path(root), source_files=tuple(source_files),
+                           dimension=dimension)
+    out: list[Judgment] = []
+    for name in sorted(declared):
+        checker = CHECKERS.get(name)
+        if checker is None:
+            # A standard naming a checker this build does not have. Standards
+            # ship as data and outlive binaries; skip it and keep the rest.
+            _logger.info("checks: %r is not a checker this build knows", name)
+            continue
+        try:
+            produced = checker(context)
+        except Exception:  # one bad checker must not lose the others
+            _logger.warning("checks: %r failed on %s", name, root, exc_info=True)
+            continue
+        wanted = declared[name]
+        out.extend(j for j in produced if j.practice_id in wanted)
+    return out
+
+
+def _to_wire(j: Judgment) -> dict:
+    """Serialize a Judgment into the short-key JSONL row an LLM would have written.
+
+    Symmetric with ``core/evidence/_jsonl.parse_jsonl_line`` so a deterministic
+    finding re-reads exactly like any other: p=practice_id, t=verdict,
+    d=dimension, w=title, vt=violation_type.
+    """
+    row = {
+        "p": j.practice_id, "t": j.verdict, "d": j.dimension,
+        "file": j.file, "line": j.line, "severity": j.severity,
+        "reason": j.reason, "confidence": j.confidence,
+    }
+    for key, value in (("req", j.req), ("w", j.title), ("snippet", j.snippet),
+                       ("end_line", j.end_line), ("context", j.context),
+                       ("scope", j.scope), ("vt", j.violation_type)):
+        if value:
+            row[key] = value
+    return row
+
+
+def _merge_into_evidence(evidence: Evidence, judgments: list[Judgment],
+                         resolver) -> int:
+    """Add *judgments* to their principles, recomputing metrics. Returns the count.
+
+    A checker reports both verdicts: a violation when it found something and a
+    compliance when it ran clean. Routing on ``j.verdict`` rather than assuming
+    violations is what keeps a clean check from scoring as a defect.
+    """
+    added = 0
+    for j in judgments:
+        principle = resolver.resolve(j.practice_id)
+        if principle is None:
+            _logger.warning(
+                "checks: dropping %s — %r is not a principle of %r",
+                j.file, j.practice_id, j.dimension,
+            )
+            continue
+        pe = evidence.principles.get(principle)
+        if pe is None:
+            pe = PrincipleEvidence(
+                practice_id=principle, display_name=principle,
+                dimension=j.dimension, severity=j.severity,
+            )
+            evidence.principles[principle] = pe
+        row = [judgment_to_dict(j)]
+        if j.verdict == "compliance":
+            pe.add_compliance(row)
+        else:
+            pe.add_violations(row)
+        added += 1
+    return added
+
+
+def _persist(jsonl_path: Path, judgments: list[Judgment]) -> None:
+    """Append to the per-dim JSONL and mirror into the run's event log.
+
+    Both stores, always. The SQL projection runs off ``events.jsonl`` while
+    the report path reads the per-dim JSONL; writing only one is how the
+    dashboard and the CLI end up disagreeing about the same run.
+    """
+    try:
+        with jsonl_path.open("a", encoding="utf-8") as out:
+            for j in judgments:
+                out.write(json.dumps(_to_wire(j)) + "\n")
+    except OSError:
+        _logger.warning("checks: could not append to %s", jsonl_path, exc_info=True)
+
+    from quodeq.data.events.writer import EventLogWriter
+
+    try:
+        writer = EventLogWriter(jsonl_path.parent.parent / "events.jsonl")
+        for j in judgments:
+            writer.emit(JudgmentCreatedEvent(payload=j))
+    except Exception:  # the findings are already in the evidence
+        _logger.warning("checks: could not mirror findings to the event log", exc_info=True)
+
+
+def apply_deterministic_checks(
+    evidence: Evidence,
+    *,
+    root: Path,
+    source_files: Sequence[str],
+    dimension: str,
+    compiled_dir: Path | None,
+    jsonl_path: Path | None,
+    evaluators_dir: Path | None = None,
+) -> int:
+    """Run *dimension*'s checkers and fold the findings into *evidence*.
+
+    Returns how many findings were added. The evidence is updated before
+    anything is written, so a persistence failure costs the run's record of
+    these findings but never the score the user is shown for this run.
+    """
+    judgments = deterministic_judgments(
+        root=root, source_files=source_files, dimension=dimension,
+        compiled_dir=compiled_dir, evaluators_dir=evaluators_dir,
+    )
+    if not judgments:
+        return 0
+
+    resolver = build_principle_resolver(dimension, evaluators_dir, compiled_dir)
+    added = _merge_into_evidence(evidence, judgments, resolver)
+    if added and jsonl_path is not None:
+        _persist(jsonl_path, judgments)
+    return added
+
+
+def _project_source_files(config) -> list[str]:
+    """Every source file in the project, not just this dimension's dispatch list.
+
+    An import graph is only meaningful whole: the outer modules an inner file
+    reaches through are exactly the ones a dimension-scoped or incrementally
+    filtered list would leave out.
+    """
+    for holder in (config.target, config.manifest):
+        files = getattr(holder, "source_files", None) if holder is not None else None
+        if files:
+            return list(files)
+    return []
+
+
+def apply_checks_for_run(config, dimension: str, evidence: Evidence) -> int:
+    """``apply_deterministic_checks`` adapted to a :class:`RunConfig`.
+
+    Called once per dimension per run. The findings are recomputed every time
+    rather than cached: they are properties of the whole import graph, and the
+    per-file content cache has no key that could represent "the graph changed".
+
+    Swallows everything. This runs inside a dimension that has already
+    succeeded, and no deterministic check is worth failing that.
+    """
+    try:
+        source_files = _project_source_files(config)
+        if not source_files:
+            return 0
+        standards_dir = config.standards_dir
+        evidence_dir = config.work_dir or config.src
+        return apply_deterministic_checks(
+            evidence,
+            root=Path(config.src),
+            source_files=source_files,
+            dimension=dimension,
+            compiled_dir=(Path(standards_dir) / "compiled") if standards_dir else None,
+            evaluators_dir=config.evaluators_dir,
+            jsonl_path=Path(evidence_dir) / f"{dimension}_evidence.jsonl",
+        )
+    except Exception:  # a check must never fail a dimension that already succeeded
+        _logger.warning("checks: skipped for %s", dimension, exc_info=True)
+        return 0

--- a/src/quodeq/analysis/dimension_runner.py
+++ b/src/quodeq/analysis/dimension_runner.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from quodeq.analysis._types import RunConfig, _AnalysisContext
 from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+from quodeq.analysis.checks.runner import apply_checks_for_run
 from quodeq.analysis.subagents.runner import DimensionCallbacks
 from quodeq.core.evidence.model import Evidence
 from quodeq.analysis._runner_markers import emit_marker
@@ -59,6 +60,14 @@ class DimensionRunner:
         if ev is None:
             log_warning(f"[{idx}/{ctx.total}] {dim_id} — no valid evidence, skipping")
             return None
+
+        # Requirements the standard marks as deterministically checkable are
+        # answered here, from the whole import graph. They cannot come out of
+        # the per-file cache the way an LLM finding does -- "does anything in
+        # this project reach Flask" is not a property of any one file.
+        checked = apply_checks_for_run(config, dim_id, ev)
+        if checked:
+            log_info(f"   {dim_id} — {checked} finding(s) from deterministic checks")
 
         if emit_log:
             # The dimension has analytically succeeded. Guard the success-log

--- a/src/quodeq/core/checks/__init__.py
+++ b/src/quodeq/core/checks/__init__.py
@@ -1,0 +1,15 @@
+"""Deterministic requirement checkers -- pure logic, no I/O.
+
+Some requirements in a standard are properties of the whole codebase rather
+than of any single file: "dependencies point inward", "no transitive framework
+dependencies in core layers". A per-file LLM pass cannot judge them, which is
+why a third of the clean-architecture standard has never produced a judgment.
+
+A checker answers one such requirement deterministically from static facts
+(an import graph, a file list) and returns ordinary ``Judgment`` objects, so
+everything downstream -- scoring, dismissal, the dashboard, SQL projection --
+treats them like any other finding.
+
+Reading the facts off disk is the data layer's job (``data/fs/import_graph``);
+this package only decides what they mean.
+"""

--- a/src/quodeq/core/checks/framework_deps.py
+++ b/src/quodeq/core/checks/framework_deps.py
@@ -1,0 +1,225 @@
+"""Framework packages reaching the inner layers -- CLEA-FRM-01 / CLEA-DEP-06.
+
+Two requirements, one traversal of the import graph:
+
+* **CLEA-FRM-01** -- an inner-layer file imports a framework package itself.
+* **CLEA-DEP-06** -- an inner-layer file reaches a framework package *through
+  a first-party module that is not itself inner-layer*. This is the standard's
+  own example ("entity A imports utility B, utility B imports Flask") and the
+  reason a per-file scan can never judge it: nothing in A names Flask.
+
+The "not itself inner-layer" clause is what keeps the transitive rule usable.
+When the path runs through another inner file, that file already carries its
+own FRM-01 violation; repeating the fact at every downstream importer turns
+one defect into dozens of findings and buries the single place to fix it.
+"""
+from __future__ import annotations
+
+from collections import deque
+
+from quodeq.core.checks.layers import is_inner_layer_path
+from quodeq.core.checks.model import ImportEdge, ImportGraph, top_level
+from quodeq.core.events.models import Judgment
+
+REQ_DIRECT = "CLEA-FRM-01"
+REQ_TRANSITIVE = "CLEA-DEP-06"
+_SEVERITY = "major"
+_SOURCE_SUFFIXES = (".py", ".pyi", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs")
+
+
+def _module_name(path: str, first_party: frozenset[str]) -> str | None:
+    """Dotted module name for a source *path*, or None if it is not first-party.
+
+    Resolution is by convention: drop the extension, then keep the segments
+    from the first one that names a first-party package. ``src/app/utils.py``
+    with ``first_party={"app"}`` yields ``app.utils``; a path that never
+    mentions a first-party package yields None, because we would be guessing.
+    """
+    normalized = path.replace("\\", "/")
+    for suffix in _SOURCE_SUFFIXES:
+        if normalized.endswith(suffix):
+            normalized = normalized[: -len(suffix)]
+            break
+    segments = [s for s in normalized.split("/") if s]
+    if segments and segments[-1] == "__init__":
+        segments.pop()
+    for i, segment in enumerate(segments):
+        if segment in first_party:
+            return ".".join(segments[i:])
+    return None
+
+
+def _index(graph: ImportGraph) -> tuple[dict[str, list[ImportEdge]], dict[str, str]]:
+    """Return (imports by file, file by module name)."""
+    by_file: dict[str, list[ImportEdge]] = {}
+    for edge in graph.edges:
+        by_file.setdefault(edge.file, []).append(edge)
+    by_module: dict[str, str] = {}
+    for path in by_file:
+        module = _module_name(path, graph.first_party)
+        if module is not None:
+            by_module[module] = path
+    return by_file, by_module
+
+
+def _resolve(module: str, by_module: dict[str, str]) -> str | None:
+    """The first-party file a dotted *module* refers to, if we have its source.
+
+    ``app.utils.text.slugify`` imports a name out of ``app.utils.text``, so
+    walk the dotted name down until it matches a module we know.
+    """
+    parts = module.split(".")
+    while parts:
+        hit = by_module.get(".".join(parts))
+        if hit is not None:
+            return hit
+        parts.pop()
+    return None
+
+
+def _direct_frameworks(
+    edges: list[ImportEdge], framework_packages: frozenset[str],
+) -> dict[str, int]:
+    """{framework package: earliest line importing it} for one file."""
+    found: dict[str, int] = {}
+    for edge in edges:
+        package = top_level(edge.module)
+        if package in framework_packages:
+            found[package] = min(found.get(package, edge.line), edge.line)
+    return found
+
+
+def _transitive_frameworks(
+    origin: str,
+    by_file: dict[str, list[ImportEdge]],
+    by_module: dict[str, str],
+    framework_packages: frozenset[str],
+    first_party: frozenset[str],
+) -> dict[str, tuple[int, str]]:
+    """{framework package: (line in *origin*, path description)} reached indirectly.
+
+    Breadth-first so the recorded path is the shortest one, which is the most
+    readable explanation of why the dependency exists. Inner-layer files are
+    never traversed: they carry their own findings.
+    """
+    found: dict[str, tuple[int, str]] = {}
+    seen = {origin}
+    queue: deque[tuple[str, int, list[str]]] = deque()
+    for edge in by_file.get(origin, ()):
+        if top_level(edge.module) not in first_party:
+            continue
+        target = _resolve(edge.module, by_module)
+        if target is None or target in seen or is_inner_layer_path(target):
+            continue
+        seen.add(target)
+        queue.append((target, edge.line, [edge.module]))
+
+    while queue:
+        current, origin_line, chain = queue.popleft()
+        edges = by_file.get(current, [])
+        for package in _direct_frameworks(edges, framework_packages):
+            if package not in found:
+                found[package] = (origin_line, " -> ".join([*chain, package]))
+        for edge in edges:
+            if top_level(edge.module) not in first_party:
+                continue
+            target = _resolve(edge.module, by_module)
+            if target is None or target in seen or is_inner_layer_path(target):
+                continue
+            seen.add(target)
+            queue.append((target, origin_line, [*chain, edge.module]))
+    return found
+
+
+def _judgment(
+    *, req: str, dimension: str, file: str, line: int, reason: str, title: str,
+    verdict: str = "violation",
+) -> Judgment:
+    return Judgment(
+        practice_id=req, req=req, verdict=verdict, dimension=dimension,
+        file=file, line=line, reason=reason, title=title,
+        severity=_SEVERITY, confidence=100,
+    )
+
+
+def _clean_report(req: str, dimension: str, anchor: str, checked: int) -> Judgment:
+    """One compliance for a requirement the check covered and found clean.
+
+    Without this, a clean project produces no judgment for these requirements
+    and they stay exactly as unmeasured as they were before the checker
+    existed -- "no findings" would be indistinguishable from "never looked".
+    One instance, not one per file: the evidence is a single graph traversal,
+    and inflating the count would buy confidence the check has not earned.
+    """
+    label = "file" if checked == 1 else "files"
+    return _judgment(
+        req=req, dimension=dimension, file=anchor, line=1, verdict="compliance",
+        title="Inner layers are free of framework dependencies",
+        reason=(
+            f"Checked the import graph of {checked} inner-layer {label}: none "
+            f"imports a framework package, directly or through another "
+            f"first-party module."
+        ),
+    )
+
+
+def check_framework_dependencies(
+    graph: ImportGraph,
+    *,
+    framework_packages: frozenset[str],
+    dimension: str,
+) -> list[Judgment]:
+    """Judge CLEA-FRM-01 and CLEA-DEP-06 against *graph*.
+
+    Returns an empty list when the project has no recognisable inner layer or
+    no framework list -- there is nothing to judge, and inventing findings from
+    an unreadable layout is worse than staying quiet.
+    """
+    if not graph.edges or not framework_packages:
+        return []
+    by_file, by_module = _index(graph)
+    inner = sorted(f for f in by_file if is_inner_layer_path(f))
+    if not inner:
+        return []
+
+    judgments: list[Judgment] = []
+    for file in inner:
+        direct = _direct_frameworks(by_file[file], framework_packages)
+        for package in sorted(direct):
+            judgments.append(_judgment(
+                req=REQ_DIRECT, dimension=dimension, file=file, line=direct[package],
+                title=f"Inner layer imports framework package '{package}'",
+                reason=(
+                    f"This file is in an inner layer and imports the framework "
+                    f"package '{package}' directly. Clean Architecture keeps "
+                    f"frameworks at the edges: business rules must not depend on "
+                    f"the delivery mechanism."
+                ),
+            ))
+        transitive = _transitive_frameworks(
+            file, by_file, by_module, framework_packages, graph.first_party,
+        )
+        for package in sorted(transitive):
+            if package in direct:
+                continue  # already billed once, as a direct import
+            line, path = transitive[package]
+            judgments.append(_judgment(
+                req=REQ_TRANSITIVE, dimension=dimension, file=file, line=line,
+                title=f"Inner layer depends on framework '{package}' transitively",
+                reason=(
+                    f"This file is in an inner layer and reaches the framework "
+                    f"package '{package}' through {path}. Nothing in this file "
+                    f"names '{package}', so the dependency is invisible when "
+                    f"reading it, but the inner layer cannot be built or tested "
+                    f"without the framework."
+                ),
+            ))
+    # A requirement the traversal covered without finding anything is clean,
+    # and saying so is the difference between "measured" and "never looked".
+    violated = {j.practice_id for j in judgments}
+    for req in (REQ_DIRECT, REQ_TRANSITIVE):
+        if req not in violated:
+            judgments.append(_clean_report(req, dimension, inner[0], len(inner)))
+
+    judgments.sort(key=lambda j: (j.file, j.practice_id, j.line))
+    return judgments

--- a/src/quodeq/core/checks/frameworks.py
+++ b/src/quodeq/core/checks/frameworks.py
@@ -1,0 +1,39 @@
+"""Packages that count as frameworks or infrastructure for Clean Architecture.
+
+Uncle Bob's line is delivery-mechanism vs business rule: a web framework, an
+ORM, a message broker client, an HTTP client or a cloud SDK is a detail the
+inner layers must be able to survive without. The list is curated rather than
+"anything not in the standard library" because precision matters more than
+reach here -- one wrong entry turns every domain file into a false positive,
+and a report nobody trusts gets ignored wholesale.
+
+Entries are top-level import names, not distribution names (``rest_framework``,
+not ``djangorestframework``).
+"""
+from __future__ import annotations
+
+FRAMEWORK_PACKAGES = frozenset({
+    # Web / API frameworks and their servers
+    "aiohttp", "bottle", "django", "falcon", "fastapi", "flask", "litestar",
+    "pyramid", "quart", "sanic", "starlette", "tornado", "rest_framework",
+    "gunicorn", "uvicorn", "werkzeug", "wsgiref",
+    # Templating and presentation
+    "jinja2", "mako", "chameleon",
+    # ORMs, query builders, migrations
+    "alembic", "mongoengine", "peewee", "pony", "sqlalchemy", "sqlmodel",
+    "tortoise",
+    # Database and cache drivers
+    "asyncpg", "mysql", "psycopg", "psycopg2", "pymongo", "pymysql", "redis",
+    "cassandra", "elasticsearch",
+    # Validation / serialization frameworks that impose base classes
+    "marshmallow", "pydantic",
+    # Task queues and messaging
+    "celery", "dramatiq", "kafka", "kombu", "pika", "rq",
+    # HTTP clients and cloud SDKs
+    "aiobotocore", "azure", "boto3", "botocore", "google", "httpx", "requests",
+    "urllib3",
+    # CLI frameworks (a delivery mechanism like any other)
+    "click", "typer",
+    # GraphQL, scraping, dashboards
+    "graphene", "strawberry", "scrapy", "dash", "streamlit",
+})

--- a/src/quodeq/core/checks/layers.py
+++ b/src/quodeq/core/checks/layers.py
@@ -1,0 +1,55 @@
+"""Which files hold inner-layer code, by directory convention.
+
+A checker can only judge a project whose layers it can name. We read that
+from directory names because the alternative -- inferring layers from import
+shape -- reports architecture violations at projects that never claimed to
+have an architecture.
+
+The consequence is deliberate: a project with no recognisable inner layer
+produces NO findings. Not a pass, not a wall of violations. Silence is the
+honest answer when the standard's subject cannot be located.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+# Directory names that conventionally hold enterprise/application logic --
+# the layers Clean Architecture requires to stay free of outer concerns.
+#
+# ``models`` is deliberately absent: it names the ORM directory at least as
+# often as the domain one, and a wrong guess here mislabels every finding
+# built on top of it.
+INNER_LAYER_DIRS = frozenset({
+    "domain",
+    "entities",
+    "entity",
+    "usecases",
+    "use_cases",
+    "use-cases",
+    "interactors",
+    "application",
+    "core",
+    "business",
+})
+
+
+def _segments(path: str) -> list[str]:
+    """Path segments, tolerating Windows separators."""
+    return [s for s in path.replace("\\", "/").split("/") if s]
+
+
+def is_inner_layer_path(path: str) -> bool:
+    """True when *path* sits under a conventional inner-layer directory.
+
+    Matching is on whole path segments: ``core_utils/`` is not ``core/``.
+    The final segment is the file name and never counts as a directory.
+    """
+    segments = _segments(path)
+    if len(segments) < 2:
+        return False
+    return any(s.lower() in INNER_LAYER_DIRS for s in segments[:-1])
+
+
+def inner_layer_files(paths: Iterable[str]) -> frozenset[str]:
+    """The subset of *paths* that live in an inner layer (possibly empty)."""
+    return frozenset(p for p in paths if is_inner_layer_path(p))

--- a/src/quodeq/core/checks/model.py
+++ b/src/quodeq/core/checks/model.py
@@ -1,0 +1,39 @@
+"""Static facts a checker reasons about."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ImportEdge:
+    """One import statement: *file* imports *module* at *line*.
+
+    ``module`` is the dotted name as written in the source
+    (``pydantic.fields``, ``app.utils.text``), not a resolved file path --
+    resolution needs the project layout and belongs to whoever built the
+    graph.
+    """
+    file: str
+    line: int
+    module: str
+
+
+@dataclass(frozen=True)
+class ImportGraph:
+    """Every intra-project import edge, plus which packages are first-party.
+
+    ``first_party`` holds top-level package names owned by the project
+    (``{"quodeq"}``, ``{"app", "lib"}``). Anything else is a dependency whose
+    source we cannot see, so a checker must not traverse through it.
+    """
+    edges: tuple[ImportEdge, ...] = ()
+    first_party: frozenset[str] = field(default_factory=frozenset)
+
+    def files(self) -> frozenset[str]:
+        """Every file that imports something."""
+        return frozenset(e.file for e in self.edges)
+
+
+def top_level(module: str) -> str:
+    """The root package of a dotted module name (``a.b.c`` -> ``a``)."""
+    return (module or "").split(".", 1)[0]

--- a/src/quodeq/core/standards/refs.py
+++ b/src/quodeq/core/standards/refs.py
@@ -89,6 +89,27 @@ def extract_requirements(data: dict, overrides: dict[str, dict] | None = None) -
     return lookup
 
 
+def extract_requirement_checks(data: dict) -> dict[str, frozenset[str]]:
+    """Extract ``{check_name: {req_id, ...}}`` from a compiled-standards dict.
+
+    A requirement opts into a deterministic checker by naming it
+    (``"check": "framework-imports"``). Grouping by checker name lets the
+    caller run each one once no matter how many requirements it answers, then
+    filter the judgments back to the requirements that actually asked.
+
+    Requirements without a ``check`` are absent from the result, so a standard
+    that declares none costs nothing.
+    """
+    grouped: dict[str, set[str]] = {}
+    for principle in data.get("principles", []):
+        for req in principle.get("requirements", []):
+            name = req.get("check")
+            req_id = req.get("id")
+            if isinstance(name, str) and name and req_id:
+                grouped.setdefault(name, set()).add(req_id)
+    return {name: frozenset(ids) for name, ids in grouped.items()}
+
+
 # ---------------------------------------------------------------------------
 # The one I/O function core still owns.
 #

--- a/src/quodeq/data/fs/import_graph.py
+++ b/src/quodeq/data/fs/import_graph.py
@@ -1,0 +1,183 @@
+"""Build an :class:`ImportGraph` from a project's source files.
+
+The checkers in ``core/checks`` are pure functions over the graph; this is the
+one place that touches the disk for them.
+
+Parsing goes through ``ast`` rather than a regex. A regex that misses an
+import fails silently in the worst direction: the checker then reports the
+dependency as absent. A file that will not parse contributes no edges at all,
+which is visibly incomplete rather than quietly wrong.
+
+Python only for now. Source in other languages simply yields no edges, so a
+mixed repo is judged on its Python and stays quiet about the rest.
+"""
+from __future__ import annotations
+
+import ast
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+
+from quodeq.core.checks.model import ImportEdge, ImportGraph
+
+_logger = logging.getLogger(__name__)
+_PY_SUFFIXES = (".py", ".pyi")
+
+
+def _relative_python_files(root: Path, files: Iterable[Path]) -> list[str]:
+    """Repo-relative posix paths of the readable Python files inside *root*.
+
+    Paths outside *root* are dropped: a caller-supplied file list is not a
+    licence to read anywhere on the disk.
+    """
+    out: list[str] = []
+    for raw in files:
+        path = Path(raw)
+        if not path.is_absolute():
+            path = root / path
+        if path.suffix not in _PY_SUFFIXES:
+            continue
+        try:
+            rel = path.resolve().relative_to(root)
+        except (ValueError, OSError):
+            continue
+        if path.is_file():
+            out.append(rel.as_posix())
+    return sorted(set(out))
+
+
+def _package_roots(root: Path, rel_files: Iterable[str]) -> tuple[set[str], set[str]]:
+    """Return (first-party package names, package-root dirs relative to *root*).
+
+    A package is the topmost directory in a file's ancestry that still has an
+    ``__init__.py``; its parent is the directory imports resolve against. That
+    makes ``src/`` layouts work without naming ``src`` as a package.
+    """
+    names: set[str] = set()
+    roots: set[str] = set()
+    for rel in rel_files:
+        parts = Path(rel).parts[:-1]
+        topmost: int | None = None
+        for depth in range(len(parts), 0, -1):
+            if (root.joinpath(*parts[:depth]) / "__init__.py").is_file():
+                topmost = depth
+            else:
+                break
+        if topmost is None:
+            continue
+        names.add(parts[topmost - 1])
+        roots.add("/".join(parts[: topmost - 1]))
+    return names, roots
+
+
+def _module_exists(root: Path, package_roots: set[str], module: str) -> bool:
+    """True when *module* names a first-party file or package on disk."""
+    tail = module.replace(".", "/")
+    for prefix in package_roots:
+        base = root / prefix if prefix else root
+        if (base / f"{tail}.py").is_file() or (base / tail / "__init__.py").is_file():
+            return True
+    return False
+
+
+def _own_package(rel: str, package_roots: set[str]) -> str | None:
+    """The dotted package *containing* the file at *rel*.
+
+    This is what a single leading dot resolves against: for ``a/b/c.py`` it is
+    ``a.b``, and for ``a/b/__init__.py`` it is ``a.b`` as well, since that file
+    *is* the package.
+    """
+    path = Path(rel)
+    segments = list(path.parts)
+    segments[-1] = path.stem
+    is_init = segments[-1] == "__init__"
+    if is_init:
+        segments.pop()
+    for prefix in sorted(package_roots, key=len, reverse=True):
+        depth = len(Path(prefix).parts) if prefix else 0
+        if prefix and "/".join(segments[:depth]) != prefix:
+            continue
+        remainder = segments[depth:]
+        if not remainder:
+            continue
+        own = remainder if is_init else remainder[:-1]
+        return ".".join(own) if own else None
+    return None
+
+
+def _from_import_base(node: ast.ImportFrom, own_package: str | None) -> str | None:
+    """Absolute module a ``from ... import`` refers to, resolving relative levels.
+
+    An unresolvable relative import (no known package for the file, or more
+    dots than it has parents) yields None: an edge pointing at the wrong module
+    is worse than a missing one.
+    """
+    if not node.level:
+        return node.module or None
+    if own_package is None:
+        return None
+    segments = own_package.split(".")
+    if node.level > 1:
+        segments = segments[: -(node.level - 1)]
+    if not segments:
+        return None
+    base = ".".join(segments)
+    return f"{base}.{node.module}" if node.module else base
+
+
+def _edges_for_file(
+    root: Path, rel: str, package_roots: set[str],
+) -> list[ImportEdge]:
+    """Parse one file into import edges (empty on any read/parse failure)."""
+    try:
+        tree = ast.parse((root / rel).read_text(encoding="utf-8"), filename=rel)
+    except (OSError, UnicodeDecodeError, SyntaxError, ValueError) as exc:
+        _logger.debug("import graph: skipping %s (%s)", rel, exc)
+        return []
+
+    own = _own_package(rel, package_roots)
+    seen: set[tuple[str, int]] = set()
+    edges: list[ImportEdge] = []
+
+    def add(module: str | None, line: int) -> None:
+        if not module or (module, line) in seen:
+            return
+        seen.add((module, line))
+        edges.append(ImportEdge(file=rel, line=line, module=module))
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                add(alias.name, node.lineno)
+        elif isinstance(node, ast.ImportFrom):
+            base = _from_import_base(node, own)
+            if not base:
+                continue
+            # ``from app.utils import text`` names a module when app/utils/text
+            # exists, and an attribute of app.utils when it doesn't. Prefer the
+            # module: that is the edge the graph can actually be traversed on.
+            for alias in node.names:
+                candidate = f"{base}.{alias.name}"
+                if alias.name != "*" and _module_exists(root, package_roots, candidate):
+                    add(candidate, node.lineno)
+                else:
+                    add(base, node.lineno)
+    return edges
+
+
+def build_import_graph(root: Path, files: Iterable[Path]) -> ImportGraph:
+    """Parse *files* under *root* into an :class:`ImportGraph`.
+
+    *files* is supplied by the caller (the analysis pipeline already knows the
+    project's source files and its ignore rules) so this module never walks the
+    tree or re-implements ignore handling.
+    """
+    root = Path(root).resolve()
+    rel_files = _relative_python_files(root, files)
+    if not rel_files:
+        return ImportGraph()
+    first_party, package_roots = _package_roots(root, rel_files)
+    edges: list[ImportEdge] = []
+    for rel in rel_files:
+        edges.extend(_edges_for_file(root, rel, package_roots))
+    return ImportGraph(edges=tuple(edges), first_party=frozenset(first_party))

--- a/src/quodeq/data/fs/standards_loader.py
+++ b/src/quodeq/data/fs/standards_loader.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from quodeq.core.standards.refs import (
     _load_compiled_data,
+    extract_requirement_checks,
     extract_requirements,
     load_compiled_refs,
 )
@@ -66,6 +67,22 @@ def load_compiled_requirements(
     if not data:
         return {}
     return extract_requirements(data, overrides=overrides)
+
+
+def load_requirement_checks(
+    compiled_dir: str | Path | None, dimension: str | None,
+    evaluators_dir: Path | None = None,
+) -> dict[str, frozenset[str]]:
+    """Load ``{check_name: {req_id, ...}}`` for *dimension* from disk.
+
+    Empty when the dimension has no standard on disk or none of its
+    requirements declares a checker -- both mean "nothing deterministic to
+    run", which callers treat identically.
+    """
+    data = _load_compiled_data(compiled_dir, dimension, evaluators_dir=evaluators_dir)
+    if not data:
+        return {}
+    return extract_requirement_checks(data)
 
 
 def build_req_refs_lookup(compiled_dir: Path, dimension: str) -> dict[str, list[dict]]:

--- a/src/quodeq/data/standards/compiled/clean-architecture.json
+++ b/src/quodeq/data/standards/compiled/clean-architecture.json
@@ -45,7 +45,8 @@
           "id": "CLEA-DEP-06",
           "text": "No transitive framework dependencies in core layers",
           "description": "Even indirect imports of framework packages in entities or use cases violate the rule. If entity A imports utility B, and utility B imports Flask, then entity A has a transitive framework dependency",
-          "refs": []
+          "refs": [],
+          "check": "framework-imports"
         },
         {
           "id": "CLEA-DEP-07",
@@ -117,7 +118,8 @@
           "id": "CLEA-FRM-01",
           "text": "Core business logic must not import framework packages",
           "description": "Use case and entity files should have zero imports from web frameworks, ORMs, or DI containers. Check the import section of every file in domain/ and usecases/ — any framework import is a violation",
-          "refs": []
+          "refs": [],
+          "check": "framework-imports"
         },
         {
           "id": "CLEA-FRM-02",

--- a/tests/analysis/test_deterministic_checks.py
+++ b/tests/analysis/test_deterministic_checks.py
@@ -1,0 +1,373 @@
+"""Wiring deterministic checkers into a run.
+
+A requirement opts into a checker by naming it: ``"check": "framework-imports"``
+in the compiled standard. At run time every named checker executes once, its
+judgments are filtered back to the requirements that asked for it, and they
+join the dimension's evidence like any other finding.
+
+Three properties matter more than the mechanism:
+
+* **Forward compatible** -- a standard naming a checker this build does not
+  have is ignored, not an error. Standards ship as data and outlive binaries.
+* **Fail-soft** -- anything that goes wrong here loses the deterministic
+  findings and keeps the LLM's. A checker must never take a run down.
+* **Both stores** -- findings reach the per-dim JSONL *and* ``events.jsonl``.
+  The SQL projection reads the latter, so writing only one makes the
+  dashboard and the CLI disagree about the same run.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from quodeq.analysis.checks.runner import (
+    apply_deterministic_checks,
+    deterministic_judgments,
+)
+from quodeq.core.evidence.model import Evidence
+
+STANDARD = {
+    "id": "clean-architecture",
+    "principles": [
+        {
+            "name": "Independence from Frameworks",
+            "requirements": [{"id": "CLEA-FRM-01", "text": "no frameworks inside",
+                              "check": "framework-imports"}],
+        },
+        {
+            "name": "Dependency Rule",
+            "requirements": [{"id": "CLEA-DEP-06", "text": "no transitive frameworks",
+                              "check": "framework-imports"}],
+        },
+    ],
+}
+
+
+@pytest.fixture
+def project(tmp_path):
+    """A tiny layered project: domain -> utils -> flask."""
+    for rel, body in (
+        ("app/__init__.py", ""),
+        ("app/domain/__init__.py", ""),
+        ("app/domain/order.py", "from app.utils import text\n"),
+        ("app/utils/__init__.py", ""),
+        ("app/utils/text.py", "import flask\n"),
+    ):
+        path = tmp_path / "repo" / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    return tmp_path / "repo"
+
+
+@pytest.fixture
+def compiled(tmp_path):
+    def _write(standard):
+        compiled_dir = tmp_path / "compiled"
+        compiled_dir.mkdir(exist_ok=True)
+        (compiled_dir / "clean-architecture.json").write_text(
+            json.dumps(standard), encoding="utf-8")
+        return compiled_dir
+    return _write
+
+
+SOURCES = ("app/domain/order.py", "app/utils/text.py", "app/utils/__init__.py")
+
+
+def _judge(project, compiled_dir, dimension="clean-architecture"):
+    return deterministic_judgments(
+        root=project, source_files=SOURCES, dimension=dimension,
+        compiled_dir=compiled_dir,
+    )
+
+
+class TestDiscovery:
+    def test_a_declared_checker_runs(self, project, compiled):
+        """order.py reaches flask through utils, and no inner file imports it
+        directly -- so DEP-06 is violated and FRM-01 comes back clean."""
+        judgments = _judge(project, compiled(STANDARD))
+
+        assert [(j.practice_id, j.verdict, j.file) for j in judgments] == [
+            ("CLEA-DEP-06", "violation", "app/domain/order.py"),
+            ("CLEA-FRM-01", "compliance", "app/domain/order.py"),
+        ]
+
+    def test_a_standard_declaring_no_checks_runs_nothing(self, project, compiled):
+        bare = {"principles": [{"name": "Dependency Rule",
+                                "requirements": [{"id": "CLEA-DEP-06", "text": "x"}]}]}
+
+        assert _judge(project, compiled(bare)) == []
+
+    def test_an_unknown_checker_name_is_ignored(self, project, compiled):
+        """Standards ship as data and outlive the binaries that read them."""
+        future = {"principles": [{"name": "Dependency Rule", "requirements": [
+            {"id": "CLEA-DEP-06", "text": "x", "check": "quantum-entanglement"}]}]}
+
+        assert _judge(project, compiled(future)) == []
+
+    def test_judgments_are_filtered_to_the_declaring_requirements(self, project, compiled):
+        """The checker can answer FRM-01 too, but only DEP-06 asked."""
+        partial = {"principles": [{"name": "Dependency Rule", "requirements": [
+            {"id": "CLEA-DEP-06", "text": "x", "check": "framework-imports"}]}]}
+        direct = {"principles": [{"name": "Independence from Frameworks", "requirements": [
+            {"id": "CLEA-FRM-01", "text": "x", "check": "framework-imports"}]}]}
+
+        assert [(j.practice_id, j.verdict)
+                for j in _judge(project, compiled(partial))] == [
+            ("CLEA-DEP-06", "violation"),
+        ]
+        # utils/text.py imports flask directly but is not an inner layer, so
+        # FRM-01 is clean -- and the checker's DEP-06 verdict is filtered out
+        # because this standard never asked for it.
+        assert [(j.practice_id, j.verdict)
+                for j in _judge(project, compiled(direct))] == [
+            ("CLEA-FRM-01", "compliance"),
+        ]
+
+    def test_a_checker_runs_once_for_many_declaring_requirements(self, project, compiled):
+        """Two requirements naming one checker must not double the findings."""
+        judgments = _judge(project, compiled(STANDARD))
+
+        assert len(judgments) == len({(j.practice_id, j.file, j.line) for j in judgments})
+
+
+class TestFailSoft:
+    def test_no_standard_for_the_dimension(self, project, compiled):
+        assert _judge(project, compiled(STANDARD), dimension="security") == []
+
+    def test_no_compiled_dir(self, project):
+        assert deterministic_judgments(
+            root=project, source_files=SOURCES, dimension="clean-architecture",
+            compiled_dir=None,
+        ) == []
+
+    def test_no_source_files(self, project, compiled):
+        assert deterministic_judgments(
+            root=project, source_files=(), dimension="clean-architecture",
+            compiled_dir=compiled(STANDARD),
+        ) == []
+
+    def test_a_checker_that_raises_does_not_take_the_run_down(
+        self, project, compiled, monkeypatch,
+    ):
+        from quodeq.analysis.checks import registry
+
+        def boom(_context):
+            raise RuntimeError("checker exploded")
+
+        monkeypatch.setitem(registry.CHECKERS, "framework-imports", boom)
+
+        assert _judge(project, compiled(STANDARD)) == []
+
+
+class TestApplyToARun:
+    def _evidence(self):
+        return Evidence(repository="r", language="python", date="2026-08-02",
+                        source_file_count=3, files_read=3, coverage_pct=100.0)
+
+    def _apply(self, project, compiled_dir, tmp_path):
+        jsonl = tmp_path / "run" / "evidence" / "clean-architecture_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        jsonl.touch()
+        evidence = self._evidence()
+        added = apply_deterministic_checks(
+            evidence, root=project, source_files=SOURCES,
+            dimension="clean-architecture", compiled_dir=compiled_dir, jsonl_path=jsonl,
+        )
+        return added, evidence, jsonl
+
+    def test_findings_land_in_the_evidence_under_their_principle(
+        self, project, compiled, tmp_path,
+    ):
+        added, evidence, _ = self._apply(project, compiled(STANDARD), tmp_path)
+
+        assert added == 2
+        assert sorted(evidence.principles) == [
+            "Dependency Rule", "Independence from Frameworks",
+        ]
+        violated = evidence.principles["Dependency Rule"]
+        assert [v["file"] for v in violated.violations] == ["app/domain/order.py"]
+        assert violated.metrics["violating"] == 1, "metrics must be recomputed"
+
+        clean = evidence.principles["Independence from Frameworks"]
+        assert len(clean.compliance) == 1
+        assert clean.violations == [], "a clean check must not score as a defect"
+
+    def test_findings_merge_into_an_existing_principle(self, project, compiled, tmp_path):
+        from quodeq.core.evidence.model import PrincipleEvidence
+
+        jsonl = tmp_path / "run" / "evidence" / "d.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        evidence = self._evidence()
+        evidence.principles["Dependency Rule"] = PrincipleEvidence(
+            practice_id="Dependency Rule", display_name="Dependency Rule",
+            dimension="clean-architecture", severity="major",
+            violations=[{"file": "other.py", "line": 1}],
+        )
+
+        apply_deterministic_checks(
+            evidence, root=project, source_files=SOURCES,
+            dimension="clean-architecture", compiled_dir=compiled(STANDARD),
+            jsonl_path=jsonl,
+        )
+
+        assert len(evidence.principles["Dependency Rule"].violations) == 2
+
+    def test_findings_reach_the_jsonl_and_the_event_log(self, project, compiled, tmp_path):
+        _added, _evidence, jsonl = self._apply(project, compiled(STANDARD), tmp_path)
+
+        wire = [json.loads(line) for line in jsonl.read_text(encoding="utf-8").splitlines()]
+        assert [(w["p"], w["t"]) for w in wire] == [
+            ("CLEA-DEP-06", "violation"), ("CLEA-FRM-01", "compliance"),
+        ]
+        assert wire[0]["file"] == "app/domain/order.py"
+
+        events = jsonl.parent.parent / "events.jsonl"
+        assert events.is_file(), "the SQL projection reads events.jsonl, not the dim JSONL"
+        payloads = [json.loads(line)["payload"]
+                    for line in events.read_text(encoding="utf-8").splitlines()]
+        assert [p["practice_id"] for p in payloads] == ["CLEA-DEP-06", "CLEA-FRM-01"]
+
+    def test_the_wire_rows_round_trip_back_to_judgments(self, project, compiled, tmp_path):
+        """Whatever we write must parse the way an LLM finding would."""
+        from quodeq.core.evidence._jsonl import parse_jsonl_line
+
+        _added, _evidence, jsonl = self._apply(project, compiled(STANDARD), tmp_path)
+
+        parsed = parse_jsonl_line(jsonl.read_text(encoding="utf-8").splitlines()[0])
+        assert parsed is not None
+        judgment, _refs = parsed
+        assert judgment.practice_id == "CLEA-DEP-06"
+        assert judgment.severity == "major"
+        assert judgment.file == "app/domain/order.py"
+
+    def test_nothing_found_writes_nothing(self, project, compiled, tmp_path):
+        clean = {"principles": [{"name": "Dependency Rule", "requirements": [
+            {"id": "CLEA-DEP-06", "text": "x"}]}]}
+
+        added, evidence, jsonl = self._apply(project, compiled(clean), tmp_path)
+
+        assert added == 0
+        assert evidence.principles == {}
+        assert jsonl.read_text(encoding="utf-8") == ""
+        assert not (jsonl.parent.parent / "events.jsonl").exists()
+
+    def test_an_unwritable_jsonl_still_updates_the_evidence(
+        self, project, compiled, tmp_path,
+    ):
+        """A persistence failure must not cost the in-memory findings."""
+        evidence = self._evidence()
+
+        added = apply_deterministic_checks(
+            evidence, root=project, source_files=SOURCES,
+            dimension="clean-architecture", compiled_dir=compiled(STANDARD),
+            jsonl_path=tmp_path / "nonexistent" / "deep" / "x.jsonl",
+        )
+
+        assert added == 2
+        assert "Dependency Rule" in evidence.principles
+
+
+class TestRunWiring:
+    """Adapting a RunConfig into checker inputs, and the call site itself."""
+
+    def _config(self, project, compiled_dir, tmp_path, *, manifest=True):
+        from types import SimpleNamespace
+
+        from quodeq.analysis._types import RunConfig
+
+        work_dir = tmp_path / "run" / "evidence"
+        work_dir.mkdir(parents=True, exist_ok=True)
+        return RunConfig(
+            src=project, language="python",
+            standards_dir=compiled_dir.parent,
+            work_dir=work_dir,
+            manifest=SimpleNamespace(source_files=list(SOURCES)) if manifest else None,
+        )
+
+    def test_findings_land_using_the_projects_full_source_list(
+        self, project, compiled, tmp_path,
+    ):
+        """The graph needs outer modules too, so it uses the project-wide list
+        rather than whatever this dimension happened to dispatch."""
+        from quodeq.analysis.checks.runner import apply_checks_for_run
+
+        config = self._config(project, compiled(STANDARD), tmp_path)
+        evidence = Evidence(repository="r", language="python", date="d",
+                            source_file_count=3, files_read=3, coverage_pct=100.0)
+
+        added = apply_checks_for_run(config, "clean-architecture", evidence)
+
+        assert added == 2
+        assert "Dependency Rule" in evidence.principles
+        assert (tmp_path / "run" / "evidence"
+                / "clean-architecture_evidence.jsonl").is_file()
+
+    def test_a_run_with_no_manifest_adds_nothing(self, project, compiled, tmp_path):
+        from quodeq.analysis.checks.runner import apply_checks_for_run
+
+        config = self._config(project, compiled(STANDARD), tmp_path, manifest=False)
+        evidence = Evidence(repository="r", language="python", date="d",
+                            source_file_count=0, files_read=0, coverage_pct=0.0)
+
+        assert apply_checks_for_run(config, "clean-architecture", evidence) == 0
+
+    def test_a_broken_config_never_raises(self, tmp_path):
+        """The call site is inside a dimension run; it must not be able to fail it."""
+        from unittest.mock import MagicMock
+
+        from quodeq.analysis.checks.runner import apply_checks_for_run
+
+        evidence = Evidence(repository="r", language="python", date="d",
+                            source_file_count=0, files_read=0, coverage_pct=0.0)
+
+        assert apply_checks_for_run(MagicMock(), "clean-architecture", evidence) == 0
+
+    def test_the_dimension_runner_calls_it_with_the_parsed_evidence(self):
+        from unittest.mock import MagicMock, patch
+
+        from quodeq.analysis.dimension_runner import DimensionRunner
+
+        evidence = Evidence(repository="r", language="python", date="d",
+                            source_file_count=1, files_read=1, coverage_pct=100.0)
+        ctx = MagicMock()
+        ctx.total = 1
+
+        with patch("quodeq.analysis.dimension_runner.process_dimension_with_cache",
+                   return_value=evidence), \
+             patch("quodeq.analysis.dimension_runner.apply_checks_for_run",
+                   return_value=0) as applied:
+            result = DimensionRunner().run(MagicMock(), "clean-architecture", 1, ctx)
+
+        assert result is evidence
+        assert applied.call_args.args[1:] == ("clean-architecture", evidence)
+
+    def test_a_failed_dimension_runs_no_checks(self):
+        """No evidence means the dimension did not run; nothing to add to."""
+        from unittest.mock import MagicMock, patch
+
+        from quodeq.analysis.dimension_runner import DimensionRunner
+
+        with patch("quodeq.analysis.dimension_runner.process_dimension_with_cache",
+                   return_value=None), \
+             patch("quodeq.analysis.dimension_runner.apply_checks_for_run") as applied:
+            DimensionRunner().run(MagicMock(), "clean-architecture", 1, MagicMock())
+
+        applied.assert_not_called()
+
+
+class TestBundledStandard:
+    def test_clean_architecture_declares_the_framework_checker(self):
+        """The shipped standard is what makes any of this run for real users."""
+        from quodeq.config.paths import default_paths
+
+        compiled = default_paths().standards_dir / "compiled" / "clean-architecture.json"
+        data = json.loads(compiled.read_text(encoding="utf-8"))
+        checks = {
+            req["id"]: req.get("check")
+            for principle in data["principles"] for req in principle["requirements"]
+        }
+
+        assert checks["CLEA-FRM-01"] == "framework-imports"
+        assert checks["CLEA-DEP-06"] == "framework-imports"
+        assert checks["CLEA-DEP-01"] is None, "the inward rule needs a declared layer map first"

--- a/tests/core/test_checks_framework_deps.py
+++ b/tests/core/test_checks_framework_deps.py
@@ -1,0 +1,233 @@
+"""Framework dependencies reaching the inner layers -- CLEA-FRM-01, CLEA-DEP-06.
+
+Twenty of the clean-architecture standard's fifty-two requirements have never
+produced a single judgment, because they are properties of the import graph
+and a per-file LLM pass cannot see a graph. CLEA-DEP-06 is the clearest case:
+"if entity A imports utility B, and utility B imports Flask, then A has a
+transitive framework dependency". Reading A tells you nothing about Flask.
+
+Two requirements, one traversal:
+
+* **CLEA-FRM-01** (direct) -- an inner-layer file imports a framework itself.
+* **CLEA-DEP-06** (transitive) -- an inner-layer file reaches a framework
+  *through a first-party module that is not itself inner-layer*.
+
+The "not itself inner-layer" clause is what keeps this from avalanching. If
+the path runs through another inner file, that file already carries its own
+FRM-01 violation; re-reporting the same fact at every downstream importer
+turns one defect into fifty findings and buries the fix site.
+"""
+from __future__ import annotations
+
+from quodeq.core.checks.framework_deps import check_framework_dependencies
+from quodeq.core.checks.model import ImportEdge, ImportGraph
+
+FRAMEWORKS = frozenset({"flask", "pydantic", "django"})
+
+
+def _graph(*edges: tuple[str, int, str]) -> ImportGraph:
+    return ImportGraph(
+        edges=tuple(ImportEdge(file=f, line=n, module=m) for f, n, m in edges),
+        first_party=frozenset({"app"}),
+    )
+
+
+def _run(graph: ImportGraph) -> list:
+    return check_framework_dependencies(
+        graph, framework_packages=FRAMEWORKS, dimension="clean-architecture",
+    )
+
+
+def _violations(graph: ImportGraph) -> list:
+    """Only the violations -- a clean requirement also reports itself clean."""
+    return [j for j in _run(graph) if j.verdict == "violation"]
+
+
+class TestDirectFrameworkImports:
+    def test_inner_file_importing_a_framework_is_a_violation(self):
+        judgments = _violations(_graph(("app/domain/order.py", 3, "flask")))
+
+        assert len(judgments) == 1
+        j = judgments[0]
+        assert j.practice_id == "CLEA-FRM-01"
+        assert j.req == "CLEA-FRM-01"
+        assert j.file == "app/domain/order.py"
+        assert j.line == 3
+        assert "flask" in j.reason
+
+    def test_submodule_import_resolves_to_its_top_level_package(self):
+        judgments = _violations(_graph(("app/domain/order.py", 3, "pydantic.fields")))
+
+        assert [j.practice_id for j in judgments] == ["CLEA-FRM-01"]
+
+    def test_outer_layer_files_may_import_frameworks_freely(self):
+        assert _violations(_graph(("app/api/routes.py", 1, "flask"))) == []
+
+    def test_non_framework_imports_are_ignored(self):
+        assert _violations(_graph(("app/domain/order.py", 1, "decimal"))) == []
+
+    def test_one_violation_per_file_and_package_not_per_import(self):
+        """Ten `from flask import x` lines are one defect, not ten findings."""
+        judgments = _violations(_graph(
+            ("app/domain/order.py", 3, "flask"),
+            ("app/domain/order.py", 4, "flask.helpers"),
+            ("app/domain/order.py", 5, "flask"),
+        ))
+
+        assert len(judgments) == 1
+        assert judgments[0].line == 3, "report the first occurrence"
+
+    def test_distinct_packages_are_distinct_findings(self):
+        judgments = _violations(_graph(
+            ("app/domain/order.py", 3, "flask"),
+            ("app/domain/order.py", 4, "django"),
+        ))
+
+        assert len(judgments) == 2
+
+
+class TestTransitiveFrameworkDependencies:
+    def test_inner_reaches_a_framework_through_an_outer_utility(self):
+        """The standard's own example: A -> B -> Flask, where B is a utility."""
+        judgments = _violations(_graph(
+            ("app/domain/order.py", 2, "app.utils.text"),
+            ("app/utils/text.py", 1, "flask"),
+        ))
+
+        assert len(judgments) == 1
+        j = judgments[0]
+        assert j.practice_id == "CLEA-DEP-06"
+        assert j.file == "app/domain/order.py"
+        assert j.line == 2, "report at the import that pulls the dependency in"
+        assert "flask" in j.reason
+        assert "app.utils.text" in j.reason, "the reason must name the path"
+
+    def test_a_path_through_another_inner_file_is_not_re_reported(self):
+        """Collapse the cascade: the inner file that imports the framework
+        already carries FRM-01, so its importers add nothing but noise."""
+        judgments = _violations(_graph(
+            ("app/domain/order.py", 2, "app.domain.money"),
+            ("app/domain/money.py", 1, "pydantic"),
+        ))
+
+        assert [j.practice_id for j in judgments] == ["CLEA-FRM-01"]
+        assert judgments[0].file == "app/domain/money.py"
+
+    def test_multi_hop_paths_through_outer_modules_resolve(self):
+        judgments = _violations(_graph(
+            ("app/domain/order.py", 2, "app.utils.a"),
+            ("app/utils/a.py", 1, "app.utils.b"),
+            ("app/utils/b.py", 1, "django"),
+        ))
+
+        assert [(j.practice_id, j.file) for j in judgments] == [
+            ("CLEA-DEP-06", "app/domain/order.py"),
+        ]
+
+    def test_direct_wins_over_transitive_for_the_same_package(self):
+        """Don't bill one file twice for one package."""
+        judgments = _violations(_graph(
+            ("app/domain/order.py", 2, "flask"),
+            ("app/domain/order.py", 3, "app.utils.text"),
+            ("app/utils/text.py", 1, "flask"),
+        ))
+
+        assert [j.practice_id for j in judgments] == ["CLEA-FRM-01"]
+
+    def test_import_cycles_terminate(self):
+        judgments = _violations(_graph(
+            ("app/domain/order.py", 2, "app.utils.a"),
+            ("app/utils/a.py", 1, "app.utils.b"),
+            ("app/utils/b.py", 1, "app.utils.a"),
+        ))
+
+        assert judgments == []
+
+    def test_third_party_modules_are_not_traversed(self):
+        """We can only see first-party source; a non-first-party hop is opaque."""
+        assert _violations(_graph(
+            ("app/domain/order.py", 2, "somelib.helpers"),
+            ("app/utils/text.py", 1, "flask"),
+        )) == []
+
+
+class TestCleanProjectsAreMeasured:
+    """A requirement nobody ever judges is not "passing", it is unmeasured.
+
+    These two requirements sat at zero judgments for the whole life of the
+    standard. Emitting violations alone would keep them there for every clean
+    project -- so a check that ran and found nothing says so, once, with the
+    scope it covered.
+    """
+
+    def test_a_clean_inner_layer_yields_one_compliance_per_requirement(self):
+        judgments = _run(_graph(("app/domain/order.py", 1, "decimal")))
+
+        assert [(j.practice_id, j.verdict) for j in judgments] == [
+            ("CLEA-DEP-06", "compliance"), ("CLEA-FRM-01", "compliance"),
+        ]
+
+    def test_the_compliance_states_what_was_checked(self):
+        judgments = _run(_graph(
+            ("app/domain/order.py", 1, "decimal"),
+            ("app/entities/user.py", 1, "typing"),
+        ))
+
+        assert all("2 inner-layer file" in j.reason for j in judgments)
+
+    def test_a_violated_requirement_gets_no_compliance(self):
+        """Only the requirement that came back clean is reported clean."""
+        judgments = _run(_graph(("app/domain/order.py", 3, "flask")))
+
+        assert [(j.practice_id, j.verdict) for j in judgments] == [
+            ("CLEA-DEP-06", "compliance"), ("CLEA-FRM-01", "violation"),
+        ]
+
+    def test_the_compliance_is_anchored_to_a_stable_file(self):
+        """Same project, same anchor -- otherwise dismissing it never sticks."""
+        graph = _graph(("app/entities/user.py", 1, "typing"),
+                       ("app/domain/order.py", 1, "decimal"))
+
+        anchors = {j.file for j in _run(graph)}
+
+        assert anchors == {"app/domain/order.py"}, "first inner file, sorted"
+
+    def test_an_unlayered_project_is_not_reported_clean(self):
+        """Nothing was checked, so there is nothing to certify."""
+        assert _run(_graph(("main.py", 1, "decimal"))) == []
+
+
+class TestFailSoft:
+    def test_no_inner_layer_yields_no_findings(self):
+        """An unlayered project is not judged, in either direction."""
+        assert _run(_graph(("main.py", 1, "flask"), ("utils.py", 1, "django"))) == []
+
+    def test_empty_graph(self):
+        assert _run(ImportGraph()) == []
+
+    def test_no_framework_list_yields_no_findings(self):
+        assert check_framework_dependencies(
+            _graph(("app/domain/order.py", 1, "flask")),
+            framework_packages=frozenset(), dimension="clean-architecture",
+        ) == []
+
+
+class TestJudgmentShape:
+    def test_findings_carry_the_dimension_and_a_severity(self):
+        j = _violations(_graph(("app/domain/order.py", 3, "flask")))[0]
+
+        assert j.dimension == "clean-architecture"
+        assert j.severity == "major"
+        assert j.confidence == 100, "a graph fact is not a guess"
+
+    def test_output_is_deterministic(self):
+        graph = _graph(
+            ("app/domain/b.py", 1, "django"),
+            ("app/domain/a.py", 1, "flask"),
+            ("app/entities/c.py", 1, "pydantic"),
+        )
+
+        first = [(j.file, j.practice_id) for j in _run(graph)]
+        second = [(j.file, j.practice_id) for j in _run(graph)]
+
+        assert first == second == sorted(first)

--- a/tests/core/test_checks_layers.py
+++ b/tests/core/test_checks_layers.py
@@ -1,0 +1,63 @@
+"""Inner-layer detection: which files hold the code that must stay pure.
+
+A deterministic checker can only judge a project whose layers it can name.
+Detection is by convention (``domain/``, ``entities/``, ``usecases/``,
+``core/``, ...) because the alternative -- guessing from import shape -- is
+how you get an architecture report full of noise about a project that never
+claimed to be layered.
+
+The fail-soft rule matters more than the name table: a project with no
+recognisable inner layer yields NO findings, not a clean bill of health and
+not a wall of violations. Silence is the honest answer when we cannot see.
+"""
+from __future__ import annotations
+
+from quodeq.core.checks.layers import inner_layer_files, is_inner_layer_path
+
+
+class TestIsInnerLayerPath:
+    def test_conventional_inner_directories(self):
+        for path in (
+            "src/domain/order.py",
+            "src/entities/user.py",
+            "app/usecases/place_order.py",
+            "app/use_cases/place_order.py",
+            "src/quodeq/core/evidence/model.py",
+            "lib/interactors/checkout.rb",
+        ):
+            assert is_inner_layer_path(path), path
+
+    def test_outer_directories_are_not_inner(self):
+        for path in (
+            "src/api/routes.py",
+            "src/infrastructure/db.py",
+            "src/adapters/sql_repo.py",
+            "src/ui/components/Button.jsx",
+            "main.py",
+        ):
+            assert not is_inner_layer_path(path), path
+
+    def test_matching_is_on_a_whole_path_segment(self):
+        """``core_utils/`` is not ``core/`` -- substring matching invents layers."""
+        assert not is_inner_layer_path("src/core_utils/helpers.py")
+        assert not is_inner_layer_path("src/domainservices/x.py")
+
+    def test_ambiguous_names_are_not_inner(self):
+        """``models/`` is the ORM directory as often as the domain one."""
+        assert not is_inner_layer_path("src/models/user.py")
+
+    def test_windows_separators_resolve(self):
+        assert is_inner_layer_path("src\\domain\\order.py")
+
+    def test_blank_input(self):
+        assert not is_inner_layer_path("")
+
+
+class TestInnerLayerFiles:
+    def test_selects_only_inner_paths(self):
+        paths = ["src/domain/a.py", "src/api/b.py", "src/entities/c.py"]
+        assert inner_layer_files(paths) == frozenset({"src/domain/a.py", "src/entities/c.py"})
+
+    def test_no_inner_layer_yields_empty(self):
+        """The fail-soft gate: an unlayered project is not judged."""
+        assert inner_layer_files(["main.py", "utils.py", "server.py"]) == frozenset()

--- a/tests/data/test_import_graph.py
+++ b/tests/data/test_import_graph.py
@@ -1,0 +1,168 @@
+"""Building the import graph off disk -- the only I/O a checker needs.
+
+The checkers in ``core/checks`` are pure functions over an ``ImportGraph``.
+This is where the graph comes from: parse each source file, record what it
+imports, and work out which top-level packages the project owns.
+
+Parsing is via ``ast``, not regex, because the failure mode of a regex here is
+silent: a missed import is a dependency the checker reports as absent. A file
+that will not parse contributes nothing rather than half a file's worth of
+edges.
+"""
+from __future__ import annotations
+
+from quodeq.data.fs.import_graph import build_import_graph
+
+
+def _write(root, rel: str, body: str):
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+class TestFirstPartyDetection:
+    def test_packages_are_the_topmost_dir_with_an_init(self, tmp_path):
+        _write(tmp_path, "app/__init__.py", "")
+        _write(tmp_path, "app/domain/__init__.py", "")
+        _write(tmp_path, "app/domain/order.py", "import flask\n")
+
+        graph = build_import_graph(tmp_path, [tmp_path / "app/domain/order.py"])
+
+        assert graph.first_party == frozenset({"app"})
+
+    def test_src_layout_is_seen_through(self, tmp_path):
+        _write(tmp_path, "src/mypkg/__init__.py", "")
+        _write(tmp_path, "src/mypkg/core/__init__.py", "")
+        _write(tmp_path, "src/mypkg/core/x.py", "import os\n")
+
+        graph = build_import_graph(tmp_path, [tmp_path / "src/mypkg/core/x.py"])
+
+        assert graph.first_party == frozenset({"mypkg"}), "src/ is not a package"
+
+    def test_a_flat_script_owns_no_package(self, tmp_path):
+        _write(tmp_path, "main.py", "import flask\n")
+
+        graph = build_import_graph(tmp_path, [tmp_path / "main.py"])
+
+        assert graph.first_party == frozenset()
+
+
+class TestEdges:
+    def test_plain_and_from_imports(self, tmp_path):
+        _write(tmp_path, "app/__init__.py", "")
+        _write(tmp_path, "app/x.py", "import flask\nfrom pydantic import BaseModel\n")
+
+        graph = build_import_graph(tmp_path, [tmp_path / "app/x.py"])
+
+        assert {(e.module, e.line) for e in graph.edges} == {("flask", 1), ("pydantic", 2)}
+
+    def test_paths_are_repo_relative_posix(self, tmp_path):
+        _write(tmp_path, "app/__init__.py", "")
+        _write(tmp_path, "app/sub/mod.py", "import os\n")
+
+        graph = build_import_graph(tmp_path, [tmp_path / "app/sub/mod.py"])
+
+        assert [e.file for e in graph.edges] == ["app/sub/mod.py"]
+
+    def test_dotted_from_import_keeps_the_full_module(self, tmp_path):
+        _write(tmp_path, "app/__init__.py", "")
+        _write(tmp_path, "app/x.py", "from app.utils.text import slugify\n")
+
+        graph = build_import_graph(tmp_path, [tmp_path / "app/x.py"])
+
+        assert [e.module for e in graph.edges] == ["app.utils.text"]
+
+    def test_relative_imports_resolve_to_absolute_modules(self, tmp_path):
+        """``from . import x`` inside app/domain must become app.domain.x --
+        an unresolved relative import is an edge the checker cannot follow."""
+        _write(tmp_path, "app/__init__.py", "")
+        _write(tmp_path, "app/domain/__init__.py", "")
+        _write(tmp_path, "app/domain/money.py", "")
+        _write(tmp_path, "app/utils/__init__.py", "")
+        _write(tmp_path, "app/utils/text.py", "")
+        _write(tmp_path, "app/domain/order.py",
+               "from . import money\nfrom ..utils import text\n")
+
+        graph = build_import_graph(tmp_path, [tmp_path / "app/domain/order.py"])
+
+        assert {e.module for e in graph.edges} == {"app.domain.money", "app.utils.text"}
+
+    def test_an_imported_name_that_is_not_a_module_keeps_the_package(self, tmp_path):
+        """``from app.utils import slugify`` imports a function, not a module."""
+        _write(tmp_path, "app/__init__.py", "")
+        _write(tmp_path, "app/utils/__init__.py", "")
+        _write(tmp_path, "app/x.py", "from app.utils import slugify\n")
+
+        graph = build_import_graph(tmp_path, [tmp_path / "app/x.py"])
+
+        assert [e.module for e in graph.edges] == ["app.utils"]
+
+    def test_function_body_imports_are_edges_too(self, tmp_path):
+        """A deferred import is still a dependency."""
+        _write(tmp_path, "app/__init__.py", "")
+        _write(tmp_path, "app/x.py", "def f():\n    import flask\n    return flask\n")
+
+        graph = build_import_graph(tmp_path, [tmp_path / "app/x.py"])
+
+        assert [e.module for e in graph.edges] == ["flask"]
+
+
+class TestFailSoft:
+    def test_a_file_that_will_not_parse_contributes_nothing(self, tmp_path):
+        _write(tmp_path, "app/__init__.py", "")
+        _write(tmp_path, "app/broken.py", "def (:\n")
+        _write(tmp_path, "app/ok.py", "import flask\n")
+
+        graph = build_import_graph(
+            tmp_path, [tmp_path / "app/broken.py", tmp_path / "app/ok.py"],
+        )
+
+        assert [e.file for e in graph.edges] == ["app/ok.py"]
+
+    def test_missing_and_non_python_files_are_skipped(self, tmp_path):
+        _write(tmp_path, "app/__init__.py", "")
+        _write(tmp_path, "app/notes.md", "# hi\n")
+
+        graph = build_import_graph(
+            tmp_path, [tmp_path / "app/notes.md", tmp_path / "app/gone.py"],
+        )
+
+        assert graph.edges == ()
+
+    def test_paths_outside_the_root_are_skipped(self, tmp_path):
+        """A file list is not a licence to read anywhere on the disk."""
+        outside = tmp_path.parent / "outside.py"
+        outside.write_text("import flask\n", encoding="utf-8")
+        root = tmp_path / "repo"
+        _write(root, "app/__init__.py", "")
+
+        assert build_import_graph(root, [outside]).edges == ()
+
+    def test_empty_file_list(self, tmp_path):
+        assert build_import_graph(tmp_path, []).edges == ()
+
+
+class TestEndToEndWithTheChecker:
+    def test_a_transitive_framework_dependency_is_found_on_disk(self, tmp_path):
+        """The whole point, exercised through real files."""
+        from quodeq.core.checks.framework_deps import check_framework_dependencies
+
+        _write(tmp_path, "app/__init__.py", "")
+        _write(tmp_path, "app/domain/__init__.py", "")
+        _write(tmp_path, "app/domain/order.py", "from app.utils import text\n")
+        _write(tmp_path, "app/utils/__init__.py", "")
+        _write(tmp_path, "app/utils/text.py", "import flask\n")
+
+        graph = build_import_graph(tmp_path, [
+            tmp_path / "app/domain/order.py",
+            tmp_path / "app/utils/text.py",
+            tmp_path / "app/utils/__init__.py",
+        ])
+        judgments = check_framework_dependencies(
+            graph, framework_packages=frozenset({"flask"}), dimension="clean-architecture",
+        )
+
+        assert [(j.practice_id, j.file) for j in judgments if j.verdict == "violation"] == [
+            ("CLEA-DEP-06", "app/domain/order.py"),
+        ]


### PR DESCRIPTION
## The gap this closes

Twenty of the clean-architecture standard's fifty-two requirements have never produced a single judgment. Not because the model finds them hard, but because they are unanswerable from where it stands: *"no transitive framework dependencies in core layers"* is a property of the import graph, and the scan reads one file at a time. Reading an entity tells you nothing about what its utility module pulls in three hops away.

So a third of our own standard has been decoration. This makes the first slice of it measurable.

## The mechanism

A requirement names a checker in the compiled standard:

```json
{ "id": "CLEA-DEP-06", "text": "...", "check": "framework-imports" }
```

Each named checker runs once per dimension per run, its judgments are filtered back to the requirements that declared it, and the results join the evidence as ordinary violations and compliances. Scoring, dismissal, the dashboard and the SQL projection need no special case.

Findings reach the per-dim JSONL **and** `events.jsonl`. The projection reads the latter, and writing only one store is how the CLI and the dashboard end up disagreeing about the same run.

## The first checker

Answers two requirements from one traversal:

- **CLEA-FRM-01** — an inner-layer file imports a framework package directly.
- **CLEA-DEP-06** — it reaches one *through a first-party module that is not itself inner-layer*.

That last clause is what makes the transitive rule usable. When the path runs through another inner file, that file already carries its own FRM-01 violation; repeating the fact at every downstream importer turns one defect into dozens of findings and buries the single place to fix it.

A clean check emits **one** compliance rather than nothing — "no violations" and "never checked" reading identically is the exact problem this set out to fix. One instance, not one per file: inflating the count would buy confidence the traversal has not earned.

## Result on quodeq itself

508 Python files, and both requirements report for the first time:

```
[compliance] CLEA-DEP-06  core/checks/framework_deps.py:1
    Checked the import graph of 58 inner-layer files: none imports a framework
    package, directly or through another first-party module.

[violation ] CLEA-FRM-01  core/events/models.py:8
    This file is in an inner layer and imports the framework package 'pydantic'
    directly.
```

One true violation, and the cascade correctly collapsed — the ~40 core modules that import `models.py` are consequences, not independent defects. The DEP-06 compliance is real: after the WS4 purification, `core/` imports nothing outside `core/`, so there is no transitive path to find.

## Choices worth your review time

- **Layers are detected by directory convention** (`domain`, `entities`, `usecases`, `core`, ...), and a project with no recognisable inner layer yields **no findings at all**. Silence is the honest answer when the standard's subject cannot be located. Inferring layers from import shape reports architecture violations at projects that never claimed to have an architecture.
- **`models/` is deliberately not an inner-layer name.** It is the ORM directory at least as often as the domain one, and a wrong guess there mislabels everything built on top of it.
- **The framework list is curated**, not "anything outside the standard library". One wrong entry turns every domain file into a false positive, and a report nobody trusts gets ignored wholesale.
- **Parsing is `ast`, not regex.** A regex that misses an import fails in the worst direction: the checker then reports the dependency as *absent*.
- **Nothing is cached.** These are graph properties; the per-file content cache has no key that could express "the graph changed". They recompute every run, which is cheap.
- **Everything is fail-soft.** A checker that raises, a standard that will not parse, a JSONL that will not open — each costs the deterministic findings and nothing else. A check that can fail a run is worse than a check that does not exist.
- **Forward compatible.** A `check` name this build does not know is skipped, not an error. Standards ship as data and outlive binaries.

## Deliberately not in scope

**CLEA-DEP-01 (the inward rule) is not wired.** It needs a declared layer map first, otherwise it flags every `services -> data` edge in a codebase that allows them on purpose — including ours. That declaration is a design decision, not something to default.

JS/TS produces no edges yet, so a mixed repo is judged on its Python and stays quiet about the rest.

## Layering

`core/checks/` is pure, `data/fs/import_graph.py` does the only I/O, `analysis/checks/` is the seam. Import baseline unchanged at 17.

## Verification

- 5575 passed, 1 skipped (`pytest -m "not integration"`)
- `tools/check_imports.py`: no new violations
- Checker run end-to-end against this repo, output above
