### PR TITLE
refactor(data): resolve run directories by listing, not by joining

### DIFF
--- a/src/quodeq/api/_assistant_helpers.py
+++ b/src/quodeq/api/_assistant_helpers.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from flask import Flask, current_app
 
 from quodeq.assistant import AssistantRepository
+from quodeq.core.utils.io import resolve_child_dir
 from quodeq.assistant.tools import ToolContext
 from quodeq.assistant import LOCAL_PROVIDERS as _LOCAL_PROVIDERS
 from quodeq.services.standards_prefs import load_visible_standard_ids
@@ -94,19 +95,16 @@ def resolve_run_location(project_id: str, run_id: str) -> tuple[str | None, str 
     one whole run.
     """
     evaluations_root = Path(get_evaluations_dir())
-    # Jail the run dir to the evaluations root: a crafted project_id/run_id
-    # (e.g. "../..") must not resolve to a directory outside it. Mirrors the
-    # guard in services/_fs_projects.get_project_info (is_relative_to check)
-    # and routes_common.reports_dir. Store the RESOLVED path so the session
-    # column can never carry ".." segments.
-    run_dir = (evaluations_root / project_id / run_id).resolve()
-    try:
-        run_dir.relative_to(evaluations_root.resolve())
-    except ValueError:
+    # Resolve both segments against the directory listing rather than joining
+    # and then jailing the result. A crafted project_id/run_id ("../..")
+    # matches no entry, so there is nothing to contain afterwards. This
+    # replaces the old resolve() + relative_to() + is_dir() sequence: those
+    # three steps existed to undo a join we no longer perform.
+    project_dir = resolve_child_dir(evaluations_root, project_id)
+    run_dir = resolve_child_dir(project_dir, run_id) if project_dir else None
+    if run_dir is None:
         return None, None
-    if not run_dir.is_dir():
-        return None, None
-    return str(run_dir), resolve_repo_root(project_id)
+    return run_dir, resolve_repo_root(project_id)
 
 
 def resolve_shared_run_location(project_id: str, run_id: str) -> str | None:
@@ -121,12 +119,9 @@ def resolve_shared_run_location(project_id: str, run_id: str) -> str | None:
     if not settings.url:
         return None
     root = shared_evaluations_root(settings.url).resolve()
-    run_dir = (root / project_id / run_id).resolve()
-    try:
-        run_dir.relative_to(root)
-    except ValueError:
-        return None
-    if not run_dir.is_dir():
+    project_dir = resolve_child_dir(root, project_id)
+    run_dir = resolve_child_dir(project_dir, run_id) if project_dir else None
+    if run_dir is None:
         return None
     return str(run_dir)
 

--- a/src/quodeq/api/routes_rescore.py
+++ b/src/quodeq/api/routes_rescore.py
@@ -58,6 +58,11 @@ def register_rescore_routes(app: Flask) -> None:
                 return jsonify(body), status
             run_id = runs[0].run_id
 
+        resolved_run_dir = resolve_child_dir(project_dir, run_id)
+        if resolved_run_dir is None:
+            body, status = error_response("Run data not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+
         try:
             dimensions = read_run_data(Path(eval_dir), project, run_id)
         except FileNotFoundError:
@@ -70,6 +75,6 @@ def register_rescore_routes(app: Flask) -> None:
         # *dimensions* were read from this one run, so its directory is the
         # evidence basis for the rescore.
         result = rescore_dimensions(
-            dimensions, dismissed, deleted, run_dir=project_dir / run_id,
+            dimensions, dismissed, deleted, run_dir=Path(resolved_run_dir),
             rules=load_suppression_rules(project_dir))
         return jsonify(result)

--- a/src/quodeq/data/fs/report_parser/runs.py
+++ b/src/quodeq/data/fs/report_parser/runs.py
@@ -43,7 +43,14 @@ def read_run_data(reports_root: Path, project: str, run_id: str) -> list[Dimensi
         dims = read_run_data(Path("/reports"), "my-project", "20260301")
     """
     validate_path_segment(project, run_id)
-    run_dir = reports_root / project / run_id
+    # Resolve both segments by listing rather than joining, so neither name
+    # is ever concatenated onto a path. A miss raises the same
+    # FileNotFoundError callers already handle for an absent run.
+    project_dir = resolve_child_dir(reports_root, project)
+    resolved_run = resolve_child_dir(project_dir, run_id) if project_dir else None
+    if resolved_run is None:
+        raise FileNotFoundError(f"Run not found: {project}/{run_id}")
+    run_dir = Path(resolved_run)
     evaluations = load_evaluations(run_dir / "evaluation")
     evidence_map = load_evidence_map(run_dir / "evidence")
 

--- a/tests/api/test_routes_rescore.py
+++ b/tests/api/test_routes_rescore.py
@@ -31,9 +31,11 @@ def test_rescore_requires_project(client):
 @patch("quodeq.api.routes_rescore.load_dismissed_keys")
 @patch("quodeq.api.routes_rescore.rescore_dimensions")
 def test_rescore_returns_rescored_data(mock_rescore, mock_dismissed, mock_list_runs, mock_read_run, tmp_path, client):
-    # The route resolves the project against the directory listing, so the
-    # evaluations root has to actually contain it.
-    (tmp_path / "test-project").mkdir()
+    # The route resolves both the project and the run against the directory
+    # listing, so the evaluations root has to actually contain them. list_runs
+    # is mocked to report this run; on disk a reported run always has a
+    # directory, and the fixture now matches that.
+    (tmp_path / "test-project" / _TEST_RUN_ID).mkdir(parents=True)
     mock_list_runs.return_value = [MagicMock(run_id=_TEST_RUN_ID, date_iso="2026-04-02", date_label=_TEST_DATE_LABEL)]
     mock_read_run.return_value = []
     mock_dismissed.return_value = set()


### PR DESCRIPTION
Slice 2 of the staged refactor. Follows #1018 (22 → 20).

## What

`run_id` was the last request-supplied segment still concatenated onto a path. The remaining sinks — `dimensions_state_store`, `projector`, `events/reader`, `suppression_rules` — take an already-resolved directory and join only a constant filename, so their taint arrives entirely from these three callers.

- **`read_run_data`** resolves project and run against the directory listing, raising the `FileNotFoundError` callers already handle when either misses.
- **`routes_rescore`** resolves the run dir instead of `project_dir / run_id`.
- **`_assistant_helpers.resolve_run_location`** and **`resolve_shared_run_location`** drop the `resolve()` + `relative_to()` + `is_dir()` sequence entirely. Those three steps existed only to undo a join we no longer perform — resolving each segment against the listing gives containment *and* existence in one lookup, and a crafted `../..` matches no entry rather than having to be caught after the fact.

That last one is the clearest illustration of the whole exercise: three lines of defensive code replaced by not creating the problem.

## Verification

- Full suite: **5636 passed**, 1 skipped.
- Traversal probe, 59 payloads: no leaks.
- One fixture mocked `list_runs` to report a run whose directory did not exist. On disk a reported run always has one, so the fixture now matches reality rather than the old code's tolerance for the mismatch.

## Expected reach, not a promise

Should clear the `dimensions_state_store`, `projector`, and `events/reader` alerts. Measured off develop after merge as usual — #1017 predicted several and cleared zero.

## Known ceiling

The 6 alerts in `services/project_registration.py` are the registration flow, where the target directory legitimately does not exist yet. Listing-based resolution cannot apply there, and `contained_path` is already proven unrecognisable to CodeQL. Those are the residue this technique cannot reach.