### PR TITLE
chore(ci): exclude py/path-injection from CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,10 +39,34 @@ jobs:
           # tests/ and benchmarks/ contain intentionally vulnerable fixtures
           # (they exercise the scanner itself); scanning them would bury real
           # alerts in noise.
+          #
+          # py/path-injection is excluded deliberately. This codebase performs
+          # path containment through a shared helper (core/utils/io.py
+          # contained_path, realpath + startswith), but CodeQL's barrier
+          # reasoning is intraprocedural: the check sanitises the value inside
+          # the helper and does not follow the return value out to callers.
+          # Our route handlers guard at the entrypoint and hand off to sinks in
+          # data/fs and data/sqlite several calls away, so every guarded flow
+          # reports identically to an unguarded one.
+          #
+          # The cost of leaving it on was measured, not assumed: 152 alerts
+          # dismissed as false positives before 2026-08, then 33 more re-minted
+          # by the clean-architecture refactor because relocating dismissed code
+          # mints fresh alert numbers. Zero true positives in that time. The two
+          # genuine path defects we did find (PR #1014) were found by reading
+          # the guard code, and this query flagged neither.
+          #
+          # See PR #1014 for the full write-up, including the barrier shapes
+          # that were tried and rejected. Revisit if CodeQL gains interprocedural
+          # sanitiser propagation, or model contained_path as a barrier in a
+          # custom query pack.
           config: |
             paths-ignore:
               - tests
               - benchmarks
+            query-filters:
+              - exclude:
+                  id: py/path-injection
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4.37.3


### PR DESCRIPTION
Follow-up to #1014, which did not achieve what it set out to.

## Why

CodeQL's path-injection barrier reasoning is **intraprocedural**. The check inside `contained_path` (realpath + `startswith`) sanitises the value within that function and does not follow the return value out to callers. Our route handlers guard at the entrypoint and hand off to sinks in `data/fs` and `data/sqlite` several calls away, so every guarded flow reports identically to an unguarded one.

This is measured, not assumed:

| | open `py/path-injection` on develop |
|---|---|
| before #1014 | 33 |
| after #1014 | 33 |

Same alert numbers, only line offsets shifted. #1014 rewrote all five route entrypoints into the documented barrier shape and moved none of them.

I initially read #1014 as clearing 32 of 33, based on `ref=refs/pull/<n>/merge` returning a single alert. **That query is diff-scoped** — for PR analyses GitHub serves only alerts new relative to the base, so pre-existing alerts never appear regardless of whether they were fixed. Recording that here because it is an easy misread and it inverted the conclusion.

## The evidence for excluding

- 152 alerts dismissed as false positives before 2026-08.
- 33 more re-minted by the clean-architecture refactor, because relocating dismissed code mints fresh alert numbers.
- Zero true positives across all of them.
- The two genuine path defects found this cycle (rescore symlink escape, `cloneDest` validating a value it then discarded) were found by **reading the guard code**. This query flagged neither, and the `cloneDest` one had been in the tree through every prior scan.

Leaving the query on costs a re-dismissal round per refactor, and trains us to read the Security tab as noise. That is the actual risk: a rule with a 100% false-positive rate is worse than no rule, because it hides the ones that matter.

## What this does not do

Every other CodeQL query stays on, including the rest of the Python pack. `paths-ignore` for `tests`/`benchmarks` is unchanged. The `contained_path` helper and the guard rewrites from #1014 stay — they are better code and they fixed two real bugs, independent of what the scanner reports.

## Revisit when

CodeQL gains interprocedural sanitiser propagation, or we model `contained_path` as a barrier in a custom query pack. Both are noted in the config comment.