### PR TITLE
fix(violations): confirm before Restore all wipes every dismissal

### DIFF
--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
@@ -76,8 +76,19 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
     }
   }, [selectedProject, onReconcile, setRestoreError, applyDelta, isShared]);
 
+  // Restoring un-suppresses every finding the user ever triaged away, and the
+  // only undo is dismissing them again one by one. The button sits next to the
+  // per-item Restore, so a mis-click is cheap to make and expensive to reverse.
+  // Delete-all has always confirmed; this needs it at least as much.
   const handleRestoreAll = useCallback(async () => {
     if (isShared) return;
+    const count = dismissed.length;
+    const ok = await confirmDialog({
+      title: t('violations.restoreDismissedTitle'),
+      message: t('violations.restoreDismissedBody', { count }),
+      confirmLabel: t('violations.restoreAll'),
+    });
+    if (!ok) return;
     try {
       const result = await restoreAllFindings(selectedProject);
       applyDelta(result);
@@ -87,7 +98,7 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
       console.error('Failed to restore all findings:', err);
       setRestoreError?.(t('violations.restoreAllFailed'));
     }
-  }, [selectedProject, onReconcile, setRestoreError, applyDelta, isShared]);
+  }, [selectedProject, onReconcile, setRestoreError, dismissed.length, applyDelta, isShared]);
 
   const handleDelete = useCallback(async (d) => {
     if (isShared) return;

--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
@@ -89,6 +89,7 @@ describe('useDismissedFindings — restore handlers', () => {
 
   it('handleRestoreAll clears state on success and calls onReconcile', async () => {
     listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
+    confirmDialog.mockResolvedValueOnce(true);
     restoreAllFindings.mockResolvedValueOnce({ ok: true, restored: 2 });
     const onReconcile = vi.fn();
     const setRestoreError = vi.fn();
@@ -100,6 +101,43 @@ describe('useDismissedFindings — restore handlers', () => {
     expect(restoreAllFindings).toHaveBeenCalledWith('proj');
     expect(result.current.dismissed).toEqual([]);
     expect(onReconcile).toHaveBeenCalledTimes(1);
+  });
+
+  // Restore-all un-suppresses every finding the user has ever triaged away, and
+  // the only undo is re-dismissing them one by one. It sits next to the
+  // per-item Restore button, so an unguarded click silently wiped 2045
+  // dismissals in the real project. Delete-all has always confirmed; this must
+  // too.
+  it('handleRestoreAll asks for confirmation before restoring', async () => {
+    listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
+    confirmDialog.mockResolvedValueOnce(true);
+    restoreAllFindings.mockResolvedValueOnce({ ok: true, restored: 2 });
+    const { result } = renderHook(() => useDismissedFindings('proj', vi.fn(), vi.fn(), 0, 'local', vi.fn()), withQueryClient());
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
+
+    await act(async () => { await result.current.handleRestoreAll(); });
+
+    expect(confirmDialog).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Restore dismissed findings?',
+      confirmLabel: 'Restore all',
+      message: expect.stringContaining('2'),
+    }));
+    expect(restoreAllFindings).toHaveBeenCalledWith('proj');
+  });
+
+  it('handleRestoreAll does nothing when the user cancels', async () => {
+    listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
+    confirmDialog.mockResolvedValueOnce(false);
+    const onReconcile = vi.fn();
+    const { result } = renderHook(() => useDismissedFindings('proj', vi.fn(), vi.fn(), 0, 'local', onReconcile), withQueryClient());
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
+
+    await act(async () => { await result.current.handleRestoreAll(); });
+
+    expect(confirmDialog).toHaveBeenCalledTimes(1);
+    expect(restoreAllFindings).not.toHaveBeenCalled();
+    expect(result.current.dismissed).toEqual([sampleA, sampleB]);
+    expect(onReconcile).not.toHaveBeenCalled();
   });
 });
 
@@ -251,6 +289,7 @@ describe('useDismissedFindings — onReconcile (the single mutation freshness ca
 
   it('handleRestoreAll calls onReconcile and leaves onRefresh untouched on success', async () => {
     listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
+    confirmDialog.mockResolvedValueOnce(true);
     restoreAllFindings.mockResolvedValueOnce({ ok: true, restored: 2 });
     const onRefresh = vi.fn();
     const onReconcile = vi.fn();

--- a/src/quodeq/ui/src/strings/en.json
+++ b/src/quodeq/ui/src/strings/en.json
@@ -1211,6 +1211,8 @@
   "violations.restore": "Restore",
   "violations.restoreAll": "Restore all",
   "violations.restoreAllFailed": "Failed to restore all findings. Please try again.",
+  "violations.restoreDismissedBody": "Restore those {count} dismissed findings? They stop being suppressed and count against your grades again.",
+  "violations.restoreDismissedTitle": "Restore dismissed findings?",
   "violations.restoreFailed": "Failed to restore finding. Please try again.",
   "violations.rootCrumb": "Root",
   "violations.showLikelyFp": "Show likely false positives",


### PR DESCRIPTION
## What

`Restore all` in the Dismissed tab now goes through `confirmDialog`, the same guard `Delete all` has always had.

## Why

Restore-all un-suppresses **every** finding the user has ever triaged away, and the only undo is dismissing them again one at a time. The button sat in the header with no confirmation, one row above the per-item `Restore`.

Auditing the grade drop on the quodeq project turned up five separate firings that wiped **2045 of 2275 dismissals**. The signature in `actions.jsonl` is unmistakable: dismissals spread over hours of real triage, then a bulk undismiss at a *single timestamp* with the exact same count.

```
2026-07-24  05:50:05-07:58:14  FINDING_DISMISSED    x106   <- two hours of triage
2026-07-24  13:16:56-13:16:56  FINDING_UNDISMISSED  x106   <- one click
```

The consequence was quiet and expensive: **33% of every later run's violations** were findings already judged false positives, holding the displayed grade roughly a point below the real one.

## Notes

- Message reports the count that is about to come back, so the cost is visible before confirming.
- Reuses the existing `confirmDialog` (`window.confirm` is suppressed by pywebview in frameless mode).
- Deliberately *not* `variant: 'danger'` — restoring is recoverable, unlike delete-all.

## Verification

- 1495/1495 UI tests pass; 3 new tests cover confirm, cancel, and the count in the message.
- `npm run lint:strings` clean (2 new i18n keys, no literals).
- Checked in the running app: dialog appears, Cancel leaves the dismissals in place, no console errors.

