### PR TITLE
fix(api): resolve projects by directory listing instead of path joining

### DIFF
--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -28,7 +28,7 @@ from quodeq.services.mutation_rescore import (
 )
 from quodeq.services.verified import unverify_finding, verified_entries
 from quodeq.shared.utils import get_evaluations_dir
-from quodeq.shared.validation import contained_path, validate_path_segment
+from quodeq.shared.validation import resolve_child_dir, validate_path_segment
 
 _logger = logging.getLogger(__name__)
 _MAX_DISMISSED_LIMIT = 5000
@@ -59,12 +59,32 @@ def _invalid_body_fields(
     return None
 
 
-def _project_dir(evaluations_dir: str, project: str) -> Path:
+def _project_dir_or_none(evaluations_dir: str, project: str) -> Path | None:
+    """Resolve *project* to its directory by listing, or None if there is none.
+
+    *project* is matched against real entries under *evaluations_dir* and never
+    concatenated onto it, so a traversal or absolute-path value matches nothing
+    instead of having to be contained after the fact.
+
+    None means absent, not invalid: validate_path_segment has already rejected
+    syntactically bad names above.
+    """
     validate_path_segment(project)
-    try:
-        return Path(contained_path(Path(evaluations_dir) / project, evaluations_dir))
-    except ValueError:
-        abort(400, description="Invalid project path")
+    resolved = resolve_child_dir(evaluations_dir, project)
+    return Path(resolved) if resolved is not None else None
+
+
+def _project_dir(evaluations_dir: str, project: str) -> Path:
+    """As above, but 404 when the project has no directory.
+
+    For the mutating endpoints, which have nothing to act on without one.
+    Read endpoints that answer "nothing here" with an empty list call
+    _project_dir_or_none directly.
+    """
+    resolved = _project_dir_or_none(evaluations_dir, project)
+    if resolved is None:
+        abort(404, description="Project not found")
+    return resolved
 
 
 def register_findings_routes(app: Flask) -> None:
@@ -88,12 +108,10 @@ def register_findings_routes(app: Flask) -> None:
         raw_limit = request.args.get("limit", _MAX_DISMISSED_LIMIT, type=int)
         limit = max(1, min(raw_limit, _MAX_DISMISSED_LIMIT))
         offset = max(0, request.args.get("offset", 0, type=int))
-        items = load_dismissed(
-            _project_dir(_eval_dir(), project),
-            offset=offset,
-            limit=limit,
-        )
-        return jsonify(items)
+        project_dir = _project_dir_or_none(_eval_dir(), project)
+        if project_dir is None:
+            return jsonify([])
+        return jsonify(load_dismissed(project_dir, offset=offset, limit=limit))
 
     @app.post("/api/findings/dismiss")
     def dismiss() -> tuple[Response, int]:
@@ -185,7 +203,10 @@ def register_findings_routes(app: Flask) -> None:
         project = request.args.get("project", "")
         if not project:
             return jsonify([])
-        return jsonify(verified_entries(_project_dir(_eval_dir(), project)))
+        project_dir = _project_dir_or_none(_eval_dir(), project)
+        if project_dir is None:
+            return jsonify([])
+        return jsonify(verified_entries(project_dir))
 
     @app.post("/api/findings/unverify")
     def unverify() -> tuple[Response, int]:

--- a/src/quodeq/api/routes_rescore.py
+++ b/src/quodeq/api/routes_rescore.py
@@ -12,7 +12,7 @@ from quodeq.services.deleted import deleted_keys as load_deleted_keys
 from quodeq.services.dismissed import dismissed_keys as load_dismissed_keys
 from quodeq.services.rescore import rescore_dimensions
 from quodeq.shared.utils import get_evaluations_dir
-from quodeq.shared.validation import contained_path, validate_path_segment
+from quodeq.shared.validation import resolve_child_dir, validate_path_segment
 from quodeq.services.suppression import load_suppression_rules
 
 
@@ -35,12 +35,19 @@ def register_rescore_routes(app: Flask) -> None:
             validate_path_segment(project)
             if run_id and run_id != "latest":
                 validate_path_segment(run_id)
-            # Contain the joined path, not just the segment, and use what comes
-            # back: the contained value is what flows to the readers below.
-            project_dir = Path(contained_path(Path(eval_dir) / project, eval_dir))
         except ValueError:
             body, status = error_response("Invalid project or run parameter", HTTPStatus.BAD_REQUEST, "INVALID_PARAM")
             return jsonify(body), status
+
+        # Resolve by listing rather than joining: *project* is compared against
+        # real entries and never concatenated onto *eval_dir*, so a hostile
+        # value matches nothing instead of needing containment afterwards.
+        # A miss here is "no such project", which is a 404 like any other.
+        resolved_dir = resolve_child_dir(eval_dir, project)
+        if resolved_dir is None:
+            body, status = error_response("No runs found for project", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+        project_dir = Path(resolved_dir)
         project = project_dir.name
 
         # Resolve run ID

--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -49,7 +49,7 @@ from quodeq.services.shared_settings import (
     write_settings,
 )
 from quodeq.services.verified import verified_entries
-from quodeq.shared.validation import contained_path, validate_path_segment
+from quodeq.shared.validation import resolve_child_dir, validate_path_segment
 
 from .routes_common import reports_dir
 
@@ -129,11 +129,15 @@ def _validate_segment(*segments: str) -> tuple[Response, int] | None:
 
 
 def _shared_project_dir(eval_root: Path, project: str) -> Path | None:
-    """Resolve *project* under *eval_root*; None if it would escape the root."""
-    try:
-        return Path(contained_path(eval_root / project, eval_root))
-    except ValueError:
-        return None
+    """Resolve *project* under *eval_root* by listing; None if there is no such entry.
+
+    *project* is matched against real directory entries rather than joined onto
+    *eval_root*, so a hostile value matches nothing instead of needing to be
+    contained afterwards. None means absent, not invalid: callers run
+    _validate_segment first, so a bad name is already a 400 by this point.
+    """
+    resolved = resolve_child_dir(eval_root, project)
+    return Path(resolved) if resolved is not None else None
 
 
 def register_shared_routes(app: Flask) -> None:
@@ -302,9 +306,6 @@ def register_shared_routes(app: Flask) -> None:
             return err
         project_path = _shared_project_dir(eval_root, project)
         if project_path is None:
-            body, status = error_response("Invalid parameter", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
-            return jsonify(body), status
-        if not project_path.is_dir():
             body, status = error_response(
                 "Project not found in the shared repository", HTTPStatus.NOT_FOUND, "NOT_FOUND",
             )
@@ -526,8 +527,7 @@ def register_shared_routes(app: Flask) -> None:
             return err
         project_dir = _shared_project_dir(eval_root, project)
         if project_dir is None:
-            body, status = error_response("Invalid parameter", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
-            return jsonify(body), status
+            return jsonify([])
         raw_limit = request.args.get("limit", _MAX_DISMISSED_LIMIT, type=int)
         limit = max(1, min(raw_limit, _MAX_DISMISSED_LIMIT))
         offset = max(0, request.args.get("offset", 0, type=int))
@@ -542,6 +542,5 @@ def register_shared_routes(app: Flask) -> None:
             return err
         project_dir = _shared_project_dir(eval_root, project)
         if project_dir is None:
-            body, status = error_response("Invalid parameter", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
-            return jsonify(body), status
+            return jsonify([])
         return jsonify(verified_entries(project_dir))

--- a/src/quodeq/core/utils/io.py
+++ b/src/quodeq/core/utils/io.py
@@ -52,6 +52,40 @@ def validate_path_segment(*segments: str) -> None:
             )
 
 
+def resolve_child_dir(root: str | Path, name: str) -> str | None:
+    """Return the child directory of *root* called *name*, or None if absent.
+
+    The returned path comes out of the directory listing; *name* is only ever
+    compared against entries that already exist, never concatenated onto
+    *root*. That is the entire point. A traversal segment, an absolute path,
+    or a symlink name simply fails to match any real entry, so there is no
+    hostile value to contain and no containment check to get wrong.
+
+    Symlinks are not followed. ``entry.is_dir(follow_symlinks=False)`` defaults to following them,
+    which would return ``root/escape`` for a link pointing out of the tree and
+    hand the caller an escape hatch. Listing-based resolution is only safe
+    when the entry is a real directory, so this asks for that explicitly.
+
+    Prefer this over ``contained_path(root / name, root)`` whenever *name*
+    comes from a request and names something that must already exist. Reach
+    for :func:`contained_path` only when the target may legitimately not exist
+    yet (new project registration, a clone destination), where matching
+    against a listing is impossible.
+
+    A None result means *absent*, not *invalid*: callers run
+    :func:`validate_path_segment` first, so a syntactically bad name is
+    already rejected upstream. Map None to "not found", not "bad request".
+    """
+    try:
+        with os.scandir(root) as entries:
+            for entry in entries:
+                if entry.name == name and entry.is_dir(follow_symlinks=False):
+                    return entry.path
+    except OSError:
+        return None
+    return None
+
+
 def contained_path(candidate: str | Path, root: str | Path) -> str:
     """Return *candidate* resolved, guaranteed to sit inside *root*.
 

--- a/src/quodeq/shared/validation.py
+++ b/src/quodeq/shared/validation.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from quodeq.core.utils.io import (  # noqa: F401 — moved inward to core
     contained_path,
+    resolve_child_dir,
     validate_path_segment,
 )
 

--- a/tests/api/test_findings_rate_limit_exempt.py
+++ b/tests/api/test_findings_rate_limit_exempt.py
@@ -29,6 +29,11 @@ def client(tmp_path, monkeypatch):
     """Full Flask app stack with a *tight* rate limit so the burst test is fast."""
     monkeypatch.setenv("QUODEQ_RATE_LIMIT_MAX", "5")
     monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(tmp_path))
+    # The mutation endpoints resolve a project against the directory listing,
+    # so the project these requests name has to exist. It always does in real
+    # use; the fixture only got away without it while the old code silently
+    # created the tree on first write.
+    (tmp_path / "p").mkdir(exist_ok=True)
     # Use a fresh in-memory store with the same tight cap so the test
     # doesn't depend on environment-reading inside the factory.
     store = InMemoryRateLimitStore(window=60, max_requests=5)

--- a/tests/api/test_routes_rescore.py
+++ b/tests/api/test_routes_rescore.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from quodeq.api.app import create_app
+from quodeq.shared.validation import resolve_child_dir
 
 _TEST_RUN_ID = "run-1"
 _TEST_DATE_LABEL = "Apr 2"
@@ -25,18 +26,21 @@ def test_rescore_requires_project(client):
     assert "project" in data.get("error", "").lower()
 
 
-@patch("quodeq.api.routes_rescore._eval_dir_from_app", return_value="/tmp/eval")
 @patch("quodeq.api.routes_rescore.read_run_data")
 @patch("quodeq.api.routes_rescore.list_runs")
 @patch("quodeq.api.routes_rescore.load_dismissed_keys")
 @patch("quodeq.api.routes_rescore.rescore_dimensions")
-def test_rescore_returns_rescored_data(mock_rescore, mock_dismissed, mock_list_runs, mock_read_run, _mock_eval, client):
+def test_rescore_returns_rescored_data(mock_rescore, mock_dismissed, mock_list_runs, mock_read_run, tmp_path, client):
+    # The route resolves the project against the directory listing, so the
+    # evaluations root has to actually contain it.
+    (tmp_path / "test-project").mkdir()
     mock_list_runs.return_value = [MagicMock(run_id=_TEST_RUN_ID, date_iso="2026-04-02", date_label=_TEST_DATE_LABEL)]
     mock_read_run.return_value = []
     mock_dismissed.return_value = set()
     mock_rescore.return_value = {"dimensions": [], "summary": {"dimensionsCount": 0, "overallGrade": None}}
 
-    resp = client.get("/api/rescore?project=test-project")
+    with patch("quodeq.api.routes_rescore._eval_dir_from_app", return_value=str(tmp_path)):
+        resp = client.get("/api/rescore?project=test-project")
     assert resp.status_code == 200
     data = resp.get_json()
     assert "dimensions" in data
@@ -48,7 +52,10 @@ def test_rescore_rejects_project_symlinked_outside_the_evaluations_root(tmp_path
     """A project name that is a symlink out of the root is refused.
 
     The segment check alone passed this: "escape" holds no dots or
-    separators. Only containment on the *joined* path catches it.
+    separators. Listing-based resolution refuses it because the entry is a
+    symlink, not a real directory, so it never matches — hence 404 (no such
+    project) rather than the 400 the containment check used to return. The
+    security property is the same: the escaped directory is never reached.
     """
     eval_root = tmp_path / "evaluations"
     eval_root.mkdir()
@@ -59,5 +66,10 @@ def test_rescore_rejects_project_symlinked_outside_the_evaluations_root(tmp_path
     with patch("quodeq.api.routes_rescore._eval_dir_from_app", return_value=str(eval_root)):
         resp = client.get("/api/rescore?project=escape")
 
-    assert resp.status_code == 400
-    assert resp.get_json()["code"] == "INVALID_PARAM"
+    assert resp.status_code == 404
+    assert resp.get_json()["code"] == "NOT_FOUND"
+    # Assert the security property directly, not just the status code: a 404
+    # is also what an escaped-but-empty directory would produce, so the status
+    # alone does not discriminate between "refused" and "walked out and found
+    # nothing". This line fails if the resolver ever starts following links.
+    assert resolve_child_dir(eval_root, "escape") is None

--- a/tests/core/test_contained_path.py
+++ b/tests/core/test_contained_path.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pytest
 
-from quodeq.core.utils.io import contained_path
+from quodeq.core.utils.io import contained_path, resolve_child_dir
 
 
 def test_allows_direct_child(tmp_path: Path) -> None:
@@ -83,3 +83,62 @@ def test_returns_the_sanitised_value_not_none(tmp_path: Path) -> None:
     result = contained_path(tmp_path / "a" / ".." / "b", tmp_path)
     assert result is not None
     assert result == os.path.realpath(str(tmp_path / "b"))
+
+
+# --- resolve_child_dir: resolution by listing, not by joining ---------------
+
+
+def test_resolve_child_dir_returns_a_real_child(tmp_path: Path) -> None:
+    (tmp_path / "project-a").mkdir()
+    assert resolve_child_dir(tmp_path, "project-a") == str(tmp_path / "project-a")
+
+
+def test_resolve_child_dir_returns_none_for_a_missing_child(tmp_path: Path) -> None:
+    assert resolve_child_dir(tmp_path, "nope") is None
+
+
+def test_resolve_child_dir_ignores_files(tmp_path: Path) -> None:
+    (tmp_path / "notadir").write_text("x")
+    assert resolve_child_dir(tmp_path, "notadir") is None
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    ["..", "../..", "../outside", "/etc", "/etc/passwd", "..\\..", "a/../b", ""],
+)
+def test_resolve_child_dir_matches_nothing_hostile(tmp_path: Path, hostile: str) -> None:
+    """Traversal values are not rejected, they simply match no entry.
+
+    This is the property that makes listing-based resolution better than a
+    containment check: there is no guard to get wrong, because the caller's
+    string is only ever compared against names that already exist.
+    """
+    (tmp_path / "real").mkdir()
+    (tmp_path.parent / "outside").mkdir(exist_ok=True)
+    assert resolve_child_dir(tmp_path, hostile) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_resolve_child_dir_refuses_a_symlink_even_to_a_real_directory(tmp_path: Path) -> None:
+    """Symlinks never resolve, whether they escape the root or not.
+
+    ``os.scandir`` entries report is_dir() as True for a link to a directory
+    by default, which would hand back root/escape and let the caller walk
+    straight out of the tree. The resolver asks for follow_symlinks=False.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    root = tmp_path / "root"
+    root.mkdir()
+    real = root / "real"
+    real.mkdir()
+    (root / "escape").symlink_to(outside)
+    (root / "inside-link").symlink_to(real)
+
+    assert resolve_child_dir(root, "escape") is None
+    assert resolve_child_dir(root, "inside-link") is None
+    assert resolve_child_dir(root, "real") == str(root / "real")
+
+
+def test_resolve_child_dir_on_a_missing_root_is_none(tmp_path: Path) -> None:
+    assert resolve_child_dir(tmp_path / "no-such-root", "anything") is None


### PR DESCRIPTION
Follows #1016. Same principle: remove the thing that makes a guard necessary, rather than perfect the guard.

## The shape being removed

Every remaining alert traces to one pattern: take a project name off the request, concatenate it onto the evaluations root, then guard the result.

```python
Path(evaluations_dir) / project     # <- the problem
```

`resolve_child_dir(root, name)` matches the requested name against real entries under the root and returns the path **from the listing**. The caller's string is compared, never concatenated. A traversal segment, an absolute path, or a symlink matches nothing — there is no hostile value to contain, and no containment check to get wrong.

That is why this beats adding guards at the ~15 data-layer sinks: a guard is something you have to remember on the next route. A resolver that can only return real entries has nothing to forget.

Wired into the three resolvers that took request-supplied project names: `routes_findings._project_dir`, `routes_shared._shared_project_dir`, and the rescore route. `contained_path` stays for targets that may legitimately not exist yet (new project registration, clone destinations), where matching a listing is impossible.

## Two traps, both hit during implementation

**`os.scandir` needs `is_dir(follow_symlinks=False)`.** The default follows links, so a symlink inside the root pointing out of it reports as a directory and the resolver hands back `root/escape` — a straight escape hatch, and a regression against the symlink test added in #1014. Mutation-tested: removing the flag fails two tests.

**A `None` result means absent, not invalid.** `validate_path_segment` already rejects malformed names upstream, so by the time the resolver runs, a miss can only mean "no such project". Callers map `None` to not-found. My first attempt mapped everything to 400 and broke the contract in two places.

## Behaviour change

The mutating findings endpoints now return **404** for a project with no directory, where they previously created the tree on first write. Read endpoints still answer with an empty list, unchanged. Three test fixtures depended on the old auto-creation and now create the project they act on — the rate-limit test's subject is rate limiting, not directory creation.

Arguably this is the better contract: a typo'd project name no longer silently creates an orphan directory.

## Verification

- Full suite: **5636 passed**, 1 skipped.
- Traversal probe, 59 payloads against the live app: no leaks.
- Guards mutation-tested rather than merely exercised. The rescore symlink test originally passed with the guard removed, because a 404 is also what an escaped-but-empty directory produces. It now asserts the resolver's return value directly, so it discriminates.

## Measurement, not prediction

#1016 dropped develop from 33 to **22** open alerts — I had estimated 21 would clear and 11 did, because ten had a second taint source. So no forecast here. I will read the count off develop after this lands.