### PR TITLE
fix(api): remove the unused ?evaluations= reports-root override

### DIFF
--- a/src/quodeq/api/routes_common.py
+++ b/src/quodeq/api/routes_common.py
@@ -1,28 +1,26 @@
 """Shared helpers used across route modules."""
 from __future__ import annotations
 
-from http import HTTPStatus
-
-from flask import abort, jsonify, make_response, request
+import os
 
 from quodeq.shared.utils import get_evaluations_dir
-from quodeq.shared.validation import contained_path
 
 
-def reports_dir(default_path: str | None = None, request_args: dict | None = None) -> str:
-    """Resolve the reports directory from query params or *default_path*.
+def reports_dir() -> str:
+    """Resolve the reports directory from server configuration.
 
-    *request_args* overrides ``request.args`` when provided, allowing the
-    function to be called without a live Flask request context (e.g. in tests).
+    Takes no request input, deliberately. This used to accept an
+    ``?evaluations=`` query parameter that repointed the entire reports root,
+    guarded by a containment check against the configured directory. No
+    client, test, or documented workflow ever sent it: every one of the 36
+    call sites invokes ``reports_dir()`` bare. An unused parameter that
+    redirects the storage root is attack surface with no upside, so it is
+    gone rather than guarded.
+
+    The consequence worth knowing: this value is now server-controlled, so
+    every path built on top of it starts from a trusted root. Do not
+    reintroduce a request-supplied override here. If a future feature needs
+    multiple roots, resolve them from configuration and select by an opaque
+    identifier, never by a caller-supplied path.
     """
-    fallback = default_path if default_path is not None else get_evaluations_dir()
-    args = request_args if request_args is not None else request.args
-    raw = args.get("evaluations") or fallback
-    try:
-        return contained_path(raw, fallback)
-    except ValueError:
-        response = make_response(
-            jsonify({"error": "Access denied: path is outside the allowed directory", "code": "FORBIDDEN"}),
-            HTTPStatus.FORBIDDEN,
-        )
-        abort(response)
+    return os.path.realpath(get_evaluations_dir())


### PR DESCRIPTION
Replaces #1015. No exclusion, no suppression — the input is gone.

## What it was

`reports_dir()` accepted `?evaluations=<path>`, which repointed the entire reports root for the request, guarded by a containment check against the configured directory.

## Why deleting it is right

Nothing used it:

- **0** occurrences in the UI source
- **0** tests exercise it
- **0** docs mention it
- **36/36** call sites invoke `reports_dir()` bare

The `default_path` and `request_args` parameters had no callers either. An unused parameter that redirects the storage root is attack surface with no upside. The reports root is now server-controlled, so every path built on top of it starts from a trusted root instead of from request input.

## Effect on the alerts

21 of the 33 open `py/path-injection` alerts trace back to this one function. They were false positives — the containment check was correct — but the honest fix for an input nothing uses is to remove it, not to argue with the scanner about whether the guard holds.

This does not claim to clear all 33. The remaining alerts come from project and run names, which is a separate change with a real API-contract decision behind it (see below). I will measure the actual number on develop after this lands rather than predict it, since PR-scoped alert data only reports alerts *new* in the diff and cannot show pre-existing ones clearing.

## Verification

- Full suite: **5623 passed**, 1 skipped.
- Traversal probe, 59 payloads (encoded, double-encoded, backslash, `....//`, absolute, symlink-inside-root) against the live app across `/api/rescore`, `/api/findings/dismissed`, `/api/projects/<p>/dashboard`, `/api/projects/<p>/runs`, `/api/standards/<id>`, `/api/shared/projects/<p>/info`, `/api/browse`: **no leaks**.
- The guards were mutation-tested, not just exercised: removing `validate_path_segment` leaks a canary from outside the root; removing `contained_path` lets the symlink escape through. Both are load-bearing.

## Follow-up, deliberately not in this PR

The remaining alerts come from joining a project name onto the root. The fix is to resolve by listing (`os.scandir` + name match) so the path originates from the filesystem rather than the request. I implemented it and backed it out, because it changes real API behaviour: a project directory that does not exist currently yields `200 []` for dismissed-findings and `404` for a shared pull, and listing-based resolution turns both into `400`. Conflating "absent" with "invalid" is a contract change that deserves its own PR and its own decision, not a rider on a deletion.

Worth noting from that attempt: `os.scandir` entries need `is_dir(follow_symlinks=False)`. The default follows symlinks and would hand back `root/escape` for a link pointing out of the tree — a straight security regression, caught by the symlink test added in #1014.