### PR TITLE
test(terminal): wait for the mount effect before asserting disableStdin

### DIFF
--- a/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
+++ b/src/quodeq/ui/src/features/terminal/TerminalPane.test.jsx
@@ -178,7 +178,14 @@ it('disables stdin while disconnected so keystrokes are not silently swallowed',
   fakeTerm.options = {};
   render(<TerminalPane active />);
   await screen.findByTestId('tty-root');
-  expect(fakeTerm.options.disableStdin).toBe(true);
+  // waitFor, not a plain assert: disableStdin is written by an effect in
+  // TerminalSessionView that bails on `if (!term) return` until the mount
+  // effect has constructed the xterm instance and populated termRef. tty-root
+  // lands on the render commit, so asserting straight after findByTestId reads
+  // fakeTerm.options before either effect has run and sees undefined, not
+  // false. Fourth instance of the post-commit-effect flake the tests above
+  // already carry; it took down an unrelated PR's ui job.
+  await waitFor(() => expect(fakeTerm.options.disableStdin).toBe(true));
 });
 
 // ── multi-session ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`TerminalPane.test.jsx`'s stdin test asserts on effect-populated state without waiting for the effect:

```js
render(<TerminalPane active />);
await screen.findByTestId('tty-root');
expect(fakeTerm.options.disableStdin).toBe(true);
```

`tty-root` lands on the render commit. `disableStdin` is written by an effect in `TerminalSessionView.jsx:231-235` that bails on `if (!term) return` until the *mount* effect has constructed the xterm instance and populated `termRef`. Under CI load the assertion wins that race and reads an empty `options` object, failing with `expected undefined to be true`.

This is the **fourth instance of the flake class this file already documents**, in the comment above the reset test:

> tty-root appears on the render commit, but the xterm instance is constructed in the view's mount EFFECT, which is what populates termRef ... driving it straight after findByTestId races under CI load.

The sibling test at line 164 already guards with `waitFor`. This one was missed.

It is not theoretical: it failed the `ui` job on #1050, a PR whose entire diff is one line of a CI workflow file.

## Fix

Wrap the assertion in `waitFor`, matching the guard the sibling test already uses.

## Verification

- Full suite as CI runs it (`npm run test:all`): **181 files, 1501 tests, all passing**. `npm run lint:strings` clean.
- **Mutation-tested rather than assumed.** Forcing `term.options.disableStdin = false` in `TerminalSessionView.jsx` makes the test fail with `expected false to be true` — not `expected undefined to be true`. That shift is the evidence: the effect has now run by assertion time, so `waitFor` closed the race instead of merely hiding it, and the assertion still has teeth.

## Scope

Only this one site. The two other plain-assert-after-`findByTestId` spots in the file are safe and deliberately left alone:

- **Line 96** (`expect(fakeTerm.focus).not.toHaveBeenCalled()`) is a negative assertion. It can go vacuous but cannot flake, so wrapping it in `waitFor` would be wrong.
- **Line 107** is already guarded by the `waitFor` on line 106.