### PR TITLE
refactor(data): resolve run/project dirs by listing in the run-parser chain

### DIFF
--- a/src/quodeq/data/fs/report_parser/_external_pid.py
+++ b/src/quodeq/data/fs/report_parser/_external_pid.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from quodeq.core.utils.io import resolve_child_dir
 from quodeq.data.sqlite._index_sync import _is_pid_alive
 
 _PID_FILENAME = ".pid"
@@ -30,15 +31,22 @@ def is_safe_run_segment(value: str) -> bool:
     return bool(_SAFE_ID_RE.fullmatch(value)) and value not in (".", "..")
 
 
-def resolve_external_pid(project_uuid: str, run_id: str, reports_root: Path) -> int | None:
+def resolve_external_pid(project_dir: Path, run_id: str) -> int | None:
     """Find the PID of the process running an external job, for cancellation.
 
     Looks for a `.pid` file written by `quodeq evaluate` at run start. Returns
     None if not found or the process is already gone.
+
+    Takes the already-resolved project directory rather than a root plus a
+    name to rejoin: callers resolve once, and this stops rebuilding the same
+    path from raw parts three layers down.
     """
-    if not is_safe_run_segment(project_uuid) or not is_safe_run_segment(run_id):
+    if not is_safe_run_segment(run_id):
         return None
-    pid_file = reports_root / project_uuid / run_id / _PID_FILENAME
+    run_dir = resolve_child_dir(project_dir, run_id)
+    if run_dir is None:
+        return None
+    pid_file = Path(run_dir) / _PID_FILENAME
     if not pid_file.exists():
         return None
     try:

--- a/src/quodeq/data/fs/report_parser/runs.py
+++ b/src/quodeq/data/fs/report_parser/runs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from quodeq.core.utils.io import resolve_child_dir
 from quodeq.core.types import DimensionResult
 from quodeq.core.types.mappers import parse_dimension_result
 from quodeq.data.fs.report_parser._evaluations import load_evaluations
@@ -188,7 +189,13 @@ def list_runs(reports_root: Path, project: str, *, limit: int = _DEFAULT_RUN_LIM
         runs = list_runs(Path("/reports"), "my-project", limit=5)
     """
     validate_path_segment(project)
-    project_dir = reports_root / project
+    # Resolve by listing, not by joining: the returned path comes from the
+    # directory enumeration, so *project* is only ever compared. No project
+    # directory means no runs, which is what a bad name produces too.
+    resolved = resolve_child_dir(reports_root, project)
+    if resolved is None:
+        return []
+    project_dir = Path(resolved)
     index_dates = project_run_dates(reports_root, project)
     run_infos: list[RunInfo] = []
     for entry in safe_read_dir(project_dir):
@@ -214,7 +221,7 @@ def list_runs(reports_root: Path, project: str, *, limit: int = _DEFAULT_RUN_LIM
         if terminal_status is not None:
             status = terminal_status
         else:
-            pid = resolve_external_pid(project_dir.name, entry.name, reports_root)
+            pid = resolve_external_pid(project_dir, entry.name)
             status = "in_progress" if pid is not None else "complete"
         cached = index_dates.get(entry.name)
         if cached is not None:

--- a/src/quodeq/services/_evaluations_index.py
+++ b/src/quodeq/services/_evaluations_index.py
@@ -303,10 +303,9 @@ class EvaluationsIndex:
             pid_file = run_dir / ".pid"
             if not pid_file.exists():
                 return True  # no PID file -> stale/crashed -> complete
-            project_uuid = run_dir.parent.name
-            run_id = run_dir.name
-            reports_root = run_dir.parent.parent
-            return resolve_external_pid(project_uuid, run_id, reports_root) is None
+            # run_dir is already resolved; pass its parent straight through
+            # instead of splitting it into names and rejoining them.
+            return resolve_external_pid(run_dir.parent, run_dir.name) is None
         snapshot = self._jobs.get_job(job_id)
         if snapshot is not None and snapshot.status in {"done", "failed", "cancelled"}:
             return True

--- a/src/quodeq/services/_external_jobs.py
+++ b/src/quodeq/services/_external_jobs.py
@@ -19,6 +19,7 @@ import time
 from pathlib import Path
 
 from quodeq.analysis._process import _kill_tree
+from quodeq.core.utils.io import resolve_child_dir
 from quodeq.data.fs.report_parser._external_pid import (  # noqa: F401 — re-exported API
     is_safe_run_segment,
     resolve_external_pid,
@@ -56,7 +57,10 @@ def cancel_external_run(
     from quodeq.data.sqlite._index_sync import _is_pid_alive
 
     grace = grace_period_s if grace_period_s is not None else _DEFAULT_GRACE_PERIOD_S
-    pid = resolve_external_pid(project_uuid, run_id, reports_root)
+    project_dir = resolve_child_dir(reports_root, project_uuid)
+    if project_dir is None:
+        return False
+    pid = resolve_external_pid(Path(project_dir), run_id)
     if pid is None:
         return False
 

--- a/tests/services/test_external_jobs.py
+++ b/tests/services/test_external_jobs.py
@@ -92,7 +92,7 @@ def test_resolve_external_pid_returns_none_without_pid_file(tmp_path):
     from quodeq.services._external_jobs import resolve_external_pid
 
     (tmp_path / "proj" / "run").mkdir(parents=True)
-    assert resolve_external_pid("proj", "run", tmp_path) is None
+    assert resolve_external_pid(tmp_path / "proj", "run") is None
 
 
 def test_resolve_external_pid_returns_pid_when_alive(tmp_path):
@@ -101,7 +101,7 @@ def test_resolve_external_pid_returns_pid_when_alive(tmp_path):
     run_dir = tmp_path / "proj" / "run"
     run_dir.mkdir(parents=True)
     (run_dir / ".pid").write_text(str(os.getpid()))
-    assert resolve_external_pid("proj", "run", tmp_path) == os.getpid()
+    assert resolve_external_pid(tmp_path / "proj", "run") == os.getpid()
 
 
 def test_resolve_external_pid_returns_none_when_process_dead(tmp_path):
@@ -111,7 +111,7 @@ def test_resolve_external_pid_returns_none_when_process_dead(tmp_path):
     run_dir.mkdir(parents=True)
     # Use a very high PID that's almost certainly not in use
     (run_dir / ".pid").write_text("999999")
-    assert resolve_external_pid("proj", "run", tmp_path) is None
+    assert resolve_external_pid(tmp_path / "proj", "run") is None
 
 
 def test_resolve_external_pid_returns_none_for_corrupt_pid_file(tmp_path):
@@ -120,7 +120,7 @@ def test_resolve_external_pid_returns_none_for_corrupt_pid_file(tmp_path):
     run_dir = tmp_path / "proj" / "run"
     run_dir.mkdir(parents=True)
     (run_dir / ".pid").write_text("not-a-number")
-    assert resolve_external_pid("proj", "run", tmp_path) is None
+    assert resolve_external_pid(tmp_path / "proj", "run") is None
 
 
 # ---------------------------------------------------------------------------
@@ -311,10 +311,10 @@ class TestResolveExternalPidValidation:
     def test_traversal_run_id_returns_none(self, tmp_path):
         # A '..' run_id would otherwise resolve to reports_root/<proj>/../.pid
         (tmp_path / ".pid").write_text("12345")
-        assert resolve_external_pid("proj", "..", tmp_path) is None
+        assert resolve_external_pid(tmp_path / "proj", "..") is None
 
     def test_traversal_project_uuid_returns_none(self, tmp_path):
-        assert resolve_external_pid("..", "run", tmp_path) is None
+        assert resolve_external_pid(tmp_path / "..", "run") is None
 
 
 class TestCancelExternalValidation:

--- a/tests/services/test_score_cache_in_progress.py
+++ b/tests/services/test_score_cache_in_progress.py
@@ -51,7 +51,7 @@ def test_in_progress_run_not_persisted_but_complete_run_is(tmp_path, monkeypatch
     assert dismissed_keys(reports / "proj"), "heavy (cached) path not activated"
 
     # Make the newer run look live: resolve_external_pid returns a pid for it.
-    def fake_pid(project, run_id, root):
+    def fake_pid(project_dir, run_id):
         return 4242 if run_id == live_run else None
     monkeypatch.setattr(_external_jobs, "resolve_external_pid", fake_pid)
     # list_runs binds the data-layer function at import time; patch its binding too.


### PR DESCRIPTION
Slice 1 of the boundary refactor — and a correction to the plan I gave.

## The plan changed, for the better

I said this needed the service layer converted to take a resolved `project_dir` instead of a `(root, project)` pair, cascading through 24 signatures and the `ActionProvider` ABC that remote projects also implement. That was wrong, or at least far more than necessary.

**Each function that joins can resolve by listing internally.** Same signature, no call-site churn, taint broken at that point:

```python
project_dir = reports_root / project                      # before
project_dir = resolve_child_dir(reports_root, project)    # after
```

So the refactor is ~24 independent one-function changes instead of one cascading API break. Each is separately shippable and separately revertible. That is a materially better shape for the remaining work, and it means the ABC never has to move.

## This slice

- **`list_runs`** resolves the project directory by listing. No directory means no runs, which is what a bad name produced before anyway.
- **`resolve_external_pid`** takes the already-resolved project directory and resolves the run by listing, instead of a name plus a root to rejoin. Its own traversal check on the project segment is gone — there is no longer a project segment to traverse with.
- **`_evaluations_index`** already held a resolved `run_dir` and was splitting it into `parent.name` / `name` / `parent.parent` to rebuild the same path three layers down. It now passes `run_dir.parent` straight through. That one is worth a look: it is the same "take a resolved value apart and reassemble it from raw pieces" habit that produced the `cloneDest` defect in #1014.
- **`_external_jobs`** resolves the project directory before use.

Targets alerts 230, 231 (`_external_pid.py`) and 233 (`run_index.py`) among others.

## Verification

- Full suite: **5636 passed**, 1 skipped.
- Traversal probe, 59 payloads: no leaks.
- Signature change caught two stale test stubs — a `fake_pid(project, run_id, root)` monkeypatch and six direct call sites — which is the kind of thing that makes a mechanical change worth doing in small slices.

## No prediction

#1017 cleared zero because every alert had a second surviving path. I will read the count off `refs/heads/develop` after this merges rather than forecast it.