### PR TITLE
feat(overview): say when a grade came from a tuned formula

### DIFF
--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -30,7 +30,7 @@ from quodeq.services._dashboard_trend import build_accumulated_trend
 from quodeq.services._trend_fetcher import make_rescoring_fetcher, make_trend_fetcher
 from quodeq.services.accumulated import compute_accumulated
 from quodeq.services.dashboard import _make_run_dimension_fetcher
-from quodeq.services.grade_formula import load_params
+from quodeq.services.grade_formula import is_custom, load_params
 from quodeq.services.scoring_view import select_trend_runs
 from quodeq.services.deleted import deleted_keys
 from quodeq.services.dismissed import dismissed_keys
@@ -310,12 +310,20 @@ def get_project_scores(
     d = deps or _NO_DEPS
     params = load_params()
 
+    # How the numbers were produced, not what they are. A tuned formula moves
+    # every score at once and leaves no other trace -- findings and runs are
+    # unchanged -- so the Overview has to be able to say so next to the grade.
+    # Computed outside the accumulated cache: it is a file-existence check, and
+    # keeping it out of the cached payload avoids another version input.
+    scoring_meta = {"customFormula": is_custom()}
+
     all_runs = list_runs(reports_root, project)
     if not all_runs:
         return {
             "accumulated": {"dimensions": [], "summary": {}},
             "trend": [],
             "availableRuns": [],
+            "scoring": scoring_meta,
         }
 
     # Build accumulated using the existing service (returns full data with
@@ -380,6 +388,7 @@ def get_project_scores(
         "accumulated": accumulated,
         "trend": trend,
         "availableRuns": available_runs,
+        "scoring": scoring_meta,
     }
 
 

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -84,7 +84,7 @@ function buildLanguageSub(projectInfo) {
     .join('  ');
 }
 
-export function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, accumulatedDimensions, projectName, projectInfo, onCardNavigate, selectedSource }) {
+export function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, accumulatedDimensions, projectName, projectInfo, onCardNavigate, selectedSource, customFormula = false }) {
   const summary = accumulated?.summary;
   const scoreNum = parseFloat(summary?.numericAverage);
   const scoreDisplay = isNaN(scoreNum) ? '—' : scoreNum.toFixed(1);
@@ -113,7 +113,13 @@ export function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, accu
           label={t('overview.statScore')}
           value={scoreDisplay}
           trailing={scoreDelta !== null ? <TrendBadge delta={scoreDelta} showLabel={false} /> : null}
-          hint={grade ? t('overview.gradeHint', { letter: gradeLetter(grade) }) : null}
+          // A tuned formula shifts every score at once with no other trace, so
+          // say so where the grade is read rather than only on the settings
+          // page that changed it.
+          hint={grade
+            ? t(customFormula ? 'overview.gradeHintCustomFormula' : 'overview.gradeHint',
+                { letter: gradeLetter(grade) })
+            : null}
         />
         <Stat
           label={t('overview.statViolations')}
@@ -288,6 +294,7 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
         projectInfo={data.projectInfo}
         onCardNavigate={onCardNavigate}
         selectedSource={data.selectedSource}
+        customFormula={data.customFormula}
       />
 
       <div className="history-panels-row">

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.test.jsx
@@ -25,6 +25,25 @@ function runHook(selectedRunId) {
   })).result.current;
 }
 
+// A tuned grade formula moves every score in the project at once and leaves no
+// other trace: same findings, same runs, different number. Setting the major
+// severity weight to 6.0 (shipped default 1.5) cost this project about a point
+// across every dimension for a month, and the Overview -- the one screen where
+// the grade is actually read -- said nothing.
+describe('AccumulatedHeroSection custom-formula warning', () => {
+  const ACC = { summary: { numericAverage: 5, overallGrade: 'Adequate', totalViolations: 3, totalCompliance: 1 } };
+
+  it('marks the score when a tuned formula produced it', () => {
+    render(<AccumulatedHeroSection accumulated={ACC} accumulatedDimensions={DIMS} customFormula />);
+    expect(screen.getByText(/custom formula/i)).toBeInTheDocument();
+  });
+
+  it('says nothing when the shipped formula produced it', () => {
+    render(<AccumulatedHeroSection accumulated={ACC} accumulatedDimensions={DIMS} customFormula={false} />);
+    expect(screen.queryByText(/custom formula/i)).not.toBeInTheDocument();
+  });
+});
+
 describe('useAccumulatedComputations dimTrends (as-of)', () => {
   it('uses the full series at the latest run', () => {
     const { dimTrends } = runHook('t1');

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -47,7 +47,7 @@ function NoCompletedEvalPanel({ availableRuns = [], onNavigate, selectedSource }
 }
 
 function DashboardContent({ runMode, data, focus, callbacks }) {
-  const { dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo, granularity, selectedSource, scoresPending } = data;
+  const { dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo, granularity, selectedSource, scoresPending, customFormula } = data;
   const { dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData } = focus;
   const { onRunSelect, onDimensionCardClick, onAccumulatedDimensionClick, onFileClick, onNavigate, onGranularityChange } = callbacks;
   // No readiness check here on purpose: the page only mounts this component
@@ -94,7 +94,7 @@ function DashboardContent({ runMode, data, focus, callbacks }) {
         accumulated: accumulated ? { ...accumulated, dimensions: accumulatedDimensions } : accumulated,
         accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex,
         trend: dashboard?.trend || [], selectedRunId, selectedProject, projectInfo, granularity, selectedSource,
-        scoresPending,
+        scoresPending, customFormula,
       }}
       callbacks={{
         onRunClick: onRunSelect, onDimensionClick: onAccumulatedDimensionClick, onNavigate, onGranularityChange,
@@ -137,7 +137,7 @@ export function selectDashboardProjectInfo({ selectedSource, projects, selectedP
 }
 
 export default function DashboardPage({ data = {}, callbacks = {}, runMode = false }) {
-  const { selectedProject, selectedSource, selectedRun, projects = [], sharedProjectInfo = null, dashboard, accumulated, loading, isFetching, scoresPending = false, error, availableRuns = [], dailyRuns, overviewRunIndex = 0, granularity = 'day', onGranularityChange, sharedHasContent = false } = data;
+  const { selectedProject, selectedSource, selectedRun, projects = [], sharedProjectInfo = null, dashboard, accumulated, loading, isFetching, scoresPending = false, error, availableRuns = [], dailyRuns, overviewRunIndex = 0, granularity = 'day', onGranularityChange, sharedHasContent = false, customFormula = false } = data;
   const projectInfo = selectDashboardProjectInfo({ selectedSource, projects, selectedProject, sharedProjectInfo });
   const { onNavigate, onRunSelect, onProjectsReload } = callbacks;
   // After a successful clone-on-add migration the project's repository_info.json
@@ -470,7 +470,7 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
         {dashboard && contentReady && (
           <DashboardContent
             runMode={runMode}
-            data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo, granularity, selectedSource, scoresPending }}
+            data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo, granularity, selectedSource, scoresPending, customFormula }}
             focus={{ dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData }}
             callbacks={{ onRunSelect, onDimensionCardClick: handlers.handleDimensionCardClick, onAccumulatedDimensionClick: handlers.handleAccumulatedDimensionClick, onFileClick: handlers.handleFileClick, onNavigate, onGranularityChange }}
           />

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -193,6 +193,11 @@ export function useDashboard({ selectedProject, selectedRun, selectedSource = "l
     dashboard: dashboardWithTrend,
     accumulated: scores?.accumulated || null,
     latestAccumulated: latestScores?.accumulated || null,
+    // How the grade was produced, not what it is. A tuned formula moves every
+    // score at once with no other trace, so the Overview has to be able to say
+    // so next to the number. This return is an explicit whitelist -- dropping
+    // the key here silently removes the warning.
+    customFormula: Boolean(scores?.scoring?.customFormula),
     rescoreLookup: {},
     loading: dashboardQuery.isLoading || scoresLoading,
     // True during background refetch when we already have placeholder data

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
@@ -611,6 +611,36 @@ describe("useDashboard frozen historical runs", () => {
   });
 });
 
+// This hook returns an explicit key whitelist, so a new field on the scores
+// payload reaches the UI only if it is named here. That seam has silently
+// dropped payload keys before, and this one carries a warning: when it goes
+// missing the Overview shows a grade computed by a tuned formula with nothing
+// to say so, which is exactly the failure it exists to prevent.
+describe("useDashboard — scoring metadata crosses the whitelist", () => {
+  it("exposes customFormula from the scores payload", async () => {
+    const fakeApi = makeFakeApi();
+    fakeApi.getProjectScores = vi.fn(async () => ({
+      accumulated: { score: 90 }, trend: [], availableRuns: [],
+      scoring: { customFormula: true },
+    }));
+    const { result } = renderHook(
+      () => useDashboard({ selectedProject: "p1", selectedRun: null }),
+      { wrapper: withStableQueryApi(fakeApi) },
+    );
+    await waitFor(() => expect(result.current.customFormula).toBe(true));
+  });
+
+  it("defaults to false when the payload omits it", async () => {
+    const fakeApi = makeFakeApi();
+    const { result } = renderHook(
+      () => useDashboard({ selectedProject: "p1", selectedRun: null }),
+      { wrapper: withStableQueryApi(fakeApi) },
+    );
+    await waitFor(() => expect(result.current.accumulated).toBeTruthy());
+    expect(result.current.customFormula).toBe(false);
+  });
+});
+
 // Note: live grade SSE merging used to live here. It was deleted in the
 // move to mutation-returns-result — the dismiss HTTP response now carries
 // the rescored payload synchronously, and the dashboard refetches the

--- a/src/quodeq/ui/src/strings/en.json
+++ b/src/quodeq/ui/src/strings/en.json
@@ -658,6 +658,7 @@
   "overview.firstEvalTitle": "First evaluation in progress",
   "overview.fixPlanTitle": "{name} fix plan",
   "overview.gradeHint": "grade {letter}",
+  "overview.gradeHintCustomFormula": "grade {letter} · custom formula",
   "overview.incompleteSetupBody": "This project was added by URL and has no local copy. Clone it now to enable evaluation.",
   "overview.insufficientEvidence": "insufficient evidence",
   "overview.insufficientGrade": "INSUFFICIENT",

--- a/tests/services/scoring/test_custom_formula_flag.py
+++ b/tests/services/scoring/test_custom_formula_flag.py
@@ -1,0 +1,53 @@
+"""The dashboard payload must say when the grade came from a tuned formula.
+
+A hand-edited grade formula moves every score in the project at once and
+leaves no other trace: findings do not change, runs do not change, only the
+number does. Setting `severityWeight.major` to 6.0 (the shipped default is
+1.5) cost this project roughly a point across every dimension for a month,
+and nothing on the Overview -- where the grade is actually read -- said the
+formula was no longer stock. `isCustom` existed, but only on the grade-formula
+settings page, which is the one place you already know.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import quodeq.services.scoring as scoring
+
+
+def _run_dir(root: Path, project: str, run_id: str) -> Path:
+    d = root / project / run_id / "evaluation"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def test_payload_flags_a_tuned_formula(tmp_path, monkeypatch):
+    _run_dir(tmp_path, "proj", "r1")
+    monkeypatch.setattr(scoring, "is_custom", lambda: True)
+
+    payload = scoring.get_project_scores(tmp_path, "proj")
+
+    assert payload is not None
+    assert payload["scoring"]["customFormula"] is True
+
+
+def test_payload_reports_stock_formula_as_not_custom(tmp_path, monkeypatch):
+    _run_dir(tmp_path, "proj", "r1")
+    monkeypatch.setattr(scoring, "is_custom", lambda: False)
+
+    payload = scoring.get_project_scores(tmp_path, "proj")
+
+    assert payload is not None
+    assert payload["scoring"]["customFormula"] is False
+
+
+def test_flag_is_present_even_when_the_project_has_no_runs(tmp_path, monkeypatch):
+    """The empty-project early return is a separate exit -- it needs the flag too,
+    or the Overview silently loses the warning exactly when a first scan lands."""
+    (tmp_path / "proj").mkdir(parents=True)
+    monkeypatch.setattr(scoring, "is_custom", lambda: True)
+
+    payload = scoring.get_project_scores(tmp_path, "proj")
+
+    assert payload is not None
+    assert payload["scoring"]["customFormula"] is True


### PR DESCRIPTION
## What

The scores payload now carries `scoring.customFormula`, and the Overview's score tile reads **"grade C · custom formula"** instead of "grade C" when a tuned formula produced the number.

## Why

A hand-edited grade formula moves every score in the project **at once** and leaves no other trace: same findings, same runs, different number. There is no diff to look at and no finding to inspect.

This is not hypothetical. `~/.quodeq/grade_formula.json` on this machine had `severityWeight.major = 6.0` against a shipped default of `1.5` — a major penalised *more than a critical*. Measured by replaying the real scoring primitives over one run, it cost about **a full point across every dimension**, and it went unnoticed for a month while the drop got attributed to the model and to the clean-arch reorg.

`is_custom()` already existed. It was surfaced only on the grade-formula settings page — the one screen where you already know the formula is tuned. The Overview, where the grade is actually read, had no idea.

## Design notes

- Computed **outside** the accumulated cache. It is a file-existence check, and keeping it out avoids adding another input to a cache version that has been a source of bugs.
- Returned from both exits of `get_project_scores`, including the no-runs early return — otherwise the warning disappears exactly when a project's first scan lands.
- `useDashboard` returns an **explicit key whitelist**, so a new payload field reaches the UI only if it is named there. That seam has silently dropped payload keys before, so it is pinned with a test. A dropped key here removes a *warning* rather than a number, which is the kind of loss nobody notices.

## Verification

- 5643 backend + 1499 UI tests pass; 5 new (3 backend incl. the empty-project exit, 2 whitelist-seam, 2 rendering).
- `npm run lint:strings` clean.
- Checked in-process against the real project: no file → `{customFormula: false}`, score 6.9; file present → `{customFormula: true}`, score still 6.9. The true case was triggered by writing the *shipped defaults*, so the flag flips with zero score impact.
- Not rendered in a browser: the running dashboard is `develop`, which lacks the backend field, and starting a second one risks the known `action_api.pid` collision. Both render branches are covered by component tests asserting the exact hint text.