### PR TITLE
fix(runs): a run that skipped dimensions no longer reports a clean done

### DIFF
--- a/src/quodeq/analysis/run_lifecycle.py
+++ b/src/quodeq/analysis/run_lifecycle.py
@@ -110,7 +110,18 @@ class RunLifecycleContext:
                 if self._current_state != RunState.FINALIZING:
                     # Caller didn't explicitly call transition_to_finalizing(); do it now.
                     self._transition(RunState.FINALIZING)
-                self._transition(RunState.DONE, exit_reason=self._pending_exit_reason)
+                # The failure-streak breaker aborts the remaining dimensions from
+                # inside the pipeline, so a truncated run reaches this clean-exit
+                # path with dims still pending. Record that rather than reporting
+                # a done/None status that reads exactly like a full run — the
+                # skipped dims are dropped from the run average, and they tend to
+                # be the ones late in the order, not a random sample.
+                skipped = self._mark_unfinished_dims_incomplete("not_reached")
+                self._transition(
+                    RunState.DONE,
+                    exit_reason=self._pending_exit_reason
+                    or ("incomplete_dimensions" if skipped else None),
+                )
         elif issubclass(exc_type, SystemExit):
             # SystemExit raised by our signal handler; state already written there.
             if self._current_state not in TERMINAL_STATES:
@@ -242,8 +253,16 @@ class RunLifecycleContext:
             deadline = deadline.replace(tzinfo=timezone.utc)
         return datetime.now(timezone.utc) >= deadline
 
-    def _mark_running_dims_incomplete(self, reason: str) -> None:
-        """Flip still-running dims to INCOMPLETE so none sticks at 'running' forever."""
+    def _mark_unfinished_dims_incomplete(self, reason: str) -> int:
+        """Flip non-terminal dims to INCOMPLETE and return how many were flipped.
+
+        Covers ``pending`` as well as ``running``. A dimension the run never
+        got to is just as unfinished as one interrupted mid-flight, and the
+        state machine allows PENDING -> INCOMPLETE precisely for this. Leaving
+        them at ``pending`` made a truncated run indistinguishable from a
+        complete one: the scored dimensions were averaged into a run grade
+        with no record that the rest never ran.
+        """
         from quodeq.data.fs.dimensions_state_store import (  # noqa: PLC0415 — signal path
             DimState,
             read_dimensions,
@@ -252,13 +271,16 @@ class RunLifecycleContext:
         try:
             entries = read_dimensions(self._run_dir).get("dimensions", {})
         except Exception:  # noqa: BLE001 — a failing flip must not mask the exit
-            return
+            return 0
+        flipped = 0
         for dim, entry in entries.items():
-            if isinstance(entry, dict) and entry.get("state") == "running":
+            if isinstance(entry, dict) and entry.get("state") in {"running", "pending"}:
                 try:
                     write_dim_state(self._run_dir, dim, DimState.INCOMPLETE, reason=reason)
+                    flipped += 1
                 except Exception as exc:  # noqa: BLE001
                     _logger.warning("failed to mark dim %s incomplete: %s", dim, exc)
+        return flipped
 
     def _install_signal_handlers(self) -> None:
         def _handle(signum: int, frame: Any) -> None:
@@ -295,8 +317,11 @@ class RunLifecycleContext:
                 time_limit_s=self._time_limit_s,
             )
             self._current_state = RunState.CANCELLED
-            if deadline_enforced:
-                self._mark_running_dims_incomplete("time_limit")
+            # Close out every unfinished dim, not just on the deadline path: a
+            # plain cancel left the in-flight dimension stuck at 'running' and
+            # the untouched ones at 'pending' for the life of the run dir.
+            self._mark_unfinished_dims_incomplete(
+                "time_limit" if deadline_enforced else "cancelled")
             raise SystemExit(128 + signum)
 
         for sig in _SIGNALS_TO_HANDLE:

--- a/tests/analysis/test_run_lifecycle.py
+++ b/tests/analysis/test_run_lifecycle.py
@@ -8,6 +8,8 @@ from unittest.mock import patch
 
 import pytest
 
+from quodeq.core.run.dimensions import DimState
+from quodeq.data.fs.dimensions_state_store import write_dim_state
 from quodeq.data.fs.run_status_store import RunState, read_status
 from quodeq.analysis.run_lifecycle import RunLifecycleContext
 
@@ -217,10 +219,17 @@ def test_set_exit_reason_persists_into_status_on_done(tmp_path: Path) -> None:
 
 def test_no_set_exit_reason_yields_null_on_done(tmp_path: Path) -> None:
     """Without set_exit_reason, a clean run still completes with
-    exit_reason=null (preserving today's contract for completed runs)."""
+    exit_reason=null (preserving today's contract for completed runs).
+
+    The declared dimension has to actually finish: a run that ends with a
+    dimension it never scored now reports ``incomplete_dimensions``, so
+    leaving 'flex' pending here would be testing the wrong contract.
+    """
     run_dir = tmp_path / "run"
     run_dir.mkdir()
     with RunLifecycleContext(run_dir, job_id="ext-test", dimensions=["flex"]) as ctx:
+        write_dim_state(run_dir, "flex", DimState.RUNNING)
+        write_dim_state(run_dir, "flex", DimState.DONE)
         ctx.transition_to_finalizing()
 
     status = read_status(run_dir)

--- a/tests/analysis/test_run_lifecycle_partial_dims.py
+++ b/tests/analysis/test_run_lifecycle_partial_dims.py
@@ -1,0 +1,85 @@
+"""A run that ends with dimensions still unscored must say so.
+
+The failure-streak circuit breaker aborts the remaining dimensions from
+inside the pipeline, so no exception reaches the lifecycle context and the
+run exits through the clean DONE path. Every dimension that never got a
+turn stayed at ``pending`` forever, and the run reported ``done`` with a
+null exit_reason -- indistinguishable from a full run.
+
+That is how three of the quodeq project's daily runs came to average only
+their worst dimensions: the ones that never ran were security-adjacent
+stragglers at the end of the order (usability, flexibility,
+clean-architecture), all scoring higher than the ones that did run.
+"""
+from pathlib import Path
+
+from quodeq.analysis.run_lifecycle import RunLifecycleContext
+from quodeq.core.run.dimensions import DimState
+from quodeq.data.fs.dimensions_state_store import read_dimensions, write_dim_state
+from quodeq.data.fs.run_status_store import read_status
+
+
+def _states(run_dir: Path) -> dict[str, str]:
+    entries = read_dimensions(run_dir).get("dimensions", {})
+    return {name: entry.get("state") for name, entry in entries.items()}
+
+
+def test_clean_exit_marks_never_started_dimensions_incomplete(tmp_path: Path) -> None:
+    with RunLifecycleContext(
+        run_dir=tmp_path, job_id="j1",
+        dimensions=["security", "usability", "flexibility"],
+    ) as lifecycle:
+        write_dim_state(tmp_path, "security", DimState.RUNNING)
+        write_dim_state(tmp_path, "security", DimState.DONE)
+        lifecycle.transition_to_finalizing()
+
+    states = _states(tmp_path)
+    assert states["security"] == "done"
+    assert states["usability"] == "incomplete"
+    assert states["flexibility"] == "incomplete"
+
+
+def test_run_with_unscored_dimensions_does_not_report_a_clean_done(tmp_path: Path) -> None:
+    with RunLifecycleContext(
+        run_dir=tmp_path, job_id="j1",
+        dimensions=["security", "usability"],
+    ) as lifecycle:
+        write_dim_state(tmp_path, "security", DimState.RUNNING)
+        write_dim_state(tmp_path, "security", DimState.DONE)
+        lifecycle.transition_to_finalizing()
+
+    status = read_status(tmp_path)
+    assert status is not None
+    assert status["state"] == "done"
+    # The run is over and a dimension never ran. Without a reason here the
+    # History row and the trend read this exactly like a complete run.
+    assert status["exit_reason"] == "incomplete_dimensions"
+
+
+def test_fully_scored_run_stays_a_clean_done(tmp_path: Path) -> None:
+    with RunLifecycleContext(
+        run_dir=tmp_path, job_id="j1", dimensions=["security"],
+    ) as lifecycle:
+        write_dim_state(tmp_path, "security", DimState.RUNNING)
+        write_dim_state(tmp_path, "security", DimState.DONE)
+        lifecycle.transition_to_finalizing()
+
+    status = read_status(tmp_path)
+    assert status is not None
+    assert status["state"] == "done"
+    assert status["exit_reason"] is None
+    assert _states(tmp_path) == {"security": "done"}
+
+
+def test_explicit_exit_reason_is_not_overwritten(tmp_path: Path) -> None:
+    """A caller-supplied reason is more specific than 'some dims were skipped'."""
+    with RunLifecycleContext(
+        run_dir=tmp_path, job_id="j1", dimensions=["security", "usability"],
+    ) as lifecycle:
+        lifecycle.set_exit_reason("time_limit")
+        lifecycle.transition_to_finalizing()
+
+    status = read_status(tmp_path)
+    assert status is not None
+    assert status["exit_reason"] == "time_limit"
+    assert _states(tmp_path)["usability"] == "incomplete"

--- a/tests/ci/test_cli_lifecycle_integration.py
+++ b/tests/ci/test_cli_lifecycle_integration.py
@@ -9,6 +9,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from quodeq.core.run.dimensions import DimState
+from quodeq.data.fs.dimensions_state_store import write_dim_state
+from quodeq.core.run.dimensions import DimState
 from quodeq.data.fs.run_status_store import read_status
 
 
@@ -134,6 +137,10 @@ def test_record_deadline_if_hit_noop_when_no_deadline(tmp_path: Path) -> None:
     with RunLifecycleContext(run_dir, job_id="ext-test", dimensions=["flex"]) as lifecycle:
         config = SimpleNamespace(options=SimpleNamespace(deadline_at=None))
         cli._record_deadline_if_hit(lifecycle, config)
+        # Finish the declared dimension: a run that ends without scoring one
+        # now reports incomplete_dimensions, which would mask what this asserts.
+        write_dim_state(run_dir, "flex", DimState.RUNNING)
+        write_dim_state(run_dir, "flex", DimState.DONE)
         lifecycle.transition_to_finalizing()
 
     status = read_status(run_dir)
@@ -155,6 +162,10 @@ def test_record_deadline_if_hit_noop_when_deadline_not_yet_reached(tmp_path: Pat
             options=SimpleNamespace(deadline_at=time.monotonic() + 3600.0),
         )
         cli._record_deadline_if_hit(lifecycle, config)
+        # Finish the declared dimension: a run that ends without scoring one
+        # now reports incomplete_dimensions, which would mask what this asserts.
+        write_dim_state(run_dir, "flex", DimState.RUNNING)
+        write_dim_state(run_dir, "flex", DimState.DONE)
         lifecycle.transition_to_finalizing()
 
     status = read_status(run_dir)


### PR DESCRIPTION
## What

Dimensions a run never got to are now closed out as `INCOMPLETE` on every exit path, and a run that ends without scoring a declared dimension reports `exit_reason='incomplete_dimensions'`.

## Why

`_mark_running_dims_incomplete` only flipped dims in state `running`, and only when the deadline had passed. Everything else stayed `pending` forever, even though `core/run/dimensions.py` has allowed `PENDING -> INCOMPLETE` from the start.

Two ways that hid a truncated run:

**1. The clean-exit path.** The failure-streak breaker aborts the remaining dimensions from inside the pipeline, so no exception reaches the lifecycle context and the run finalizes as `state=done, exit_reason=null` — byte-identical to a full run. Three of the quodeq project's recent daily runs look like this:

```
run       state  exit  dims
fbc3be24  done   None  {done: 4, pending: 3}   reasons={failure_streak}
ae732bd1  done   None  {done: 5, pending: 2}   reasons={failure_streak}
51908cc4  done   None  {done: 5, pending: 1}   reasons={failure_streak}
```

The run grade averages only the dimensions that ran, and the skipped ones are not a random sample — they sit late in the dimension order. On this project the stragglers are `usability` (8.4), `flexibility` (6.4) and `clean-architecture` (6.5), while the survivors include `security` (5.8) and `reliability` (6.0). A 3-of-7 run displayed **4.10** where the full run scored **4.69**, and that number went into the trend as if it were comparable.

**2. Plain cancels.** The flip was gated on `deadline_enforced`, so a SIGTERM cancel left the in-flight dimension stuck at `running` for the life of the run directory (visible on `3b8ccfd7`, `45515cb9`, `82882502`, `ca704332`).

## Scope

This makes the run state honest. It deliberately does **not** change how the average is computed or filter partial runs out of the trend — that needs a product call about what a partial run should show, and it now has a reliable signal to key off. Flagging it rather than folding it in silently.

## Verification

- 5617 passed, 1 skipped, 0 failed (`pytest -m "not integration"`).
- 4 new tests: pending dims flipped on clean exit, `incomplete_dimensions` set, a fully-scored run still reports a null exit_reason, and an explicit reason (`time_limit`) still wins.
- Two existing lifecycle tests declared a dimension they never ran and asserted a null exit_reason. Their stated intent is the *completed-run* contract, so they now complete the dimension instead of asserting the truncated case. The deadline tests were left alone: an explicit reason already takes precedence.