### PR TITLE
feat(analysis): two more deterministic checkers, entity imports and config reads

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -167,8 +167,22 @@ Three rules hold everywhere in this path:
 | Piece | File |
 |---|---|
 | Pure judgment logic | `src/quodeq/core/checks/` |
-| Import graph (the only I/O) | `src/quodeq/data/fs/import_graph.py` |
-| Registry + run wiring | `src/quodeq/analysis/checks/` |
+| Static facts off disk (the only I/O) | `src/quodeq/data/fs/import_graph.py`, `symbol_uses.py` |
+| Registry + fact memo + run wiring | `src/quodeq/analysis/checks/` |
+
+Shipped checkers, and the requirements they answer:
+
+| `check` | Requirements |
+|---|---|
+| `framework-imports` | CLEA-FRM-01, CLEA-DEP-06 |
+| `entity-imports` | CLEA-DEP-02 |
+| `config-reads` | CLEA-DEP-07 |
+
+Adding one is: a pure function in `core/checks/` returning `Judgment`s, an entry
+in `CHECKERS`, and a `"check"` key on the requirement. New facts (beyond the
+import graph and symbol uses) get their own collector in `data/fs/` and a lazy
+accessor on `CheckContext`, which memoises per context so several checkers
+share one walk of the tree.
 
 ## Key Design Rules
 

--- a/src/quodeq/analysis/checks/registry.py
+++ b/src/quodeq/analysis/checks/registry.py
@@ -1,42 +1,81 @@
-"""Name -> checker lookup.
+"""Name -> checker lookup, and the facts they share.
 
 A requirement opts into a checker by naming it in the compiled standard
 (``"check": "framework-imports"``). Standards ship as data and outlive the
 binaries that read them, so a name this build does not recognise is ignored
 rather than treated as an error: an older quodeq reading a newer standard
 loses that check and keeps everything else.
+
+Every checker reads the same import graph. Parsing it once per context, and
+only when a checker actually asks, keeps three checkers from walking the tree
+three times without paying for facts nobody wanted.
 """
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
+from quodeq.core.checks.config_reads import CONFIG_SYMBOLS, check_config_reads
+from quodeq.core.checks.entity_imports import check_entity_imports
 from quodeq.core.checks.framework_deps import check_framework_dependencies
 from quodeq.core.checks.frameworks import FRAMEWORK_PACKAGES
+from quodeq.core.checks.model import ImportGraph, SymbolUse
 from quodeq.core.events.models import Judgment
 from quodeq.data.fs.import_graph import build_import_graph
+from quodeq.data.fs.symbol_uses import build_symbol_uses
 
 
 @dataclass(frozen=True)
 class CheckContext:
-    """What every checker gets: the project, its sources, and the dimension."""
+    """What every checker gets: the project, its sources, and the dimension.
+
+    Also memoises the parsed facts, so several checkers over one context share
+    a single walk of the tree. The cache lives on the context rather than in a
+    module global: it is then scoped to the call that created it, and two
+    projects can never see each other's graph.
+    """
     root: Path
     source_files: Sequence[str]
     dimension: str
+    _cache: dict = field(default_factory=dict, repr=False, compare=False)
+
+    def _paths(self) -> list[Path]:
+        return [Path(f) for f in self.source_files]
+
+    def graph(self) -> ImportGraph:
+        if "graph" not in self._cache:
+            self._cache["graph"] = build_import_graph(self.root, self._paths())
+        return self._cache["graph"]
+
+    def config_symbol_uses(self) -> tuple[SymbolUse, ...]:
+        if "uses" not in self._cache:
+            self._cache["uses"] = build_symbol_uses(
+                self.root, self._paths(), CONFIG_SYMBOLS,
+            )
+        return self._cache["uses"]
 
 
 def _framework_imports(context: CheckContext) -> list[Judgment]:
-    graph = build_import_graph(
-        context.root, [Path(f) for f in context.source_files],
-    )
     return check_framework_dependencies(
-        graph,
+        context.graph(),
         framework_packages=FRAMEWORK_PACKAGES,
         dimension=context.dimension,
     )
 
 
+def _entity_imports(context: CheckContext) -> list[Judgment]:
+    return check_entity_imports(context.graph(), dimension=context.dimension)
+
+
+def _config_reads(context: CheckContext) -> list[Judgment]:
+    return check_config_reads(
+        context.graph(), context.config_symbol_uses(), dimension=context.dimension,
+    )
+
+
 CHECKERS: dict[str, Callable[[CheckContext], list[Judgment]]] = {
     "framework-imports": _framework_imports,
+    "entity-imports": _entity_imports,
+    "config-reads": _config_reads,
 }

--- a/src/quodeq/core/checks/_judgments.py
+++ b/src/quodeq/core/checks/_judgments.py
@@ -1,0 +1,38 @@
+"""One shape for every deterministic finding.
+
+Checkers are added over time by different hands; without a shared constructor
+they drift on severity, confidence and whether a clean result says anything at
+all. Those are exactly the fields that decide how a finding scores.
+"""
+from __future__ import annotations
+
+from quodeq.core.events.models import Judgment
+
+SEVERITY = "major"
+_CONFIDENCE = 100  # a static fact is not a guess
+
+
+def violation(*, req: str, dimension: str, file: str, line: int,
+              title: str, reason: str) -> Judgment:
+    return Judgment(
+        practice_id=req, req=req, verdict="violation", dimension=dimension,
+        file=file, line=line, title=title, reason=reason,
+        severity=SEVERITY, confidence=_CONFIDENCE,
+    )
+
+
+def compliance(*, req: str, dimension: str, anchor: str,
+               title: str, reason: str) -> Judgment:
+    """A requirement the check covered and found clean.
+
+    Emitting nothing would leave the requirement exactly as unmeasured as it
+    was before the checker existed -- "no violations" and "never looked" must
+    not read the same. One instance per requirement, not one per file:
+    confidence is scored on instance count, and a single traversal has not
+    earned more than one.
+    """
+    return Judgment(
+        practice_id=req, req=req, verdict="compliance", dimension=dimension,
+        file=anchor, line=1, title=title, reason=reason,
+        severity=SEVERITY, confidence=_CONFIDENCE,
+    )

--- a/src/quodeq/core/checks/config_reads.py
+++ b/src/quodeq/core/checks/config_reads.py
@@ -1,0 +1,93 @@
+"""Configuration read from an inner layer -- CLEA-DEP-07.
+
+"Configuration and environment variables are not read in inner layers." The
+requirement is easy to state and easy to miss by eye, because the environment
+reaches the inner layer under a dozen spellings: ``os.environ``, an aliased
+``import os as o``, ``from os import getenv``, or a config package that hides
+the read behind its own API. A text search finds the first spelling and misses
+the rest; parsed and alias-resolved, they all look the same.
+
+Business rules that read their own configuration cannot be instantiated twice
+with different settings, which is the practical cost the requirement is about.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from quodeq.core.checks._judgments import compliance, violation
+from quodeq.core.checks.layers import inner_layer_files
+from quodeq.core.checks.model import ImportGraph, SymbolUse, top_level
+from quodeq.core.events.models import Judgment
+
+REQ = "CLEA-DEP-07"
+
+# Dotted names whose use means "this code reads its environment".
+CONFIG_SYMBOLS = frozenset({
+    "os.environ", "os.environb", "os.getenv", "os.getenvb", "os.putenv",
+})
+
+# Packages that exist to load configuration. Importing one into an inner layer
+# is the same defect as reading os.environ there, one level of indirection up.
+CONFIG_PACKAGES = frozenset({
+    "dotenv", "configparser", "dynaconf", "decouple", "environs",
+    "pydantic_settings", "hydra", "omegaconf",
+})
+
+
+def check_config_reads(
+    graph: ImportGraph,
+    symbol_uses: Sequence[SymbolUse],
+    *,
+    dimension: str,
+) -> list[Judgment]:
+    """Judge CLEA-DEP-07 against *graph* and the resolved *symbol_uses*.
+
+    Empty when the project has no recognisable inner layer.
+    """
+    known = graph.files() | {u.file for u in symbol_uses}
+    inner = sorted(inner_layer_files(known))
+    if not inner:
+        return []
+
+    inner_set = set(inner)
+    # One finding per (file, source): three os.environ reads in one module are
+    # one dependency on the environment.
+    first_line: dict[tuple[str, str], int] = {}
+
+    def note(file: str, source: str, line: int) -> None:
+        key = (file, source)
+        first_line[key] = min(first_line.get(key, line), line)
+
+    for use in symbol_uses:
+        if use.file in inner_set and use.symbol in CONFIG_SYMBOLS:
+            note(use.file, use.symbol, use.line)
+    for edge in graph.edges:
+        if edge.file in inner_set and top_level(edge.module) in CONFIG_PACKAGES:
+            note(edge.file, top_level(edge.module), edge.line)
+
+    judgments = [
+        violation(
+            req=REQ, dimension=dimension, file=file, line=line,
+            title=f"Inner layer reads configuration via '{source}'",
+            reason=(
+                f"This file is in an inner layer and reads configuration "
+                f"through '{source}'. Business rules that fetch their own "
+                f"settings cannot be run twice with different ones: pass the "
+                f"values in from the layer that owns them."
+            ),
+        )
+        for (file, source), line in first_line.items()
+    ]
+    if not judgments:
+        count = len(inner)
+        label = "file" if count == 1 else "files"
+        judgments.append(compliance(
+            req=REQ, dimension=dimension, anchor=inner[0],
+            title="Inner layers do not read configuration",
+            reason=(
+                f"Checked {count} inner-layer {label}: none reads the "
+                f"environment or imports a configuration package."
+            ),
+        ))
+    judgments.sort(key=lambda j: (j.file, j.line))
+    return judgments

--- a/src/quodeq/core/checks/entity_imports.py
+++ b/src/quodeq/core/checks/entity_imports.py
@@ -1,0 +1,75 @@
+"""Entities importing outward -- CLEA-DEP-02.
+
+"Entities must not import from use case or adapter layers." A per-file pass can
+see the import statement but not what the imported module *is*: whether
+``app.gateways.orders`` is an adapter or just a badly named domain helper is a
+question about the project's shape, and shape is what a graph has.
+
+Judged on the imported module's dotted name rather than by resolving it to a
+file, so the verdict holds even when that module's source is outside the
+scanned file list -- which is the normal case for anything the scan skipped.
+
+Scope is entities specifically, not every inner layer. A use case reaching an
+adapter is the inward rule (CLEA-DEP-01), and reporting it here would file one
+requirement's finding under another's ID.
+"""
+from __future__ import annotations
+
+from quodeq.core.checks._judgments import compliance, violation
+from quodeq.core.checks.layers import is_entity_layer_path, is_outer_layer_module
+from quodeq.core.checks.model import ImportGraph, top_level
+from quodeq.core.events.models import Judgment
+
+REQ = "CLEA-DEP-02"
+
+
+def check_entity_imports(graph: ImportGraph, *, dimension: str) -> list[Judgment]:
+    """Judge CLEA-DEP-02 against *graph*.
+
+    Empty when the project has no directory we can name as its entity layer:
+    an unnameable layer is one we have no standing to judge.
+    """
+    entities = sorted(f for f in graph.files() if is_entity_layer_path(f))
+    if not entities:
+        return []
+
+    entity_set = set(entities)
+    # One finding per (entity file, target module): ten imports of the same
+    # adapter are one dependency, and the fix is the same edit.
+    first_line: dict[tuple[str, str], int] = {}
+    for edge in graph.edges:
+        if edge.file not in entity_set:
+            continue
+        if top_level(edge.module) not in graph.first_party:
+            continue  # third-party is a framework question (CLEA-FRM-01)
+        if not is_outer_layer_module(edge.module):
+            continue
+        key = (edge.file, edge.module)
+        first_line[key] = min(first_line.get(key, edge.line), edge.line)
+
+    judgments = [
+        violation(
+            req=REQ, dimension=dimension, file=file, line=line,
+            title=f"Entity layer imports '{module}'",
+            reason=(
+                f"This file is in the entity layer and imports '{module}', "
+                f"which lives in an outer layer. Dependencies point inward: "
+                f"entities must be usable without the adapters and delivery "
+                f"mechanisms built on top of them."
+            ),
+        )
+        for (file, module), line in first_line.items()
+    ]
+    if not judgments:
+        count = len(entities)
+        label = "file" if count == 1 else "files"
+        judgments.append(compliance(
+            req=REQ, dimension=dimension, anchor=entities[0],
+            title="Entity layer has no outward dependencies",
+            reason=(
+                f"Checked the imports of {count} entity-layer {label}: none "
+                f"reaches a use case, adapter or infrastructure package."
+            ),
+        ))
+    judgments.sort(key=lambda j: (j.file, j.line))
+    return judgments

--- a/src/quodeq/core/checks/framework_deps.py
+++ b/src/quodeq/core/checks/framework_deps.py
@@ -17,13 +17,13 @@ from __future__ import annotations
 
 from collections import deque
 
+from quodeq.core.checks._judgments import compliance, violation
 from quodeq.core.checks.layers import is_inner_layer_path
 from quodeq.core.checks.model import ImportEdge, ImportGraph, top_level
 from quodeq.core.events.models import Judgment
 
 REQ_DIRECT = "CLEA-FRM-01"
 REQ_TRANSITIVE = "CLEA-DEP-06"
-_SEVERITY = "major"
 _SOURCE_SUFFIXES = (".py", ".pyi", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs")
 
 
@@ -131,29 +131,11 @@ def _transitive_frameworks(
     return found
 
 
-def _judgment(
-    *, req: str, dimension: str, file: str, line: int, reason: str, title: str,
-    verdict: str = "violation",
-) -> Judgment:
-    return Judgment(
-        practice_id=req, req=req, verdict=verdict, dimension=dimension,
-        file=file, line=line, reason=reason, title=title,
-        severity=_SEVERITY, confidence=100,
-    )
-
-
 def _clean_report(req: str, dimension: str, anchor: str, checked: int) -> Judgment:
-    """One compliance for a requirement the check covered and found clean.
-
-    Without this, a clean project produces no judgment for these requirements
-    and they stay exactly as unmeasured as they were before the checker
-    existed -- "no findings" would be indistinguishable from "never looked".
-    One instance, not one per file: the evidence is a single graph traversal,
-    and inflating the count would buy confidence the check has not earned.
-    """
+    """One compliance for a requirement the check covered and found clean."""
     label = "file" if checked == 1 else "files"
-    return _judgment(
-        req=req, dimension=dimension, file=anchor, line=1, verdict="compliance",
+    return compliance(
+        req=req, dimension=dimension, anchor=anchor,
         title="Inner layers are free of framework dependencies",
         reason=(
             f"Checked the import graph of {checked} inner-layer {label}: none "
@@ -186,7 +168,7 @@ def check_framework_dependencies(
     for file in inner:
         direct = _direct_frameworks(by_file[file], framework_packages)
         for package in sorted(direct):
-            judgments.append(_judgment(
+            judgments.append(violation(
                 req=REQ_DIRECT, dimension=dimension, file=file, line=direct[package],
                 title=f"Inner layer imports framework package '{package}'",
                 reason=(
@@ -203,7 +185,7 @@ def check_framework_dependencies(
             if package in direct:
                 continue  # already billed once, as a direct import
             line, path = transitive[package]
-            judgments.append(_judgment(
+            judgments.append(violation(
                 req=REQ_TRANSITIVE, dimension=dimension, file=file, line=line,
                 title=f"Inner layer depends on framework '{package}' transitively",
                 reason=(

--- a/src/quodeq/core/checks/layers.py
+++ b/src/quodeq/core/checks/layers.py
@@ -33,9 +33,70 @@ INNER_LAYER_DIRS = frozenset({
 })
 
 
+# The innermost of the inner layers. CLEA-DEP-02 is specifically about
+# entities, not about every inner layer: a use case reaching an adapter is a
+# different requirement (the inward rule), and conflating them would report one
+# finding under the other's ID.
+#
+# ``core`` is here because it is the near-universal name for a package holding
+# domain types when a project does not literally say "entities".
+ENTITY_LAYER_DIRS = frozenset({"domain", "entities", "entity", "core"})
+
+# Directory names that conventionally hold delivery, infrastructure and
+# persistence concerns -- what entities must not depend on.
+#
+# Kept to names that are unambiguous in context. ``data`` and ``models`` are
+# deliberately absent: both name a domain directory about as often as an
+# adapter one, and a wrong guess here fabricates layering violations.
+OUTER_LAYER_DIRS = frozenset({
+    "adapters",
+    "adapter",
+    "infrastructure",
+    "infra",
+    "frameworks",
+    "framework",
+    "controllers",
+    "presenters",
+    "gateways",
+    "repositories",
+    "persistence",
+    "drivers",
+    "external",
+    "api",
+    "web",
+    "ui",
+    "views",
+    "rest",
+    "http",
+    "database",
+})
+
+
 def _segments(path: str) -> list[str]:
     """Path segments, tolerating Windows separators."""
     return [s for s in path.replace("\\", "/").split("/") if s]
+
+
+def is_entity_layer_path(path: str) -> bool:
+    """True when *path* sits under a conventional entity/domain directory."""
+    segments = _segments(path)
+    if len(segments) < 2:
+        return False
+    return any(s.lower() in ENTITY_LAYER_DIRS for s in segments[:-1])
+
+
+def is_outer_layer_module(module: str) -> bool:
+    """True when a dotted module name passes through an outer-layer package.
+
+    Judged on the name rather than by resolving it to a file, so it holds even
+    when the imported module's source is outside the scanned file list. Whole
+    segments only: ``app.website.render`` is not ``web``.
+    """
+    return any(
+        part.lower() in OUTER_LAYER_DIRS
+        for part in (module or "").split(".")
+        if part
+    )
 
 
 def is_inner_layer_path(path: str) -> bool:

--- a/src/quodeq/core/checks/model.py
+++ b/src/quodeq/core/checks/model.py
@@ -34,6 +34,19 @@ class ImportGraph:
         return frozenset(e.file for e in self.edges)
 
 
+@dataclass(frozen=True)
+class SymbolUse:
+    """One use of a watched symbol, resolved to its canonical dotted name.
+
+    ``import os as o`` followed by ``o.environ`` records ``os.environ``, as does
+    ``from os import environ``. Resolving aliases is why this is collected by
+    parsing rather than by searching for the text.
+    """
+    file: str
+    line: int
+    symbol: str
+
+
 def top_level(module: str) -> str:
     """The root package of a dotted module name (``a.b.c`` -> ``a``)."""
     return (module or "").split(".", 1)[0]

--- a/src/quodeq/data/fs/import_graph.py
+++ b/src/quodeq/data/fs/import_graph.py
@@ -24,7 +24,7 @@ _logger = logging.getLogger(__name__)
 _PY_SUFFIXES = (".py", ".pyi")
 
 
-def _relative_python_files(root: Path, files: Iterable[Path]) -> list[str]:
+def relative_python_files(root: Path, files: Iterable[Path]) -> list[str]:
     """Repo-relative posix paths of the readable Python files inside *root*.
 
     Paths outside *root* are dropped: a caller-supplied file list is not a
@@ -173,7 +173,7 @@ def build_import_graph(root: Path, files: Iterable[Path]) -> ImportGraph:
     tree or re-implements ignore handling.
     """
     root = Path(root).resolve()
-    rel_files = _relative_python_files(root, files)
+    rel_files = relative_python_files(root, files)
     if not rel_files:
         return ImportGraph()
     first_party, package_roots = _package_roots(root, rel_files)

--- a/src/quodeq/data/fs/symbol_uses.py
+++ b/src/quodeq/data/fs/symbol_uses.py
@@ -1,0 +1,119 @@
+"""Find uses of watched symbols, resolved through the file's own imports.
+
+``os.environ`` reaches a module under several names: a plain attribute access,
+an aliased ``import os as o``, a bare ``environ`` from ``from os import
+environ``, a renamed ``ge`` from ``getenv as ge``. A text search finds the
+spelling you happened to think of; binding each reference back to its canonical
+dotted name finds all of them, and that needs the import statements.
+
+The rule that keeps it precise: a reference only counts when the file actually
+imported the thing it refers to. A local variable named ``os`` is not the
+standard library.
+"""
+from __future__ import annotations
+
+import ast
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+
+from quodeq.core.checks.model import SymbolUse
+from quodeq.data.fs.import_graph import relative_python_files
+
+_logger = logging.getLogger(__name__)
+
+
+def _alias_map(tree: ast.AST) -> dict[str, str]:
+    """``{local name: canonical dotted name}`` for everything the file imports.
+
+    ``import os.path`` binds the name ``os``, not ``os.path`` -- so an unaliased
+    dotted import maps its top package to itself, matching what Python does.
+    Relative imports are skipped: watched symbols are library names, never
+    first-party ones.
+    """
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.asname:
+                    aliases[alias.asname] = alias.name
+                else:
+                    top = alias.name.split(".", 1)[0]
+                    aliases[top] = top
+        elif isinstance(node, ast.ImportFrom) and not node.level and node.module:
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                aliases[alias.asname or alias.name] = f"{node.module}.{alias.name}"
+    return aliases
+
+
+def _dotted(node: ast.AST) -> str | None:
+    """The dotted name of a pure ``Name``/``Attribute`` chain, else None."""
+    parts: list[str] = []
+    current = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name):
+        return None
+    parts.append(current.id)
+    return ".".join(reversed(parts))
+
+
+def _watched(dotted: str, aliases: dict[str, str], names: frozenset[str]) -> str | None:
+    """The watched symbol *dotted* refers to, after alias resolution."""
+    head, _, rest = dotted.partition(".")
+    base = aliases.get(head)
+    if base is None:
+        return None  # never imported here, so not the symbol we are watching
+    resolved = f"{base}.{rest}" if rest else base
+    parts = resolved.split(".")
+    # Longest prefix wins: os.environ.get is a use of os.environ.
+    for depth in range(len(parts), 0, -1):
+        candidate = ".".join(parts[:depth])
+        if candidate in names:
+            return candidate
+    return None
+
+
+def _uses_in_file(root: Path, rel: str, names: frozenset[str]) -> list[SymbolUse]:
+    try:
+        tree = ast.parse((root / rel).read_text(encoding="utf-8"), filename=rel)
+    except (OSError, UnicodeDecodeError, SyntaxError, ValueError) as exc:
+        _logger.debug("symbol uses: skipping %s (%s)", rel, exc)
+        return []
+
+    aliases = _alias_map(tree)
+    if not aliases:
+        return []
+    seen: set[tuple[int, str]] = set()
+    found: list[SymbolUse] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Name, ast.Attribute)):
+            continue
+        dotted = _dotted(node)
+        if dotted is None:
+            continue
+        symbol = _watched(dotted, aliases, names)
+        # ast.walk visits os.environ.get, os.environ and os in turn; the
+        # dedupe below is what stops one expression counting three times.
+        if symbol is None or (node.lineno, symbol) in seen:
+            continue
+        seen.add((node.lineno, symbol))
+        found.append(SymbolUse(file=rel, line=node.lineno, symbol=symbol))
+    return found
+
+
+def build_symbol_uses(
+    root: Path, files: Iterable[Path], names: frozenset[str],
+) -> tuple[SymbolUse, ...]:
+    """Every use of a *names* symbol in *files*, as canonical dotted names."""
+    if not names:
+        return ()
+    root = Path(root).resolve()
+    found: list[SymbolUse] = []
+    for rel in relative_python_files(root, files):
+        found.extend(_uses_in_file(root, rel, names))
+    found.sort(key=lambda u: (u.file, u.line, u.symbol))
+    return tuple(found)

--- a/src/quodeq/data/standards/compiled/clean-architecture.json
+++ b/src/quodeq/data/standards/compiled/clean-architecture.json
@@ -21,7 +21,8 @@
           "id": "CLEA-DEP-02",
           "text": "Entities must not import from use case or adapter layers",
           "description": "Domain entities should have zero imports from application or infrastructure code. Check import statements in entity files — they should only reference other entities, value objects, or standard library types",
-          "refs": []
+          "refs": [],
+          "check": "entity-imports"
         },
         {
           "id": "CLEA-DEP-03",
@@ -52,7 +53,8 @@
           "id": "CLEA-DEP-07",
           "text": "Configuration and environment variables are not read in inner layers",
           "description": "Entities and use cases must not read from os.environ, config files, or settings modules directly. Configuration is injected from the outermost layer through constructor parameters or interfaces",
-          "refs": []
+          "refs": [],
+          "check": "config-reads"
         },
         {
           "id": "CLEA-DEP-08",

--- a/tests/analysis/test_deterministic_checks.py
+++ b/tests/analysis/test_deterministic_checks.py
@@ -370,4 +370,34 @@ class TestBundledStandard:
 
         assert checks["CLEA-FRM-01"] == "framework-imports"
         assert checks["CLEA-DEP-06"] == "framework-imports"
+        assert checks["CLEA-DEP-02"] == "entity-imports"
+        assert checks["CLEA-DEP-07"] == "config-reads"
         assert checks["CLEA-DEP-01"] is None, "the inward rule needs a declared layer map first"
+
+    def test_every_declared_checker_name_exists(self):
+        """A standard naming a checker we do not ship is silently inert."""
+        import json as _json
+
+        from quodeq.analysis.checks.registry import CHECKERS
+        from quodeq.config.paths import default_paths
+
+        compiled_dir = default_paths().standards_dir / "compiled"
+        declared = set()
+        for path in compiled_dir.glob("*.json"):
+            data = _json.loads(path.read_text(encoding="utf-8"))
+            for principle in data.get("principles", []):
+                for req in principle.get("requirements", []):
+                    if req.get("check"):
+                        declared.add(req["check"])
+
+        assert declared <= set(CHECKERS), f"unknown: {declared - set(CHECKERS)}"
+
+    def test_the_context_parses_the_tree_once_per_context(self, project):
+        """Three checkers over one context must not be three walks of the tree."""
+        from quodeq.analysis.checks.registry import CheckContext
+
+        context = CheckContext(root=project, source_files=SOURCES,
+                               dimension="clean-architecture")
+
+        assert context.graph() is context.graph()
+        assert context.config_symbol_uses() is context.config_symbol_uses()

--- a/tests/core/test_checks_inner_purity.py
+++ b/tests/core/test_checks_inner_purity.py
@@ -1,0 +1,198 @@
+"""Two more requirements the per-file scan could never answer.
+
+* **CLEA-DEP-02** -- "Entities must not import from use case or adapter layers".
+  Judged on the *module name* being imported rather than on resolving it to a
+  file, so it still works when the target's source is not in the file list.
+* **CLEA-DEP-07** -- "Configuration and environment variables are not read in
+  inner layers". ``os.environ`` reaches the inner layer under a dozen spellings
+  (aliased import, ``from os import environ``, a config package); each is
+  invisible to a text search and obvious to an AST.
+
+Both follow the pattern set by the framework checker: a layer we cannot name
+is a layer we do not judge, and a check that ran clean says so once.
+"""
+from __future__ import annotations
+
+from quodeq.core.checks.config_reads import check_config_reads
+from quodeq.core.checks.entity_imports import check_entity_imports
+from quodeq.core.checks.model import ImportEdge, ImportGraph, SymbolUse
+
+
+def _graph(*edges: tuple[str, int, str]) -> ImportGraph:
+    return ImportGraph(
+        edges=tuple(ImportEdge(file=f, line=n, module=m) for f, n, m in edges),
+        first_party=frozenset({"app"}),
+    )
+
+
+def _entities(graph: ImportGraph) -> list:
+    return check_entity_imports(graph, dimension="clean-architecture")
+
+
+def _violations(judgments: list) -> list:
+    return [j for j in judgments if j.verdict == "violation"]
+
+
+class TestEntitiesDoNotImportOutward:
+    def test_an_entity_importing_an_adapter_is_a_violation(self):
+        judgments = _violations(_entities(_graph(
+            ("app/domain/order.py", 4, "app.adapters.sql_repo"),
+        )))
+
+        assert len(judgments) == 1
+        j = judgments[0]
+        assert j.practice_id == "CLEA-DEP-02"
+        assert j.file == "app/domain/order.py"
+        assert j.line == 4
+        assert "app.adapters.sql_repo" in j.reason
+
+    def test_every_conventional_outer_layer_counts(self):
+        for module in (
+            "app.adapters.x", "app.infrastructure.x", "app.controllers.x",
+            "app.presenters.x", "app.gateways.x", "app.repositories.x",
+            "app.api.x", "app.web.x", "app.ui.x", "app.persistence.x",
+        ):
+            judgments = _violations(_entities(_graph(("app/domain/o.py", 1, module))))
+            assert len(judgments) == 1, module
+
+    def test_entities_may_import_other_entities(self):
+        assert _violations(_entities(_graph(
+            ("app/domain/order.py", 1, "app.domain.money"),
+            ("app/entities/user.py", 1, "app.entities.role"),
+        ))) == []
+
+    def test_third_party_and_stdlib_imports_are_not_outer_layers(self):
+        """``requests`` is a framework question (FRM-01), not a layering one."""
+        assert _violations(_entities(_graph(
+            ("app/domain/order.py", 1, "decimal"),
+            ("app/domain/order.py", 2, "requests"),
+        ))) == []
+
+    def test_matching_is_on_whole_segments(self):
+        assert _violations(_entities(_graph(
+            ("app/domain/order.py", 1, "app.website.render"),
+            ("app/domain/order.py", 2, "app.apiary.x"),
+        ))) == []
+
+    def test_a_use_case_layer_importing_an_adapter_is_not_this_requirement(self):
+        """DEP-02 is about entities. Use cases reaching adapters is DEP-01."""
+        assert _violations(_entities(_graph(
+            ("app/usecases/place_order.py", 1, "app.adapters.sql_repo"),
+        ))) == []
+
+    def test_one_violation_per_target_module_not_per_import_line(self):
+        judgments = _violations(_entities(_graph(
+            ("app/domain/order.py", 3, "app.adapters.sql"),
+            ("app/domain/order.py", 4, "app.adapters.sql"),
+        )))
+
+        assert len(judgments) == 1
+        assert judgments[0].line == 3
+
+    def test_a_clean_entity_layer_reports_itself_clean(self):
+        judgments = _entities(_graph(("app/domain/order.py", 1, "decimal")))
+
+        assert [(j.practice_id, j.verdict) for j in judgments] == [
+            ("CLEA-DEP-02", "compliance"),
+        ]
+
+    def test_no_entity_layer_means_no_judgment_at_all(self):
+        """``core/`` and ``domain/`` we can name; ``lib/`` we cannot."""
+        assert _entities(_graph(("lib/order.py", 1, "app.adapters.sql"))) == []
+
+    def test_core_counts_as_an_entity_layer(self):
+        judgments = _violations(_entities(_graph(
+            ("src/pkg/core/model.py", 1, "app.infrastructure.db"),
+        )))
+
+        assert [j.file for j in judgments] == ["src/pkg/core/model.py"]
+
+
+def _config(graph: ImportGraph, *uses: tuple[str, int, str]) -> list:
+    return check_config_reads(
+        graph,
+        tuple(SymbolUse(file=f, line=n, symbol=s) for f, n, s in uses),
+        dimension="clean-architecture",
+    )
+
+
+class TestInnerLayersDoNotReadConfig:
+    def test_reading_os_environ_in_an_inner_layer_is_a_violation(self):
+        judgments = _violations(_config(
+            _graph(("app/domain/order.py", 1, "os")),
+            ("app/domain/order.py", 7, "os.environ"),
+        ))
+
+        assert len(judgments) == 1
+        j = judgments[0]
+        assert j.practice_id == "CLEA-DEP-07"
+        assert j.line == 7
+        assert "os.environ" in j.reason
+
+    def test_importing_a_config_package_is_a_violation(self):
+        judgments = _violations(_config(
+            _graph(("app/domain/order.py", 2, "dotenv")),
+        ))
+
+        assert [j.practice_id for j in judgments] == ["CLEA-DEP-07"]
+        assert "dotenv" in judgments[0].reason
+
+    def test_outer_layers_may_read_configuration(self):
+        assert _violations(_config(
+            _graph(("app/api/routes.py", 1, "os"), ("app/domain/order.py", 1, "decimal")),
+            ("app/api/routes.py", 3, "os.environ"),
+        )) == []
+
+    def test_one_violation_per_file_and_source(self):
+        judgments = _violations(_config(
+            _graph(("app/domain/order.py", 1, "os")),
+            ("app/domain/order.py", 7, "os.environ"),
+            ("app/domain/order.py", 9, "os.environ"),
+            ("app/domain/order.py", 11, "os.getenv"),
+        ))
+
+        assert len(judgments) == 2
+        assert [j.line for j in judgments] == [7, 11]
+
+    def test_a_clean_inner_layer_reports_itself_clean(self):
+        judgments = _config(_graph(("app/domain/order.py", 1, "decimal")))
+
+        assert [(j.practice_id, j.verdict) for j in judgments] == [
+            ("CLEA-DEP-07", "compliance"),
+        ]
+
+    def test_no_inner_layer_means_no_judgment_at_all(self):
+        assert _config(
+            _graph(("main.py", 1, "os")), ("main.py", 3, "os.environ"),
+        ) == []
+
+    def test_a_use_case_layer_counts_as_inner(self):
+        """Unlike DEP-02, this requirement covers every inner layer."""
+        judgments = _violations(_config(
+            _graph(("app/usecases/place_order.py", 1, "os")),
+            ("app/usecases/place_order.py", 4, "os.getenv"),
+        ))
+
+        assert [j.file for j in judgments] == ["app/usecases/place_order.py"]
+
+
+class TestSharedShape:
+    def test_both_checkers_are_deterministic_and_sorted(self):
+        graph = _graph(
+            ("app/domain/b.py", 1, "app.adapters.x"),
+            ("app/domain/a.py", 1, "app.web.y"),
+        )
+
+        first = [(j.file, j.line) for j in _entities(graph)]
+        assert first == sorted(first) == [(j.file, j.line) for j in _entities(graph)]
+
+    def test_findings_carry_the_dimension_severity_and_full_confidence(self):
+        j = _violations(_entities(_graph(("app/domain/o.py", 1, "app.api.x"))))[0]
+
+        assert j.dimension == "clean-architecture"
+        assert j.severity == "major"
+        assert j.confidence == 100
+
+    def test_empty_inputs(self):
+        assert _entities(ImportGraph()) == []
+        assert check_config_reads(ImportGraph(), (), dimension="d") == []

--- a/tests/data/test_symbol_uses.py
+++ b/tests/data/test_symbol_uses.py
@@ -1,0 +1,123 @@
+"""Finding a watched symbol however it was spelled.
+
+``os.environ`` reaches a module under several names -- an aliased import, a
+direct ``from os import environ``, a renamed one -- and a text search finds the
+spelling you thought of. Binding each reference back to its canonical dotted
+name is the whole job, and it needs the import statements, so it needs a parse.
+
+The rule that keeps this precise: a reference only counts when the file
+actually imported the thing. A local variable called ``os`` is not the standard
+library.
+"""
+from __future__ import annotations
+
+from quodeq.data.fs.symbol_uses import build_symbol_uses
+
+WATCHED = frozenset({"os.environ", "os.getenv"})
+
+
+def _write(root, rel: str, body: str):
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _uses(tmp_path, body: str, names=WATCHED):
+    _write(tmp_path, "app/x.py", body)
+    found = build_symbol_uses(tmp_path, [tmp_path / "app/x.py"], names)
+    return [(u.symbol, u.line) for u in found]
+
+
+class TestSpellings:
+    def test_plain_attribute_access(self, tmp_path):
+        assert _uses(tmp_path, "import os\nv = os.environ['X']\n") == [("os.environ", 2)]
+
+    def test_aliased_module(self, tmp_path):
+        assert _uses(tmp_path, "import os as o\nv = o.getenv('X')\n") == [("os.getenv", 2)]
+
+    def test_from_import(self, tmp_path):
+        assert _uses(tmp_path, "from os import environ\nv = environ['X']\n") == [
+            ("os.environ", 2)]
+
+    def test_from_import_renamed(self, tmp_path):
+        assert _uses(tmp_path, "from os import getenv as ge\nv = ge('X')\n") == [
+            ("os.getenv", 2)]
+
+    def test_a_longer_chain_reports_the_watched_prefix(self, tmp_path):
+        assert _uses(tmp_path, "import os\nv = os.environ.get('X')\n") == [
+            ("os.environ", 2)]
+
+    def test_submodule_import_binds_the_top_package(self, tmp_path):
+        assert _uses(tmp_path, "import os.path\nv = os.environ['X']\n") == [
+            ("os.environ", 2)]
+
+
+class TestPrecision:
+    def test_a_local_name_that_was_never_imported_does_not_count(self, tmp_path):
+        assert _uses(tmp_path, "os = {'a': 1}\nv = os.environ\n") == []
+
+    def test_an_unwatched_symbol_is_ignored(self, tmp_path):
+        assert _uses(tmp_path, "import os\nv = os.getcwd()\n") == []
+
+    def test_an_attribute_on_an_unrelated_object_is_ignored(self, tmp_path):
+        assert _uses(tmp_path, "import os\nv = cfg.environ\n") == []
+
+    def test_repeated_use_on_one_line_is_recorded_once(self, tmp_path):
+        assert _uses(tmp_path, "import os\nv = os.environ['A'] + os.environ['B']\n") == [
+            ("os.environ", 2)]
+
+    def test_each_line_is_its_own_use(self, tmp_path):
+        assert _uses(
+            tmp_path, "import os\na = os.environ['A']\nb = os.environ['B']\n",
+        ) == [("os.environ", 2), ("os.environ", 3)]
+
+
+class TestFailSoft:
+    def test_a_file_that_will_not_parse_contributes_nothing(self, tmp_path):
+        _write(tmp_path, "app/broken.py", "def (:\n")
+
+        assert build_symbol_uses(tmp_path, [tmp_path / "app/broken.py"], WATCHED) == ()
+
+    def test_no_names_to_watch(self, tmp_path):
+        assert _uses(tmp_path, "import os\nv = os.environ\n", frozenset()) == []
+
+    def test_paths_outside_the_root_are_skipped(self, tmp_path):
+        outside = tmp_path.parent / "outside_symbols.py"
+        outside.write_text("import os\nv = os.environ\n", encoding="utf-8")
+        root = tmp_path / "repo"
+        root.mkdir()
+
+        assert build_symbol_uses(root, [outside], WATCHED) == ()
+
+    def test_results_are_sorted(self, tmp_path):
+        _write(tmp_path, "app/b.py", "import os\nv = os.environ\n")
+        _write(tmp_path, "app/a.py", "import os\nv = os.getenv('X')\n")
+
+        found = build_symbol_uses(
+            tmp_path, [tmp_path / "app/b.py", tmp_path / "app/a.py"], WATCHED,
+        )
+
+        assert [u.file for u in found] == ["app/a.py", "app/b.py"]
+
+
+class TestEndToEndWithTheChecker:
+    def test_an_env_read_in_a_domain_file_is_found_on_disk(self, tmp_path):
+        from quodeq.core.checks.config_reads import CONFIG_SYMBOLS, check_config_reads
+        from quodeq.data.fs.import_graph import build_import_graph
+
+        _write(tmp_path, "app/__init__.py", "")
+        _write(tmp_path, "app/domain/__init__.py", "")
+        _write(tmp_path, "app/domain/pricing.py",
+               "from os import getenv\n\n\ndef rate():\n    return getenv('RATE')\n")
+        files = [tmp_path / "app/domain/pricing.py"]
+
+        judgments = check_config_reads(
+            build_import_graph(tmp_path, files),
+            build_symbol_uses(tmp_path, files, CONFIG_SYMBOLS),
+            dimension="clean-architecture",
+        )
+
+        assert [(j.practice_id, j.verdict, j.file, j.line) for j in judgments] == [
+            ("CLEA-DEP-07", "violation", "app/domain/pricing.py", 5),
+        ]


### PR DESCRIPTION
Follows #1012, which built the mechanism and wired one checker. Two more requirements move from **never judged** to measured — reusing the facts that PR already collects, plus one new collector.

## CLEA-DEP-02 — entities must not import from use case or adapter layers

Judged on the **imported module's dotted name**, not by resolving it to a file. That means the verdict holds when the target's source is outside the scanned list, which is the normal case for anything the scan skipped.

Scope is entities specifically, not every inner layer. A use case reaching an adapter is the inward rule (DEP-01); reporting it here would file one requirement's finding under another's ID.

## CLEA-DEP-07 — configuration is not read in inner layers

The environment reaches a module under several spellings:

```python
os.environ["X"]                    # plain
import os as o; o.getenv("X")      # aliased module
from os import environ             # bare name
from os import getenv as ge        # renamed
import dotenv                      # hidden behind a package
```

A text search finds the spelling you thought of. Binding each reference back to its canonical dotted name *through the file's own imports* finds all of them — that's the new collector, `data/fs/symbol_uses.py`. Its precision rule: a reference only counts when the file actually imported the thing. A local variable named `os` is not the standard library.

## Result on quodeq

Four requirements now report where none did:

```
[violation ] CLEA-DEP-07  core/evidence/_refs.py:23
    reads configuration through 'os.environ'
[violation ] CLEA-FRM-01  core/events/models.py:8
    imports the framework package 'pydantic' directly
[compliance] CLEA-DEP-02  61 entity-layer files, none reaches outward
[compliance] CLEA-DEP-06  61 inner-layer files, no transitive framework dep
```

Both violations are true, and neither is news to a human. The point is that the standard can now see them **every run, without spending a token**.

The DEP-07 finding is fair despite the `env` injection seam in `_cwe_url_template` — the default path still reads `os.environ` from inside `core/`. Worth fixing, but it threads through ~15 call sites, so not here.

## Supporting changes worth a look

- **`core/checks/_judgments.py`** — one constructor for violations and compliances. Severity, confidence, and whether a clean result says anything at all are exactly the fields that decide how a finding scores, and exactly what drifts when each checker rolls its own `Judgment`.
- **`CheckContext` memoises the parsed facts lazily.** Three checkers over one context share one walk of the tree, and nothing is parsed that no declared checker asked for. The cache lives on the context, **not in a module global** — scoped to the call that made it, and two projects can never see each other's graph. (A global memo here would have been a CLEA-TES-03 violation in the checker that reports CLEA-TES-03's neighbours.)
- **`OUTER_LAYER_DIRS` excludes `data` and `models`** on purpose. Both name a domain directory about as often as an adapter one, and a wrong guess there *fabricates* layering violations rather than finding them.
- **`ENTITY_LAYER_DIRS` includes `core`** — the near-universal name for a package of domain types when a project doesn't literally say "entities". This is what makes the requirement measurable on our own repo.
- **A test asserts every `check` name in every shipped standard resolves to a real checker.** A typo there is otherwise silently inert, which is the worst failure mode this design has.

## Verification

- 5613 passed, 1 skipped (`pytest -m "not integration"`)
- `tools/check_imports.py`: no new violations, baseline unchanged at 17
- All four checks run end-to-end against this repo, output above
