### PR TITLE
fix(analysis): explicit time limit no longer resets per dimension launch

### DIFF
--- a/src/quodeq/analysis/subagents/_pool_launcher.py
+++ b/src/quodeq/analysis/subagents/_pool_launcher.py
@@ -60,13 +60,16 @@ def _resolve_time_limit(user_budget: int | None, queue_size: int) -> int:
 def _extend_run_deadline(options: AnalysisOptions, time_limit: int) -> None:
     """Ratchet the run-level deadline forward to cover this pool's budget.
 
-    The granted (possibly auto-scaled) pool budget can exceed the run
-    deadline computed from the user's original limit; without this, the
-    job watchdog SIGTERMs a healthy run at original-limit+grace while the
-    pool believes it has hours left. Never shortens the deadline, and
-    leaves unlimited runs (no deadline) alone. Emits a marker so the job
-    watchdog follows, and notifies the lifecycle (via the CLI-wired
-    callback) so status.json and the dashboard countdown follow too.
+    AUTO-SCALED budgets only (the caller gates on time_limit=None): the
+    granted pool budget can exceed a deadline pre-set by an outer caller;
+    without this, the job watchdog SIGTERMs a healthy run at
+    original-limit+grace while the pool believes it has hours left. Never
+    call this with an explicit user budget — that budget is a run-wide
+    hard cap, and re-extending it per dim launch defeats it. Never
+    shortens the deadline, and leaves unlimited runs (no deadline) alone.
+    Emits a marker so the job watchdog follows, and notifies the lifecycle
+    (via the CLI-wired callback) so status.json and the dashboard
+    countdown follow too.
     """
     if time_limit == _UNLIMITED_BUDGET or options.deadline_at is None:
         return
@@ -127,7 +130,12 @@ def _launch_pool(
     # Must happen BEFORE base_ac is built: the pool snapshots deadline_at,
     # and every deadline consumer (watchdog, drain checks, dashboard
     # countdown) must agree on the granted budget, not the pre-scale one.
-    _extend_run_deadline(config.options, time_limit)
+    # Only the AUTO-SCALED budget may ratchet the deadline. An explicit
+    # time_limit is a run-wide HARD CAP: extending it here handed every
+    # dim's pool a fresh full budget, so a 1h run kept running for
+    # "1h after the LAST dim launch" (observed: run 838d807e).
+    if config.options.time_limit is None:
+        _extend_run_deadline(config.options, time_limit)
     base_ac = AnalysisConfig(
         analysis_budget=config.options.analysis_budget,
         compiled_dir=compiled_dir,

--- a/tests/analysis/test_time_limit_autoscale.py
+++ b/tests/analysis/test_time_limit_autoscale.py
@@ -149,14 +149,16 @@ class TestLaunchPoolExtendsDeadline:
     def test_launch_pool_flows_extended_deadline_into_pool(self, tmp_path):
         """The AnalysisConfig handed to the pool must carry the EXTENDED
         deadline, not the stale pre-scale one, so worker drain checks and
-        the run deadline agree on a single number."""
+        the run deadline agree on a single number. Only the AUTO-SCALED
+        budget (time_limit=None) may ratchet; the deadline here comes from
+        an outer caller."""
         from quodeq.analysis.subagents import _pool_launcher
 
         original = time.monotonic() + 60
         config = RunConfig(
             src=tmp_path,
             language="python",
-            options=AnalysisOptions(deadline_at=original, time_limit=60),
+            options=AnalysisOptions(deadline_at=original, time_limit=None),
         )
         params = _pool_launcher.LaunchPoolParams(
             evidence_dir=tmp_path,
@@ -179,3 +181,38 @@ class TestLaunchPoolExtendsDeadline:
 
         assert config.options.deadline_at > original
         assert captured["config"].deadline_at == config.options.deadline_at
+
+    def test_explicit_budget_never_extends_deadline(self, tmp_path):
+        """An explicit time_limit is a HARD CAP on the whole run. Each
+        dim's pool launch must NOT ratchet the run deadline forward by a
+        fresh full budget, or a 1h run becomes '1h after the LAST dim
+        launch' (observed: run 838d807e, 1h budget, deadline pushed 43min
+        past start+1h and still climbing at dim 5/6)."""
+        from quodeq.analysis.subagents import _pool_launcher
+
+        # Mid-run: most of the 3600s budget is already spent.
+        original = time.monotonic() + 100
+        config = RunConfig(
+            src=tmp_path,
+            language="python",
+            options=AnalysisOptions(deadline_at=original, time_limit=3600),
+        )
+        params = _pool_launcher.LaunchPoolParams(
+            evidence_dir=tmp_path,
+            queue_path=tmp_path / "queue.json",
+            prompt="p",
+            all_files=[f"f{i}.py" for i in range(600)],
+        )
+
+        def _fake_pool(*, paths, options, config):
+            pool = MagicMock()
+            pool.run.return_value = []
+            return pool
+
+        with patch.object(_pool_launcher, "SubagentPool", side_effect=_fake_pool), \
+             patch.object(_pool_launcher, "get_ai_cmd", return_value="ollama"), \
+             patch("quodeq.analysis.subagents._pool_launcher.emit_marker") as marker:
+            _pool_launcher._launch_pool(config, "dim-x", params)
+
+        assert config.options.deadline_at == original
+        assert "deadline_extended" not in [c.args[0] for c in marker.call_args_list]


### PR DESCRIPTION
## Problem

A run with an explicit 1h budget was still going at 1h20 (run 838d807e: deadline pushed 43min past start+1h and climbing at dim 5/6).

`_launch_pool` called `_extend_run_deadline` unconditionally. With an explicit budget, `_resolve_time_limit` returns the full budget verbatim for every dimension, so each dim launch reset the run deadline to now + full budget. A 1h budget on 6 dimensions could run up to ~6h.

Regression from two Aug 1 commits interacting: 65401de9 added the ratchet for auto-scaled budgets, 08e57f99 made explicit budgets hard caps but left the ratchet call unconditional. After the hard-cap change the ratchet only ever fired with the full explicit budget, exactly where it must not.

## Fix

Gate the ratchet on `time_limit is None` (the auto-scale path it was built for). Pools already stop dispatching at the run deadline and drain, so explicit budgets behave as documented: dispatch until the cap, drain, carry the remainder forward. Unlimited (0) and no-limit runs are unchanged.

## Tests

- New `test_explicit_budget_never_extends_deadline`: reproduced the bug before the fix (deadline jumped by a fresh full budget mid-run).
- Repaired `test_launch_pool_flows_extended_deadline_into_pool`: it used an explicit budget and a stale "scales to 7200s" premise, passing only via clock drift. Now exercises the auto-scale path the ratchet is for.
- `tests/analysis` + `tests/services`: 2487 passed, 7 skipped.