### PR TITLE
test(core): guard every finding marker against silent persistence loss

### DIFF
--- a/src/quodeq/analysis/mcp/provenance_gate.py
+++ b/src/quodeq/analysis/mcp/provenance_gate.py
@@ -37,6 +37,8 @@ from __future__ import annotations
 import logging
 import re
 
+from quodeq.core.finding_markers import PROVENANCE_DOWNGRADE
+
 _log = logging.getLogger(__name__)
 
 # The standard requirement IDs whose critical bar depends on reachable input
@@ -47,7 +49,10 @@ _log = logging.getLogger(__name__)
 PROVENANCE_GATED_REQS: frozenset[str] = frozenset({"R-FT-2", "S-AUT-3", "S-INT-10"})
 
 # Marker stamped on a finding the gate de-escalates (additive output field).
-DOWNGRADE_MARKER = "provenance_downgrade"
+# The name comes from the marker registry rather than a literal here: the
+# registry is what the persistence guard enumerates, so a marker defined only
+# at its producer is a marker nothing checks the seams for.
+DOWNGRADE_MARKER = PROVENANCE_DOWNGRADE
 
 # Language-neutral trust-boundary INGRESS-CHANNEL concepts. Matched as whole
 # words/phrases. NEVER code syntax, never rhetoric, never the FP pattern's words.

--- a/src/quodeq/analysis/mcp/scope_gate.py
+++ b/src/quodeq/analysis/mcp/scope_gate.py
@@ -56,11 +56,15 @@ from quodeq.analysis.mcp.provenance_gate import (
     names_operator_source,
 )
 from quodeq.context.trust_model import TrustModel
+from quodeq.core.finding_markers import SCOPE_DOWNGRADE
 
 _log = logging.getLogger(__name__)
 
-#: Additive output field describing why a severity moved.
-SCOPE_DOWNGRADE_MARKER = "scope_downgrade"
+#: Additive output field describing why a severity moved. The name comes from
+#: the marker registry rather than a literal here: the registry is what the
+#: persistence guard enumerates, so a marker defined only at its producer is a
+#: marker nothing checks the seams for.
+SCOPE_DOWNGRADE_MARKER = SCOPE_DOWNGRADE
 
 # Path-shaped requirements. R-FT-2 is deliberately ABSENT: it is the
 # null-guard pattern, its severity does not turn on network exposure, and

--- a/src/quodeq/core/finding_markers.py
+++ b/src/quodeq/core/finding_markers.py
@@ -1,0 +1,83 @@
+"""The additive markers a sink may stamp on a finding, in one enumerable place.
+
+A marker is a field outside the core finding schema that a producer adds to
+record WHY a finding looks the way it does: which gate moved its severity, or
+that it came from cache rather than this scan. The severity itself reaches the
+grade; the marker is the only thing that can ever explain it.
+
+Markers are unusually easy to lose. Each one has to be threaded by hand through
+a chain of serialization boundaries -- ``_VIOLATION_FIELDS``, ``build_finding``,
+``Finding``, ``FindingSpec``, ``Judgment``, the evidence JSONL, the SQLite
+projection, the SSE stream, the UI model -- and **no boundary raises when one is
+missed**. ``_VIOLATION_FIELDS`` is a strict whitelist that silently drops unknown
+keys, and ``build_finding`` returns only the fields it names. A gap produces no
+error, no warning and no failing test: just a finding that quietly forgot why it
+was downgraded.
+
+That has now happened three times, once per marker that exists:
+
+* ``carried_forward`` -- dropped on the report path, so cache-replayed findings
+  reappeared as new the moment a dimension finished.
+* ``provenance_downgrade`` -- missing from ``_VIOLATION_FIELDS`` and
+  ``build_finding``, so a critical demoted to major lost the reason (#1044).
+* ``scope_downgrade`` -- reached the per-dim JSONL but not ``events.jsonl``,
+  which is what the SQL projection and the dashboard read, so a finding capped
+  major -> minor showed up as an unexplained minor.
+
+Three instances of one bug, found one at a time, each fixed only where it was
+noticed. This module exists so the fourth is caught by a test instead.
+
+**Adding a marker means adding it here.** ``tests/core/test_finding_marker_persistence.py``
+is parametrized over :data:`PERSISTED_MARKERS` and will fail for any registered
+marker that does not survive every boundary, so registering a new one forces its
+seams closed rather than leaving them to be discovered later. Producers import
+their name from here rather than defining a private literal, which is what makes
+an unregistered marker visible at the definition site.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+#: Set by ``apply_provenance_gate`` when it de-escalates a critical finding to
+#: major because the evidence names no external source. A bool: the gate records
+#: only THAT it fired, since the ``from`` severity is ``critical`` by construction.
+PROVENANCE_DOWNGRADE = "provenance_downgrade"
+
+#: Set by ``apply_scope_gate`` when a project's declared trust model caps a major
+#: finding at minor. A dict, not a bool: the point is recovering WHICH rule fired
+#: and what it waived, so the restore path can put the severity back when the
+#: trust model tightens.
+SCOPE_DOWNGRADE = "scope_downgrade"
+
+#: Set by cache replay on a finding carried over from an earlier run rather than
+#: produced by this scan. Not a severity gate, but the same persistence problem:
+#: lose it and a replayed finding is indistinguishable from a newly found one.
+CARRIED_FORWARD = "carried_forward"
+
+
+@dataclass(frozen=True)
+class FindingMarker:
+    """A marker name plus a value a producer actually writes for it.
+
+    *sample* is what the persistence guard round-trips. It is deliberately a
+    real value from the producing code path rather than a generic sentinel:
+    the markers do not share a shape (two bools and a dict), and a boundary
+    that coerces -- ``bool(...)`` over a dict, say -- passes a sentinel-based
+    test while corrupting the real thing.
+    """
+
+    name: str
+    sample: Any
+
+
+#: Every marker that must survive the full persistence path. Parametrizes the
+#: guard test; see this module's docstring before adding to it.
+PERSISTED_MARKERS: tuple[FindingMarker, ...] = (
+    FindingMarker(PROVENANCE_DOWNGRADE, True),
+    FindingMarker(
+        SCOPE_DOWNGRADE,
+        {"rule": "sourceless_path", "from": "major", "to": "minor"},
+    ),
+    FindingMarker(CARRIED_FORWARD, True),
+)

--- a/tests/core/test_finding_marker_persistence.py
+++ b/tests/core/test_finding_marker_persistence.py
@@ -1,0 +1,115 @@
+"""Every registered finding marker must survive every persistence boundary.
+
+The class this closes (issue #1046): a marker is an additive field outside the
+core finding schema, threaded by hand through a chain of serializers, and **no
+boundary raises when one is missed**. ``_VIOLATION_FIELDS`` is a strict whitelist
+that silently drops unknown keys; ``build_finding`` returns only fields it names.
+A gap is invisible -- no error, no warning, just a finding that forgot why it was
+downgraded.
+
+It has happened once per marker that exists: ``carried_forward`` on the report
+path, ``provenance_downgrade`` in ``_VIOLATION_FIELDS`` and ``build_finding``
+(#1044), and ``scope_downgrade`` reaching the per-dim JSONL but never
+``events.jsonl``. Three instances of one bug, each found and fixed alone.
+
+So this is parametrized over :data:`PERSISTED_MARKERS` rather than written per
+marker. Registering a marker opts it into every check below at once, which is
+the point: the next marker's seams are forced closed when it is added instead of
+after someone notices a finding lost its explanation.
+
+The boundaries, and why each is here rather than covered by the round trip:
+
+* ``_VIOLATION_FIELDS`` / ``build_finding`` -- the two ends of the
+  ``evaluation/<dim>.json`` path. The round trip covers both, but a direct
+  assertion names WHICH end broke instead of just that something did.
+* ``Finding`` / ``FindingSpec`` -- the in-memory carrier. A marker with no field
+  cannot be carried even when both parsers know it.
+* ``Judgment`` -- the event payload written to ``events.jsonl``, which the SQL
+  projection and the dashboard read. This is the one a report-path-only test
+  misses: ``scope_downgrade`` cleared every other boundary while the dashboard
+  still showed an unexplained minor.
+* the round trip -- the boundaries composed, through a real file.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from quodeq.analysis._report_assembly import build_report_json
+from quodeq.analysis._report_constants import _VIOLATION_FIELDS
+from quodeq.analysis._report_findings import _flatten_findings
+from quodeq.core.events.models import Judgment
+from quodeq.core.finding_builder import FindingSpec
+from quodeq.core.finding_markers import PERSISTED_MARKERS
+from quodeq.core.types import Finding
+from quodeq.data.fs.report_parser._report_parsing import build_finding, parse_report_json
+
+
+def _violation(marker=None) -> dict:
+    """A violation dict, optionally carrying *marker* at its sample value."""
+    item = {
+        "principle": "Access Control", "file": "a.py", "line": 7,
+        "severity": "major", "title": "t", "reason": "r",
+    }
+    if marker is not None:
+        item[marker.name] = marker.sample
+    return item
+
+
+@pytest.mark.parametrize("marker", PERSISTED_MARKERS, ids=lambda m: m.name)
+class TestMarkerSurvivesPersistence:
+    def test_listed_in_violation_fields(self, marker):
+        """_flatten_findings copies ONLY these keys into evaluation/<dim>.json."""
+        assert marker.name in _VIOLATION_FIELDS
+
+    def test_carried_by_finding(self, marker):
+        assert marker.name in Finding.__dataclass_fields__
+
+    def test_carried_by_finding_spec(self, marker):
+        assert marker.name in FindingSpec.__dataclass_fields__
+
+    def test_carried_by_judgment(self, marker):
+        """The event payload written to events.jsonl.
+
+        Not redundant with the report path: a marker can clear every other
+        boundary and still never reach the SQL projection or the dashboard.
+        """
+        assert marker.name in Judgment.model_fields
+
+    def test_survives_the_write_whitelist(self, marker):
+        flattened = _flatten_findings([_violation(marker)], "P1", _VIOLATION_FIELDS)
+        assert flattened[0][marker.name] == marker.sample
+
+    def test_read_back_by_build_finding(self, marker):
+        finding = build_finding(_violation(marker), include_severity=True)
+        assert getattr(finding, marker.name) == marker.sample
+
+    def test_full_report_json_round_trip(self, marker, tmp_path):
+        """evidence -> build_report_json -> real file -> parse_report_json."""
+        evidence = {
+            "principles": {
+                "auth": {
+                    "display_name": "Access Control",
+                    "violations": [_violation(marker)],
+                    "compliance": [],
+                },
+            },
+        }
+        report_path = tmp_path / "security.json"
+        report_path.write_text(json.dumps(build_report_json("security", evidence, None)))
+
+        parsed = parse_report_json(report_path)
+
+        assert parsed is not None
+        assert getattr(parsed["violations"][0], marker.name) == marker.sample
+
+    def test_absent_marker_is_not_invented(self, marker):
+        """A finding no producer stamped must not acquire the marker.
+
+        Guards the other direction: a boundary that defaults to the sample
+        value instead of an empty one would pass every test above.
+        """
+        flattened = _flatten_findings([_violation()], "P1", _VIOLATION_FIELDS)
+        assert marker.name not in flattened[0]
+        assert getattr(build_finding(_violation(), include_severity=True), marker.name) != marker.sample


### PR DESCRIPTION
## Problem

A **marker** is an additive field a sink stamps on a finding to record *why* it looks the way it does: which gate moved its severity, or that it came from cache rather than this scan. The severity reaches the grade; the marker is the only thing that can ever explain it.

Markers are unusually easy to lose. Each is threaded by hand through `_VIOLATION_FIELDS`, `build_finding`, `Finding`, `FindingSpec`, `Judgment`, the evidence JSONL, the SQLite projection, the SSE stream and the UI model — and **no boundary raises when one is missed**. `_VIOLATION_FIELDS` is a strict whitelist that silently drops unknown keys; `build_finding` returns only fields it names. A gap produces no error, no warning, no failing test.

It has happened **once per marker that exists**:

| marker | how it was lost |
|---|---|
| `carried_forward` | dropped on the report path, so replayed findings reappeared as new when a dimension finished |
| `provenance_downgrade` | missing from both `_VIOLATION_FIELDS` and `build_finding` (#1044) |
| `scope_downgrade` | reached the per-dim JSONL but never `events.jsonl` — what the SQL projection and dashboard read — so a finding capped major → minor rendered as an unexplained minor |

Three instances of one bug, found one at a time, months apart, each fixed only where it was noticed.

## Approach

Enumerate them. `core/finding_markers.py` owns the marker names and a sample value each producer actually writes. The two gates now take their marker name from the registry instead of a private literal:

```python
DOWNGRADE_MARKER = PROVENANCE_DOWNGRADE     # provenance_gate.py
SCOPE_DOWNGRADE_MARKER = SCOPE_DOWNGRADE    # scope_gate.py
```

Their existing public constant names are kept as aliases, so nothing downstream changes. Sourcing the name from the registry is what makes an **unregistered** marker visible at its definition site rather than at some boundary months later.

`tests/core/test_finding_marker_persistence.py` is parametrized over `PERSISTED_MARKERS` and asserts, per marker: listed in `_VIOLATION_FIELDS`; a field on `Finding`, `FindingSpec` and `Judgment`; survives `_flatten_findings`; read back by `build_finding`; survives a full `build_report_json` → real file → `parse_report_json` round trip; and is **not** invented on a finding no producer stamped. Registering a marker opts it into all of that at once.

The `Judgment` assertion is the one worth keeping separate from the round trip — it is the boundary a report-path-only test misses, and precisely the gap that was live on develop.

Sample values are real values, not sentinels: the markers do not share a shape (two bools and a dict), and a boundary that coerces — `bool()` over a dict — passes a sentinel-based test while corrupting the real value.

## Verification

Full suite: **5841 passed**, 1 skipped, 13 deselected. The guard's own 24 cases pass.

A green guard proves nothing on its own, so it was mutation-tested:

| mutation | result |
|---|---|
| drop `scope_downgrade` from `_VIOLATION_FIELDS` | 3 fail |
| drop `provenance_downgrade` from `build_finding` | 2 fail |
| remove `scope_downgrade` from `Judgment` (the `events.jsonl` gap) | 1 fail |
| **register a 4th marker with nothing wired** | **all 8 fail** |

That last row is the case this exists for: the next gate's marker cannot be added without its seams being forced closed.

Closes #1046.
