### PR TITLE
chore(ci): stop running py/path-injection in CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,10 +39,35 @@ jobs:
           # tests/ and benchmarks/ contain intentionally vulnerable fixtures
           # (they exercise the scanner itself); scanning them would bury real
           # alerts in noise.
+          #
+          # py/path-injection is excluded because it has never been right here.
+          # 292 alerts to date: 153 triaged and dismissed as false positives,
+          # 118 closed by rewrites or by code simply moving, 21 open. No true
+          # positives. The two genuine traversal defects we did find (the
+          # rescore symlink escape, cloneDest passing a raw request string) came
+          # from reading the guard code, not from this query. Quodeq is a
+          # single-operator desktop app, so its "user-provided value" is the
+          # local user's own project path, and they already own the filesystem.
+          #
+          # It is also unfixable rather than merely noisy. Five PRs of
+          # structural rewrites (#1014, #1016, #1017, #1018, #1019) moved the
+          # count 33 -> 22, and #1019 minted a fresh alert on the os.scandir
+          # call inside resolve_child_dir, the helper written to eliminate path
+          # injection by never concatenating. The remaining sinks are the
+          # generic I/O wrappers in core/utils/io.py, where every caller's taint
+          # converges by design, and the registration flow, where the target
+          # directory legitimately does not exist yet so listing cannot apply.
+          #
+          # Traversal is covered behaviourally instead, by
+          # tests/api/test_codeql_triage_guards.py. Extend that when adding a
+          # route that takes a path segment; do not re-enable this query.
           config: |
             paths-ignore:
               - tests
               - benchmarks
+            query-filters:
+              - exclude:
+                  id: py/path-injection
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4.37.3


### PR DESCRIPTION
Excludes `py/path-injection` from the CodeQL suite via a `query-filters` entry in the existing inline config.

## Why

The query has raised **292 alerts** on this repo and found **zero** true positives.

| state | count | how they closed |
|---|---|---|
| dismissed | 153 | triaged, all false positives |
| fixed | 118 | rewrites, or code simply moving between files |
| open | 21 | this PR |

Both genuine traversal defects found this cycle (the rescore symlink escape, and `cloneDest` validating a local then passing the raw request string on) came from *reading* the guard code. Neither was reported by this query.

Quodeq is a single-operator desktop app. The "user-provided value" in every one of these flows is the local user's own project path, and they already own the filesystem.

## It is unfixable, not just noisy

Five PRs of structural rewrites (#1014, #1016, #1017, #1018, #1019) moved the count 33 -> 22. Then #1019 minted alert #275 on the `os.scandir` call **inside `resolve_child_dir`** - the helper added specifically to eliminate path injection by resolving from a directory listing instead of concatenating.

What remains cannot be cleared by any rewrite:

- **3 alerts** in `core/utils/io.py` are `open()`, `read_text()` and `scandir()` inside `open_text`, `read_json` and `resolve_child_dir`. These are the codebase's generic I/O wrappers; every caller's taint converges on them by design.
- **~6 alerts** in `services/project_registration.py` are the registration flow, where the target directory legitimately does not exist yet, so listing-based resolution cannot apply and `contained_path` is already proven unrecognisable as a barrier.

CodeQL's path-injection barrier reasoning is intraprocedural, so a `realpath` + `startswith` check inside a helper does not propagate through the return to callers. #1014 rewrote all five route entrypoints into the documented barrier shape and cleared nothing.

## What replaces it

`tests/api/test_codeql_triage_guards.py` already asserts the behaviour the query was standing in for: traversal and absolute-path rejection on project creation and evaluation start, symlink scope escape, and traversal project ids across routes. That file is the thing to extend when adding a route that takes a path segment.

The rationale is recorded as a comment in the workflow so this does not get re-enabled on a hunch.

## Effect

The 21 open alerts should close as no-longer-detected on the next `develop` analysis. Nothing else about the CodeQL setup changes - the JavaScript suite, the `paths-ignore` for fixtures, and every other Python query keep running.