### PR TITLE
feat(analysis): declared per-project trust model, and gate every finding sink through one helper

### DIFF
--- a/.quodeq/project-profile.json
+++ b/.quodeq/project-profile.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "multiTenant": false,
+  "networkExposure": "loopback"
+}

--- a/README.md
+++ b/README.md
@@ -266,6 +266,33 @@ By default, Quodeq evaluates the six ISO 25010 dimensions. It also ships with **
 
 Numeric thresholds on the built-in standards (max function lines, max parameters, ...) can be tuned per project from the dashboard. Overrides live in `.quodeq/standards-overrides.json` at the repo root, so the whole team scans with the same numbers.
 
+### Threat model
+
+By default Quodeq scores a project as if it were a hosted multi-tenant service. For a
+local-first tool that produces noise: a file path built from a value the operator already
+controls gets reported as an attack surface, and the real findings get buried under it.
+
+A project can say what it actually is, in `.quodeq/project-profile.json` at the repo root:
+
+```json
+{
+  "version": 1,
+  "multiTenant": false,
+  "networkExposure": "loopback"
+}
+```
+
+`multiTenant` answers whether more than one user's data lives behind the same code.
+`networkExposure` is one of `loopback`, `lan`, or `public`, and answers whether an
+untrusted party can open a socket to the process.
+
+Findings the declared model rules out are capped at `minor` rather than dropped, and
+carry a marker naming the rule that moved them, so nothing becomes invisible. A finding
+whose evidence names a real remote source is never capped, whatever the profile says.
+
+The file is optional. Without it Quodeq infers what it can from your manifests and
+otherwise assumes the most pessimistic model, which is how it behaves today.
+
 ---
 
 ## Privacy

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from quodeq.analysis._types import RunConfig
 from quodeq.context.precedent import load_precedent_corpus, load_precedent_fingerprints
 from quodeq.context.project_shape import detect_shape
+from quodeq.context.trust_model import resolve_trust_model
 from quodeq.data.fs.standards_loader import load_compiled_refs, load_compiled_requirements
 from quodeq.shared.url_validation import validate_url_safe
 
@@ -460,6 +461,7 @@ def _build_router_context(
         compiled_refs = load_compiled_refs(compiled_dir, dimension) or {}
         compiled_reqs = load_compiled_requirements(compiled_dir, dimension) or {}
         project_shape = detect_shape(work_dir) if work_dir is not None else None
+        trust_model = resolve_trust_model(work_dir) if work_dir is not None else None
         precedents = load_precedent_fingerprints(project_dir) if project_dir else set()
         corpus = (
             load_precedent_corpus(project_dir, run_dir)
@@ -471,6 +473,7 @@ def _build_router_context(
             dimension=dimension,
             work_dir=work_dir,
             project_shape=project_shape,
+            trust_model=trust_model,
             precedent_fingerprints=precedents,
             precedent_corpus=corpus,
         )

--- a/src/quodeq/analysis/api_prompt_assembly.py
+++ b/src/quodeq/analysis/api_prompt_assembly.py
@@ -13,6 +13,7 @@ from quodeq.analysis.prompts.builder import _load_evaluation_rules
 from quodeq.config.prompt_templates import render_template
 from quodeq.context.path_role import Role, path_role
 from quodeq.context.project_shape import Deployment, ProjectShape, detect_shape
+from quodeq.context.trust_model import TrustModel
 
 _log = logging.getLogger(__name__)
 
@@ -72,16 +73,26 @@ def _build_files_block(source_files: list[Path], repo_root: Path | None = None) 
     return "\n\n".join(parts)
 
 
-def _format_shape_block(shape: ProjectShape) -> str:
-    """Render a project-shape briefing for the LLM, or empty when unknown.
+def _format_shape_block(
+    shape: ProjectShape, trust_model: TrustModel | None = None,
+) -> str:
+    """Render a project briefing for the LLM, or empty when nothing is known.
 
-    Skipped for ``UNKNOWN`` deployments: the heuristics didn't fire and we
-    don't want to plant a wrong assumption in the model's head.
+    A declared trust model is briefed even when shape detection returned
+    UNKNOWN: detection is a guess, the declaration is the team telling us the
+    answer, and suppressing it would waste the only reliable signal we have.
     """
-    if shape.deployment is Deployment.UNKNOWN:
+    relaxing = trust_model is not None and (
+        trust_model.relaxes_remote() or not trust_model.multi_tenant)
+    if shape.deployment is Deployment.UNKNOWN and not relaxing:
         return ""
-    parts: list[str] = [f"deployment={shape.deployment.value}",
-                        f"single_user={'true' if shape.is_single_user else 'false'}"]
+    parts: list[str] = []
+    if shape.deployment is not Deployment.UNKNOWN:
+        parts.append(f"deployment={shape.deployment.value}")
+        parts.append(f"single_user={'true' if shape.is_single_user else 'false'}")
+    if trust_model is not None:
+        parts.append(f"multi_tenant={'true' if trust_model.multi_tenant else 'false'}")
+        parts.append(f"network_exposure={trust_model.network_exposure}")
     if shape.runtime_langs:
         parts.append(f"runtime={'+'.join(shape.runtime_langs)}")
     if shape.web_frameworks:
@@ -107,6 +118,18 @@ def _format_shape_block(shape: ProjectShape) -> str:
             " This is a single-user CLI, not a hosted service. Concurrent"
             " caller and multi-tenant findings rarely apply."
         )
+    if trust_model is not None and trust_model.relaxes_remote():
+        note += (
+            " No untrusted party can open a socket to this process, so a file"
+            " path built from a value this process already controls is a"
+            " hardening gap, not a trust boundary crossing. Report it as"
+            " `minor` unless you can name a remote source that reaches the line."
+        )
+    if trust_model is not None and not trust_model.multi_tenant:
+        note += (
+            " There is exactly one user, so findings about reaching another"
+            " user's data, ownership checks, and tenant isolation do not apply."
+        )
     return f"## Project Shape\n\n**{summary}**.{note}"
 
 
@@ -118,19 +141,26 @@ def assemble_api_prompt(
     repo_name: str,
     repo_root: Path | None = None,
     project_shape: ProjectShape | None = None,
+    trust_model: TrustModel | None = None,
 ) -> str:
     """Assemble a complete evaluation prompt for the API runner.
 
     *project_shape* is computed from *repo_root* when not supplied; pass an
     explicit shape to skip detection (e.g. when a cached shape is being
-    reused across dimensions).
+    reused across dimensions). *trust_model* is never detected here -- it is
+    resolved by the caller (declared profile, then detection, then the
+    conservative default) and threaded through so the model is briefed on
+    the same trust boundary the deterministic scope gate enforces.
     """
     template = load_template(template_name="api_prompt.md")
     rules = _load_evaluation_rules()
     files_block = _build_files_block(source_files, repo_root=repo_root)
     if project_shape is None and repo_root is not None:
         project_shape = detect_shape(repo_root)
-    shape_block = _format_shape_block(project_shape) if project_shape else ""
+    # Fall back to an UNKNOWN shape rather than skipping the block outright:
+    # a declared trust model must still be briefed even without a shape
+    # verdict. _format_shape_block itself returns "" when nothing is known.
+    shape_block = _format_shape_block(project_shape or ProjectShape(), trust_model)
     return render_template(template, {
         "DIMENSION": dimension,
         "REPO_NAME": repo_name,

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -53,8 +53,7 @@ from quodeq.analysis.cache.dimension_helpers import (
 )
 from quodeq.analysis.cache.gc import maybe_collect_legacy_entries
 from quodeq.analysis.cache.local import LocalFileBackend
-from quodeq.analysis.mcp.provenance_gate import apply_provenance_gate
-from quodeq.analysis.mcp.scope_gate import apply_scope_gate
+from quodeq.analysis.mcp.severity_gates import apply_severity_gates
 from quodeq.analysis.subagents._source_files import _list_source_files
 from quodeq.analysis.subagents.runner import (
     DimensionCallbacks,
@@ -257,16 +256,13 @@ def _write_findings(
     # already-cached findings on the very next run, without a cache miss or
     # a CacheKey change.
     #
-    # Order matters, same as in enrich(): apply_provenance_gate first,
-    # because it can rewrite ``critical`` down to ``major``, and
-    # apply_scope_gate only ever acts on ``major``. Reversing the order
-    # would miss every finding that starts as ``critical``.
+    # apply_severity_gates owns the sequence and the order it must run in
+    # (see severity_gates.py); this call site owns only the decision to
+    # re-gate on replay at all.
     for finding in findings:
-        apply_provenance_gate(finding)
-        apply_scope_gate(finding, trust_model)
+        apply_severity_gates(finding, trust_model)
     for finding in pending:
-        apply_provenance_gate(finding)
-        apply_scope_gate(finding, trust_model)
+        apply_severity_gates(finding, trust_model)
     # Every caller of this function is a cache replay -- the dispatcher
     # writes its own fresh findings and never comes through here. Stamp the
     # origin so the live evaluation feed can show only what this scan is

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -54,11 +54,13 @@ from quodeq.analysis.cache.dimension_helpers import (
 from quodeq.analysis.cache.gc import maybe_collect_legacy_entries
 from quodeq.analysis.cache.local import LocalFileBackend
 from quodeq.analysis.mcp.provenance_gate import apply_provenance_gate
+from quodeq.analysis.mcp.scope_gate import apply_scope_gate
 from quodeq.analysis.subagents._source_files import _list_source_files
 from quodeq.analysis.subagents.runner import (
     DimensionCallbacks,
     process_dimension_with_subagents,
 )
+from quodeq.context.trust_model import TrustModel, resolve_trust_model
 from quodeq.core.evidence.model import Evidence
 from quodeq.analysis._runner_markers import emit_marker
 
@@ -217,6 +219,7 @@ def _write_findings(
     jsonl: Path, findings: list[dict], *, append: bool,
     emit_events: bool = True,
     unconsolidated: list[dict] | None = None,
+    trust_model: TrustModel | None = None,
 ) -> None:
     """Replay cached findings into this run's evidence JSONL.
 
@@ -241,10 +244,29 @@ def _write_findings(
     # inflate the grade. The gate only touches un-gated criticals, so
     # re-gating an already-gated (or non-critical) finding is a no-op --
     # safe to apply unconditionally to every cached finding.
+    #
+    # The scope gate is re-applied here for the identical reason: it too
+    # runs at the FindingEnricher sink (enrich(), after apply_provenance_gate),
+    # which cache replay bypasses just like the provenance gate. CacheKey
+    # deliberately does not fingerprint the declared trust model (that would
+    # defeat the point of gating at replay time instead of at the cache key),
+    # so a cached ``major`` finding survives untouched across a
+    # ``.quodeq/project-profile.json`` edit unless something re-caps it on
+    # every replay -- this is that something. The practical effect: editing
+    # the profile to declare, say, ``networkExposure: loopback`` re-caps
+    # already-cached findings on the very next run, without a cache miss or
+    # a CacheKey change.
+    #
+    # Order matters, same as in enrich(): apply_provenance_gate first,
+    # because it can rewrite ``critical`` down to ``major``, and
+    # apply_scope_gate only ever acts on ``major``. Reversing the order
+    # would miss every finding that starts as ``critical``.
     for finding in findings:
         apply_provenance_gate(finding)
+        apply_scope_gate(finding, trust_model)
     for finding in pending:
         apply_provenance_gate(finding)
+        apply_scope_gate(finding, trust_model)
     # Every caller of this function is a cache replay -- the dispatcher
     # writes its own fresh findings and never comes through here. Stamp the
     # origin so the live evaluation feed can show only what this scan is
@@ -283,6 +305,14 @@ def process_dimension_with_cache(
         # skip this branch). Reclaim entries orphaned by the schema bump,
         # once per process. Best-effort: never blocks the run.
         maybe_collect_legacy_entries(cache.root)
+
+    # Resolved once per dimension and threaded through to every _write_findings
+    # call below, mirroring how the live path resolves it (_api_runner.py,
+    # findings_server.py): guard on ``config.src`` being set rather than
+    # assuming it, even though ``resolve_trust_model`` already degrades to
+    # CONSERVATIVE on ``None`` -- passing ``None`` through instead makes
+    # apply_scope_gate's no-op explicit rather than incidental.
+    trust_model = resolve_trust_model(config.src) if config.src is not None else None
 
     files, _ext, _excluded = _list_source_files(config, dim_id)
     if not files:
@@ -355,6 +385,7 @@ def process_dimension_with_cache(
         _write_findings(
             jsonl, classify.cached_findings, append=True,
             unconsolidated=classify.unconsolidated_findings,
+            trust_model=trust_model,
         )
         if jsonl.exists():
             deduplicate_jsonl(jsonl)
@@ -385,6 +416,7 @@ def process_dimension_with_cache(
         _write_findings(
             jsonl, classify.cached_findings, append=True,
             unconsolidated=classify.unconsolidated_findings,
+            trust_model=trust_model,
         )
 
     # Persist the per-file cache keys to a sidecar so the discard path can

--- a/src/quodeq/analysis/checks/runner.py
+++ b/src/quodeq/analysis/checks/runner.py
@@ -13,6 +13,9 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from quodeq.analysis.checks.registry import CHECKERS, CheckContext
+from quodeq.analysis.mcp.provenance_gate import DOWNGRADE_MARKER
+from quodeq.analysis.mcp.severity_gates import apply_severity_gates
+from quodeq.context.trust_model import TrustModel, resolve_trust_model
 from quodeq.core.events.models import Judgment, JudgmentCreatedEvent
 from quodeq.core.evidence._jsonl import judgment_to_dict
 from quodeq.core.evidence._req_mapping import build_principle_resolver
@@ -120,17 +123,44 @@ def _merge_into_evidence(evidence: Evidence, judgments: list[Judgment],
     return added
 
 
-def _persist(jsonl_path: Path, judgments: list[Judgment]) -> None:
+def _gate(j: Judgment, trust_model: TrustModel | None) -> tuple[Judgment, dict]:
+    """Run one judgment through the shared severity gates.
+
+    Returns the judgment at its gated severity and the wire row that produced
+    it. Both, because they carry different amounts of the result: ``Judgment``
+    is frozen and has no ``scope_downgrade`` field, so the scope gate's audit
+    marker survives only on the row. The severity itself -- the part that
+    reaches the score -- lands on both.
+
+    ``_to_wire`` is what makes this cheap: it already emits the short-key shape
+    (``t``/``req``/``severity``/``reason``/``w``) the gates read at the other
+    two sinks, so a checker finding is gated on exactly the evidence an LLM
+    finding would be.
+    """
+    row = _to_wire(j)
+    if not apply_severity_gates(row, trust_model):
+        return j, row
+    update: dict = {"severity": row["severity"]}
+    if row.get(DOWNGRADE_MARKER):
+        update["provenance_downgrade"] = True
+    return j.model_copy(update=update), row
+
+
+def _persist(jsonl_path: Path, judgments: list[Judgment], rows: list[dict]) -> None:
     """Append to the per-dim JSONL and mirror into the run's event log.
 
     Both stores, always. The SQL projection runs off ``events.jsonl`` while
     the report path reads the per-dim JSONL; writing only one is how the
     dashboard and the CLI end up disagreeing about the same run.
+
+    *rows* are the gated wire rows from :func:`_gate`, written rather than
+    re-derived from *judgments*: re-deriving would silently drop the scope
+    gate's marker, which has no field on ``Judgment`` to be re-derived from.
     """
     try:
         with jsonl_path.open("a", encoding="utf-8") as out:
-            for j in judgments:
-                out.write(json.dumps(_to_wire(j)) + "\n")
+            for row in rows:
+                out.write(json.dumps(row) + "\n")
     except OSError:
         _logger.warning("checks: could not append to %s", jsonl_path, exc_info=True)
 
@@ -153,6 +183,7 @@ def apply_deterministic_checks(
     compiled_dir: Path | None,
     jsonl_path: Path | None,
     evaluators_dir: Path | None = None,
+    trust_model: TrustModel | None = None,
 ) -> int:
     """Run *dimension*'s checkers and fold the findings into *evidence*.
 
@@ -167,10 +198,21 @@ def apply_deterministic_checks(
     if not judgments:
         return 0
 
+    # Gate BEFORE the evidence merge, not just before the write. The evidence
+    # is what the score is computed from, so gating only on the way to disk
+    # would leave the grade reflecting the ungated severity while the stored
+    # finding disagreed with it.
+    gated: list[Judgment] = []
+    rows: list[dict] = []
+    for raw in judgments:
+        judgment, row = _gate(raw, trust_model)
+        gated.append(judgment)
+        rows.append(row)
+
     resolver = build_principle_resolver(dimension, evaluators_dir, compiled_dir)
-    added = _merge_into_evidence(evidence, judgments, resolver)
+    added = _merge_into_evidence(evidence, gated, resolver)
     if added and jsonl_path is not None:
-        _persist(jsonl_path, judgments)
+        _persist(jsonl_path, gated, rows)
     return added
 
 
@@ -204,6 +246,13 @@ def apply_checks_for_run(config, dimension: str, evidence: Evidence) -> int:
             return 0
         standards_dir = config.standards_dir
         evidence_dir = config.work_dir or config.src
+        # Resolved once per dimension and threaded down, the same way
+        # process_dimension_with_cache does it: resolution reads the project
+        # profile and walks the manifests, which is per-project work, not
+        # per-finding work. Guarding on ``config.src`` rather than assuming it
+        # keeps apply_scope_gate's no-op explicit -- resolve_trust_model would
+        # degrade to CONSERVATIVE on None, which is a different statement.
+        trust_model = resolve_trust_model(config.src) if config.src is not None else None
         return apply_deterministic_checks(
             evidence,
             root=Path(config.src),
@@ -212,6 +261,7 @@ def apply_checks_for_run(config, dimension: str, evidence: Evidence) -> int:
             compiled_dir=(Path(standards_dir) / "compiled") if standards_dir else None,
             evaluators_dir=config.evaluators_dir,
             jsonl_path=Path(evidence_dir) / f"{dimension}_evidence.jsonl",
+            trust_model=trust_model,
         )
     except Exception:  # a check must never fail a dimension that already succeeded
         _logger.warning("checks: skipped for %s", dimension, exc_info=True)

--- a/src/quodeq/analysis/mcp/enricher.py
+++ b/src/quodeq/analysis/mcp/enricher.py
@@ -12,9 +12,8 @@ from pathlib import Path
 from typing import Callable, Protocol, runtime_checkable
 
 from quodeq.analysis.mcp.enrichment import enrich_code
-from quodeq.analysis.mcp.provenance_gate import apply_provenance_gate
 from quodeq.analysis.mcp.ref_scoring import select_best_refs
-from quodeq.analysis.mcp.scope_gate import apply_scope_gate
+from quodeq.analysis.mcp.severity_gates import apply_severity_gates
 from quodeq.context.path_role import NON_PROD_ROLES, path_role
 from quodeq.context.precedent import (
     PrecedentCorpus,
@@ -248,16 +247,17 @@ class FindingEnricher:
         _apply_precedent_downweight(
             finding, self._precedent_fingerprints, self._precedent_corpus,
         )
-        apply_provenance_gate(finding)  # deterministic critical-severity gate (#639)
         # Gates the LIVE path only: this method runs once per freshly-dispatched
         # finding, before it ever reaches the cache. A cached finding replayed on
         # a later run does NOT come back through here -- cache replay bypasses
-        # enrich() entirely and writes straight to the per-dim JSONL. That path
-        # (dimension_runner._write_findings) applies apply_provenance_gate and
-        # apply_scope_gate itself, in the same order, for the same reason. Both
-        # call sites are required: this one gates what the model just emitted,
-        # the other re-gates what a warm cache is about to replay, and skipping
-        # either leaves a class of findings (fresh vs. cached) ungated.
-        apply_scope_gate(finding, self._trust_model)
+        # enrich() entirely and writes straight to the per-dim JSONL, and a
+        # deterministic checker never comes through here at all. Those two sinks
+        # (dimension_runner._write_findings, checks.runner) call the same helper
+        # for the same reason. Every call site is required: this one gates what
+        # the model just emitted, the others gate what a warm cache is about to
+        # replay and what a checker just computed, and skipping any one leaves a
+        # class of findings ungated. See severity_gates.py for why the sequence
+        # lives there rather than being repeated here.
+        apply_severity_gates(finding, self._trust_model)
 
         return finding

--- a/src/quodeq/analysis/mcp/enricher.py
+++ b/src/quodeq/analysis/mcp/enricher.py
@@ -249,9 +249,15 @@ class FindingEnricher:
             finding, self._precedent_fingerprints, self._precedent_corpus,
         )
         apply_provenance_gate(finding)  # deterministic critical-severity gate (#639)
-        # Runs at the SINK, after the cache: cached findings pass through here
-        # on every run, so editing .quodeq/project-profile.json re-caps existing
-        # results without touching CacheKey (which is deliberately permissive).
+        # Gates the LIVE path only: this method runs once per freshly-dispatched
+        # finding, before it ever reaches the cache. A cached finding replayed on
+        # a later run does NOT come back through here -- cache replay bypasses
+        # enrich() entirely and writes straight to the per-dim JSONL. That path
+        # (dimension_runner._write_findings) applies apply_provenance_gate and
+        # apply_scope_gate itself, in the same order, for the same reason. Both
+        # call sites are required: this one gates what the model just emitted,
+        # the other re-gates what a warm cache is about to replay, and skipping
+        # either leaves a class of findings (fresh vs. cached) ungated.
         apply_scope_gate(finding, self._trust_model)
 
         return finding

--- a/src/quodeq/analysis/mcp/enricher.py
+++ b/src/quodeq/analysis/mcp/enricher.py
@@ -14,6 +14,7 @@ from typing import Callable, Protocol, runtime_checkable
 from quodeq.analysis.mcp.enrichment import enrich_code
 from quodeq.analysis.mcp.provenance_gate import apply_provenance_gate
 from quodeq.analysis.mcp.ref_scoring import select_best_refs
+from quodeq.analysis.mcp.scope_gate import apply_scope_gate
 from quodeq.context.path_role import NON_PROD_ROLES, path_role
 from quodeq.context.precedent import (
     PrecedentCorpus,
@@ -21,6 +22,7 @@ from quodeq.context.precedent import (
     precedent_text as _precedent_text,
 )
 from quodeq.context.project_shape import Deployment, ProjectShape
+from quodeq.context.trust_model import TrustModel
 
 _logger = logging.getLogger(__name__)
 
@@ -61,6 +63,7 @@ class CompiledContext:
     dimension: str | None = None
     work_dir: Path | None = None
     project_shape: ProjectShape | None = None
+    trust_model: TrustModel | None = None
     precedent_fingerprints: set[str] = field(default_factory=set)
     precedent_corpus: PrecedentCorpus | None = None
 
@@ -190,6 +193,7 @@ class FindingEnricher:
         self._dimension = context.dimension
         self._work_dir = context.work_dir
         self._project_shape = context.project_shape
+        self._trust_model = context.trust_model
         self._precedent_fingerprints = context.precedent_fingerprints
         self._precedent_corpus = context.precedent_corpus
         self._read_file: Callable[[Path], str] = file_reader or _default_read_file
@@ -245,5 +249,9 @@ class FindingEnricher:
             finding, self._precedent_fingerprints, self._precedent_corpus,
         )
         apply_provenance_gate(finding)  # deterministic critical-severity gate (#639)
+        # Runs at the SINK, after the cache: cached findings pass through here
+        # on every run, so editing .quodeq/project-profile.json re-caps existing
+        # results without touching CacheKey (which is deliberately permissive).
+        apply_scope_gate(finding, self._trust_model)
 
         return finding

--- a/src/quodeq/analysis/mcp/findings_server.py
+++ b/src/quodeq/analysis/mcp/findings_server.py
@@ -19,6 +19,7 @@ from quodeq.analysis.mcp.dispatch import read_message, dispatch as _dispatch
 from quodeq.data.fs.standards_loader import load_compiled_refs as _load_compiled_refs
 from quodeq.context.precedent import load_precedent_corpus, load_precedent_fingerprints
 from quodeq.context.project_shape import detect_shape
+from quodeq.context.trust_model import resolve_trust_model
 from quodeq.data.fs.standards_loader import load_compiled_requirements as _load_compiled_requirements
 from quodeq.data.fs.standards_prefs import load_project_overrides
 
@@ -43,6 +44,7 @@ def _build_compiled_context(sa: ServerArgs) -> CompiledContext:
                 req_to_dim[req_id] = dim
 
     project_shape = detect_shape(work_dir) if work_dir is not None else None
+    trust_model = resolve_trust_model(work_dir) if work_dir is not None else None
 
     return CompiledContext(
         compiled_refs=compiled_refs or {},
@@ -51,6 +53,7 @@ def _build_compiled_context(sa: ServerArgs) -> CompiledContext:
         dimension=sa.dimension,
         work_dir=work_dir,
         project_shape=project_shape,
+        trust_model=trust_model,
     )
 
 

--- a/src/quodeq/analysis/mcp/scope_gate.py
+++ b/src/quodeq/analysis/mcp/scope_gate.py
@@ -15,10 +15,11 @@ which is why an undeclared project resolves to
 The gate ships two rules: rule 1 relaxes an unproven-provenance path/key
 finding when the model declares no untrusted party can reach the process at
 all, and rule 2 relaxes a finding whose premise is a second trust principal
-when the model declares there is only one. (Rule 2 is evaluated first in
-code, because its evidence is more specific and would otherwise be masked by
-rule 1 -- see the comment on ``apply_scope_gate``.) There is no third,
-remote-ingress rule; the comment below ``_CROSS_PRINCIPAL_REQS`` records why.
+when the model declares there is only one AND no untrusted party can reach
+the process. (Rule 2 is evaluated first in code, because its evidence is more
+specific and would otherwise be masked by rule 1 -- see the comment on
+``apply_scope_gate``.) There is no third, remote-ingress rule; the comment
+below ``_CROSS_PRINCIPAL_REQS`` records why.
 
 Every rule requires BOTH a gated requirement id AND evidence in the model's
 prose, the same two-condition shape ``provenance_gate`` uses. A finding that
@@ -60,11 +61,16 @@ _CROSS_PRINCIPAL_REQS: frozenset[str] = frozenset({"S-AUT-10", "S-AUT-3"})
 # moment someone rebinds the app to 0.0.0.0, and nothing would be left to
 # re-flag it. Only the SOURCELESS case (rule 1 above) is scope-dependent.
 
-# Concepts that only exist when there is more than one trust principal.
+# Concepts that only exist when there is more than one trust principal. Every
+# term already gets an automatic ``s?`` plural suffix below, so a plural form
+# ("other users") is never listed separately -- only distinct WORD forms
+# ("impersonate" / "impersonation", "hijack" / "hijacking" / "hijacked") need
+# their own entry.
 _CROSS_PRINCIPAL_TERMS: frozenset[str] = frozenset({
-    "other user", "another user", "other users", "idor",
+    "other user", "another user", "idor",
     "insecure direct object", "ownership verification", "ownership check",
-    "tenant", "tenancy", "impersonate", "impersonation", "hijack",
+    "tenant", "tenancy", "impersonate", "impersonation",
+    "hijack", "hijacking", "hijacked",
 })
 
 _CROSS_PATTERN = re.compile(
@@ -109,7 +115,19 @@ def apply_scope_gate(finding: dict, model: TrustModel | None) -> bool:
 
     # Rule 2 first: a named cross-principal concept is more specific evidence
     # than the absence of a source, and would otherwise be masked by rule 1.
-    if (not model.multi_tenant and req in _CROSS_PRINCIPAL_REQS
+    #
+    # Both axes are required, not just ``multi_tenant``. ``multi_tenant=False``
+    # only says there is no SECOND user whose data could be reached -- it says
+    # nothing about whether a stranger can reach the process at all. S-AUT-10
+    # also covers "Authorization checks MUST be enforced on every request", so
+    # a public-facing single-user service with a missing authz check is still
+    # genuinely vulnerable: the attacker is an unauthenticated stranger, not a
+    # second tenant. Without ``relaxes_remote()`` here, this waiver would
+    # silently evaporate the moment the app becomes network-exposed, the same
+    # failure shape that got the old remote-ingress rule deleted (see the
+    # comment below ``_CROSS_PRINCIPAL_REQS``).
+    if (not model.multi_tenant and model.relaxes_remote()
+            and req in _CROSS_PRINCIPAL_REQS
             and _CROSS_PATTERN.search(prose)):
         return _downgrade(finding, "cross_principal")
 

--- a/src/quodeq/analysis/mcp/scope_gate.py
+++ b/src/quodeq/analysis/mcp/scope_gate.py
@@ -59,7 +59,10 @@ _CROSS_PRINCIPAL_REQS: frozenset[str] = frozenset({"S-AUT-10", "S-AUT-3"})
 # proves it reads attacker-controlled input regardless of how the process
 # happens to be bound today. Waiving that would silently evaporate the
 # moment someone rebinds the app to 0.0.0.0, and nothing would be left to
-# re-flag it. Only the SOURCELESS case (rule 1 above) is scope-dependent.
+# re-flag it. Both rules honor this: rule 1 only fires on a SOURCELESS
+# finding, and rule 2 (see its own comment in ``apply_scope_gate``) also
+# backs off the instant the prose names an external source, even though its
+# own trigger is a cross-principal concept, not provenance.
 
 # Concepts that only exist when there is more than one trust principal. Every
 # term already gets an automatic ``s?`` plural suffix below, so a plural form
@@ -126,9 +129,27 @@ def apply_scope_gate(finding: dict, model: TrustModel | None) -> bool:
     # silently evaporate the moment the app becomes network-exposed, the same
     # failure shape that got the old remote-ingress rule deleted (see the
     # comment below ``_CROSS_PRINCIPAL_REQS``).
+    #
+    # The tenancy check alone is not enough either, which is why a provenance
+    # check joins it. "Another user's session" is ambiguous: it can describe a
+    # genuine second-tenant read (impossible once ``multi_tenant`` is False)
+    # OR it can describe an unauthenticated stranger reaching the SAME single
+    # user's own session -- still live on a loopback bind via browser CSRF or
+    # DNS rebinding -- when the finding also names how that stranger gets in
+    # (e.g. "query parameter"). The cross-principal phrasing cannot tell those
+    # two readings apart; ``names_external_source`` can, because it reads the
+    # ingress term instead of the relationship term. So both a tenancy check
+    # (rules out reading #1) and a provenance check (rules out reading #2) are
+    # required before this rule may relax anything.
+    #
+    # ``names_operator_source`` is deliberately NOT added alongside it: argv
+    # and the environment are the operator's own inputs, set by whoever
+    # launches the process, and carry no attacker reading here even when the
+    # finding's premise is cross-principal.
     if (not model.multi_tenant and model.relaxes_remote()
             and req in _CROSS_PRINCIPAL_REQS
-            and _CROSS_PATTERN.search(prose)):
+            and _CROSS_PATTERN.search(prose)
+            and not names_external_source(prose)):
         return _downgrade(finding, "cross_principal")
 
     if not model.relaxes_remote():

--- a/src/quodeq/analysis/mcp/scope_gate.py
+++ b/src/quodeq/analysis/mcp/scope_gate.py
@@ -12,6 +12,14 @@ the process at all, and only that declaration gives this gate its authority --
 which is why an undeclared project resolves to
 ``trust_model.CONSERVATIVE`` and nothing here fires.
 
+The gate ships two rules: rule 1 relaxes an unproven-provenance path/key
+finding when the model declares no untrusted party can reach the process at
+all, and rule 2 relaxes a finding whose premise is a second trust principal
+when the model declares there is only one. (Rule 2 is evaluated first in
+code, because its evidence is more specific and would otherwise be masked by
+rule 1 -- see the comment on ``apply_scope_gate``.) There is no third,
+remote-ingress rule; the comment below ``_CROSS_PRINCIPAL_REQS`` records why.
+
 Every rule requires BOTH a gated requirement id AND evidence in the model's
 prose, the same two-condition shape ``provenance_gate`` uses. A finding that
 names no scope-dependent concept is never touched.
@@ -43,16 +51,14 @@ SCOPE_DOWNGRADE_MARKER = "scope_downgrade"
 _PATH_REQS: frozenset[str] = frozenset({"S-AUT-3", "S-INT-10"})
 _CROSS_PRINCIPAL_REQS: frozenset[str] = frozenset({"S-AUT-10", "S-AUT-3"})
 
-# Reqs whose OWN premise is remote reachability (S-INT-10 is literally titled
-# "externally controlled path"; S-AUT-10 covers cross-session/cross-tenant
-# hijack over a request). A named external source there is relaxed under
-# loopback, because the requirement's premise -- an untrusted party can reach
-# this -- is exactly what the declaration says is false. S-AUT-3 is
-# deliberately ABSENT: it is a general path/key-from-a-value finding with no
-# such premise, so a genuinely named source (e.g. "request body") is real
-# evidence that stays major regardless of the network declaration -- only its
-# sourceless case (rule 1) is scope-dependent.
-_INGRESS_REQS: frozenset[str] = frozenset({"S-INT-10", "S-AUT-10"})
+# There is deliberately no rule that relaxes a NAMED external source (e.g.
+# "request body", "query parameter") under loopback, even for reqs like
+# S-INT-10 whose own premise is remote reachability. A loopback bind is a
+# runtime setting (QUODEQ_ACTION_API_HOST), not a code property: the code
+# proves it reads attacker-controlled input regardless of how the process
+# happens to be bound today. Waiving that would silently evaporate the
+# moment someone rebinds the app to 0.0.0.0, and nothing would be left to
+# re-flag it. Only the SOURCELESS case (rule 1 above) is scope-dependent.
 
 # Concepts that only exist when there is more than one trust principal.
 _CROSS_PRINCIPAL_TERMS: frozenset[str] = frozenset({
@@ -109,9 +115,6 @@ def apply_scope_gate(finding: dict, model: TrustModel | None) -> bool:
 
     if not model.relaxes_remote():
         return False
-
-    if req in _INGRESS_REQS and names_external_source(prose):
-        return _downgrade(finding, "remote_ingress")
 
     if (req in _PATH_REQS
             and not names_external_source(prose)

--- a/src/quodeq/analysis/mcp/scope_gate.py
+++ b/src/quodeq/analysis/mcp/scope_gate.py
@@ -16,10 +16,17 @@ The gate ships two rules: rule 1 relaxes an unproven-provenance path/key
 finding when the model declares no untrusted party can reach the process at
 all, and rule 2 relaxes a finding whose premise is a second trust principal
 when the model declares there is only one AND no untrusted party can reach
-the process. (Rule 2 is evaluated first in code, because its evidence is more
-specific and would otherwise be masked by rule 1 -- see the comment on
-``apply_scope_gate``.) There is no third, remote-ingress rule; the comment
-below ``_CROSS_PRINCIPAL_REQS`` records why.
+the process AND the finding's prose does not name an external source.
+(Rule 2 is evaluated first in code, because its evidence is more specific
+and would otherwise be masked by rule 1 -- see the comment on
+``apply_scope_gate``.) The third precondition for rule 2 exists because
+a finding whose prose names proven external ingress has a second reading the
+cross-principal phrasing hides: an unauthenticated attacker reaching the
+single user's own data via browser CSRF or DNS rebinding on the loopback
+bind. Multi-tenant=False rules out the second-tenant reading, but it says
+nothing about this one, so the finding must stay major when the prose
+names how the stranger gets in. There is no third, remote-ingress rule;
+the comment below ``_CROSS_PRINCIPAL_REQS`` records why.
 
 Every rule requires BOTH a gated requirement id AND evidence in the model's
 prose, the same two-condition shape ``provenance_gate`` uses. A finding that

--- a/src/quodeq/analysis/mcp/scope_gate.py
+++ b/src/quodeq/analysis/mcp/scope_gate.py
@@ -1,0 +1,121 @@
+"""Deterministic severity gate for a project's DECLARED threat model.
+
+``provenance_gate`` answers "where did this value come from?" and guards the
+``critical`` bar. This module answers a different question -- "is there anyone
+this finding's attacker could be?" -- and guards the ``major`` bar.
+
+The distinction matters, because this is a CHANGE to the standard rather than
+enforcement of it. ``evaluation_rules.md`` criterion 7 says a finding whose
+source cannot be named is legitimately ``major``. That is right by default. It
+stops being right once a project has declared that no untrusted party can reach
+the process at all, and only that declaration gives this gate its authority --
+which is why an undeclared project resolves to
+``trust_model.CONSERVATIVE`` and nothing here fires.
+
+Every rule requires BOTH a gated requirement id AND evidence in the model's
+prose, the same two-condition shape ``provenance_gate`` uses. A finding that
+names no scope-dependent concept is never touched.
+
+Caps ``major`` -> ``minor``; never drops. A team that later ships as a hosted
+service must be able to recover the list of what was waived, so the finding
+survives with a ``scope_downgrade`` marker naming the rule that moved it.
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+from quodeq.analysis.mcp.provenance_gate import (
+    names_external_source,
+    names_operator_source,
+)
+from quodeq.context.trust_model import TrustModel
+
+_log = logging.getLogger(__name__)
+
+#: Additive output field describing why a severity moved.
+SCOPE_DOWNGRADE_MARKER = "scope_downgrade"
+
+# Path-shaped requirements. R-FT-2 is deliberately ABSENT: it is the
+# null-guard pattern, its severity does not turn on network exposure, and
+# including it would sweep in ~87 reliability findings this gate has no
+# opinion about.
+_PATH_REQS: frozenset[str] = frozenset({"S-AUT-3", "S-INT-10"})
+_CROSS_PRINCIPAL_REQS: frozenset[str] = frozenset({"S-AUT-10", "S-AUT-3"})
+
+# Reqs whose OWN premise is remote reachability (S-INT-10 is literally titled
+# "externally controlled path"; S-AUT-10 covers cross-session/cross-tenant
+# hijack over a request). A named external source there is relaxed under
+# loopback, because the requirement's premise -- an untrusted party can reach
+# this -- is exactly what the declaration says is false. S-AUT-3 is
+# deliberately ABSENT: it is a general path/key-from-a-value finding with no
+# such premise, so a genuinely named source (e.g. "request body") is real
+# evidence that stays major regardless of the network declaration -- only its
+# sourceless case (rule 1) is scope-dependent.
+_INGRESS_REQS: frozenset[str] = frozenset({"S-INT-10", "S-AUT-10"})
+
+# Concepts that only exist when there is more than one trust principal.
+_CROSS_PRINCIPAL_TERMS: frozenset[str] = frozenset({
+    "other user", "another user", "other users", "idor",
+    "insecure direct object", "ownership verification", "ownership check",
+    "tenant", "tenancy", "impersonate", "impersonation", "hijack",
+})
+
+_CROSS_PATTERN = re.compile(
+    "|".join(rf"\b{re.escape(t)}s?\b"
+             for t in sorted(_CROSS_PRINCIPAL_TERMS, key=len, reverse=True)),
+    re.IGNORECASE,
+)
+
+
+def _prose(finding: dict) -> str:
+    """The model's natural-language evidence. The code snippet is never read,
+    so the decision stays language-independent."""
+    return " ".join(str(finding.get(k) or "") for k in ("reason", "w"))
+
+
+def _downgrade(finding: dict, rule: str) -> bool:
+    finding[SCOPE_DOWNGRADE_MARKER] = {"rule": rule, "from": "major", "to": "minor"}
+    finding["severity"] = "minor"
+    _log.debug(
+        "scope gate: %s capped %s finding to minor (%s)",
+        rule, finding.get("req"), finding.get("file"),
+    )
+    return True
+
+
+def apply_scope_gate(finding: dict, model: TrustModel | None) -> bool:
+    """Cap a ``major`` finding the declared trust model puts out of scope.
+
+    Returns True iff it downgraded. Only ever touches ``major`` violations on
+    a gated req: ``critical`` belongs to ``provenance_gate``, and letting both
+    gates write the same field at the same severity would make the outcome
+    depend on call order.
+    """
+    if model is None:
+        return False
+    if finding.get("t") != "violation":
+        return False
+    if finding.get("severity") != "major":
+        return False
+    req = finding.get("req")
+    prose = _prose(finding)
+
+    # Rule 2 first: a named cross-principal concept is more specific evidence
+    # than the absence of a source, and would otherwise be masked by rule 1.
+    if (not model.multi_tenant and req in _CROSS_PRINCIPAL_REQS
+            and _CROSS_PATTERN.search(prose)):
+        return _downgrade(finding, "cross_principal")
+
+    if not model.relaxes_remote():
+        return False
+
+    if req in _INGRESS_REQS and names_external_source(prose):
+        return _downgrade(finding, "remote_ingress")
+
+    if (req in _PATH_REQS
+            and not names_external_source(prose)
+            and not names_operator_source(prose)):
+        return _downgrade(finding, "sourceless_path")
+
+    return False

--- a/src/quodeq/analysis/mcp/severity_gates.py
+++ b/src/quodeq/analysis/mcp/severity_gates.py
@@ -1,0 +1,56 @@
+"""The one place every deterministic severity gate is applied to a finding.
+
+Quodeq has two gates, and they must run together, in one order, at every sink
+that produces a finding. Enforcing that by convention has failed twice:
+
+* issue #657 -- cache replay wrote findings without ``apply_provenance_gate``,
+  so a stale critical replayed at critical and inflated the grade.
+* the trust-model work -- the same replay path was then missing
+  ``apply_scope_gate`` for the same reason, and needed the same fix again.
+
+Both were one shape: a code path nobody enumerated. Three sinks exist today --
+``FindingEnricher.enrich`` (live), ``_write_findings`` (cache replay) and
+``checks.runner`` (deterministic checkers) -- and the only thing that stopped
+the third from being a third instance of that bug was that no shipped standard
+declares a ``check`` on a gated requirement yet.
+
+So the sequence lives here rather than at the call sites. A fourth sink gets
+the gates by calling one function, and a new gate is added in one place instead
+of three. Callers are responsible only for resolving the :class:`TrustModel`
+(once, not per finding) and calling this.
+
+ORDER IS LOAD-BEARING, which is the other reason not to leave this to callers:
+``apply_provenance_gate`` can rewrite ``critical`` -> ``major``, and
+``apply_scope_gate`` only ever looks at ``major``. Run scope first and a
+critical the provenance gate was about to demote never becomes eligible for
+the scope gate at all, so a finding that should end at ``minor`` stops at
+``major``. The gates are deliberately split at that severity boundary (see
+``apply_scope_gate``'s docstring) precisely so this order is the only correct
+one.
+"""
+from __future__ import annotations
+
+from quodeq.analysis.mcp.provenance_gate import apply_provenance_gate
+from quodeq.analysis.mcp.scope_gate import apply_scope_gate
+from quodeq.context.trust_model import TrustModel
+
+
+def apply_severity_gates(finding: dict, trust_model: TrustModel | None) -> bool:
+    """Apply every severity gate to *finding*, in place. True iff one fired.
+
+    *finding* is the short-key wire dict (``t``, ``req``, ``severity``,
+    ``reason``, ``w``) every sink already speaks. *trust_model* may be ``None``,
+    which no-ops the scope gate -- the honest value for a caller that has no
+    project root to resolve one from.
+
+    Neither gate ever drops a finding or raises on a well-formed dict; both are
+    no-ops on anything they do not recognise, so calling this on an already
+    gated finding (as cache replay does) is safe.
+    """
+    downgraded = apply_provenance_gate(finding)
+    # Not ``or``-shortcircuited: the scope gate must run even when the
+    # provenance gate already fired, because that is exactly the critical ->
+    # major -> minor case this order exists to allow.
+    if apply_scope_gate(finding, trust_model):
+        downgraded = True
+    return downgraded

--- a/src/quodeq/analysis/subprocess.py
+++ b/src/quodeq/analysis/subprocess.py
@@ -28,6 +28,7 @@ from quodeq.analysis._provider_cache import get_provider_configs
 from quodeq.analysis.api_prompt_assembly import assemble_api_prompt
 from quodeq.analysis.stream.counters import count_files_in_stream
 from quodeq.analysis.subagents.file_queue import FileQueue
+from quodeq.context.trust_model import resolve_trust_model
 from quodeq.shared import cancellation
 from quodeq.shared.utils import get_ai_cmd
 
@@ -413,6 +414,11 @@ def _run_api_analysis_bridge(
 
     overrides = load_project_overrides(work_dir)
     standards_text = _load_standards_text(cfg.compiled_dir, cfg.dimension, overrides=overrides)
+    # Resolved once per dimension, not per batch: same declared-then-detected
+    # trust model the finding sink applies (quodeq.context.trust_model),
+    # briefed here so the model generates fewer out-of-scope findings for the
+    # sink to have to claw back.
+    trust_model = resolve_trust_model(work_dir)
 
     for batch in _batch_files_by_size(source_files, _api_prompt_char_budget()):
         # A cancelled run (signal, breaker, fatal provider error) must not
@@ -426,6 +432,7 @@ def _run_api_analysis_bridge(
             dimension=cfg.dimension or "general",
             repo_name=str(work_dir.name),
             repo_root=work_dir,
+            trust_model=trust_model,
         )
 
         # POSIX-style separators: paths flow into findings (file fields,

--- a/src/quodeq/context/project_shape.py
+++ b/src/quodeq/context/project_shape.py
@@ -138,10 +138,15 @@ def _python_signals(repo: Path) -> tuple[Deployment | None, list[str], list[str]
     names = [_strip_dep_spec(d).lower() for d in raw if isinstance(d, str)]
     web = _matches_any(names, _PY_WEB_FRAMEWORKS)
     desktop = _matches_any(names, _PY_DESKTOP_HINTS)
-    if web and not desktop:
-        return Deployment.WEB_SERVICE, web, desktop
-    if desktop and not web:
+    # Desktop wins outright when both are present. A desktop app routinely
+    # embeds a web framework for its own UI (pywebview + flask, Electron +
+    # express); a hosted service does not pull in pywebview. Returning None
+    # here made detect_shape report UNKNOWN, which disables every downstream
+    # shape consumer -- see detect_shape's own priority comment.
+    if desktop:
         return Deployment.DESKTOP, web, desktop
+    if web:
+        return Deployment.WEB_SERVICE, web, desktop
     return None, web, desktop
 
 

--- a/src/quodeq/context/trust_model.py
+++ b/src/quodeq/context/trust_model.py
@@ -131,7 +131,17 @@ def _detected_fields(project_root: Path) -> tuple[bool | None, str | None]:
     """
     try:
         shape = detect_shape(project_root)
-    except OSError as exc:  # unreadable manifests must not fail a scan
+    except Exception as exc:  # noqa: BLE001 - unreadable/pathological manifests must not fail a scan
+        # detect_shape's own manifest readers (project_shape.py) only catch
+        # OSError/tomllib.TOMLDecodeError/json.JSONDecodeError, not every
+        # failure mode: deeply nested package.json/pyproject.toml/Cargo.toml
+        # content overflows the C JSON decoder's or tomllib's recursion limit
+        # and raises RecursionError, a RuntimeError subclass neither of those
+        # readers catches. project_root is analyzed, untrusted input with a
+        # well-defined conservative fallback, so any detection failure -- not
+        # just OSError -- must degrade here rather than escape and fail the
+        # scan. project_shape.py itself is out of scope for this fix; this
+        # catch is deliberately wide as the boundary that must not leak.
         _logger.warning("Project shape detection failed for %s: %s", project_root, exc)
         return None, None
     if shape.deployment is Deployment.WEB_SERVICE:

--- a/src/quodeq/context/trust_model.py
+++ b/src/quodeq/context/trust_model.py
@@ -1,0 +1,151 @@
+"""Per-project declared threat model.
+
+Quodeq scores every project as if it were a hosted multi-tenant service. For a
+local-first tool that is wrong in a measurable way: a path built from a value
+the operator already controls is reported as an attack surface. See
+``project_shape``'s own docstring -- shape assumptions are the largest single
+FP source in the audit corpus.
+
+Detection cannot fix this on its own. The manifest of a loopback Flask app is
+byte-identical to that of a hosted one; whether an untrusted party can open a
+socket is information only the team has. So the model is DECLARED, in the
+analyzed repository at ``<project root>/.quodeq/project-profile.json``,
+alongside ``standards-visibility.json`` and ``standards-overrides.json`` so the
+whole team shares it:
+
+    {"version": 1, "multiTenant": false, "networkExposure": "loopback"}
+
+Resolution is PER FIELD: a declared value wins, ``detect_shape`` fills what is
+undeclared, and anything still unknown falls back to :data:`CONSERVATIVE`. That
+last step is the no-regression guarantee -- a project that declares nothing and
+detects as nothing is scored exactly as it was before this module existed.
+
+Nothing here may fail a scan. Every malformed-input branch warns and degrades.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from quodeq.context.project_shape import Deployment, detect_shape
+
+_logger = logging.getLogger(__name__)
+
+PROFILE_RELPATH = Path(".quodeq") / "project-profile.json"
+
+SUPPORTED_VERSION = 1
+
+# Only ``loopback`` relaxes anything. ``lan`` is accepted so a team can describe
+# itself honestly rather than mis-declaring as loopback, and so a later rule can
+# use it without a file-format migration, but it grants nothing today: a LAN is
+# not a trust boundary this code can reason about.
+NETWORK_EXPOSURES: frozenset[str] = frozenset({"loopback", "lan", "public"})
+
+
+@dataclass(frozen=True)
+class TrustModel:
+    """The two axes a finding's severity can legitimately turn on."""
+
+    multi_tenant: bool
+    network_exposure: str
+
+    def relaxes_remote(self) -> bool:
+        """True when no untrusted party can open a socket to this process."""
+        return self.network_exposure == "loopback"
+
+
+#: What an undeclared, undetectable project gets. Deliberately the most
+#: pessimistic model, so absence of information never relaxes a finding.
+CONSERVATIVE = TrustModel(multi_tenant=True, network_exposure="public")
+
+
+def _read_profile(project_root: Path) -> dict:
+    """Parse the profile file; ``{}`` for absent, unreadable or malformed."""
+    path = project_root / PROFILE_RELPATH
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, UnicodeDecodeError) as exc:
+        _logger.warning("Ignoring malformed project profile %s: %s", path, exc)
+        return {}
+    if not isinstance(data, dict):
+        _logger.warning("Ignoring project profile %s: not a JSON object", path)
+        return {}
+    if data.get("version") != SUPPORTED_VERSION:
+        _logger.warning(
+            "Ignoring project profile %s: unsupported version %r (expected %d)",
+            path, data.get("version"), SUPPORTED_VERSION,
+        )
+        return {}
+    return data
+
+
+def _declared_fields(data: dict) -> tuple[bool | None, str | None]:
+    """Extract the two axes from a parsed profile, per field.
+
+    A bad value for one axis never discards the other: the file is a
+    declaration, not a transaction.
+    """
+    multi_tenant: bool | None = None
+    raw_tenant = data.get("multiTenant")
+    if isinstance(raw_tenant, bool):
+        multi_tenant = raw_tenant
+    elif raw_tenant is not None:
+        _logger.warning("project profile: multiTenant must be a boolean, got %r", raw_tenant)
+
+    exposure: str | None = None
+    raw_exposure = data.get("networkExposure")
+    if isinstance(raw_exposure, str) and raw_exposure.strip().lower() in NETWORK_EXPOSURES:
+        exposure = raw_exposure.strip().lower()
+    elif raw_exposure is not None:
+        _logger.warning(
+            "project profile: networkExposure must be one of %s, got %r",
+            sorted(NETWORK_EXPOSURES), raw_exposure,
+        )
+    return multi_tenant, exposure
+
+
+def _detected_fields(project_root: Path) -> tuple[bool | None, str | None]:
+    """Derive the two axes from manifest detection; ``None`` where unknown.
+
+    ``LIBRARY`` maps to unknown on purpose. ``_shape_irrelevant_to_hosted_service``
+    treats libraries as non-hosted, which is sound for concurrency findings and
+    wrong for trust boundaries: a library's paths may be fed from an HTTP
+    request in the consuming application, and the author cannot know.
+    """
+    try:
+        shape = detect_shape(project_root)
+    except OSError as exc:  # unreadable manifests must not fail a scan
+        _logger.warning("Project shape detection failed for %s: %s", project_root, exc)
+        return None, None
+    if shape.deployment is Deployment.WEB_SERVICE:
+        return True, "public"
+    if shape.deployment is Deployment.DESKTOP:
+        return False, "loopback"
+    if shape.deployment is Deployment.CLI and shape.is_single_user:
+        return False, "loopback"
+    return None, None
+
+
+def resolve_trust_model(project_root: Path | str | None) -> TrustModel:
+    """Resolve the effective trust model for *project_root*.
+
+    Per field: declared, then detected, then :data:`CONSERVATIVE`.
+    """
+    if not project_root:
+        return CONSERVATIVE
+    root = Path(project_root)
+    declared_tenant, declared_exposure = _declared_fields(_read_profile(root))
+    detected_tenant, detected_exposure = _detected_fields(root)
+
+    multi_tenant = declared_tenant
+    if multi_tenant is None:
+        multi_tenant = detected_tenant
+    if multi_tenant is None:
+        multi_tenant = CONSERVATIVE.multi_tenant
+
+    exposure = declared_exposure or detected_exposure or CONSERVATIVE.network_exposure
+    return TrustModel(multi_tenant=multi_tenant, network_exposure=exposure)

--- a/src/quodeq/context/trust_model.py
+++ b/src/quodeq/context/trust_model.py
@@ -62,22 +62,35 @@ CONSERVATIVE = TrustModel(multi_tenant=True, network_exposure="public")
 
 
 def _read_profile(project_root: Path) -> dict:
-    """Parse the profile file; ``{}`` for absent, unreadable or malformed."""
+    """Parse the profile file; ``{}`` for absent, unreadable or malformed.
+
+    This is advisory data an operator hand-writes, with a well-defined
+    conservative fallback, so parsing failures of *any* kind degrade rather
+    than propagate -- not just the well-behaved ``OSError``/``ValueError``/
+    ``UnicodeDecodeError`` trio. In particular, deeply nested JSON (e.g. tens
+    of thousands of nested arrays) overflows the C decoder's call stack and
+    raises ``RecursionError``, which is a ``RuntimeError`` and would
+    otherwise escape and fail the scan.
+    """
     path = project_root / PROFILE_RELPATH
     if not path.is_file():
         return {}
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError, UnicodeDecodeError) as exc:
-        _logger.warning("Ignoring malformed project profile %s: %s", path, exc)
+    except Exception as exc:  # noqa: BLE001 - advisory data must never fail a scan
+        _logger.warning("Ignoring unreadable or malformed project profile %s: %s", path, exc)
         return {}
     if not isinstance(data, dict):
         _logger.warning("Ignoring project profile %s: not a JSON object", path)
         return {}
-    if data.get("version") != SUPPORTED_VERSION:
+    version = data.get("version")
+    # ``bool`` is a subclass of ``int`` in Python, so ``True == 1``: without the
+    # explicit bool exclusion, a profile declaring ``"version": true`` would
+    # silently pass this gate as version 1.
+    if isinstance(version, bool) or not isinstance(version, int) or version != SUPPORTED_VERSION:
         _logger.warning(
             "Ignoring project profile %s: unsupported version %r (expected %d)",
-            path, data.get("version"), SUPPORTED_VERSION,
+            path, version, SUPPORTED_VERSION,
         )
         return {}
     return data

--- a/tests/analysis/cache/test_dimension_runner.py
+++ b/tests/analysis/cache/test_dimension_runner.py
@@ -1109,6 +1109,152 @@ class TestCacheReplayAppliesProvenanceGate:
         assert "provenance_downgrade" not in findings[0]
 
 
+class TestCacheReplayAppliesScopeGate:
+    """Task 4 follow-up: the scope gate must be re-applied on the replay
+    path too, exactly like the provenance gate is for issue #657.
+
+    ``FindingEnricher.enrich()`` calls ``apply_scope_gate`` right after
+    ``apply_provenance_gate`` on the live path, but that method only runs
+    once per freshly-dispatched finding -- cache replay writes straight to
+    the per-dim JSONL via ``_write_findings`` and never touches ``enrich()``.
+    Without re-gating here, a ``major`` finding already sitting in a warm
+    cache would never be re-capped after the operator declares a tighter
+    trust model in ``.quodeq/project-profile.json``, which on a repo with
+    warm caches is most findings -- the feature would be largely inert.
+    """
+
+    @staticmethod
+    def _cached_finding(file: str, req: str, severity: str, reason: str) -> dict:
+        return {
+            "file": file, "line": 1, "t": "violation",
+            "w": "Path built from an unvalidated value", "p": "Access Control",
+            "d": "security", "req": req, "severity": severity,
+            "snippet": "open(name)", "reason": reason,
+        }
+
+    @staticmethod
+    def _write_profile(src: Path, *, multi_tenant: bool, network_exposure: str) -> None:
+        profile_dir = src / ".quodeq"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        (profile_dir / "project-profile.json").write_text(json.dumps({
+            "version": 1,
+            "multiTenant": multi_tenant,
+            "networkExposure": network_exposure,
+        }))
+
+    @staticmethod
+    def _findings_in(jsonl: Path) -> list[dict]:
+        return [
+            json.loads(ln) for ln in jsonl.read_text().splitlines()
+            if ln.strip() and "_marker" not in ln
+        ]
+
+    def _replay_all_hits(
+        self, tmp_path: Path, cache: LocalFileBackend, finding: dict,
+        *, profile: tuple[bool, str] | None,
+    ) -> RunConfig:
+        config, src = _setup(tmp_path, {"a.py": "x"})
+        if profile is not None:
+            multi_tenant, network_exposure = profile
+            self._write_profile(
+                src, multi_tenant=multi_tenant, network_exposure=network_exposure,
+            )
+        key = build_cache_key_for_file(config, "a.py", "security")
+        cache.put(key, CacheEntry(
+            key=key, schema_version=1,
+            findings=[finding],
+            files_read=1, file_path="a.py", dimension="security",
+            model_id="test-model",
+        ))
+        dispatcher = FakeDispatcher(src)
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=dispatcher,
+        ):
+            process_dimension_with_cache(
+                config, "security", idx=1, ctx=_make_ctx(),
+                callbacks=_make_callbacks(), cache=cache,
+            )
+        assert dispatcher.calls == [], "all-hits path must not dispatch"
+        return config
+
+    def test_cached_major_scope_finding_is_capped_under_loopback_single_tenant(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        # A cached major S-AUT-3 whose reason names no external or operator
+        # source -- the sourceless-path rule's exact target.
+        finding = self._cached_finding(
+            "a.py", "S-AUT-3", "major",
+            "Path built from a filename argument with no bounds check.",
+        )
+        config = self._replay_all_hits(
+            tmp_path, cache, finding,
+            profile=(False, "loopback"),
+        )
+
+        jsonl = (config.work_dir or config.src) / "security_evidence.jsonl"
+        findings = self._findings_in(jsonl)
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "minor", (
+            "a cache-replayed major S-AUT-3 finding must be capped to minor "
+            "once the project declares a loopback, single-tenant trust model "
+            "-- this is exactly the case a warm cache would otherwise hide"
+        )
+        assert findings[0].get("scope_downgrade", {}).get("rule") == "sourceless_path"
+
+    def test_cached_major_scope_finding_untouched_without_declared_trust_model(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        # Same finding, but no .quodeq/project-profile.json -- resolution
+        # falls back to CONSERVATIVE, which relaxes nothing.
+        finding = self._cached_finding(
+            "a.py", "S-AUT-3", "major",
+            "Path built from a filename argument with no bounds check.",
+        )
+        config = self._replay_all_hits(tmp_path, cache, finding, profile=None)
+
+        jsonl = (config.work_dir or config.src) / "security_evidence.jsonl"
+        findings = self._findings_in(jsonl)
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "major", (
+            "without a declared trust model the conservative default must "
+            "not relax anything"
+        )
+        assert "scope_downgrade" not in findings[0]
+
+    def test_cached_critical_scope_gated_req_ends_at_minor_after_both_gates(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        # Cross-gate ordering: a critical S-AUT-3 naming no source must first
+        # be downgraded to major by the provenance gate, and THEN capped to
+        # minor by the scope gate -- the scope gate only ever acts on major,
+        # so running it before the provenance gate would leave this finding
+        # stuck at major (or, worse, unseen at critical). Assert the end
+        # state the finding settles at, not an intermediate severity.
+        finding = self._cached_finding(
+            "a.py", "S-AUT-3", "critical",
+            "Path built from a filename argument with no bounds check.",
+        )
+        config = self._replay_all_hits(
+            tmp_path, cache, finding,
+            profile=(False, "loopback"),
+        )
+
+        jsonl = (config.work_dir or config.src) / "security_evidence.jsonl"
+        findings = self._findings_in(jsonl)
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "minor", (
+            "a cache-replayed critical S-AUT-3 finding naming no source must "
+            "end at minor after passing through both gates in sequence under "
+            "a loopback single-tenant model"
+        )
+        # Both gates must have actually fired, proving the order: the
+        # provenance gate moved critical -> major, and the scope gate then
+        # moved major -> minor.
+        assert findings[0].get("provenance_downgrade") is True
+        assert findings[0].get("scope_downgrade", {}).get("rule") == "sourceless_path"
+
+
 class TestFilesReadReflectsAnalyzedCount:
     """files_read on the returned Evidence must equal the number of source
     files reproducible from cache at run end — NOT len(input_files)."""

--- a/tests/analysis/mcp/test_scope_gate.py
+++ b/tests/analysis/mcp/test_scope_gate.py
@@ -1,0 +1,138 @@
+"""Tests for the declared-threat-model severity gate."""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.analysis.mcp.scope_gate import (
+    SCOPE_DOWNGRADE_MARKER,
+    apply_scope_gate,
+)
+from quodeq.context.trust_model import CONSERVATIVE, TrustModel
+
+LOCAL = TrustModel(multi_tenant=False, network_exposure="loopback")
+LAN = TrustModel(multi_tenant=False, network_exposure="lan")
+
+
+def _finding(**kw) -> dict:
+    base = {"t": "violation", "req": "S-AUT-3", "severity": "major",
+            "w": "Path traversal via job_id",
+            "reason": "The job_id is used to construct a file path without validation."}
+    base.update(kw)
+    return base
+
+
+# --- rule 1: sourceless path hardening ------------------------------------
+
+def test_sourceless_path_capped_under_loopback():
+    f = _finding()
+    assert apply_scope_gate(f, LOCAL) is True
+    assert f["severity"] == "minor"
+    assert f[SCOPE_DOWNGRADE_MARKER]["rule"] == "sourceless_path"
+    assert f[SCOPE_DOWNGRADE_MARKER]["from"] == "major"
+    assert f[SCOPE_DOWNGRADE_MARKER]["to"] == "minor"
+
+
+def test_sourceless_path_untouched_under_conservative():
+    # The no-regression guarantee, at the gate.
+    f = _finding()
+    assert apply_scope_gate(f, CONSERVATIVE) is False
+    assert f["severity"] == "major"
+    assert SCOPE_DOWNGRADE_MARKER not in f
+
+
+def test_lan_does_not_relax():
+    f = _finding()
+    assert apply_scope_gate(f, LAN) is False
+    assert f["severity"] == "major"
+
+
+def test_named_external_source_is_not_sourceless():
+    # An actual request-fed path stays major even on a loopback project: the
+    # rule is about unproven provenance, not about waiving real ingress.
+    f = _finding(reason="The filename comes straight from the request body.")
+    apply_scope_gate(f, LOCAL)
+    assert f["severity"] == "major"
+
+
+def test_operator_source_is_not_sourceless():
+    f = _finding(reason="The output path is taken from a command-line argument.")
+    apply_scope_gate(f, LOCAL)
+    assert f["severity"] == "major"
+
+
+def test_r_ft_2_is_excluded_from_rule_one():
+    # 87 reliability null-guard findings live here. Their severity does not
+    # turn on network exposure, so this gate must not touch them.
+    f = _finding(req="R-FT-2",
+                 reason="The argument is dereferenced without a null guard.")
+    assert apply_scope_gate(f, LOCAL) is False
+    assert f["severity"] == "major"
+
+
+# --- rule 2: cross-principal ----------------------------------------------
+
+def test_cross_principal_capped_when_single_tenant():
+    f = _finding(req="S-AUT-10", w="Session hijacking via IDOR",
+                 reason="No ownership verification, so one user can reach "
+                        "another user's terminal session.")
+    assert apply_scope_gate(f, LOCAL) is True
+    assert f["severity"] == "minor"
+    assert f[SCOPE_DOWNGRADE_MARKER]["rule"] == "cross_principal"
+
+
+def test_cross_principal_untouched_when_multi_tenant():
+    f = _finding(req="S-AUT-10",
+                 reason="No ownership verification, so one user can reach "
+                        "another user's terminal session.")
+    model = TrustModel(multi_tenant=True, network_exposure="loopback")
+    assert apply_scope_gate(f, model) is False
+    assert f["severity"] == "major"
+
+
+# --- rule 3: remote ingress -----------------------------------------------
+
+def test_remote_ingress_capped_under_loopback():
+    f = _finding(req="S-INT-10",
+                 reason="The path is taken from a query parameter without validation.")
+    assert apply_scope_gate(f, LOCAL) is True
+    assert f["severity"] == "minor"
+    assert f[SCOPE_DOWNGRADE_MARKER]["rule"] == "remote_ingress"
+
+
+# --- invariants -----------------------------------------------------------
+
+def test_never_touches_critical():
+    # The critical bar belongs to the provenance gate. Two gates writing the
+    # same field at the same severity would make the result order-dependent.
+    f = _finding(severity="critical")
+    assert apply_scope_gate(f, LOCAL) is False
+    assert f["severity"] == "critical"
+
+
+def test_never_touches_minor():
+    f = _finding(severity="minor")
+    assert apply_scope_gate(f, LOCAL) is False
+
+
+def test_never_touches_compliance():
+    f = _finding(t="compliance")
+    assert apply_scope_gate(f, LOCAL) is False
+
+
+def test_ignores_non_gated_req():
+    f = _finding(req="S-ACC-6", reason="Unbounded read with no size limit.")
+    assert apply_scope_gate(f, LOCAL) is False
+    assert f["severity"] == "major"
+
+
+def test_none_model_is_a_no_op():
+    f = _finding()
+    assert apply_scope_gate(f, None) is False
+    assert f["severity"] == "major"
+
+
+def test_never_drops_a_finding():
+    f = _finding()
+    apply_scope_gate(f, LOCAL)
+    assert f["severity"] in ("minor", "major")
+    assert f.get("w"), "the finding must survive intact, only its severity moves"

--- a/tests/analysis/mcp/test_scope_gate.py
+++ b/tests/analysis/mcp/test_scope_gate.py
@@ -125,17 +125,6 @@ def test_cross_principal_untouched_when_names_external_source():
     assert SCOPE_DOWNGRADE_MARKER not in f
 
 
-def test_cross_principal_capped_with_sourceless_prose():
-    # Regression guard: no named external or operator source, so provenance
-    # is silent and the tenancy reading alone still relaxes the finding.
-    f = _finding(req="S-AUT-10", w="Session hijacking via IDOR",
-                 reason="No ownership verification, so one user can reach "
-                        "another user's terminal session.")
-    assert apply_scope_gate(f, LOCAL) is True
-    assert f["severity"] == "minor"
-    assert f[SCOPE_DOWNGRADE_MARKER]["rule"] == "cross_principal"
-
-
 def test_cross_principal_capped_when_naming_operator_source():
     # argv/env are the operator's own inputs, not an attacker channel, even
     # when the finding's premise is cross-principal: the operator-source

--- a/tests/analysis/mcp/test_scope_gate.py
+++ b/tests/analysis/mcp/test_scope_gate.py
@@ -1,8 +1,6 @@
 """Tests for the declared-threat-model severity gate."""
 from __future__ import annotations
 
-import pytest
-
 from quodeq.analysis.mcp.scope_gate import (
     SCOPE_DOWNGRADE_MARKER,
     apply_scope_gate,
@@ -11,6 +9,7 @@ from quodeq.context.trust_model import CONSERVATIVE, TrustModel
 
 LOCAL = TrustModel(multi_tenant=False, network_exposure="loopback")
 LAN = TrustModel(multi_tenant=False, network_exposure="lan")
+PUBLIC = TrustModel(multi_tenant=False, network_exposure="public")
 
 
 def _finding(**kw) -> dict:
@@ -89,6 +88,43 @@ def test_cross_principal_untouched_when_multi_tenant():
     assert f["severity"] == "major"
 
 
+def test_cross_principal_untouched_when_public_single_tenant():
+    # multi_tenant=False only says there is no SECOND user whose data could
+    # be reached -- it says nothing about whether a stranger can reach the
+    # process. S-AUT-10 also covers "Authorization checks MUST be enforced
+    # on every request", so a public-facing single-user service missing an
+    # authz check is genuinely vulnerable to an unauthenticated attacker.
+    f = _finding(req="S-AUT-10", w="Session hijacking via IDOR",
+                 reason="No ownership verification, so one user can reach "
+                        "another user's terminal session.")
+    assert apply_scope_gate(f, PUBLIC) is False
+    assert f["severity"] == "major"
+
+
+def test_cross_principal_untouched_when_lan_single_tenant():
+    f = _finding(req="S-AUT-10", w="Session hijacking via IDOR",
+                 reason="No ownership verification, so one user can reach "
+                        "another user's terminal session.")
+    assert apply_scope_gate(f, LAN) is False
+    assert f["severity"] == "major"
+
+
+def test_cross_principal_matches_hijacking_gerund():
+    # "hijack" gets an automatic s? suffix, matching "hijack"/"hijacks" but
+    # not the -ing/-ed forms a real finding in the corpus uses ("Session
+    # hijacking via IDOR"). "hijacking" and "hijacked" must be their own
+    # terms, the same way "impersonate"/"impersonation" already are. This
+    # reason deliberately contains no other cross-principal term (no "other
+    # user", no "idor", no bare "hijack") so only the gerund can be doing
+    # the matching.
+    f = _finding(req="S-AUT-10", w="Session hijacking via session id reuse",
+                 reason="The session id is predictable, allowing session "
+                        "hijacking by a party who guesses it.")
+    assert apply_scope_gate(f, LOCAL) is True
+    assert f["severity"] == "minor"
+    assert f[SCOPE_DOWNGRADE_MARKER]["rule"] == "cross_principal"
+
+
 # --- invariants -----------------------------------------------------------
 
 def test_never_touches_critical():
@@ -126,3 +162,21 @@ def test_never_drops_a_finding():
     apply_scope_gate(f, LOCAL)
     assert f["severity"] in ("minor", "major")
     assert f.get("w"), "the finding must survive intact, only its severity moves"
+
+
+def test_cross_principal_evaluated_before_sourceless_path():
+    # S-AUT-3 is the only req in BOTH _PATH_REQS and _CROSS_PRINCIPAL_REQS.
+    # Construct prose that satisfies BOTH rules' evidence conditions at once:
+    # sourceless (no external/operator source named) AND cross-principal
+    # (names another user). Both rules would cap this the same way
+    # (major -> minor), so the only observable difference is which rule name
+    # lands in scope_downgrade["rule"] -- and that label is how someone later
+    # audits what was waived, so the documented order (cross_principal first,
+    # because it is more specific evidence) must actually hold in code, not
+    # just in the comment.
+    f = _finding(req="S-AUT-3",
+                 reason="No ownership check, so one user can reach another "
+                        "user's data via this path.")
+    assert apply_scope_gate(f, LOCAL) is True
+    assert f["severity"] == "minor"
+    assert f[SCOPE_DOWNGRADE_MARKER]["rule"] == "cross_principal"

--- a/tests/analysis/mcp/test_scope_gate.py
+++ b/tests/analysis/mcp/test_scope_gate.py
@@ -109,6 +109,47 @@ def test_cross_principal_untouched_when_lan_single_tenant():
     assert f["severity"] == "major"
 
 
+def test_cross_principal_untouched_when_names_external_source():
+    # The named ingress ("query parameter") supports a second reading the
+    # cross-principal phrasing hides: an unauthenticated attacker reaching
+    # the single user's own session via CSRF/DNS rebinding on the loopback
+    # bind. multi_tenant=False rules out the SECOND-TENANT reading, but it
+    # says nothing about this one, so the finding must stay major.
+    f = _finding(req="S-AUT-10", w="IDOR via session id in query parameter",
+                 reason="The session id is taken directly from a query "
+                        "parameter and used to look up a terminal session "
+                        "without ownership verification, allowing an "
+                        "attacker to reach another user's active session.")
+    assert apply_scope_gate(f, LOCAL) is False
+    assert f["severity"] == "major"
+    assert SCOPE_DOWNGRADE_MARKER not in f
+
+
+def test_cross_principal_capped_with_sourceless_prose():
+    # Regression guard: no named external or operator source, so provenance
+    # is silent and the tenancy reading alone still relaxes the finding.
+    f = _finding(req="S-AUT-10", w="Session hijacking via IDOR",
+                 reason="No ownership verification, so one user can reach "
+                        "another user's terminal session.")
+    assert apply_scope_gate(f, LOCAL) is True
+    assert f["severity"] == "minor"
+    assert f[SCOPE_DOWNGRADE_MARKER]["rule"] == "cross_principal"
+
+
+def test_cross_principal_capped_when_naming_operator_source():
+    # argv/env are the operator's own inputs, not an attacker channel, even
+    # when the finding's premise is cross-principal: the operator-source
+    # exclusion from rule 1 is deliberately NOT extended to this rule.
+    f = _finding(req="S-AUT-10", w="Session hijacking via IDOR",
+                 reason="The session id comes from a command-line argument "
+                        "and is used to look up a terminal session without "
+                        "ownership verification, allowing one user to reach "
+                        "another user's session.")
+    assert apply_scope_gate(f, LOCAL) is True
+    assert f["severity"] == "minor"
+    assert f[SCOPE_DOWNGRADE_MARKER]["rule"] == "cross_principal"
+
+
 def test_cross_principal_matches_hijacking_gerund():
     # "hijack" gets an automatic s? suffix, matching "hijack"/"hijacks" but
     # not the -ing/-ed forms a real finding in the corpus uses ("Session

--- a/tests/analysis/mcp/test_scope_gate.py
+++ b/tests/analysis/mcp/test_scope_gate.py
@@ -210,3 +210,33 @@ def test_cross_principal_evaluated_before_sourceless_path():
     assert apply_scope_gate(f, LOCAL) is True
     assert f["severity"] == "minor"
     assert f[SCOPE_DOWNGRADE_MARKER]["rule"] == "cross_principal"
+
+
+# --- integration: wired into FindingEnricher.enrich ------------------------
+
+from quodeq.analysis.mcp.enricher import CompiledContext, FindingEnricher
+
+
+def _enricher(model):
+    return FindingEnricher(CompiledContext(dimension="security", trust_model=model))
+
+
+def test_enrich_applies_scope_gate():
+    f = _enricher(LOCAL).enrich({
+        "t": "violation", "req": "S-AUT-3", "severity": "major",
+        "w": "Path traversal via job_id",
+        "reason": "The job_id is used to construct a file path without validation.",
+        "file": "src/app.py", "line": 10,
+    })
+    assert f["severity"] == "minor"
+    assert f[SCOPE_DOWNGRADE_MARKER]["rule"] == "sourceless_path"
+
+
+def test_enrich_without_trust_model_is_unchanged():
+    f = _enricher(None).enrich({
+        "t": "violation", "req": "S-AUT-3", "severity": "major",
+        "w": "Path traversal via job_id",
+        "reason": "The job_id is used to construct a file path without validation.",
+        "file": "src/app.py", "line": 10,
+    })
+    assert f["severity"] == "major"

--- a/tests/analysis/mcp/test_scope_gate.py
+++ b/tests/analysis/mcp/test_scope_gate.py
@@ -89,16 +89,6 @@ def test_cross_principal_untouched_when_multi_tenant():
     assert f["severity"] == "major"
 
 
-# --- rule 3: remote ingress -----------------------------------------------
-
-def test_remote_ingress_capped_under_loopback():
-    f = _finding(req="S-INT-10",
-                 reason="The path is taken from a query parameter without validation.")
-    assert apply_scope_gate(f, LOCAL) is True
-    assert f["severity"] == "minor"
-    assert f[SCOPE_DOWNGRADE_MARKER]["rule"] == "remote_ingress"
-
-
 # --- invariants -----------------------------------------------------------
 
 def test_never_touches_critical():

--- a/tests/analysis/mcp/test_scope_gate_replay.py
+++ b/tests/analysis/mcp/test_scope_gate_replay.py
@@ -1,0 +1,120 @@
+"""Replay the scope gate over a real self-scan and pin the counts.
+
+The synthetic fixtures prove each rule fires; they cannot prove the rules
+COVER what they were designed to cover. During design, two coverage claims
+survived a green unit suite and were only caught by replaying this run.
+
+Skipped when the evaluation is not present (CI, other machines).
+"""
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis.mcp.provenance_gate import apply_provenance_gate
+from quodeq.analysis.mcp.scope_gate import apply_scope_gate
+from quodeq.context.trust_model import CONSERVATIVE, TrustModel
+
+_RUN = Path.home() / ".quodeq/evaluations/d33f1fd0-d685-4c3c-97f5-9ae26a1b3723"
+_SECURITY = _RUN / "3a19b93f-1e01-428a-9d38-fea8e8929e63/evaluation/security.json"
+
+pytestmark = pytest.mark.skipif(
+    not _SECURITY.is_file(), reason="self-scan run 3a19b93f not present on this machine")
+
+LOCAL = TrustModel(multi_tenant=False, network_exposure="loopback")
+
+
+def _violations(severity: str):
+    data = json.loads(_SECURITY.read_text(encoding="utf-8"))
+    return [v for v in data["violations"] if v["severity"] == severity]
+
+
+def _finding(v: dict, severity: str) -> dict:
+    return {"t": "violation", "req": v.get("req"), "severity": severity,
+            "w": v["title"], "reason": v["reason"], "file": v["file"]}
+
+
+def _majors():
+    return _violations("major")
+
+
+def test_replay_counts_match_the_spec():
+    majors = _majors()
+    assert len(majors) == 77, "fixture run drifted; re-derive the expected counts"
+
+    # remote_ingress was deleted (see scope_gate.py's module docstring and
+    # the comment below _CROSS_PRINCIPAL_REQS) -- there is no third rule to
+    # count here anymore.
+    hits = {"sourceless_path": 0, "cross_principal": 0}
+    demoted = 0
+    for v in majors:
+        f = _finding(v, "major")
+        if apply_scope_gate(f, LOCAL):
+            demoted += 1
+            hits[f["scope_downgrade"]["rule"]] += 1
+            assert f["severity"] == "minor"
+
+    assert hits["sourceless_path"] == 32, hits
+    assert hits["cross_principal"] == 1, hits
+    assert demoted == 33, hits
+    assert len(majors) - demoted == 44
+
+
+def test_replay_is_a_no_op_under_the_conservative_default():
+    for v in _majors():
+        f = _finding(v, "major")
+        assert apply_scope_gate(f, CONSERVATIVE) is False
+
+
+def test_the_one_real_bug_survives():
+    """The unbounded r.read() in FetchClient must stay major: it is real, it
+    needs no hostile actor, and no rule here has any business touching it."""
+    for v in _majors():
+        if "_fetch_client_class" not in v["file"]:
+            continue
+        f = _finding(v, "major")
+        assert apply_scope_gate(f, LOCAL) is False
+        return
+    pytest.skip("unbounded-read finding not in this run")
+
+
+def test_replay_chains_provenance_then_scope_on_criticals():
+    """Every other test in this module calls apply_scope_gate directly on
+    findings already labeled major, so the ordinary finding-sink pipeline
+    (apply_provenance_gate runs first and guards the critical bar; only what
+    survives it can ever reach apply_scope_gate as major) is never exercised
+    end to end. Chain both gates, in production order, over the run's real
+    criticals and observe what actually happens.
+
+    Observed on the pinned run: 2 of the 4 criticals name only an
+    operator-controlled source ("command-line arguments", an environment
+    variable) -- apply_provenance_gate drops those to major, because that is
+    not remote ingress. apply_scope_gate then leaves both alone: its
+    sourceless_path rule requires NO named source at all, and an
+    operator-controlled source is still a named source, so it does not
+    double-dip on a finding provenance_gate already downgraded. The other 2
+    criticals name proven external ingress ("query parameter",
+    "user-provided") and neither gate touches them. Net effect: 2 stay
+    critical, 2 become major, zero reach minor, zero scope_gate demotions
+    fire after provenance_gate already ran.
+    """
+    criticals = _violations("critical")
+    assert len(criticals) == 4, "fixture run drifted; re-derive the expected counts"
+
+    provenance_hits = 0
+    scope_hits = 0
+    end_severities = Counter()
+    for v in criticals:
+        f = _finding(v, "critical")
+        if apply_provenance_gate(f):
+            provenance_hits += 1
+        if apply_scope_gate(f, LOCAL):
+            scope_hits += 1
+        end_severities[f["severity"]] += 1
+
+    assert provenance_hits == 2, end_severities
+    assert scope_hits == 0, end_severities
+    assert end_severities == Counter({"critical": 2, "major": 2}), end_severities

--- a/tests/analysis/test_deterministic_checks.py
+++ b/tests/analysis/test_deterministic_checks.py
@@ -62,10 +62,10 @@ def project(tmp_path):
 
 @pytest.fixture
 def compiled(tmp_path):
-    def _write(standard):
+    def _write(standard, dimension="clean-architecture"):
         compiled_dir = tmp_path / "compiled"
         compiled_dir.mkdir(exist_ok=True)
-        (compiled_dir / "clean-architecture.json").write_text(
+        (compiled_dir / f"{dimension}.json").write_text(
             json.dumps(standard), encoding="utf-8")
         return compiled_dir
     return _write
@@ -354,6 +354,205 @@ class TestRunWiring:
             DimensionRunner().run(MagicMock(), "clean-architecture", 1, MagicMock())
 
         applied.assert_not_called()
+
+
+class TestSeverityGates:
+    """A checker's findings go through the same severity gates as everyone else.
+
+    The checks path is the third finding sink, after ``FindingEnricher.enrich``
+    (live) and ``_write_findings`` (cache replay). It used to write straight to
+    the evidence and the JSONL, so a checker declared on a gated requirement
+    would land at whatever severity it assigned -- the same "code path nobody
+    enumerated" shape as issue #657.
+
+    No shipped standard declares a ``check`` on a gated requirement today, so
+    these use a fake checker on ``S-AUT-3``: the point is that the wiring holds
+    the moment one does.
+    """
+
+    GATED = {
+        "id": "security",
+        "principles": [{
+            "name": "Authentication",
+            "requirements": [{"id": "S-AUT-3", "text": "paths built from values",
+                              "check": "fake-gated"}],
+        }],
+    }
+
+    def _checker(self, monkeypatch, *, severity, reason):
+        from quodeq.analysis.checks import registry
+        from quodeq.core.events.models import Judgment
+
+        def fake(_context):
+            return [Judgment(
+                practice_id="S-AUT-3", req="S-AUT-3", verdict="violation",
+                dimension="security", file="app/utils/text.py", line=1,
+                severity=severity, reason=reason, title="Path built from a value",
+            )]
+
+        monkeypatch.setitem(registry.CHECKERS, "fake-gated", fake)
+
+    def _apply(self, project, compiled, tmp_path, *, trust_model=None):
+        from quodeq.analysis.checks.runner import apply_deterministic_checks
+
+        jsonl = tmp_path / "run" / "evidence" / "security_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        evidence = Evidence(repository="r", language="python", date="d",
+                            source_file_count=3, files_read=3, coverage_pct=100.0)
+        added = apply_deterministic_checks(
+            evidence, root=project, source_files=SOURCES, dimension="security",
+            compiled_dir=compiled(self.GATED, "security"), jsonl_path=jsonl,
+            trust_model=trust_model,
+        )
+        return added, evidence, jsonl
+
+    def _violation(self, evidence):
+        return evidence.principles["Authentication"].violations[0]
+
+    def test_a_critical_naming_no_external_source_is_downgraded(
+        self, project, compiled, tmp_path, monkeypatch,
+    ):
+        """The provenance gate (#639) must reach a checker finding too."""
+        self._checker(monkeypatch, severity="critical",
+                      reason="Path is built from a caller-supplied value.")
+
+        added, evidence, jsonl = self._apply(project, compiled, tmp_path)
+
+        assert added == 1
+        violation = self._violation(evidence)
+        assert violation["severity"] == "major", "evidence drives the score"
+        assert violation["provenance_downgrade"] is True
+
+        wire = json.loads(jsonl.read_text(encoding="utf-8").splitlines()[0])
+        assert wire["severity"] == "major", "the JSONL is what the report reads"
+
+        events = jsonl.parent.parent / "events.jsonl"
+        payload = json.loads(events.read_text(encoding="utf-8").splitlines()[0])["payload"]
+        assert payload["severity"] == "major", "the SQL projection reads events.jsonl"
+        assert payload["provenance_downgrade"] is True
+
+    def test_a_critical_naming_a_real_external_source_is_left_alone(
+        self, project, compiled, tmp_path, monkeypatch,
+    ):
+        """The gate must not flatten a genuine critical."""
+        self._checker(monkeypatch, severity="critical",
+                      reason="Path is built from the request body.")
+
+        _added, evidence, _jsonl = self._apply(project, compiled, tmp_path)
+
+        assert self._violation(evidence)["severity"] == "critical"
+
+    def test_a_major_out_of_the_declared_scope_is_capped(
+        self, project, compiled, tmp_path, monkeypatch,
+    ):
+        """The scope gate must reach a checker finding too."""
+        from quodeq.context.trust_model import TrustModel
+
+        self._checker(monkeypatch, severity="major",
+                      reason="Path is built from a value with no validation.")
+
+        _added, evidence, jsonl = self._apply(
+            project, compiled, tmp_path,
+            trust_model=TrustModel(multi_tenant=False, network_exposure="loopback"),
+        )
+
+        assert self._violation(evidence)["severity"] == "minor"
+        wire = json.loads(jsonl.read_text(encoding="utf-8").splitlines()[0])
+        assert wire["severity"] == "minor"
+        assert wire["scope_downgrade"]["rule"] == "sourceless_path"
+
+    def test_a_conservative_trust_model_caps_nothing(
+        self, project, compiled, tmp_path, monkeypatch,
+    ):
+        from quodeq.context.trust_model import CONSERVATIVE
+
+        self._checker(monkeypatch, severity="major",
+                      reason="Path is built from a value with no validation.")
+
+        _added, evidence, _jsonl = self._apply(
+            project, compiled, tmp_path, trust_model=CONSERVATIVE)
+
+        assert self._violation(evidence)["severity"] == "major"
+
+    def test_the_gates_run_in_order_so_a_critical_can_fall_twice(
+        self, project, compiled, tmp_path, monkeypatch,
+    ):
+        """Provenance first (critical -> major), then scope (major -> minor).
+
+        Reversing the order loses the second hop entirely: apply_scope_gate
+        only ever looks at ``major``, so it would see a ``critical`` and pass.
+        """
+        from quodeq.context.trust_model import TrustModel
+
+        self._checker(monkeypatch, severity="critical",
+                      reason="Path is built from a value with no validation.")
+
+        _added, evidence, _jsonl = self._apply(
+            project, compiled, tmp_path,
+            trust_model=TrustModel(multi_tenant=False, network_exposure="loopback"),
+        )
+
+        violation = self._violation(evidence)
+        assert violation["severity"] == "minor"
+        assert violation["provenance_downgrade"] is True
+
+    def test_a_compliance_is_never_touched(
+        self, project, compiled, tmp_path, monkeypatch,
+    ):
+        from quodeq.analysis.checks.runner import deterministic_judgments
+        from quodeq.analysis.checks import registry
+        from quodeq.core.events.models import Judgment
+
+        def fake(_context):
+            return [Judgment(practice_id="S-AUT-3", req="S-AUT-3",
+                             verdict="compliance", dimension="security",
+                             file="app/utils/text.py", line=1, severity="critical",
+                             reason="No path is built from a value here.")]
+
+        monkeypatch.setitem(registry.CHECKERS, "fake-gated", fake)
+        judgments = deterministic_judgments(
+            root=project, source_files=SOURCES, dimension="security",
+            compiled_dir=compiled(self.GATED, "security"))
+
+        assert [j.severity for j in judgments] == ["critical"]
+
+
+class TestTrustModelWiring:
+    """``apply_checks_for_run`` resolves the trust model the way the cache path does."""
+
+    def _config(self, project, compiled_dir, tmp_path):
+        from types import SimpleNamespace
+
+        from quodeq.analysis._types import RunConfig
+
+        work_dir = tmp_path / "run" / "evidence"
+        work_dir.mkdir(parents=True, exist_ok=True)
+        return RunConfig(
+            src=project, language="python", standards_dir=compiled_dir.parent,
+            work_dir=work_dir, manifest=SimpleNamespace(source_files=list(SOURCES)),
+        )
+
+    def test_the_trust_model_is_resolved_once_per_dimension(
+        self, project, compiled, tmp_path,
+    ):
+        """Resolution reads the profile and walks the manifests; doing it per
+        finding would repeat that work for every judgment."""
+        from unittest.mock import patch
+
+        from quodeq.analysis.checks.runner import apply_checks_for_run
+        from quodeq.context.trust_model import CONSERVATIVE
+
+        config = self._config(project, compiled(STANDARD), tmp_path)
+        evidence = Evidence(repository="r", language="python", date="d",
+                            source_file_count=3, files_read=3, coverage_pct=100.0)
+
+        with patch("quodeq.analysis.checks.runner.resolve_trust_model",
+                   return_value=CONSERVATIVE) as resolve:
+            added = apply_checks_for_run(config, "clean-architecture", evidence)
+
+        assert added == 2, "two findings"
+        assert resolve.call_count == 1
+        assert resolve.call_args.args[0] == project
 
 
 class TestBundledStandard:

--- a/tests/analysis/test_prompt_trust_model.py
+++ b/tests/analysis/test_prompt_trust_model.py
@@ -1,0 +1,35 @@
+"""The prompt must brief the model on a declared trust model, and its
+vocabulary must stay in sync with the deterministic gate."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from quodeq.analysis.api_prompt_assembly import _format_shape_block
+from quodeq.context.project_shape import Deployment, ProjectShape
+from quodeq.context.trust_model import CONSERVATIVE, TrustModel
+
+LOCAL = TrustModel(multi_tenant=False, network_exposure="loopback")
+DESKTOP_SHAPE = ProjectShape(deployment=Deployment.DESKTOP, is_single_user=True)
+
+
+def test_loopback_note_mentions_trust_boundaries():
+    block = _format_shape_block(DESKTOP_SHAPE, LOCAL).lower()
+    assert "path" in block
+    assert "trust boundary" in block or "trust-boundary" in block
+
+
+def test_conservative_model_adds_no_relaxing_note():
+    block = _format_shape_block(DESKTOP_SHAPE, CONSERVATIVE).lower()
+    assert "no untrusted" not in block
+
+
+def test_block_renders_when_shape_unknown_but_model_declared():
+    # The declaration is the authority. An UNKNOWN shape must no longer
+    # suppress the briefing when the team has told us the answer.
+    block = _format_shape_block(ProjectShape(), LOCAL)
+    assert block, "a declared trust model must be briefed even without a shape verdict"
+    assert "loopback" in block
+
+
+def test_still_empty_when_nothing_is_known():
+    assert _format_shape_block(ProjectShape(), CONSERVATIVE) == ""

--- a/tests/context/test_project_shape.py
+++ b/tests/context/test_project_shape.py
@@ -64,11 +64,39 @@ dependencies = ["pywebview>=5.0"]
 dev = ["flask"]
 """)
     shape = detect_shape(tmp_path)
-    # Both signals present -> Python returns None (ambiguous), falling back
-    # to UNKNOWN unless something else votes. Desktop hint at the *project*
-    # priority pass wins below — but here pyproject is ambiguous, no other
-    # manifests exist, so verdict is UNKNOWN.
-    assert shape.deployment is Deployment.UNKNOWN
+    # Both signals present -> desktop wins outright (see _python_signals).
+    # This assertion used to be UNKNOWN, which was the bug: it made
+    # detect_shape discard a manifest that unambiguously ships a desktop
+    # app just because a web framework also showed up as a dev dependency.
+    assert shape.deployment is Deployment.DESKTOP
+
+
+def test_desktop_beats_web_in_one_manifest(tmp_path):
+    """A desktop app that embeds a web framework is DESKTOP, not UNKNOWN.
+
+    detect_shape's own comment says desktop signals beat web signals because
+    web hints show up in the dev dependencies of desktop apps. That priority
+    was unreachable: _python_signals collapsed the both-present case to None.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "app"\n'
+        'dependencies = ["flask>=3.0", "pywebview>=6.2"]\n',
+        encoding="utf-8",
+    )
+    shape = detect_shape(tmp_path)
+    assert shape.deployment is Deployment.DESKTOP
+    assert shape.is_single_user is True
+    # The web framework is still reported; it is context, not a verdict.
+    assert "flask" in shape.web_frameworks
+
+
+def test_web_only_manifest_still_web_service(tmp_path):
+    """Guard against over-correcting: no desktop hint means no desktop verdict."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "svc"\ndependencies = ["flask>=3.0"]\n',
+        encoding="utf-8",
+    )
+    assert detect_shape(tmp_path).deployment is Deployment.WEB_SERVICE
 
 
 def test_package_json_express_is_web_service(tmp_path: Path) -> None:

--- a/tests/context/test_trust_model.py
+++ b/tests/context/test_trust_model.py
@@ -118,3 +118,31 @@ def test_permission_denied_profile_degrades(tmp_path):
         assert resolve_trust_model(tmp_path) == CONSERVATIVE
     finally:
         os.chmod(path, 0o644)
+
+
+def test_deeply_nested_profile_degrades(tmp_path):
+    # Bracket nesting deep enough to overflow the C JSON decoder's recursion
+    # limit raises RecursionError, a RuntimeError subclass that the narrow
+    # (OSError, ValueError, UnicodeDecodeError) catch does not cover. This is
+    # advisory data with a conservative fallback, so it must degrade like any
+    # other malformed profile, never escape and fail the scan.
+    path = tmp_path / PROFILE_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("[" * 80000 + "]" * 80000, encoding="utf-8")
+    assert resolve_trust_model(tmp_path) == CONSERVATIVE
+
+
+def test_declared_false_overrides_detected_true(tmp_path):
+    # A falsy declared value must still win over a truthy detected one. Without
+    # this, an `or`-chained resolution would pass the whole suite.
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "svc"\ndependencies = ["flask>=3.0"]\n', encoding="utf-8")
+    _write_profile(tmp_path, {"version": 1, "multiTenant": False})
+    assert resolve_trust_model(tmp_path).multi_tenant is False
+
+
+def test_boolean_version_is_rejected(tmp_path):
+    # bool is a subclass of int in Python, so True == 1: a naive
+    # `!= SUPPORTED_VERSION` check would accept "version": true as version 1.
+    _write_profile(tmp_path, {"version": True, "networkExposure": "loopback"})
+    assert resolve_trust_model(tmp_path) == CONSERVATIVE

--- a/tests/context/test_trust_model.py
+++ b/tests/context/test_trust_model.py
@@ -146,3 +146,21 @@ def test_boolean_version_is_rejected(tmp_path):
     # `!= SUPPORTED_VERSION` check would accept "version": true as version 1.
     _write_profile(tmp_path, {"version": True, "networkExposure": "loopback"})
     assert resolve_trust_model(tmp_path) == CONSERVATIVE
+
+
+def test_deeply_nested_package_json_degrades(tmp_path):
+    # Same RecursionError overflow as the declared-side fix, but reached
+    # through detection: detect_shape parses package.json via _read_json,
+    # whose except json.JSONDecodeError does not catch RecursionError (a
+    # RuntimeError subclass). _detected_fields must degrade this too, not
+    # just the declared-profile path.
+    (tmp_path / "package.json").write_text(
+        "[" * 80000 + "]" * 80000, encoding="utf-8")
+    assert resolve_trust_model(tmp_path) == CONSERVATIVE
+
+
+def test_deeply_nested_pyproject_toml_degrades(tmp_path):
+    # Same class of bug, via tomllib on the pyproject.toml detection path.
+    (tmp_path / "pyproject.toml").write_text(
+        "a = " + "[" * 5000 + "]" * 5000, encoding="utf-8")
+    assert resolve_trust_model(tmp_path) == CONSERVATIVE

--- a/tests/context/test_trust_model.py
+++ b/tests/context/test_trust_model.py
@@ -1,0 +1,120 @@
+"""Tests for the declared project trust model."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+from quodeq.context.trust_model import (
+    CONSERVATIVE,
+    PROFILE_RELPATH,
+    TrustModel,
+    resolve_trust_model,
+)
+
+
+def _write_profile(root, payload):
+    path = root / PROFILE_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _desktop_manifest(root):
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "app"\ndependencies = ["pywebview>=6.2"]\n',
+        encoding="utf-8",
+    )
+
+
+def test_absent_profile_and_no_manifest_is_conservative(tmp_path):
+    # The no-regression guarantee: an undeclared, undetectable project is
+    # scored exactly as it is today.
+    assert resolve_trust_model(tmp_path) == CONSERVATIVE
+
+
+def test_none_root_is_conservative():
+    assert resolve_trust_model(None) == CONSERVATIVE
+
+
+def test_declared_wins_over_detection(tmp_path):
+    _desktop_manifest(tmp_path)  # detection would say loopback
+    _write_profile(tmp_path, {"version": 1, "networkExposure": "public"})
+    resolved = resolve_trust_model(tmp_path)
+    assert resolved.network_exposure == "public"
+
+
+def test_detection_fills_undeclared_fields(tmp_path):
+    # Field-level fallback: declaring one axis must not blank the other.
+    _desktop_manifest(tmp_path)
+    _write_profile(tmp_path, {"version": 1, "networkExposure": "public"})
+    assert resolve_trust_model(tmp_path).multi_tenant is False
+
+
+def test_detection_used_when_no_profile(tmp_path):
+    _desktop_manifest(tmp_path)
+    resolved = resolve_trust_model(tmp_path)
+    assert resolved.multi_tenant is False
+    assert resolved.network_exposure == "loopback"
+
+
+def test_library_does_not_relax(tmp_path):
+    # A library's paths may be fed from an HTTP request in the consuming app,
+    # and the author cannot know. It must declare to get the relaxation.
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "lib"\ndependencies = []\n', encoding="utf-8")
+    assert resolve_trust_model(tmp_path) == CONSERVATIVE
+
+
+@pytest.mark.parametrize("payload", [
+    {"version": 2, "networkExposure": "loopback"},      # wrong version
+    {"networkExposure": "loopback"},                     # missing version
+    {"version": 1, "networkExposure": "carrier-pigeon"}, # unknown value
+    {"version": 1, "multiTenant": "false"},              # wrong type
+    [1, 2, 3],                                           # not an object
+])
+def test_malformed_profile_degrades_never_raises(tmp_path, payload):
+    _write_profile(tmp_path, payload)
+    assert resolve_trust_model(tmp_path) == CONSERVATIVE
+
+
+def test_unreadable_profile_degrades(tmp_path):
+    path = tmp_path / PROFILE_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+    assert resolve_trust_model(tmp_path) == CONSERVATIVE
+
+
+def test_unknown_keys_are_ignored(tmp_path):
+    _write_profile(tmp_path, {
+        "version": 1, "networkExposure": "loopback", "futureField": 42})
+    assert resolve_trust_model(tmp_path).network_exposure == "loopback"
+
+
+def test_lan_behaves_as_public_for_relaxation(tmp_path):
+    _write_profile(tmp_path, {"version": 1, "networkExposure": "lan"})
+    resolved = resolve_trust_model(tmp_path)
+    assert resolved.network_exposure == "lan"   # recorded faithfully
+    assert resolved.relaxes_remote() is False   # but grants nothing
+
+
+def test_loopback_relaxes():
+    assert TrustModel(multi_tenant=False, network_exposure="loopback").relaxes_remote() is True
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32" or os.geteuid() == 0,
+    reason="chmod-based unreadability is meaningless on Windows or as root",
+)
+def test_permission_denied_profile_degrades(tmp_path):
+    # Distinct from malformed JSON content: this is a genuine OS-level read
+    # failure (the file is well-formed and never even gets parsed).
+    path = tmp_path / PROFILE_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"version": 1, "networkExposure": "loopback"}), encoding="utf-8")
+    os.chmod(path, 0o000)
+    try:
+        assert resolve_trust_model(tmp_path) == CONSERVATIVE
+    finally:
+        os.chmod(path, 0o644)

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -1,7 +1,7 @@
 # Grandfathered layer-import violations. Do NOT add entries without
 # justification -- the goal is to burn this list down, not grow it.
 # Regenerate intentionally: python tools/check_imports.py --update-baseline
-src/quodeq/analysis/subprocess.py:263:llm_bridge
+src/quodeq/analysis/subprocess.py:264:llm_bridge
 src/quodeq/api/_evaluation_routes.py:21:analysis
 src/quodeq/api/import_project.py:31:data
 src/quodeq/api/import_project.py:32:data


### PR DESCRIPTION
Targets `develop`, and carries the whole `feat/project-trust-model` line plus the checks-path gate fix — develop has none of these commits yet. Two related pieces; happy to split if you'd rather review them separately.

## Part 1 — declared per-project trust model

Quodeq scores every project as if it were a hosted multi-tenant service. For a local-first tool that is wrong in a measurable way: a path built from a value the operator already controls gets reported as an attack surface.

Detection cannot fix this alone — the manifest of a loopback Flask app is byte-identical to a hosted one. So the model is **declared**, at `<project root>/.quodeq/project-profile.json`, alongside `standards-overrides.json`:

```json
{"version": 1, "multiTenant": false, "networkExposure": "loopback"}
```

Resolution is per field: declared wins, `detect_shape` fills what is undeclared, anything still unknown falls back to `CONSERVATIVE`. That last step is the no-regression guarantee — a project that declares nothing and detects as nothing is scored exactly as before.

`scope_gate.py` then caps `major` findings a declared model puts out of scope (never drops, and `critical` stays with `provenance_gate`). Two rules: `sourceless_path` and `cross_principal`. Quodeq declares its own model in this PR, which is what lets the scope gate cap the 32 sourceless path-hardening findings its own scan reports against itself.

## Part 2 — one owner for the severity gates

`apply_checks_for_run` wrote deterministic-checker findings straight into the dimension's evidence and JSONL, applying neither `apply_provenance_gate` nor `apply_scope_gate`. It is the third finding sink, after `FindingEnricher.enrich` (live) and `_write_findings` (cache replay), and the only unguarded one.

**Impact today is zero.** The four requirements carrying a `"check"` field (`CLEA-DEP-02/06/07`, `CLEA-FRM-01`) appear in neither `PROVENANCE_GATED_REQS` nor scope_gate's `_PATH_REQS`/`_CROSS_PRINCIPAL_REQS`. The moment a standard declares a `"check"` on `S-AUT-3`, `S-INT-10`, `S-AUT-10` or `R-FT-2`, those findings land at whatever severity the checker assigned.

This is the shape of two bugs already fixed here: #657 (cache replay bypassed the provenance gate) and Part 1 above (the same path bypassed the scope gate). Both were "a code path nobody enumerated", and both were fixed by adding a call at the site that was missing it — which is what left the third site missing too.

So the sequence now has one owner: `analysis/mcp/severity_gates.py::apply_severity_gates` holds both gates and the order they must run in, and all three sinks call it.

| Sink | Call site |
|---|---|
| live | `enricher.py` |
| cache replay | `dimension_runner.py` |
| checkers (was unguarded) | `checks/runner.py` |

Verified these are the only three: every `JudgmentCreatedEvent(` emitter in the tree maps to one of them, and the other `*_evidence.jsonl` writers only merge or read.

Two details that mattered:

- **Gating happens before the evidence merge, not just before the write.** `Evidence` is what the score is computed from, so gating only on the way to disk would leave the grade reflecting the ungated severity while the stored finding disagreed with it.
- **`Judgment` is frozen and has no `scope_downgrade` field**, so `_gate` returns both the re-severitied `Judgment` (evidence + event log) and the gated wire row (JSONL, which keeps the scope gate's audit marker).

The trust model is resolved once per dimension via `resolve_trust_model(config.src)`, mirroring `process_dimension_with_cache`.

## Tests

Full suite: **5743 passed, 1 skipped** (pre-existing skip, needs a local self-scan evaluation).

For the gate fix: both gates firing on a checker finding, the ordering that lets a critical fall twice (critical → major → minor), a genuine critical surviving, a conservative model capping nothing, compliance untouched, and once-per-dimension trust-model resolution.

Because a green suite does not prove a guard is tested, both load-bearing claims were mutation-checked:
- reversing the gate order → fails exactly the ordering test
- merging ungated evidence → fails three tests

## Known gap, not fixed here

`scope_downgrade` is a dead field on **every** path: no `Judgment` field, no SQLite column, and `parse_jsonl_line` drops it on read-back — unlike `provenance_downgrade`, which has a full seam through Judgment, Finding, a SQLite column + migration, row mappers and the UI model. The severity flip survives everywhere since `severity` is first-class; only the audit trail is lost. Fixing it needs a schema migration, so it is deliberately out of scope.