### PR TITLE
feat(history): say when a score-history point came from a partial scan

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -48,16 +48,30 @@ function buildTrendData(trend, selectedRunId, granularity = 'day') {
 }
 
 
-function RunHistoryTooltip({ active, payload }) {
+// Every point here is the PROJECT grade -- the latest known score for each
+// dimension, not the grade of that one scan. A scan that only measured
+// clean-architecture still plots a full project number, which is what makes
+// the line comparable across runs. The cost is that a point refreshed by 1 of
+// 7 dimensions looks identical to one backed by a full sweep, so say when the
+// refresh was partial. A complete scan needs no annotation.
+export function RunHistoryTooltip({ active, payload }) {
   if (!active || !payload?.length) return null;
   const entry = payload[0]?.payload;
   if (!entry) return null;
   const score = Number.isFinite(entry.numericAverage) ? entry.numericAverage.toFixed(1) : '—';
   const grade = gradeLetter(entry.overallGrade);
+  const refreshed = entry.dimensionsCount;
+  const total = entry.accumulatedDimensionsCount;
+  const partial = Number.isFinite(refreshed) && Number.isFinite(total) && refreshed < total;
   return (
     <div className="run-history-tooltip">
       <span className="rht-date">{entry.periodLabel || entry.dateLabel}</span>
       <span className="rht-score">{score} - {grade}</span>
+      {partial && (
+        <span className="rht-coverage">
+          {t('history.partialRefresh', { count: refreshed, total })}
+        </span>
+      )}
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.test.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
-import RunHistoryPanel from './RunHistoryPanel.jsx';
+import RunHistoryPanel, { RunHistoryTooltip } from './RunHistoryPanel.jsx';
 
 const TREND = [
   { runId: 'r1', dateISO: '2026-03-25T14:00:00', dateLabel: '25 Mar 2026', numericAverage: 9.5, overallGrade: 'Exemplary' },
@@ -31,6 +31,29 @@ describe('RunHistoryPanel', () => {
     render(<RunHistoryPanel trend={[TREND[0]]} selectedRunId="r1" granularity="month" onGranularityChange={() => {}} />);
     expect(screen.getByLabelText('Group score history by')).toBeInTheDocument();
     expect(screen.queryByText(/MIN /)).not.toBeInTheDocument();
+  });
+
+  // Every point on this chart is the PROJECT grade (latest known score per
+  // dimension), not the grade of that one scan. So a scan that only measured
+  // clean-architecture still plots a full project number. Without saying how
+  // much the scan refreshed, a point backed by 1 of 7 dimensions is
+  // indistinguishable from one backed by a full sweep.
+  it('says how much of the project a partial scan refreshed', () => {
+    const entry = {
+      periodLabel: '1 Aug 2026', numericAverage: 7.6, overallGrade: 'Good',
+      dimensionsCount: 1, accumulatedDimensionsCount: 7,
+    };
+    render(<RunHistoryTooltip active payload={[{ payload: entry }]} />);
+    expect(screen.getByText(/1.*7/)).toBeInTheDocument();
+  });
+
+  it('does not annotate a scan that refreshed every dimension', () => {
+    const entry = {
+      periodLabel: '3 Aug 2026', numericAverage: 6.9, overallGrade: 'Adequate',
+      dimensionsCount: 7, accumulatedDimensionsCount: 7,
+    };
+    const { container } = render(<RunHistoryTooltip active payload={[{ payload: entry }]} />);
+    expect(container.querySelector('.rht-coverage')).toBeNull();
   });
 
   it('hides the stats line instead of rendering Infinity when no bucket has a numeric score', () => {

--- a/src/quodeq/ui/src/strings/en.json
+++ b/src/quodeq/ui/src/strings/en.json
@@ -512,6 +512,7 @@
   "history.dimensionScoresAria": "Dimension scores bar chart",
   "history.dimensionScoresTitle": "Dimension Scores",
   "history.dimsCount": "{count} dims",
+  "history.partialRefresh": "refreshed {count} of {total} dimensions",
   "history.evalsCountMany": "{count} evals",
   "history.evalsCountOne": "{count} eval",
   "history.evaluationsHeader": "EVALUATIONS",

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -2271,6 +2271,9 @@
 
 .rht-date  { color: var(--color-text-muted); }
 .rht-score { font-weight: 600; color: var(--color-text); }
+/* Only rendered when the scan refreshed some of the dimensions, so it must
+   read as a qualifier on the score above it, not as a third headline. */
+.rht-coverage { color: var(--color-text-muted); font-size: 0.72rem; }
 
 /* ── History panels row (Score History + Dimension Scores side-by-side) ── */
 


### PR DESCRIPTION
## What

The score-history tooltip now reads **"refreshed 6 of 7 dimensions"** when the scan behind that point measured only some of them. A full scan stays unannotated.

## Why

Every point on this chart is the **project** grade — the latest known score per dimension (`acc_by_dim` in `build_accumulated_trend`) — not the grade of the scan that produced it. That is deliberate and correct: it is what makes the line comparable, so a scan of only `clean-architecture` plots a full project number instead of collapsing the line to that one dimension's score.

The cost is that the chart could not distinguish a point backed by a full sweep from one backed by a single dimension. On this project that is the common case, not a corner case — **32 of the last 34 runs measured fewer than all dimensions**, several of them exactly one:

```
fecha       run       midio   runAvg  accAvg  <- plotted
1 Aug 2026  57df42b8  1/1      6.6     7.6
2 Aug 2026  fbc3be24  4/7      6.9     7.0
3 Aug 2026  0ace6d40  7/7      6.9     6.9
```

`runAvg` and `accAvg` diverge by a full point on the single-dimension scans, and the chart plots `accAvg` with nothing to say the scan behind it touched one dimension.

## Notes

- No new data: `dimensionsCount` and `accumulatedDimensionsCount` were already in the trend payload and already preserved through `scoreFiltering.js`. Only the tooltip changed.
- `RunHistoryTooltip` is now exported so the branch can be tested directly; Recharts otherwise only renders it through a real hover.
- Styled as a muted qualifier under the score, not a third headline.

## Verification

- 1497/1497 UI tests pass; 2 new tests cover the partial annotation and the absence of it on a full scan.
- `npm run lint:strings` clean (1 new key, no literals).
- Checked in the running app against real data: tooltip reads "23 Jul 2026 / 7.7 - B / refreshed 6 of 7 dimensions", no console errors.