### PR TITLE
fix(security): one recognized path-containment barrier for the API routes

### DIFF
--- a/src/quodeq/api/routes_common.py
+++ b/src/quodeq/api/routes_common.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 from http import HTTPStatus
-from pathlib import Path
 
 from flask import abort, jsonify, make_response, request
 
 from quodeq.shared.utils import get_evaluations_dir
+from quodeq.shared.validation import contained_path
 
 
 def reports_dir(default_path: str | None = None, request_args: dict | None = None) -> str:
@@ -18,12 +18,11 @@ def reports_dir(default_path: str | None = None, request_args: dict | None = Non
     fallback = default_path if default_path is not None else get_evaluations_dir()
     args = request_args if request_args is not None else request.args
     raw = args.get("evaluations") or fallback
-    resolved = Path(raw).resolve()
-    default_resolved = Path(fallback).resolve()
-    if not resolved.is_relative_to(default_resolved):
+    try:
+        return contained_path(raw, fallback)
+    except ValueError:
         response = make_response(
             jsonify({"error": "Access denied: path is outside the allowed directory", "code": "FORBIDDEN"}),
             HTTPStatus.FORBIDDEN,
         )
         abort(response)
-    return str(resolved)

--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -28,7 +28,7 @@ from quodeq.services.mutation_rescore import (
 )
 from quodeq.services.verified import unverify_finding, verified_entries
 from quodeq.shared.utils import get_evaluations_dir
-from quodeq.shared.validation import validate_path_segment
+from quodeq.shared.validation import contained_path, validate_path_segment
 
 _logger = logging.getLogger(__name__)
 _MAX_DISMISSED_LIMIT = 5000
@@ -61,11 +61,10 @@ def _invalid_body_fields(
 
 def _project_dir(evaluations_dir: str, project: str) -> Path:
     validate_path_segment(project)
-    base = Path(evaluations_dir).resolve()
-    resolved = (base / project).resolve()
-    if not resolved.is_relative_to(base):
+    try:
+        return Path(contained_path(Path(evaluations_dir) / project, evaluations_dir))
+    except ValueError:
         abort(400, description="Invalid project path")
-    return resolved
 
 
 def register_findings_routes(app: Flask) -> None:

--- a/src/quodeq/api/routes_project_list.py
+++ b/src/quodeq/api/routes_project_list.py
@@ -330,7 +330,13 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
                 return jsonify(body), status
             if not ephemeral and clone_dest:
                 try:
-                    contained_dest = contained_path(clone_dest, Path.home())
+                    # Containment and the directory check both live in the try
+                    # so every rejection exits here. Falling through past a
+                    # failed containment check on a sentinel would leave the
+                    # unguarded value live on one path.
+                    dest = Path(contained_path(clone_dest, Path.home()))
+                    if not dest.is_dir():
+                        raise ValueError("cloneDest is not an existing directory")
                 except OSError:
                     body, status = error_response(
                         "Invalid cloneDest path",
@@ -339,18 +345,6 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
                     )
                     return jsonify(body), status
                 except ValueError:
-                    # Return here rather than falling through with a sentinel.
-                    # Every failure branch around a containment check has to
-                    # exit: continuing past a swallowed rejection leaves the
-                    # unguarded value live on one path, which is a real hole
-                    # and is also what CodeQL flags.
-                    body, status = error_response(
-                        "cloneDest must be an existing directory under your home folder",
-                        HTTPStatus.BAD_REQUEST,
-                        "INVALID_CLONE_DEST",
-                    )
-                    return jsonify(body), status
-                if not Path(contained_dest).is_dir():
                     body, status = error_response(
                         "cloneDest must be an existing directory under your home folder",
                         HTTPStatus.BAD_REQUEST,
@@ -360,7 +354,7 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
                 # Hand the *contained* path to the cloner. The previous code
                 # resolved into a local and then passed the raw request string
                 # on, so the check guarded a value nothing downstream used.
-                clone_dest = contained_dest
+                clone_dest = str(dest)
         else:
             # For local repos, fail fast if the path doesn't exist — registering
             # a project for a missing directory would leave an orphan UUID dir

--- a/src/quodeq/api/routes_project_list.py
+++ b/src/quodeq/api/routes_project_list.py
@@ -334,8 +334,8 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
                     # so every rejection exits here. Falling through past a
                     # failed containment check on a sentinel would leave the
                     # unguarded value live on one path.
-                    dest = Path(contained_path(clone_dest, Path.home()))
-                    if not dest.is_dir():
+                    dest = contained_path(clone_dest, Path.home())
+                    if not os.path.isdir(dest):
                         raise ValueError("cloneDest is not an existing directory")
                 except OSError:
                     body, status = error_response(
@@ -354,7 +354,7 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
                 # Hand the *contained* path to the cloner. The previous code
                 # resolved into a local and then passed the raw request string
                 # on, so the check guarded a value nothing downstream used.
-                clone_dest = str(dest)
+                clone_dest = dest
         else:
             # For local repos, fail fast if the path doesn't exist — registering
             # a project for a missing directory would leave an orphan UUID dir

--- a/src/quodeq/api/routes_project_list.py
+++ b/src/quodeq/api/routes_project_list.py
@@ -339,8 +339,18 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
                     )
                     return jsonify(body), status
                 except ValueError:
-                    contained_dest = None
-                if contained_dest is None or not Path(contained_dest).is_dir():
+                    # Return here rather than falling through with a sentinel.
+                    # Every failure branch around a containment check has to
+                    # exit: continuing past a swallowed rejection leaves the
+                    # unguarded value live on one path, which is a real hole
+                    # and is also what CodeQL flags.
+                    body, status = error_response(
+                        "cloneDest must be an existing directory under your home folder",
+                        HTTPStatus.BAD_REQUEST,
+                        "INVALID_CLONE_DEST",
+                    )
+                    return jsonify(body), status
+                if not Path(contained_dest).is_dir():
                     body, status = error_response(
                         "cloneDest must be an existing directory under your home folder",
                         HTTPStatus.BAD_REQUEST,

--- a/src/quodeq/api/routes_project_list.py
+++ b/src/quodeq/api/routes_project_list.py
@@ -18,7 +18,7 @@ from quodeq.api.zip import export_project_zip
 from quodeq.services._fs_clone import CloneError
 from quodeq.services._fs_scan import scan_project
 from quodeq.services.base import ActionProvider
-from quodeq.shared.validation import validate_path_segment, validate_relative_scope
+from quodeq.shared.validation import contained_path, validate_path_segment, validate_relative_scope
 
 _logger = logging.getLogger(__name__)
 
@@ -329,10 +329,8 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
                 )
                 return jsonify(body), status
             if not ephemeral and clone_dest:
-                dest_path = Path(clone_dest)
-                home = Path.home().resolve()
                 try:
-                    dest_resolved = dest_path.resolve()
+                    contained_dest = contained_path(clone_dest, Path.home())
                 except OSError:
                     body, status = error_response(
                         "Invalid cloneDest path",
@@ -340,13 +338,19 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
                         "INVALID_CLONE_DEST",
                     )
                     return jsonify(body), status
-                if not dest_resolved.is_dir() or not dest_resolved.is_relative_to(home):
+                except ValueError:
+                    contained_dest = None
+                if contained_dest is None or not Path(contained_dest).is_dir():
                     body, status = error_response(
                         "cloneDest must be an existing directory under your home folder",
                         HTTPStatus.BAD_REQUEST,
                         "INVALID_CLONE_DEST",
                     )
                     return jsonify(body), status
+                # Hand the *contained* path to the cloner. The previous code
+                # resolved into a local and then passed the raw request string
+                # on, so the check guarded a value nothing downstream used.
+                clone_dest = contained_dest
         else:
             # For local repos, fail fast if the path doesn't exist — registering
             # a project for a missing directory would leave an orphan UUID dir

--- a/src/quodeq/api/routes_rescore.py
+++ b/src/quodeq/api/routes_rescore.py
@@ -12,7 +12,7 @@ from quodeq.services.deleted import deleted_keys as load_deleted_keys
 from quodeq.services.dismissed import dismissed_keys as load_dismissed_keys
 from quodeq.services.rescore import rescore_dimensions
 from quodeq.shared.utils import get_evaluations_dir
-from quodeq.shared.validation import validate_path_segment
+from quodeq.shared.validation import contained_path, validate_path_segment
 from quodeq.services.suppression import load_suppression_rules
 
 
@@ -30,14 +30,18 @@ def register_rescore_routes(app: Flask) -> None:
             body, status = error_response("project query parameter is required", HTTPStatus.BAD_REQUEST, "MISSING_PARAM")
             return jsonify(body), status
         run_id = request.args.get("run", "")
+        eval_dir = _eval_dir_from_app(app)
         try:
             validate_path_segment(project)
             if run_id and run_id != "latest":
                 validate_path_segment(run_id)
+            # Contain the joined path, not just the segment, and use what comes
+            # back: the contained value is what flows to the readers below.
+            project_dir = Path(contained_path(Path(eval_dir) / project, eval_dir))
         except ValueError:
             body, status = error_response("Invalid project or run parameter", HTTPStatus.BAD_REQUEST, "INVALID_PARAM")
             return jsonify(body), status
-        eval_dir = _eval_dir_from_app(app)
+        project = project_dir.name
 
         # Resolve run ID
         if not run_id or run_id == "latest":
@@ -53,7 +57,6 @@ def register_rescore_routes(app: Flask) -> None:
             body, status = error_response("Run data not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
             return jsonify(body), status
 
-        project_dir = Path(eval_dir) / project
         dismissed = load_dismissed_keys(project_dir)
         deleted = load_deleted_keys(project_dir)
 

--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -49,7 +49,7 @@ from quodeq.services.shared_settings import (
     write_settings,
 )
 from quodeq.services.verified import verified_entries
-from quodeq.shared.validation import validate_path_segment
+from quodeq.shared.validation import contained_path, validate_path_segment
 
 from .routes_common import reports_dir
 
@@ -130,11 +130,10 @@ def _validate_segment(*segments: str) -> tuple[Response, int] | None:
 
 def _shared_project_dir(eval_root: Path, project: str) -> Path | None:
     """Resolve *project* under *eval_root*; None if it would escape the root."""
-    base = eval_root.resolve()
-    resolved = (base / project).resolve()
-    if not resolved.is_relative_to(base):
+    try:
+        return Path(contained_path(eval_root / project, eval_root))
+    except ValueError:
         return None
-    return resolved
 
 
 def register_shared_routes(app: Flask) -> None:

--- a/src/quodeq/core/utils/io.py
+++ b/src/quodeq/core/utils/io.py
@@ -7,6 +7,7 @@ the evidence parser and standards loader can use them without reaching into
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import IO, Any
 
@@ -49,3 +50,33 @@ def validate_path_segment(*segments: str) -> None:
                 f"Invalid path segment: {seg!r}. "
                 f"Use only alphanumeric characters, hyphens, underscores, and dots."
             )
+
+
+def contained_path(candidate: str | Path, root: str | Path) -> str:
+    """Return *candidate* resolved, guaranteed to sit inside *root*.
+
+    Raises ValueError when it escapes. Symlinks are followed, so a link
+    pointing out of the root is rejected on its real target.
+
+    Two things about the implementation are deliberate and should survive
+    future cleanups:
+
+    1. It uses ``os.path.realpath`` + ``startswith(root + os.sep)`` rather than
+       the more idiomatic ``Path.resolve().is_relative_to()``. Both are correct,
+       but static analysers (CodeQL's ``py/path-injection`` among them) only
+       model the former as a containment barrier. Written the idiomatic way,
+       every guarded flow from a request parameter down to a file read still
+       reports as an unguarded path injection.
+    2. It *returns* the safe path instead of raising-only. Callers must use the
+       return value and discard their own variable. A validator that only
+       raises leaves the original tainted value flowing to the sink, so no
+       amount of checking inside it registers as a barrier.
+    """
+    real = os.path.realpath(str(candidate))
+    root_real = os.path.realpath(str(root))
+    if real != root_real and not real.startswith(root_real + os.sep):
+        raise ValueError(
+            f"Path escapes its root directory: {candidate!r} is not inside {root!r}. "
+            "Ensure the path has no '..' segments or symlinks leaving the root."
+        )
+    return real

--- a/src/quodeq/shared/validation.py
+++ b/src/quodeq/shared/validation.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 from pathlib import Path
 
 
-from quodeq.core.utils.io import validate_path_segment  # noqa: F401 — moved inward to core
+from quodeq.core.utils.io import (  # noqa: F401 — moved inward to core
+    contained_path,
+    validate_path_segment,
+)
 
 
 def validate_relative_scope(scope: str) -> None:
@@ -22,10 +25,11 @@ def validate_relative_scope(scope: str) -> None:
         raise ValueError(f"Invalid scope path: {scope!r}. Parent-directory segments are not allowed.")
 
 
-def validate_resolved_within(path: Path, root: Path) -> None:
-    """Raise ValueError if *path* resolves outside *root*."""
-    if not path.resolve().is_relative_to(root.resolve()):
-        raise ValueError(
-            "Path escapes its root directory. "
-            "Ensure the path does not contain '..' segments or symlinks that resolve outside the project root."
-        )
+def validate_resolved_within(path: Path, root: Path) -> Path:
+    """Return *path* contained within *root*, raising ValueError if it escapes.
+
+    Thin ``Path``-typed wrapper over :func:`contained_path`. Use the returned
+    value, not the argument you passed in: the point of the check is that the
+    contained path is what flows onward.
+    """
+    return Path(contained_path(path, root))

--- a/tests/api/test_routes_rescore.py
+++ b/tests/api/test_routes_rescore.py
@@ -1,5 +1,6 @@
 """Tests for the /api/rescore endpoint."""
 import json
+import os
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -40,3 +41,23 @@ def test_rescore_returns_rescored_data(mock_rescore, mock_dismissed, mock_list_r
     data = resp.get_json()
     assert "dimensions" in data
     assert "summary" in data
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_rescore_rejects_project_symlinked_outside_the_evaluations_root(tmp_path, client):
+    """A project name that is a symlink out of the root is refused.
+
+    The segment check alone passed this: "escape" holds no dots or
+    separators. Only containment on the *joined* path catches it.
+    """
+    eval_root = tmp_path / "evaluations"
+    eval_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (eval_root / "escape").symlink_to(outside)
+
+    with patch("quodeq.api.routes_rescore._eval_dir_from_app", return_value=str(eval_root)):
+        resp = client.get("/api/rescore?project=escape")
+
+    assert resp.status_code == 400
+    assert resp.get_json()["code"] == "INVALID_PARAM"

--- a/tests/core/test_contained_path.py
+++ b/tests/core/test_contained_path.py
@@ -1,0 +1,85 @@
+"""Containment guard behaviour for `contained_path`.
+
+The shape of this helper is load-bearing (see its docstring): it must return
+the safe path rather than only raising, and it must use realpath +
+startswith so static analysers recognise it as a barrier. The last test in
+this module pins the return-value contract, which is the part a well-meaning
+"simplify this to a plain validator" refactor would otherwise delete.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from quodeq.core.utils.io import contained_path
+
+
+def test_allows_direct_child(tmp_path: Path) -> None:
+    child = tmp_path / "project-a"
+    assert contained_path(child, tmp_path) == os.path.realpath(str(child))
+
+
+def test_allows_nested_descendant(tmp_path: Path) -> None:
+    nested = tmp_path / "project-a" / "run-1" / "findings.jsonl"
+    assert contained_path(nested, tmp_path) == os.path.realpath(str(nested))
+
+
+def test_allows_the_root_itself(tmp_path: Path) -> None:
+    assert contained_path(tmp_path, tmp_path) == os.path.realpath(str(tmp_path))
+
+
+def test_rejects_parent_traversal(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="escapes its root"):
+        contained_path(tmp_path / ".." / "elsewhere", tmp_path)
+
+
+def test_rejects_sibling_prefix_collision(tmp_path: Path) -> None:
+    """`/root-evil` must not pass containment for root `/root`.
+
+    A naive ``startswith(root)`` without the separator admits this.
+    """
+    root = tmp_path / "root"
+    root.mkdir()
+    sibling = tmp_path / "root-evil"
+    sibling.mkdir()
+    with pytest.raises(ValueError, match="escapes its root"):
+        contained_path(sibling, root)
+
+
+def test_rejects_absolute_path_outside_root(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="escapes its root"):
+        contained_path("/etc/passwd", tmp_path)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_rejects_symlink_escaping_the_root(tmp_path: Path) -> None:
+    """Containment is judged on the real target, not the link path."""
+    root = tmp_path / "root"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (root / "escape").symlink_to(outside)
+    with pytest.raises(ValueError, match="escapes its root"):
+        contained_path(root / "escape", root)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_returns_the_real_target_for_an_internal_symlink(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    (root / "real").mkdir(parents=True)
+    (root / "link").symlink_to(root / "real")
+    assert contained_path(root / "link", root) == os.path.realpath(str(root / "real"))
+
+
+def test_returns_the_sanitised_value_not_none(tmp_path: Path) -> None:
+    """The barrier contract: callers use the return value.
+
+    A validator that returns ``None`` leaves the caller's own (tainted)
+    variable flowing to the file sink, which is what made the previous
+    ``validate_resolved_within`` useless as a barrier.
+    """
+    result = contained_path(tmp_path / "a" / ".." / "b", tmp_path)
+    assert result is not None
+    assert result == os.path.realpath(str(tmp_path / "b"))


### PR DESCRIPTION
## Why

All 33 open CodeQL alerts are the same rule, `py/path-injection`, all high. Another 152 of that rule are already dismissed as false positives on this repo. This is wave three.

They recur because CodeQL models exactly one containment shape (`os.path.realpath` + `startswith(root + os.sep)`), and every guard in the route layer used pathlib `resolve()` + `is_relative_to`. Moving code mints fresh alert numbers, so the clean-architecture refactor resurrected the whole dismissed set. The practical cost is not the dismissals, it is that the Security tab stops being a signal: last round the two genuine gaps (G1, G2) were found by a manual route audit, not by CodeQL.

## What

`contained_path()` in `core/utils/io.py`, next to `validate_path_segment`, re-exported from `shared/validation.py`. Five tainted entrypoints now route through it:

| entrypoint | alerts |
|---|---|
| `reports_dir()` in `routes_common.py` | 21 |
| `routes_project_list.py` cloneDest | 12 |
| `routes_rescore.py` | 10 |
| `_project_dir()` in `routes_findings.py` | 10 |
| `_shared_project_dir()` in `routes_shared.py` | 8 |

(Counts exceed 33 because most alerts have several sources.)

Two properties of the helper are load-bearing and documented on the function itself:

1. **It returns the safe path** instead of only raising. A raise-only validator leaves the caller's own tainted variable flowing to the sink, so no amount of checking inside it registers as a barrier. This is why the previous `validate_resolved_within` was never going to help; it also had zero callers.
2. **It uses realpath + startswith**, not `is_relative_to`, purely so the analyser recognises it.

The other 23 `is_relative_to` sites in the codebase are not on tainted flows and are untouched.

## Two real gaps found while wiring it

- `GET /api/rescore` validated the project *segment* but never checked the joined path, so a symlink inside the evaluations root escaped containment entirely. Now contained, with a regression test.
- `POST /api/projects` resolved `cloneDest` into a local, validated that local, then passed the **raw request string** to the cloner. The check guarded a value nothing downstream used.

## Behaviour

Status codes and error payloads are unchanged at all five sites. One note: rescore now derives `project` from the contained path, so a project entry that is itself a symlink resolves to its target name. Degenerate inputs that previously produced a 404 still produce a 404.

## Verification

- Full non-integration suite green: **5585 passed, 1 skipped**.
- 9 new unit tests for the guard, including the `/root-evil` vs `/root` sibling-prefix case and symlink escape.
- 1 new route regression test for the rescore gap.

**The open question this PR answers:** whether CodeQL recognises the barrier through a cross-module helper call. The differential scan on this PR is the test. If the 33 clear, the class is dead permanently and a future unguarded route still gets flagged. If they do not, we fall back to excluding the rule in `codeql-config.yml` with better information than we have now.