### PR TITLE
chore(git): stop tracking the ui/node_modules symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 .claude/
 .worktrees/
 .DS_Store
-node_modules/
-src/quodeq/ui/node_modules/
+# No trailing slash: that form matches directories only, so a symlink named
+# node_modules slips past it and gets committed. Bare name covers both.
+node_modules
 src/quodeq/ui/dist/
 src/quodeq/static/
 dist/

--- a/src/quodeq/ui/node_modules
+++ b/src/quodeq/ui/node_modules
@@ -1,1 +1,0 @@
-/Users/victor/GitHub/quodeq/src/quodeq/ui/node_modules


### PR DESCRIPTION
## What

`src/quodeq/ui/node_modules` is tracked on `develop` as a **symlink** (mode `120000`), not a directory:

```
120000 blob ac0d4843    src/quodeq/ui/node_modules
```

Its 54-byte content is an absolute path pointing at itself:

```
/Users/victor/GitHub/quodeq/src/quodeq/ui/node_modules
```

This PR removes it from the index and closes the gap that let it in.

## Why it got committed

Both ignore rules ended in a slash:

```
node_modules/
src/quodeq/ui/node_modules/
```

A trailing slash matches **directories only**. At the moment of commit `0718b7fb` the path was a symlink, so neither pattern applied and `git add` picked it up alongside the real changes.

## Why it keeps showing up

`npm install` replaces the symlink with a real directory. Git compares HEAD's symlink against a directory and reports a deletion, so every working tree with installed dependencies carries a permanent, unstaged:

```
 D src/quodeq/ui/node_modules
```

It was never staged, so it never got pushed. It just sits in `git status` forever and adds noise to every `git add -A`.

## The change

- `git rm --cached src/quodeq/ui/node_modules` (index only, nothing deleted on disk)
- Collapse the two ignore rules into a bare `node_modules`, which matches files, directories and symlinks at any depth, with a comment recording the trap

## Verification

- `git check-ignore` confirms the bare pattern catches both forms: the existing symlink and a freshly created real directory
- `git ls-files -s | grep '^120000'` returns nothing, so no other stray symlinks are tracked
- `git status` is clean in a worktree that has the symlink on disk
- `pyproject.toml` already lists `src/quodeq/ui/node_modules` in both `wheel-exclude` and `source-exclude`, so wheel and sdist contents are unchanged

No application code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)