### PR TITLE
fix(context): detect_shape must degrade on any unreadable manifest

### DIFF
--- a/src/quodeq/context/project_shape.py
+++ b/src/quodeq/context/project_shape.py
@@ -8,15 +8,30 @@ assumption.
 The shape is the single biggest source of false positives in the current
 audit corpus (~40%) because the scanner defaults to "hosted multi-tenant
 web service" assumptions on what is in fact a desktop / CLI / library.
+
+Every manifest here is *analyzed*, untrusted input from the repository under
+evaluation, and detection is advisory with a well-defined UNKNOWN fallback.
+So nothing in this module may raise: a manifest that cannot be read or whose
+shape is nonsense degrades that one signal and leaves the rest intact. That
+has to hold against every failure mode, not the well-behaved ones -- deeply
+nested JSON or TOML overflows the parser's call stack and raises
+``RecursionError``, a ``RuntimeError`` subclass, and a scalar where a list
+belongs raises ``TypeError`` with every parser succeeding. ``detect_shape``
+has four callers that guard nothing (``_api_runner``, ``api_prompt_assembly``,
+``mcp/findings_server``, and the ``context`` re-export), so an escape here
+fails the whole run.
 """
 from __future__ import annotations
 
 import json
+import logging
 import re
 import tomllib
 from dataclasses import dataclass, field, asdict
 from enum import Enum
 from pathlib import Path
+
+_logger = logging.getLogger(__name__)
 
 
 class Deployment(str, Enum):
@@ -78,7 +93,8 @@ _JS_UI_LIBS = ("react", "vue", "svelte", "preact", "@angular/core", "solid-js")
 def _read_text(path: Path) -> str | None:
     try:
         return path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
+    except Exception as exc:  # noqa: BLE001 - detection must never fail a scan
+        _logger.warning("Ignoring unreadable manifest %s: %s", path, exc)
         return None
 
 
@@ -86,7 +102,12 @@ def _read_toml(path: Path) -> dict[str, object] | None:
     try:
         with path.open("rb") as fh:
             return tomllib.load(fh)
-    except (OSError, tomllib.TOMLDecodeError):
+    except Exception as exc:  # noqa: BLE001 - detection must never fail a scan
+        # Wider than OSError/TOMLDecodeError on purpose: tomllib is a
+        # recursive-descent parser, so deeply nested tables overflow the stack
+        # and raise RecursionError. It bottoms out far shallower than the C
+        # JSON decoder -- a few thousand levels, not tens of thousands.
+        _logger.warning("Ignoring unreadable TOML manifest %s: %s", path, exc)
         return None
 
 
@@ -96,7 +117,10 @@ def _read_json(path: Path) -> dict[str, object] | None:
         return None
     try:
         data = json.loads(text)
-    except json.JSONDecodeError:
+    except Exception as exc:  # noqa: BLE001 - detection must never fail a scan
+        # Wider than json.JSONDecodeError: deeply nested arrays exhaust the C
+        # decoder's call stack and raise RecursionError, a RuntimeError.
+        _logger.warning("Ignoring unreadable JSON manifest %s: %s", path, exc)
         return None
     return data if isinstance(data, dict) else None
 
@@ -127,14 +151,19 @@ def _python_signals(repo: Path) -> tuple[Deployment | None, list[str], list[str]
         return None, [], []
     project_raw = pyproject.get("project") or {}
     project = project_raw if isinstance(project_raw, dict) else {}
-    deps_list = project.get("dependencies") or []
+    # isinstance, not `or []`: a scalar `dependencies = 5` is valid TOML, so
+    # every reader above succeeds and `list(5)` raised TypeError straight out
+    # of detect_shape. Same guard the optional-dependencies branch already
+    # uses -- a nonsense value drops that one signal, it does not fail a scan.
+    deps_raw = project.get("dependencies")
+    deps_list = deps_raw if isinstance(deps_raw, list) else []
     optional_deps = project.get("optional-dependencies") or {}
     optional_flat: list[str] = []
     if isinstance(optional_deps, dict):
         for group in optional_deps.values():
             if isinstance(group, list):
                 optional_flat.extend(group)
-    raw = list(deps_list) + optional_flat
+    raw = deps_list + optional_flat
     names = [_strip_dep_spec(d).lower() for d in raw if isinstance(d, str)]
     web = _matches_any(names, _PY_WEB_FRAMEWORKS)
     desktop = _matches_any(names, _PY_DESKTOP_HINTS)

--- a/tests/context/test_project_shape.py
+++ b/tests/context/test_project_shape.py
@@ -168,3 +168,65 @@ def test_unknown_deployment_is_single_user() -> None:
     shape = ProjectShape()
     assert shape.deployment is Deployment.UNKNOWN
     assert shape.is_single_user is True
+
+
+class TestPathologicalManifestsDegrade:
+    """detect_shape must never fail a scan over a manifest it cannot read.
+
+    Its contract is "fall back to UNKNOWN whenever signals are absent or
+    contradictory", and four callers (_api_runner, api_prompt_assembly,
+    mcp/findings_server, and context/__init__'s re-export) invoke it with no
+    guard of their own. Anything that escapes here fails the run.
+
+    The manifests below are all *analyzed*, untrusted input from the repo
+    under evaluation, not files Quodeq controls.
+    """
+
+    def test_deeply_nested_package_json(self, tmp_path: Path, deeply_nested_json: str) -> None:
+        # _read_json caught only json.JSONDecodeError. Nesting deep enough to
+        # exhaust the C decoder's call stack raises RecursionError instead --
+        # a RuntimeError subclass, so it escaped.
+        _write(tmp_path / "package.json", deeply_nested_json)
+        assert detect_shape(tmp_path).deployment is Deployment.UNKNOWN
+
+    def test_deeply_nested_pyproject_toml(self, tmp_path: Path) -> None:
+        # Same class through tomllib, which is a pure-Python recursive-descent
+        # parser and so overflows at a much shallower depth than the C JSON
+        # decoder. _read_toml caught only OSError/TOMLDecodeError.
+        _write(tmp_path / "pyproject.toml", "a = " + "[" * 5000 + "]" * 5000)
+        assert detect_shape(tmp_path).deployment is Deployment.UNKNOWN
+
+    def test_deeply_nested_cargo_toml(self, tmp_path: Path) -> None:
+        # _rust_signals shares _read_toml, so Cargo.toml is the same hole.
+        _write(tmp_path / "Cargo.toml", "a = " + "[" * 5000 + "]" * 5000)
+        assert detect_shape(tmp_path).deployment is Deployment.UNKNOWN
+
+    def test_dependencies_that_are_not_a_list(self, tmp_path: Path) -> None:
+        """Not a RecursionError, and not fixed by widening the readers.
+
+        ``dependencies = 5`` parses as perfectly valid TOML, so every reader
+        succeeds; _python_signals then did ``list(deps_list)`` on an int and
+        raised TypeError. Guarding only the readers would leave this escape
+        open, which is the whole point of fixing detect_shape at the source
+        rather than wrapping each caller.
+        """
+        _write(tmp_path / "pyproject.toml", '[project]\nname = "x"\ndependencies = 5\n')
+        assert detect_shape(tmp_path).deployment is Deployment.UNKNOWN
+
+    def test_a_readable_manifest_still_detects_after_a_broken_sibling(
+        self, tmp_path: Path, deeply_nested_json: str,
+    ) -> None:
+        """Degrading is per-manifest, not all-or-nothing.
+
+        A pathological package.json must not blank the verdict a perfectly
+        good pyproject.toml supports -- otherwise the fix trades a crash for
+        silent, total detection loss.
+        """
+        _write(tmp_path / "package.json", deeply_nested_json)
+        _write(
+            tmp_path / "pyproject.toml",
+            '[project]\nname = "x"\ndependencies = ["flask>=3.0"]\n',
+        )
+        shape = detect_shape(tmp_path)
+        assert shape.deployment is Deployment.WEB_SERVICE
+        assert shape.web_frameworks == ["flask"]


### PR DESCRIPTION
Follow-up to [#1029](https://github.com/quodeq/quodeq/pull/1029), closing the residual exposure flagged there.

## The exposure

`project_shape`'s three readers each caught only their well-behaved failures:

| Reader | Caught | Missed |
|---|---|---|
| `_read_json` | `json.JSONDecodeError` | `RecursionError` |
| `_read_toml` | `OSError`, `TOMLDecodeError` | `RecursionError` |
| `_read_text` | `OSError`, `UnicodeDecodeError` | everything else |

Deeply nested JSON or TOML in an analyzed repo overflows the parser's call stack and raises `RecursionError`, a `RuntimeError` subclass none of those tuples cover, so it escaped `detect_shape` and failed the run.

`feat/project-trust-model` guards this at **one** caller (`_detected_fields`), and that commit's own comment records `project_shape.py` as out of scope. The other four callers — `_api_runner:462`, `api_prompt_assembly:132`, `mcp/findings_server:45`, and the `context/__init__` re-export — have no guard at all. Hence fixing it at the source.

## Widening the readers was not sufficient

Probing every path out of `detect_shape` turned up a fourth escape that the readers don't touch:

```
nested package.json    RecursionError
nested pyproject.toml  RecursionError
nested Cargo.toml      RecursionError
dependencies = 5       TypeError: 'int' object is not iterable   <-- not a reader bug
```

`dependencies = 5` is perfectly valid TOML, so every reader succeeds and `_python_signals` then calls `list(5)`. Guarded with the same `isinstance` check the `optional-dependencies` branch three lines below already uses. Had I only widened the readers, this PR would have claimed a fix it didn't deliver.

`pyproject.toml` and `Cargo.toml` share `_read_toml`, so both are the same hole. tomllib is a pure-Python recursive-descent parser and bottoms out around a few thousand levels — far shallower than the C JSON decoder's tens of thousands.

## Verification

Re-probed 14 pathological manifests after the fix: **zero escapes**, all degrading to `UNKNOWN`.

One test pins that degradation is **per-manifest**, not all-or-nothing: a pathological `package.json` must not blank the `WEB_SERVICE` verdict a good `pyproject.toml` supports. Without it the fix would trade a crash for silent total detection loss, which is harder to notice and worse.

Full suite: `5691 passed, 1 skipped`.

## Relationship to the trust-model branch

No conflict. That branch touches `_python_signals`' desktop/web priority (lines 141-145); this touches the readers and the `deps_list` guard. Its caller-side `except Exception` in `_detected_fields` becomes belt-and-braces once this lands — worth keeping, since `detect_shape` could still grow a new failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)