### PR TITLE
fix(analysis): stop the trust-model prompt telling the model findings don't apply

### DIFF
--- a/src/quodeq/analysis/api_prompt_assembly.py
+++ b/src/quodeq/analysis/api_prompt_assembly.py
@@ -118,17 +118,28 @@ def _format_shape_block(
             " This is a single-user CLI, not a hosted service. Concurrent"
             " caller and multi-tenant findings rarely apply."
         )
+    # Both notes below mirror scope_gate.py's own two rules, deliberately at
+    # the same preconditions, so the prompt never advises something the
+    # deterministic gate would not also do. Neither ever tells the model a
+    # category "does not apply" -- that invites the model to omit the
+    # finding, which is unrecoverable, unlike a severity cap. Always report;
+    # only the severity guidance changes.
     if trust_model is not None and trust_model.relaxes_remote():
         note += (
-            " No untrusted party can open a socket to this process, so a file"
-            " path built from a value this process already controls is a"
-            " hardening gap, not a trust boundary crossing. Report it as"
-            " `minor` unless you can name a remote source that reaches the line."
+            " No untrusted party can open a socket to this process. For a"
+            " path or key finding whose source you cannot name, still report"
+            " it, at `minor` instead of `major`. Do not omit it."
         )
-    if trust_model is not None and not trust_model.multi_tenant:
+    # The second axis check requires relaxes_remote() too, same as the
+    # gate's cross_principal rule: multi_tenant=False alone says nothing
+    # about whether a stranger can reach the process, so on a public,
+    # single-tenant project an authorization finding stays fully in scope.
+    if (trust_model is not None and not trust_model.multi_tenant
+            and trust_model.relaxes_remote()):
         note += (
-            " There is exactly one user, so findings about reaching another"
-            " user's data, ownership checks, and tenant isolation do not apply."
+            " There is exactly one user account. For an authorization"
+            " finding whose only issue is reaching another user's data, still"
+            " report it, at `minor` instead of `major`. Do not omit it."
         )
     return f"## Project Shape\n\n**{summary}**.{note}"
 

--- a/src/quodeq/context/project_shape.py
+++ b/src/quodeq/context/project_shape.py
@@ -185,8 +185,10 @@ def _matches_any(haystack: list[str], needles: tuple[str, ...]) -> list[str]:
 def _python_signals(repo: Path) -> tuple[Deployment | None, list[str], list[str]]:
     """Return ``(deployment_hint, web_frameworks, desktop_hints)`` from pyproject.
 
-    A deployment hint is only set when the manifest is unambiguous; the
-    caller fuses signals across all manifests before settling on a verdict.
+    A deployment hint is not only set when the manifest is unambiguous: when a
+    manifest lists BOTH web and desktop dependencies, desktop wins outright
+    (see the comment below) rather than the hint going unset. The caller
+    still fuses hints across all manifests before settling on a verdict.
     """
     pyproject = _read_toml(repo / "pyproject.toml")
     if pyproject is None:

--- a/tests/analysis/mcp/test_findings_server.py
+++ b/tests/analysis/mcp/test_findings_server.py
@@ -1,8 +1,9 @@
 """Verify the MCP findings server wires EventLogWriter into FindingsRouter."""
 import io
+import json
 from pathlib import Path
 
-from quodeq.analysis.mcp.findings_server import _build_router
+from quodeq.analysis.mcp.findings_server import _build_compiled_context, _build_router
 from quodeq.analysis.mcp.enricher import CompiledContext
 from quodeq.analysis.mcp.args import ServerArgs
 from quodeq.core.events.models import EventType
@@ -113,6 +114,42 @@ def test_build_router_wires_load_precedent_corpus_with_project_and_run_dir(
 
     assert calls == [(project_dir, project_dir / "run-1")]
     assert ctx.precedent_corpus is sentinel
+
+
+class TestBuildCompiledContextResolvesTrustModel:
+    """C2: findings_server.py:47 (``trust_model = resolve_trust_model(work_dir)
+    if work_dir is not None else None``) is one of three live wiring points
+    for the declared trust model. Nothing failed when a reviewer set all
+    three to None at once and the full suite stayed green -- these tests
+    close that gap by exercising ``_build_compiled_context`` directly against
+    a real declared profile, so they fail if that line is ever neutered.
+    """
+
+    def test_resolves_declared_trust_model_from_work_dir(self, tmp_path: Path):
+        profile_dir = tmp_path / ".quodeq"
+        profile_dir.mkdir()
+        (profile_dir / "project-profile.json").write_text(json.dumps({
+            "version": 1, "multiTenant": False, "networkExposure": "loopback",
+        }))
+
+        sa = ServerArgs()
+        sa.work_dir = str(tmp_path)
+
+        ctx = _build_compiled_context(sa)
+
+        assert ctx.trust_model is not None
+        assert ctx.trust_model.multi_tenant is False
+        assert ctx.trust_model.network_exposure == "loopback"
+
+    def test_no_work_dir_means_no_trust_model(self, tmp_path: Path):
+        # Sanity check on the ``if work_dir is not None else None`` guard
+        # itself -- without a work dir there is nothing to resolve against.
+        sa = ServerArgs()
+        sa.work_dir = None
+
+        ctx = _build_compiled_context(sa)
+
+        assert ctx.trust_model is None
 
 
 def test_build_router_emits_findings_to_jsonl_and_event_log(tmp_path: Path):

--- a/tests/analysis/test_api_runner_coverage.py
+++ b/tests/analysis/test_api_runner_coverage.py
@@ -336,6 +336,32 @@ class TestBuildRouterContext:
             ctx = _build_router_context(Path("/nonexistent"), "security", None, None, None)
         assert ctx is None
 
+    def test_resolves_declared_trust_model_from_work_dir(self, tmp_path):
+        """C2: _api_runner.py:464 (``trust_model = resolve_trust_model(work_dir)
+        if work_dir is not None else None``) is one of three live wiring
+        points for the declared trust model. Nothing failed when a reviewer
+        set all three to None at once and the full suite stayed green -- this
+        closes that gap by exercising _build_router_context directly against
+        a real declared profile, using a compiled_dir/dimension combination
+        that never touches disk for standards loading (dimension=None short-
+        circuits _load_compiled_data), so only the trust_model line is
+        exercised for real.
+        """
+        profile_dir = tmp_path / ".quodeq"
+        profile_dir.mkdir()
+        (profile_dir / "project-profile.json").write_text(json.dumps({
+            "version": 1, "multiTenant": False, "networkExposure": "loopback",
+        }))
+
+        ctx = _build_router_context(
+            Path("/nonexistent-compiled-dir"), None, tmp_path, None, None,
+        )
+
+        assert ctx is not None
+        assert ctx.trust_model is not None
+        assert ctx.trust_model.multi_tenant is False
+        assert ctx.trust_model.network_exposure == "loopback"
+
 
 # ---------------------------------------------------------------------------
 # run_api_analysis — appends to file

--- a/tests/analysis/test_prompt_trust_model.py
+++ b/tests/analysis/test_prompt_trust_model.py
@@ -2,20 +2,23 @@
 vocabulary must stay in sync with the deterministic gate."""
 from __future__ import annotations
 
-from pathlib import Path
-
 from quodeq.analysis.api_prompt_assembly import _format_shape_block
 from quodeq.context.project_shape import Deployment, ProjectShape
 from quodeq.context.trust_model import CONSERVATIVE, TrustModel
 
 LOCAL = TrustModel(multi_tenant=False, network_exposure="loopback")
+PUBLIC_SINGLE_TENANT = TrustModel(multi_tenant=False, network_exposure="public")
 DESKTOP_SHAPE = ProjectShape(deployment=Deployment.DESKTOP, is_single_user=True)
 
 
-def test_loopback_note_mentions_trust_boundaries():
+def test_loopback_note_advises_minor_not_omission():
+    # I3: the note must advise the same thing the gate enforces -- report at
+    # minor, never omit -- not a blanket "does not apply".
     block = _format_shape_block(DESKTOP_SHAPE, LOCAL).lower()
     assert "path" in block
-    assert "trust boundary" in block or "trust-boundary" in block
+    assert "minor" in block
+    assert "not apply" not in block
+    assert "omit" in block
 
 
 def test_conservative_model_adds_no_relaxing_note():
@@ -33,3 +36,30 @@ def test_block_renders_when_shape_unknown_but_model_declared():
 
 def test_still_empty_when_nothing_is_known():
     assert _format_shape_block(ProjectShape(), CONSERVATIVE) == ""
+
+
+# --- I3 / minor #4: the single-tenant half was untested --------------------
+
+def test_single_tenant_note_advises_minor_not_does_not_apply():
+    block = _format_shape_block(DESKTOP_SHAPE, LOCAL).lower()
+    assert "not apply" not in block
+    assert "one user" in block
+    assert "minor" in block
+
+
+def test_single_tenant_note_omitted_without_loopback():
+    # The gate's cross-principal rule requires BOTH axes (multi_tenant=False
+    # AND relaxes_remote()) -- see test_cross_principal_untouched_when_public
+    # _single_tenant in test_scope_gate.py. A public single-tenant model must
+    # not get authorization-relaxing advice the gate would never honor for
+    # it: a public-facing single-user service missing an authz check is
+    # still genuinely vulnerable to an unauthenticated stranger.
+    block = _format_shape_block(DESKTOP_SHAPE, PUBLIC_SINGLE_TENANT).lower()
+    assert "one user" not in block
+    assert "authorization" not in block
+
+
+def test_no_note_claims_a_category_does_not_apply():
+    for model in (LOCAL, PUBLIC_SINGLE_TENANT, CONSERVATIVE):
+        block = _format_shape_block(DESKTOP_SHAPE, model).lower()
+        assert "not apply" not in block

--- a/tests/analysis/test_subprocess_coverage.py
+++ b/tests/analysis/test_subprocess_coverage.py
@@ -393,6 +393,46 @@ class TestRunApiAnalysisBridge:
 
         assert mock_api.call_args.kwargs["config"].n_subagents == 1
 
+    def test_trust_model_reaches_assemble_api_prompt(self, tmp_path):
+        """C2: subprocess.py:435 (``trust_model=trust_model``, fed from
+        subprocess.py:421's ``trust_model = resolve_trust_model(work_dir)``)
+        is one of three live wiring points for the declared trust model.
+        Nothing failed when a reviewer set all three to None at once and the
+        full suite stayed green -- this closes that gap by asserting the
+        resolved model, from a real declared profile, actually reaches
+        assemble_api_prompt's kwargs.
+
+        Patched at ``quodeq.analysis.subprocess.assemble_api_prompt``
+        (the name subprocess.py imported into its OWN namespace via
+        ``from ... import assemble_api_prompt``), not at
+        ``quodeq.analysis.api_prompt_assembly.assemble_api_prompt`` -- the
+        latter only rebinds the origin module's attribute and would silently
+        fail to intercept the call subprocess.py already bound at import
+        time.
+        """
+        stream = tmp_path / "stream.json"
+        jsonl = tmp_path / "evidence.jsonl"
+        (tmp_path / "main.py").write_text("x = 1")
+        profile_dir = tmp_path / ".quodeq"
+        profile_dir.mkdir()
+        (profile_dir / "project-profile.json").write_text(json.dumps({
+            "version": 1, "multiTenant": False, "networkExposure": "loopback",
+        }))
+
+        cfg = AnalysisConfig(ai_cmd="ollama", ai_model="llama3.1", jsonl_file=jsonl)
+        provider = {"ollama": {"type": "api", "model": "llama3.1", "api_base": "http://localhost:11434/v1"}}
+
+        with patch("quodeq.analysis.subprocess.get_provider_configs", return_value=provider), \
+             patch("quodeq.analysis.subprocess.assemble_api_prompt", return_value="prompt") as mock_assemble, \
+             patch("quodeq.analysis._api_runner.run_api_analysis"):
+            _run_api_analysis_bridge(tmp_path, "test", stream, cfg)
+
+        mock_assemble.assert_called_once()
+        trust_model = mock_assemble.call_args.kwargs["trust_model"]
+        assert trust_model is not None
+        assert trust_model.multi_tenant is False
+        assert trust_model.network_exposure == "loopback"
+
 
 # ---------------------------------------------------------------------------
 # run_analysis dispatch


### PR DESCRIPTION
## What

Salvages the three things from `feat/project-trust-model` that #1054 did not carry, rebuilt as a small delta against current develop. #1052 (the whole branch) is being closed in favour of this — its core work shipped via #1054.

## 1. The prompt told the model findings "do not apply"

This is the substantive one. On develop the Project Shape note currently says:

> "There is exactly one user, so findings about reaching another user's data, ownership checks, and tenant isolation do not apply."

Telling a model a category does not apply invites it to **omit** the finding. An omission is unrecoverable — unlike a severity cap, which the gate applies deterministically and which can be undone. Both notes are rewritten to keep the finding and move only the severity guidance:

> "...still report it, at `minor` instead of `major`. Do not omit it."

## 2. The single-tenant note fired where the gate would not

Develop gates that note on `multi_tenant` alone. `scope_gate.py`'s own `cross_principal` rule additionally requires `relaxes_remote()`, because `multi_tenant=False` says nothing about whether a stranger can reach the process.

Net effect on develop: a **public, single-tenant** project is told its authorization findings are relaxed when the deterministic gate would never relax them there. The precondition now matches the gate.

Mutation-verified: dropping `relaxes_remote()` from the condition fails `test_single_tenant_note_omitted_without_loopback`. The single-tenant half of the note previously had no test at all — only the loopback half did.

## 3. Wiring coverage, and one stale docstring

`test(analysis)` adds three tests asserting the resolved `TrustModel` actually reaches each builder/call. Per the original commit, all three wiring points could be set to `None` at once and the suite stayed green — the feature could ship inert on every fresh scan. Each test builds a real `.quodeq/project-profile.json`.

`_python_signals`' docstring claimed a deployment hint "is only set when the manifest is unambiguous". Verified false against develop's own code: when a manifest lists both web and desktop dependencies, `if desktop: return Deployment.DESKTOP` sets it. The tie-break comment ten lines below already explained this; only the docstring was stale.

## Verification

- Full suite `pytest -m "not integration"`: **5824 passed**, 1 skipped, 13 deselected
- The four touched test files: 86 passed
- Mutation test above confirms the new precondition is not vacuously covered

No UI files touched.

## Related

- #1054 — shipped the scope-gate fixes; did not include these
- #1052 — the full branch, closed in favour of this
- #1044 — `provenance_downgrade` persistence
- #1046 — guard test so the next marker cannot repeat the persistence bug class
