### PR TITLE
ci(windows): scale the per-test timeout with the contention scale

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,9 +68,21 @@ jobs:
         # miss a 5s window purely by not being scheduled. Multiply every
         # budget() wait here rather than hand-tuning ~45 call sites for the
         # slowest runner and slowing local runs down with them.
+        #
+        # --timeout must move with that scale. pyproject.toml caps every test
+        # at 60s, which is generous on an idle box but not against 4x-scaled
+        # waits on a saturated one: a runner-wide stall inflates every worker
+        # at once (run 31077131601 pushed four workers 3-10x for ~100s), and
+        # whichever test is mid-flight when it crosses 60s is killed. On
+        # Windows pytest-timeout only has the thread method, which ends the
+        # test by calling os._exit, so the worker dies without reporting and
+        # xdist blames it on "worker crashed while running <test>" - a
+        # segfault-shaped message for what is really a timeout. 60 * 4 keeps
+        # the cap proportional to the waits it has to cover; a genuine
+        # deadlock still fails inside the job's 15-minute budget.
         env:
           QUODEQ_TEST_TIMEOUT_SCALE: "4"
-        run: uv run pytest tests/ -v -ra --tb=short -m "not integration" -n auto
+        run: uv run pytest tests/ -v -ra --tb=short -m "not integration" -n auto --timeout=240
 
   ui:
     # The web UI ships ~1600 tests (vitest .test.jsx + node:test .test.js) that


### PR DESCRIPTION
## Problem

Windows CI intermittently fails with `worker 'gwN' crashed while running <test>`, on a different, unrelated test each time. It read as a hard crash in whichever test was named, so it kept getting mistaken for a real failure in the PR under test (most recently #1043, whose diff touches only `_pool_launcher.py` but whose failures were in `tests/api/`).

It is not a crash. It is the per-test timeout.

`pyproject.toml` caps every test at 60s. On Windows `pytest-timeout` only offers `timeout_method = "thread"`, which ends the test by calling `os._exit` — so the worker dies without reporting and xdist attributes it to whatever test was in flight. The timing is exact: in run 31077131601, gw1 went down 61.2s after its last completed test and gw2 60.0s after its own.

The cap is reachable because the job sets `QUODEQ_TEST_TIMEOUT_SCALE=4` to give every `budget()` wait 4x headroom under `-n auto`, but the hard cap never moved with it. Tests are permitted to wait four times longer against a ceiling that stayed at 60s.

A runner-wide stall is then enough to cross it. In run 31077131601 four workers inflated 3-10x at once for ~100s (06:26:25-06:28:05):

| worker | tests in that window |
|---|---|
| gw0 | 38.5s, 17.5s, 23.3s |
| gw1 | **63.0s** — killed |
| gw2 | 38.1s, **60.1s** — killed |
| gw3 | 24.6s, 19.3s, 39.9s |

The same kinds of tests run in 8-13s outside that window in the same run. Only the two workers holding the heaviest tests crossed 60s.

Same class on develop (run 31057685484, commit 65f5055c): victim at 64.1s, next-slowest test 29.5s, entirely different test. 2 of the last 3 Windows failures are this.

Windows-only because it is the only platform running `-n auto`.

## Fix

Pass `--timeout=240` (60 x the documented 4x scale) on the Windows invocation, so the hard cap stays proportional to the waits it has to cover. Would have cleared all three kills (63.0s, 60.1s, 64.1s) with room to spare.

This does not weaken the gate meaningfully: the cap exists to stop a deadlocked socket/subprocess test hanging the suite, and 240s still fails well inside the job's existing `timeout-minutes: 15` backstop.

## Verification

- Re-running #1043's failed Windows job on the identical commit went green with no code change, confirming the flake diagnosis.
- `--timeout` on the command line overrides the `pyproject.toml` value (`pytest --help`).
- Smoke-tested the exact flag combination locally: `pytest tests/api/test_routes_findings.py tests/api/test_assistant_shared_sessions.py -q -ra --tb=short -m "not integration" -n auto --timeout=240` — 37 passed.
- Workflow YAML re-parsed; the Windows step's `run` and `env` are as intended.

## Follow-up not done here

The tests that get killed cost 8-40s on Windows against 0.02-0.18s locally. That gap is what puts them within reach of the cap at all, and it is worth its own investigation — but raising the ceiling to match the scale the job already declares is the correct standalone fix for the flake.