### PR TITLE
fix(ui): wait for the xterm mount effect before driving onOpen

### DIFF
--- a/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
@@ -151,9 +151,17 @@ it('shows a busy banner and an honest Retry (not a fake takeover) when another w
 
 it('resets xterm on every socket (re)open so a live-backend reconnect does not duplicate scrollback', async () => {
   fakeTerm.reset.mockClear();
+  fakeTerm.open.mockClear();
   fakeTerm.options = {};
   render(<TerminalPane active />);
   await screen.findByTestId('tty-root');
+  // waitFor, not a plain assert: tty-root appears on the render commit, but
+  // the xterm instance is constructed in the view's mount EFFECT, which is
+  // what populates termRef. onOpen bails out silently on `if (!term) return`
+  // until that effect has run, so driving it straight after findByTestId
+  // races under CI load and reset() is never called. Third instance of the
+  // post-commit-effect flake the mount and focus tests above already carry.
+  await waitFor(() => expect(fakeTerm.open).toHaveBeenCalled());
   // Simulate the socket (re)opening: the view's onOpen must reset the screen
   // BEFORE the server's scrollback replay lands, and re-enable input.
   expect(typeof lastSocketOpts.onOpen).toBe('function');


### PR DESCRIPTION
## Why

The `ui` job failed on [#1029](https://github.com/quodeq/quodeq/pull/1029), a Python-only PR:

```
FAIL src/features/terminal/TerminalPane.test.jsx > resets xterm on every socket (re)open ...
AssertionError: expected "vi.fn()" to be called at least once
  159|   expect(typeof lastSocketOpts.onOpen).toBe('function');
  160|   lastSocketOpts.onOpen();
  161|   expect(fakeTerm.reset).toHaveBeenCalled();
```

## Root cause

The test drives the view's `onOpen` immediately after `await screen.findByTestId('tty-root')`. `tty-root` appears on the **render commit**, but the xterm instance is constructed in the **mount effect**, and that effect is what populates `termRef`. Until it runs, `onOpen` bails out silently:

```js
onOpen: () => {
  const term = termRef.current;
  if (!term) return;     // <- silent no-op, reset() never happens
  ...
}
```

So under CI load the callback is a no-op and the assertion fails. Not a product bug — the production path only calls `onOpen` from a real socket open, which cannot precede mount.

This is the **third instance of the same race in this one file**. The two tests directly above it already carry `waitFor` plus comments naming it ("the Terminal constructor runs in the view's mount EFFECT, which can land a beat later under CI load", "flaked on develop, same race the mount test above was hardened against").

## Fix

Gate on `fakeTerm.open`, which `TerminalSessionView.jsx:140` calls three synchronous lines before `termRef.current = term` — observing it proves the ref is populated. Also `mockClear()` it alongside `reset`, since the mock is shared across tests in this file and would otherwise read as already-called from an earlier one.

## Verification

Failing test 5x locally: 22 passed each time. Full UI suite: `181 files, 1501 tests, all passing`. Develop's own `ui` job is green, so this is a latent flake that will keep hitting unrelated PRs until fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)