### PR TITLE
fix(analysis): keep provenance_downgrade across the report JSON round trip

### DIFF
--- a/src/quodeq/analysis/_report_constants.py
+++ b/src/quodeq/analysis/_report_constants.py
@@ -29,6 +29,12 @@ _VIOLATION_FIELDS = (
     # Without this entry the cache-replay marker is dropped the moment a
     # dimension finishes and its report is written.
     "carried_forward",
+    # Same reasoning: without this entry the provenance gate's marker (that it
+    # de-escalated the finding from critical to major for naming no external
+    # source) is dropped the moment a dimension finishes and its report is
+    # written, leaving a downgraded finding indistinguishable from an ordinary
+    # major in evaluation/<dim>.json.
+    "provenance_downgrade",
 )
 _COMPLIANCE_FIELDS = (
     "file", "line", "end_line", "title", "reason",

--- a/src/quodeq/data/fs/report_parser/_report_parsing.py
+++ b/src/quodeq/data/fs/report_parser/_report_parsing.py
@@ -39,6 +39,7 @@ def build_finding(item: dict, *, include_severity: bool) -> Finding:
         context=item.get("context"),
         scope=item.get("scope"),
         include_severity=include_severity,
+        provenance_downgrade=bool(item.get("provenance_downgrade")),
         carried_forward=bool(item.get("carried_forward")),
     ))
 

--- a/tests/services/test_provenance_downgrade_read_paths.py
+++ b/tests/services/test_provenance_downgrade_read_paths.py
@@ -1,0 +1,103 @@
+"""provenance_downgrade must survive the evaluation/<dim>.json round trip.
+
+``apply_provenance_gate`` stamps this marker when it de-escalates a critical
+R-FT-2/S-AUT-3/S-INT-10 finding to major because the evidence names no external
+source. The marker is the only record of WHY the severity moved, so a finding
+that loses it is indistinguishable from an ordinary major.
+
+Two boundaries have to agree, and neither raises when it disagrees:
+
+  write  ``_flatten_findings`` copies ONLY the keys in ``_VIOLATION_FIELDS``
+         into evaluation/<dim>.json -- a strict whitelist that silently drops
+         anything unlisted.
+  read   ``build_finding`` re-hydrates that JSON back into a ``Finding``, and
+         only fields it explicitly names come back.
+
+This mirrors tests/services/test_carried_forward_read_paths.py, which documents
+the same bug class on the sibling marker: a gap in either parser makes the
+marker vanish as a dimension finishes and its report is written.
+"""
+from __future__ import annotations
+
+import json
+
+from quodeq.analysis._report_assembly import build_report_json
+from quodeq.analysis._report_constants import _VIOLATION_FIELDS
+from quodeq.analysis._report_findings import _flatten_findings
+from quodeq.analysis.mcp.provenance_gate import DOWNGRADE_MARKER
+from quodeq.data.fs.report_parser._report_parsing import build_finding, parse_report_json
+
+
+def _gated_finding() -> dict:
+    """A finding shaped like one apply_provenance_gate has just downgraded."""
+    return {
+        "file": "a.py", "line": 7, "severity": "major", "req": "S-AUT-3",
+        "title": "Path built from a filename argument with no bounds check.",
+        "reason": "The path is assembled from a value with no named source.",
+        DOWNGRADE_MARKER: True,
+    }
+
+
+def test_marker_survives_the_full_report_json_round_trip(tmp_path):
+    """End-to-end: evidence -> evaluation/<dim>.json on disk -> parsed Finding.
+
+    This is the path a dimension actually takes when it finishes, and it
+    crosses BOTH the write whitelist and the read parser, so it fails if
+    either one drops the marker.
+    """
+    evidence = {
+        "principles": {
+            "auth": {
+                "display_name": "Access Control",
+                "violations": [_gated_finding()],
+                "compliance": [],
+            },
+        },
+    }
+
+    report = build_report_json("security", evidence, None)
+    report_path = tmp_path / "security.json"
+    report_path.write_text(json.dumps(report))
+
+    parsed = parse_report_json(report_path)
+
+    assert parsed is not None, "report must parse"
+    assert len(parsed["violations"]) == 1
+    assert parsed["violations"][0].provenance_downgrade is True, (
+        "the provenance gate's downgrade marker must survive the "
+        "evaluation/<dim>.json round trip, or a downgraded finding loses "
+        "the record of why its severity moved"
+    )
+
+
+def test_report_write_whitelist_carries_the_marker_through_flatten():
+    """_VIOLATION_FIELDS is a strict whitelist. Omission drops the marker
+    silently -- no error, just a finding that forgot it was downgraded."""
+    items = [
+        _gated_finding(),
+        {"file": "b.py", "line": 2, "severity": "major", "title": "t", "reason": "r"},
+    ]
+
+    flattened = _flatten_findings(items, "Access Control", _VIOLATION_FIELDS)
+
+    downgraded, untouched = flattened
+    assert downgraded[DOWNGRADE_MARKER] is True
+    # A finding the gate never touched must not gain the key.
+    assert DOWNGRADE_MARKER not in untouched
+
+
+def test_report_json_read_path_carries_the_marker():
+    item = {
+        "principle": "Access Control", "file": "a.py", "line": 7,
+        "severity": "major", "title": "t", "reason": "r",
+        DOWNGRADE_MARKER: True,
+    }
+    assert build_finding(item, include_severity=True).provenance_downgrade is True
+
+
+def test_report_json_read_path_defaults_to_false():
+    item = {
+        "principle": "Access Control", "file": "a.py", "line": 7,
+        "severity": "major", "title": "t", "reason": "r",
+    }
+    assert build_finding(item, include_severity=True).provenance_downgrade is False


### PR DESCRIPTION
## What

`apply_provenance_gate` ([provenance_gate.py](src/quodeq/analysis/mcp/provenance_gate.py)) stamps `provenance_downgrade` when it de-escalates a critical R-FT-2 / S-AUT-3 / S-INT-10 finding to major for naming no external source. That marker is the only record of **why** the severity moved. It was dropped at both ends of the `evaluation/<dim>.json` path:

| | site | failure |
|---|---|---|
| write | `_VIOLATION_FIELDS` in `_report_constants.py` | `_flatten_findings` copies **only** whitelisted keys into the report, so the marker never reached the file |
| read | `build_finding` in `_report_parsing.py` | the field was not named, so it could not come back |

Either gap alone loses the marker: a downgraded finding read back through the report path is indistinguishable from an ordinary major.

Neither boundary raises on a miss. The whitelist silently drops unknown keys, which is the same failure mode as the `carried_forward` read-path bug and the `scope_downgrade` vertical on `feat/project-trust-model` (f61c1e74), used here as the reference implementation.

## Scope

The rest of the vertical was already intact: `FindingSpec` and `build_finding_base` carry the field, and the JSONL, SQLite schema + v5→v6 migration, row mappers, SSE stream and response builders all name it. **These two were the only holes** — no schema change, no migration.

Carried as a `bool`, not `scope_downgrade`'s dict: the gate only records *that* it fired, and the `from` severity is `critical` by construction.

## Tests

New [`tests/services/test_provenance_downgrade_read_paths.py`](tests/services/test_provenance_downgrade_read_paths.py), placed beside its sibling `test_carried_forward_read_paths.py` so the bug class stays greppable in one place.

- **round trip** — evidence → `build_report_json` → real JSON file → `parse_report_json` → `Finding`. Crosses both boundaries, so it fails if either regresses.
- **write boundary** — `_flatten_findings` against `_VIOLATION_FIELDS`; also asserts an untouched finding does *not* gain the key.
- **read boundary** — `build_finding` alone.
- **unset default** — pins the default to `False`, so a finding the gate never touched does not acquire the marker.

**Red verified before the fix:** the three substantive tests fail without it (one per gap, plus end-to-end). The default test passes both before and after, as it should.

Emission stays sparse: the JSONL serializer only writes the marker when `True`, so unaffected findings omit the key rather than carrying `provenance_downgrade: false` on every violation. Identical to `carried_forward`; both absent and `False` read back as `False`.

## Verification

Full suite `pytest -m "not integration"`: **5762 passed, 1 skipped, 13 deselected** — no regressions from adding a key to the report JSON.

## Note for review

#1032 carries the `feat/project-trust-model` line, where `scope_downgrade` closed these same two seams. Whichever of the two lands second will hit a small conflict on adjacent lines in `_VIOLATION_FIELDS` and in `build_finding`. Both additions are wanted; the resolution is to keep both entries.
