### PR TITLE
fix(scoring): the severity floor must not override the volume ceiling

### DIFF
--- a/src/quodeq/core/scoring/_principle.py
+++ b/src/quodeq/core/scoring/_principle.py
@@ -85,8 +85,13 @@ def _score_numerical(
     base = violation_base(ctx.vt_counts, params=params)
     lift = compliance_lift(ctx.ct_counts, ctx.vt_counts, params=params)
     raw = base + (_BASE_SCORE - base) * lift
-    final_pts = round(max(severity_grade_floor(ctx.vt_counts, params=params),
-                          min(violation_ceiling(ctx.vt_counts, params=params), raw)), 1)
+    # Floor first, ceiling last -- see the note in core/scoring/projector_scoring.py.
+    # This is the path real runs take (services/evidence_rescore); the other two
+    # copies are the projector and the legacy no-evidence fallback. All three
+    # must agree or the same principle scores differently depending on which
+    # read surface asked.
+    final_pts = round(min(violation_ceiling(ctx.vt_counts, params=params),
+                          max(severity_grade_floor(ctx.vt_counts, params=params), raw)), 1)
     return PrincipleScore(
         **kwargs, base_score=round(base, 1),
         deductions=build_deductions(ctx.vt_counts, scale_multiplier=ctx.scale_mult),

--- a/src/quodeq/core/scoring/projector_scoring.py
+++ b/src/quodeq/core/scoring/projector_scoring.py
@@ -106,7 +106,14 @@ def compute_principle_grade(
     floor = severity_grade_floor(vt_counts, params=params)
 
     raw = base + (10.0 - base) * lift
-    final = max(floor, min(ceil, raw))
+    # Floor first, ceiling last. The two guards cross when a principle carries a
+    # LOT of issues that all happen to be minor: the minor-only floor (8.0) rises
+    # above the volume ceiling. Clamping the other way round handed back the
+    # floor and discarded the ceiling -- the one guard that encodes volume -- so
+    # a principle with 269 findings read "Good". Algebraically identical whenever
+    # floor <= ceil, so only the contradictory case moves.
+    # Keep byte-identical with services/rescore.py.
+    final = min(ceil, max(floor, raw))
     final = round(final, 1)
     grade = score_to_grade_label(final, params=params)
 

--- a/src/quodeq/services/rescore.py
+++ b/src/quodeq/services/rescore.py
@@ -77,7 +77,9 @@ def _score_principle(
     floor = severity_grade_floor(vt_counts, params=params)
 
     raw = base + (10.0 - base) * lift
-    final = max(floor, min(ceil, raw))
+    # Floor first, ceiling last -- see the note in core/scoring/projector_scoring.py.
+    # Keep byte-identical with it.
+    final = min(ceil, max(floor, raw))
     final = round(final, 1)
     grade = score_to_grade_label(final, params=params)
     return final, grade

--- a/tests/core/test_floor_ceiling_conflict.py
+++ b/tests/core/test_floor_ceiling_conflict.py
@@ -1,0 +1,136 @@
+"""The severity floor must not override the volume ceiling.
+
+`severity_grade_floor` says "only minor issues, so you can't be that bad".
+`violation_ceiling` says "this much violation load caps you". They are both
+guards, and they cross when a principle has a LOT of issues that happen to all
+be minor. The clamp resolved that by letting the floor win unconditionally:
+
+    final = max(floor, min(ceil, raw))
+
+so `usability Learnability` on the quodeq project -- 250 distinct minor
+violation types, 0 major, 0 critical -- came out at floor=8.0 ("Good") while
+the ceiling said 7.01 and the curve said 3.35. The one guard that encodes
+VOLUME was the one discarded, which is precisely what made 269 findings
+invisible to the grade.
+
+Clamping to the floor first and the ceiling last keeps the ceiling
+authoritative. Note the two orderings are algebraically identical whenever
+floor <= ceil, which is every other principle on that project (34 of 35), so
+this only ever moves the contradictory case.
+"""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.core.scoring.internals import (
+    severity_grade_floor,
+    violation_base,
+    violation_ceiling,
+    compliance_lift,
+)
+from quodeq.core.scoring.params import DEFAULT_PARAMS
+from quodeq.core.scoring.projector_scoring import compute_principle_grade
+from quodeq.core.types.finding import Finding
+
+
+def _clamp(floor: float, ceil: float, raw: float) -> float:
+    """The production clamp, imported by value from both call sites."""
+    return min(ceil, max(floor, raw))
+
+
+@pytest.mark.parametrize(
+    ("floor", "ceil", "raw"),
+    [
+        (0.0, 10.0, 5.0),    # wide open
+        (5.0, 7.0, 6.0),     # raw between
+        (5.0, 7.0, 2.0),     # raw below floor
+        (5.0, 7.0, 9.0),     # raw above ceiling
+        (8.0, 8.0, 3.0),     # floor == ceil
+        (0.0, 6.5, 6.5),     # raw at ceiling
+    ],
+)
+def test_agrees_with_the_old_ordering_whenever_floor_fits_under_the_ceiling(
+    floor: float, ceil: float, raw: float,
+) -> None:
+    """The change must be surgical: identical everywhere the guards don't cross."""
+    assert floor <= ceil
+    assert _clamp(floor, ceil, raw) == max(floor, min(ceil, raw))
+
+
+def test_ceiling_wins_when_the_guards_cross() -> None:
+    """Learnability's real numbers: 250 minor types, no major, no critical."""
+    floor, ceil, raw = 8.0, 7.01, 3.35
+    assert floor > ceil, "this is the contradictory case"
+    assert _clamp(floor, ceil, raw) == 7.01
+    # The old ordering handed back the floor and threw the ceiling away.
+    assert max(floor, min(ceil, raw)) == 8.0
+
+
+def _minor(i: int, verdict: str = "violation") -> Finding:
+    """Distinct `reason` per item so tally_types counts them as separate types."""
+    return Finding(
+        practice_id="Learnability", verdict=verdict, file=f"f{i}.py", line=i,
+        end_line=i, title="t", reason=f"distinct reason {i}", snippet="s",
+        severity="minor", cwe=None, req=f"U-LRN-{i}", req_refs=[], context="",
+        dimension="usability", violation_type=None, scope="", confidence=100,
+    )
+
+
+def test_principle_grade_does_not_read_good_under_a_pile_of_minor_findings() -> None:
+    """The production path, not a hand-rolled clamp.
+
+    250 minor violations against 53 compliances puts the minor-only floor (8.0)
+    above the volume ceiling (~7.0). The grade must respect the ceiling.
+    """
+    result = compute_principle_grade(
+        principle_id="Learnability",
+        findings=[_minor(i) for i in range(250)],
+        compliance=[_minor(i, verdict="compliance") for i in range(53)],
+        source_file_count=1800,
+        scale_multiplier=1,
+    )
+    assert result["score"] is not None
+    assert result["score"] < 8.0, (
+        f"269 findings scored {result['score']} -- the severity floor "
+        "overrode the volume ceiling and hid the backlog"
+    )
+
+
+def test_the_evidence_path_agrees_with_the_projector() -> None:
+    """The clamp exists in THREE places and real runs use this one.
+
+    `rescore_dimensions` only falls back to services/rescore's copy when a run
+    has no evidence on disk; every modern run goes through
+    services/evidence_rescore -> core/scoring/engine -> _principle. Fixing the
+    other two copies left the displayed grade completely unchanged, and the
+    projector-level test above still passed -- which is exactly how a
+    three-copy invariant rots. Pin the path users actually hit.
+    """
+    from quodeq.core.scoring._principle import _score_numerical, _build_context
+
+    pdata = {
+        "violations": [{"severity": "minor", "reason": f"distinct {i}"} for i in range(250)],
+        "compliance": [{"severity": "minor", "reason": f"ok {i}"} for i in range(53)],
+        "metrics": {"compliance_percentage": 17.5, "confidence_level": "high",
+                    "is_balanced": True, "total_instances": 303},
+    }
+    ctx = _build_context("Learnability", pdata, scale_mult=1, files_read=1800)
+    score = _score_numerical(ctx, params=DEFAULT_PARAMS)
+    assert score.final_score < 8.0, (
+        f"evidence path scored {score.final_score}: the severity floor still "
+        "overrides the volume ceiling where it actually matters"
+    )
+
+
+def test_a_pile_of_minor_findings_cannot_read_as_good() -> None:
+    """End to end through the real primitives, no hand-picked numbers."""
+    violations = {"critical": 0, "major": 0, "minor": 250}
+    compliance = {"minor": 53}
+    floor = severity_grade_floor(violations, params=DEFAULT_PARAMS)
+    ceil = violation_ceiling(violations, params=DEFAULT_PARAMS)
+    base = violation_base(violations, params=DEFAULT_PARAMS)
+    lift = compliance_lift(compliance, violations, params=DEFAULT_PARAMS)
+    raw = base + (10.0 - base) * lift
+
+    assert floor == 8.0 and ceil < floor, "minor-only floor sits above the volume ceiling"
+    assert round(_clamp(floor, ceil, raw), 1) < 8.0


### PR DESCRIPTION
## The bug

`severity_grade_floor` says *"only minor issues, so you can't be that bad"*. `violation_ceiling` says *"this much violation load caps you"*. Both are guards, and they **cross** when a principle carries a lot of issues that all happen to be minor. The clamp resolved the conflict by letting the floor win:

```python
final = max(floor, min(ceil, raw))
```

`usability / Learnability` on this project — **262 distinct minor violation types, zero major, zero critical**:

```
floor = 8.0     (minor-only)
ceil  = 6.97    (volume)
raw   = 3.21    (curve)
final = 8.0     <- "Good"
```

`min(6.97, 3.21)` = 3.21, then `max(8.0, 3.21)` = **8.0**. The guard that exists to encode volume is the one thrown away, so 268 findings read as *Good*.

## The fix

Clamp floor-first, ceiling-last: `min(ceil, max(floor, raw))`.

The two orderings are **algebraically identical whenever `floor <= ceil`** — 34 of this project's 35 principles — so only the contradictory case can move. That property is pinned by a parametrised test rather than asserted in a comment.

## Impact (measured on run 0ace6d40)

| | before | after |
|---|---|---|
| Learnability | 8.0 | **7.3** |
| usability | 8.5 | 8.4 |
| project | 6.9 | 6.9 |

It **lowers** the grade, which is the point: a principle with 268 open findings should not read the same as one with a handful.

## The part worth reading

The clamp existed in **three copies**. I fixed `core/scoring/projector_scoring.py` and `services/rescore.py` first, the unit test went green — **and the displayed grade did not move at all**. Real runs go through `services/evidence_rescore` → `core/scoring/engine` → `core/scoring/_principle`, a third copy that no test covered and that my grep for the exact expression had not matched. It only surfaced by rescoring real project data and noticing Learnability was still 8.0.

So the tests now:
- pin the **evidence path** specifically, with a comment saying why it is the one that matters;
- pin the equivalence property, so the surgical claim is checked rather than trusted;
- were **mutation-tested**: reverting `_principle.py` alone turns the suite red.

## Verification

- 5653 passed, 1 skipped, 0 failed. No existing test changed — consistent with the equivalence property.
- Impact measured through `rescore_dimensions` against real project data, not a fixture.