### PR TITLE
fix(config): degrade per-project config reads on any parse failure

### DIFF
--- a/src/quodeq/analysis/fingerprint.py
+++ b/src/quodeq/analysis/fingerprint.py
@@ -103,7 +103,12 @@ def _dimension_params_by_stat(
     _ = (c_size, c_mtime_ns, o_size, o_mtime_ns)
     try:
         data = json.loads(compiled.read_text(encoding="utf-8"))
-    except (OSError, ValueError, UnicodeDecodeError):
+    except Exception:  # noqa: BLE001 - keying must never abort analysis
+        # Deliberately wider than OSError/ValueError/UnicodeDecodeError:
+        # deeply nested JSON overflows the C decoder's call stack and raises
+        # RecursionError, a RuntimeError subclass that would otherwise escape.
+        # This sits on the per-dimension cache-keying path, so any escape here
+        # fails the run rather than degrading to an unkeyed hash.
         return "", {}
     overrides = load_project_overrides(project_root) if project_root else {}
     try:

--- a/src/quodeq/data/fs/compiled_standards.py
+++ b/src/quodeq/data/fs/compiled_standards.py
@@ -4,12 +4,21 @@ api/standards_overrides_routes globbed this directory and json-parsed each
 file inline; the mechanics live here so the route keeps only its mapping
 logic. Unreadable, unparseable and non-object files are skipped rather
 than raised: a single hand-edited standard must never 500 a request.
+
+"Unparseable" means every failure mode, not the well-behaved
+``OSError``/``ValueError``/``UnicodeDecodeError`` trio: deeply nested JSON
+overflows the C decoder's call stack and raises ``RecursionError``, which is a
+``RuntimeError`` and would otherwise escape and 500 the very request this
+module exists to protect.
 """
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Iterator
 from pathlib import Path
+
+_logger = logging.getLogger(__name__)
 
 
 def iter_compiled_standards(compiled_dir: Path) -> Iterator[tuple[str, dict]]:
@@ -24,7 +33,8 @@ def iter_compiled_standards(compiled_dir: Path) -> Iterator[tuple[str, dict]]:
     for path in sorted(compiled_dir.glob("*.json")):
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, ValueError, UnicodeDecodeError):
+        except Exception as exc:  # noqa: BLE001 - one bad standard must never 500 a request
+            _logger.warning("Skipping unreadable compiled standard %s: %s", path, exc)
             continue
         if isinstance(data, dict):
             yield path.stem, data

--- a/src/quodeq/data/fs/standards_prefs.py
+++ b/src/quodeq/data/fs/standards_prefs.py
@@ -4,6 +4,14 @@ Reads/writes ``<project root>/.quodeq/standards-visibility.json`` and reads
 ``standards-overrides.json`` + compiled dimension files. The pure logic
 (validation, partitioning, param resolution) stays in ``core/standards/``;
 the API layer goes through ``services/standards_prefs.py``.
+
+Every read here is advisory, hand-writable config with a well-defined default,
+so a parse failure of *any* kind degrades with a warning -- not just the
+well-behaved ``OSError``/``ValueError``/``UnicodeDecodeError`` trio. In
+particular, deeply nested JSON (tens of thousands of nested arrays, a ~160KB
+file a buggy generator produces by accident) overflows the C decoder's call
+stack and raises ``RecursionError``, which is a ``RuntimeError`` and would
+otherwise escape and fail the scan.
 """
 from __future__ import annotations
 
@@ -30,8 +38,9 @@ def load_visible_standard_ids(project_root: str | Path | None) -> tuple[str, ...
         return DEFAULT_VISIBLE_STANDARDS
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError, UnicodeDecodeError) as exc:
-        _logger.warning("Ignoring malformed standards visibility %s: %s", path, exc)
+    except Exception as exc:  # noqa: BLE001 - config must never fail a scan; see module docstring
+        _logger.warning(
+            "Ignoring unreadable or malformed standards visibility %s: %s", path, exc)
         return DEFAULT_VISIBLE_STANDARDS
     ids = data.get("visibleStandardIds") if isinstance(data, dict) else None
     if not isinstance(ids, list):
@@ -60,8 +69,9 @@ def load_project_overrides(project_root: str | Path | None) -> dict[str, dict]:
         return {}
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError, UnicodeDecodeError) as exc:
-        _logger.warning("Ignoring malformed standards overrides %s: %s", path, exc)
+    except Exception as exc:  # noqa: BLE001 - config must never fail a scan; see module docstring
+        _logger.warning(
+            "Ignoring unreadable or malformed standards overrides %s: %s", path, exc)
         return {}
     overrides = data.get("overrides") if isinstance(data, dict) else None
     if not isinstance(overrides, dict):
@@ -89,7 +99,8 @@ def collect_declared_params(compiled_dir: Path) -> dict[str, dict]:
     for path in sorted(Path(compiled_dir).glob("*.json")):
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, ValueError, UnicodeDecodeError):
+        except Exception as exc:  # noqa: BLE001 - one bad standard must not sink the rest
+            _logger.warning("Skipping unreadable declared params in %s: %s", path, exc)
             continue
         for principle in data.get("principles", []):
             for req in principle.get("requirements", []):

--- a/src/quodeq/data/fs/suppression_rules.py
+++ b/src/quodeq/data/fs/suppression_rules.py
@@ -9,6 +9,12 @@ Best-effort like its siblings: an absent, unreadable or malformed file yields
 no rules. Individual entries are validated and skipped rather than raising —
 one half-written rule must never suppress everything, and a suppression store
 that fails closed is safer than one that fails open.
+
+"Malformed" covers every parse failure, not the well-behaved
+``OSError``/``ValueError``/``UnicodeDecodeError`` trio: deeply nested JSON
+overflows the C decoder's call stack and raises ``RecursionError``, a
+``RuntimeError`` subclass that would otherwise escape. Every rescore loads
+this file, so an escape here fails the whole scoring path.
 """
 from __future__ import annotations
 
@@ -29,8 +35,9 @@ def load_suppression_rules(project_dir: Path) -> tuple[SuppressionRule, ...]:
         return ()
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError, UnicodeDecodeError) as exc:
-        _logger.warning("Ignoring malformed suppression rules %s: %s", path, exc)
+    except Exception as exc:  # noqa: BLE001 - a bad rules file must never fail a rescore
+        _logger.warning(
+            "Ignoring unreadable or malformed suppression rules %s: %s", path, exc)
         return ()
     raw_rules = data.get("rules") if isinstance(data, dict) else None
     if not isinstance(raw_rules, list):

--- a/tests/analysis/test_fingerprint_dimension_params.py
+++ b/tests/analysis/test_fingerprint_dimension_params.py
@@ -143,3 +143,19 @@ def test_shape_invalid_params_list_hashes_empty_without_raising(tmp_path, projec
     bad_dir = tmp_path / "standards-bad-list"
     _write_compiled_raw_params(bad_dir, DIM, "M-ANA-2", ["max_lines"])
     assert dimension_params_state(bad_dir, DIM, project_root) == ("", {})
+
+
+def test_deeply_nested_compiled_file_hashes_empty(standards_dir, project_root, deeply_nested_json):
+    """A compiled dimension file must degrade the same way a missing one does.
+
+    Deeply nested JSON overflows the C decoder's call stack and raises
+    RecursionError, a RuntimeError subclass the narrow
+    (OSError, ValueError, UnicodeDecodeError) catch did not cover. Cache keying
+    already treats an unparseable compiled file as ("", {}); this is the same
+    failure reached through a different exception type, and it sits on the
+    per-file hot path, so an escape here aborts the whole run.
+    """
+    (standards_dir / "compiled" / f"{DIM}.json").write_text(
+        deeply_nested_json, encoding="utf-8")
+
+    assert dimension_params_state(standards_dir, DIM, project_root) == ("", {})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,42 @@
 """Shared test fixtures and helpers."""
 from __future__ import annotations
 
+import json
+
 import pytest
+
+# Deep enough to exhaust the C JSON decoder's call stack on a default 8MB
+# main-thread stack. ~160KB of text -- trivially producible by hand or by a
+# buggy generator, which is what makes this a real degradation path and not a
+# curiosity.
+_STACK_OVERFLOW_NESTING = 80_000
+
+
+@pytest.fixture(scope="session")
+def deeply_nested_json() -> str:
+    """JSON text that makes ``json.loads`` raise ``RecursionError``.
+
+    ``RecursionError`` subclasses ``RuntimeError``, not ``ValueError``, so it
+    escapes the ``(OSError, ValueError, UnicodeDecodeError)`` tuple that the
+    degrade-to-default config readers catch. Every reader whose contract is
+    "a malformed file degrades, it never fails a scan" needs a regression test
+    against this payload.
+
+    The depth at which the decoder overflows depends on the interpreter's
+    stack size, so the fixture proves the payload really does overflow *this*
+    interpreter and skips otherwise. Without that check a build with a deeper
+    stack would parse the payload fine and every test using it would pass
+    while exercising nothing.
+    """
+    payload = "[" * _STACK_OVERFLOW_NESTING + "]" * _STACK_OVERFLOW_NESTING
+    try:
+        json.loads(payload)
+    except RecursionError:
+        return payload
+    pytest.skip(
+        f"this interpreter parses {_STACK_OVERFLOW_NESTING} levels of JSON "
+        "nesting without overflowing; the RecursionError regression cannot be "
+        "exercised here")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/data/test_compiled_standards.py
+++ b/tests/data/test_compiled_standards.py
@@ -33,6 +33,18 @@ class TestIterCompiledStandards:
 
         assert [stem for stem, _ in iter_compiled_standards(tmp_path)] == ["good"]
 
+    def test_skips_a_deeply_nested_file(self, tmp_path, deeply_nested_json):
+        """A hand-edited standard must never 500 a request, RecursionError
+        included: the C JSON decoder overflows its call stack on deeply nested
+        input and raises a RuntimeError subclass, which the narrow
+        (OSError, ValueError, UnicodeDecodeError) catch let escape."""
+        from quodeq.data.fs.compiled_standards import iter_compiled_standards
+
+        _write(tmp_path, "good", {"id": "good"})
+        (tmp_path / "nested.json").write_text(deeply_nested_json, encoding="utf-8")
+
+        assert [stem for stem, _ in iter_compiled_standards(tmp_path)] == ["good"]
+
     def test_missing_dir_yields_nothing(self, tmp_path):
         from quodeq.data.fs.compiled_standards import iter_compiled_standards
 

--- a/tests/data/test_standards_overrides.py
+++ b/tests/data/test_standards_overrides.py
@@ -174,3 +174,29 @@ class TestDimensionParams:
     def test_requirements_without_params_are_absent(self):
         effective, _ = dimension_params(self.DIM, {})
         assert "M-ANA-3" not in effective
+
+
+def test_deeply_nested_overrides_file_degrades(tmp_path, deeply_nested_json):
+    """Sibling of the visibility-file regression, same root cause.
+
+    "a bad file never fails analysis" (core/standards/overrides.py) has to
+    survive RecursionError from the C JSON decoder, which is a RuntimeError
+    subclass and so escaped the narrow catch tuple.
+    """
+    path = tmp_path / OVERRIDES_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(deeply_nested_json, encoding="utf-8")
+
+    assert load_project_overrides(tmp_path) == {}
+
+
+def test_deeply_nested_declared_params_file_is_skipped(tmp_path, deeply_nested_json):
+    """collect_declared_params reads ~/.quodeq/evaluators/*.json, which users
+    hand-author. One pathological file must be skipped like any other
+    unparseable one, not abort the whole PUT that validates against it."""
+    (tmp_path / "broken.json").write_text(deeply_nested_json, encoding="utf-8")
+    (tmp_path / "good.json").write_text(json.dumps({
+        "principles": [{"requirements": [REQ]}],
+    }), encoding="utf-8")
+
+    assert collect_declared_params(tmp_path) == {"M-ANA-2": REQ["params"]}

--- a/tests/data/test_standards_visibility.py
+++ b/tests/data/test_standards_visibility.py
@@ -125,3 +125,19 @@ def test_saved_file_is_pretty_printed_with_trailing_newline(tmp_path):
     save_visible_standard_ids(tmp_path, ["security"])
     text = (tmp_path / VISIBILITY_RELPATH).read_text(encoding="utf-8")
     assert text == '{\n  "version": 1,\n  "visibleStandardIds": [\n    "security"\n  ]\n}\n'
+
+
+def test_deeply_nested_file_degrades_to_defaults(tmp_path, deeply_nested_json):
+    """The documented contract holds for *any* parse failure, not a chosen trio.
+
+    Bracket nesting deep enough to overflow the C JSON decoder raises
+    RecursionError, a RuntimeError subclass that the narrow
+    (OSError, ValueError, UnicodeDecodeError) catch did not cover. It escaped
+    and failed the scan instead of degrading, which is what this file's own
+    docstring ("a malformed file never fails a read") promises it will not do.
+    """
+    path = tmp_path / VISIBILITY_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(deeply_nested_json, encoding="utf-8")
+
+    assert load_visible_standard_ids(tmp_path) == DEFAULT_VISIBLE_STANDARDS

--- a/tests/services/test_suppression_rules.py
+++ b/tests/services/test_suppression_rules.py
@@ -94,6 +94,21 @@ class TestLoadSuppressionRules:
         (tmp_path / "suppression_rules.json").write_text("{nope", encoding="utf-8")
         assert load_suppression_rules(tmp_path) == ()
 
+    def test_deeply_nested_file_yields_no_rules(self, tmp_path, deeply_nested_json):
+        """"Malformed" has to mean every parse failure, not a chosen trio.
+
+        Deeply nested JSON overflows the C decoder's call stack and raises
+        RecursionError -- a RuntimeError subclass, so the narrow
+        (OSError, ValueError, UnicodeDecodeError) catch let it escape and fail
+        the scoring path that loads this file on every rescore.
+        """
+        from quodeq.data.fs.suppression_rules import load_suppression_rules
+
+        (tmp_path / "suppression_rules.json").write_text(
+            deeply_nested_json, encoding="utf-8")
+
+        assert load_suppression_rules(tmp_path) == ()
+
     def test_entries_missing_a_required_field_are_skipped(self, tmp_path):
         """A half-written rule must not silently suppress everything."""
         from quodeq.data.fs.suppression_rules import load_suppression_rules


### PR DESCRIPTION
## The defect

Every per-project JSON config reader under `.quodeq/` caught `(OSError, ValueError, UnicodeDecodeError)` around `json.loads`. That tuple does not cover `RecursionError`, which the C JSON decoder raises on deeply nested input and which subclasses `RuntimeError` — so it escaped and failed the scan, which is exactly what each reader's documented contract ("a malformed file degrades to the default with a warning, it never fails a scan") promises it will not do.

Reproduced on the project interpreter (CPython 3.14.3):

```
path.write_text("[" * 80000 + "]" * 80000)   # ~160KB
load_visible_standard_ids(project_root)
# RecursionError: Stack overflow (used 8144 kB) while decoding a JSON array from a unicode string
```

A ~160KB text file is trivially producible by hand or by a buggy generator.

## Audit result

| Reader | File it parses | Contract it broke |
|---|---|---|
| `standards_prefs.load_visible_standard_ids` | `<repo>/.quodeq/standards-visibility.json` | defaults on malformed |
| `standards_prefs.load_project_overrides` | `<repo>/.quodeq/standards-overrides.json` | `{}` on malformed |
| `standards_prefs.collect_declared_params` | `~/.quodeq/evaluators/*.json` | skip the bad file |
| `compiled_standards.iter_compiled_standards` | compiled / evaluator standards | "must never 500 a request" |
| `suppression_rules.load_suppression_rules` | `<project>/suppression_rules.json` | `()` on malformed |
| `fingerprint._dimension_params_by_stat` | `compiled/<dimension>.json` | `("", {})` on malformed |

`core/standards/overrides.py` and `core/standards/visibility.py` were audited and need no change: both are pure logic with no file or JSON access. The actual reader for `standards-overrides.json` is `load_project_overrides`.

## The fix

Widen the catch to `except Exception` with `# noqa: BLE001`, matching the reference fix in `context/trust_model.py::_read_profile` on `feat/project-trust-model`, and state the real breadth in each docstring and log message. The two silent `continue` skips now warn, so a dropped standard is visible rather than inferred.

`Exception` still lets `KeyboardInterrupt` and `SystemExit` through — they subclass `BaseException`.

## Tests

One regression test per reader, driven by a shared `deeply_nested_json` fixture in `tests/conftest.py`. The fixture asserts the payload really does overflow *this* interpreter and skips otherwise: overflow depth is stack-size dependent (the same 80k payload parses fine on a build with a deeper stack), so without that check all six tests would pass while exercising nothing.

Verified red before the fix (all six `RecursionError`), green after. Full suite: `5686 passed, 1 skipped` (the skip is the pre-existing Windows-only ConPTY test — the new fixture did not skip).

## Out of scope, worth flagging

`context/project_shape.py`'s `_read_json` / `_read_toml` have the same narrow pattern for `package.json` / `pyproject.toml`. `feat/project-trust-model` deliberately fixed that at the caller (`_detected_fields`) and marked `project_shape.py` itself out of scope, so it is left alone here to avoid conflicting with that decision. The other four `detect_shape` callers (`_api_runner`, `api_prompt_assembly`, `mcp/findings_server`, `context/__init__`) remain exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)