### PR TITLE
chore(deps): stop Dependabot reopening eslint major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,18 @@ updates:
       tanstack:
         patterns:
           - "@tanstack/*"
+    # eslint majors are not ours to take. eslint.config.js exists for exactly
+    # one rule, eslint-plugin-react's react/jsx-no-literals, which drives the
+    # i18n string ratchet in tools/check_strings.mjs. The plugin's latest
+    # release (7.37.5) caps its peer range at eslint ^9.7, so eslint 10 fails
+    # `npm ci` with ERESOLVE and takes the whole UI build down with it, not
+    # just linting (#1036). Same class as the react/tanstack groups above, but
+    # ungroupable: no published plugin version accepts eslint 10, so there is
+    # no combination Dependabot could open that would install. Drop this ignore
+    # once eslint-plugin-react widens its peer range.
+    ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Why

Dependabot opened #1036 to bump eslint 9.39.5 → 10.8.0. It fails CI, and no amount of rebasing will fix it.

The failure is at install, not at lint. `npm ci` dies before anything is built, which is why both the `ui` and `smoke` jobs go red:

```
While resolving: eslint-plugin-react@7.37.5
Found: eslint@10.8.0
Could not resolve dependency:
peer eslint@"^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7" from eslint-plugin-react@7.37.5
```

`eslint-plugin-react@7.37.5` is the latest published release, and its peer range stops at `^9.7`. There is no version on npm that accepts eslint 10.

## Why not group it instead

The react and tanstack groups already in this file solve a similar ERESOLVE class by bumping peers together. That does not work here: grouping only helps when some combination of versions installs, and here none does. The bump has to wait on upstream.

## Why not `--legacy-peer-deps`

That would turn CI green while leaving a real risk. `eslint.config.js` is single-purpose: its only rule is eslint-plugin-react's `react/jsx-no-literals`, which drives the i18n string ratchet in `tools/check_strings.mjs`. eslint 10 changed flat-config APIs the plugin was never tested against, so forcing the install risks the ratchet miscounting silently instead of failing loudly. Not a trade worth making for a dev-only lint tool.

## Change

One `ignore` entry on the npm ecosystem block, with the reasoning inline in the same style as the existing group comments.

Follow-up: drop the entry once eslint-plugin-react widens its peer range. Only eslint **majors** are ignored, so 9.x updates still flow.

## Verification

- `.github/dependabot.yml` parses; the `ignore` key lands on the npm block, `directories` and both groups (`react`, `tanstack`) unchanged.
- Closing #1036 alongside this.