### PR TITLE
fix(security): validate dimension against the installed set before path use

### DIFF
--- a/src/quodeq/core/standards/__init__.py
+++ b/src/quodeq/core/standards/__init__.py
@@ -7,6 +7,8 @@ core layer holds only the parsing/extraction logic.
 from quodeq.core.standards.refs import (
     extract_refs,
     extract_requirements,
+    is_known_dimension,
+    known_dimension_ids,
     load_compiled_refs,
     ref_label,
 )
@@ -14,6 +16,8 @@ from quodeq.core.standards.refs import (
 __all__ = [
     "extract_refs",
     "extract_requirements",
+    "is_known_dimension",
+    "known_dimension_ids",
     "load_compiled_refs",
     "ref_label",
 ]

--- a/src/quodeq/core/standards/refs.py
+++ b/src/quodeq/core/standards/refs.py
@@ -110,6 +110,53 @@ def extract_requirement_checks(data: dict) -> dict[str, frozenset[str]]:
     return {name: frozenset(ids) for name, ids in grouped.items()}
 
 
+def known_dimension_ids(
+    compiled_dir: str | Path | None, evaluators_dir: str | Path | None = None,
+) -> frozenset[str]:
+    """Return the dimension ids actually installed on disk.
+
+    A dimension is "known" when a same-named ``<id>.json`` file sits
+    directly inside *compiled_dir* (built-in, compiled standards) or
+    *evaluators_dir* (custom, user-imported standards) -- the two places a
+    standard's definition can live. The set is rebuilt from a directory
+    listing every call rather than cached, so a newly imported custom
+    standard is recognised immediately.
+
+    Listing is the point, not joining: a traversal segment or absolute path
+    never matches a real directory entry, so there is nothing to sanitise --
+    the caller compares the candidate dimension against this set before
+    building any path from it.
+    """
+    ids: set[str] = set()
+    for directory in (compiled_dir, evaluators_dir):
+        if not directory:
+            continue
+        path = Path(directory)
+        if not path.is_dir():
+            continue
+        ids.update(p.stem for p in path.glob("*.json"))
+    return frozenset(ids)
+
+
+def is_known_dimension(
+    dimension: str | None,
+    compiled_dir: str | Path | None,
+    evaluators_dir: str | Path | None = None,
+) -> bool:
+    """True if *dimension* names a standard actually installed on disk.
+
+    Comparison is case-insensitive, matching every other place dimension ids
+    are compared in this codebase (see
+    ``core.standards.visibility.normalize_ids``): older eval payloads and
+    request values may carry ``"Security"`` where a fresh compile writes
+    ``security.json``, and both must be recognised as the same dimension.
+    """
+    if not dimension:
+        return False
+    known_lower = {d.lower() for d in known_dimension_ids(compiled_dir, evaluators_dir)}
+    return dimension.lower() in known_lower
+
+
 # ---------------------------------------------------------------------------
 # The one I/O function core still owns.
 #
@@ -127,8 +174,20 @@ def _load_compiled_data(
     """Load raw compiled standards JSON from *compiled_dir*. Returns None on error.
 
     Falls back to *evaluators_dir* for custom evaluators when provided.
+
+    *dimension* is request-reachable (routed here from the action API's
+    per-dimension endpoints), so it is checked against
+    :func:`is_known_dimension` before it ever reaches a path join. A
+    dimension outside that installed set is treated the same as one with no
+    compiled data at all: this returns ``None`` rather than raising, matching
+    every other failure mode in this function.
     """
     if not dimension:
+        return None
+    if (compiled_dir or evaluators_dir) and not is_known_dimension(
+        dimension, compiled_dir, evaluators_dir,
+    ):
+        _logger.warning("Rejected unknown dimension for compiled standards lookup: %r", dimension)
         return None
     if compiled_dir:
         path = Path(compiled_dir) / f"{dimension}.json"

--- a/src/quodeq/services/_fs_reports.py
+++ b/src/quodeq/services/_fs_reports.py
@@ -55,15 +55,20 @@ def get_dimension_eval(
     dimension: str,
     *,
     compiled_dir: Path | None = None,
+    evaluators_dir: Path | None = None,
 ) -> dict[str, Any] | None:
     """Return parsed evaluation data for a single dimension in a run."""
     base = (Path(reports_dir) / project / run_id).resolve()
     if not base.is_relative_to(Path(reports_dir).resolve()):
         return None
     effective_compiled = compiled_dir or default_paths().standards_dir / "compiled"
+    effective_evaluators = evaluators_dir or default_paths().evaluators_dir
     result = resolve_dimension_eval(
         base, project, run_id, dimension,
-        options=_ResolveOptions(compiled_dir=effective_compiled if effective_compiled.exists() else None),
+        options=_ResolveOptions(
+            compiled_dir=effective_compiled if effective_compiled.exists() else None,
+            evaluators_dir=effective_evaluators if effective_evaluators.exists() else None,
+        ),
     )
     if result is not None:
         return to_camel_dict(result) if isinstance(result, ViolationResponse) else result

--- a/src/quodeq/services/violations.py
+++ b/src/quodeq/services/violations.py
@@ -1,12 +1,14 @@
 """Violation resolution and aggregation for the filesystem action provider."""
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from quodeq.data.fs.report_parser import parse_eval_from_json, parse_eval_markdown
+from quodeq.core.standards.refs import is_known_dimension
 from quodeq.core.types import ViolationFileEntry, ViolationResponse, ViolationSummary
 from quodeq.shared.utils import _env_int, read_text
 from quodeq.services.violation_context import ViolationContext  # noqa: F401 — re-export
@@ -17,6 +19,8 @@ from quodeq.services.violations_parsing import (
     parse_violations_from_jsonl,
     parse_violations_from_stream,
 )
+
+_logger = logging.getLogger(__name__)
 
 _DEFAULT_MAX_VIOLATION_FILES = 20
 
@@ -34,6 +38,7 @@ class _ResolveOptions:
     exists_fn: Callable[[Path], bool] = Path.exists
     stat_fn: Callable[[Path], Any] = Path.stat
     compiled_dir: Path | None = None
+    evaluators_dir: Path | None = None
 
 
 def _dismissed_key_for_violation(v: dict) -> tuple:
@@ -179,11 +184,27 @@ def resolve_dimension_eval(
 
     *options* bundles injectable filesystem callbacks and the compiled
     standards directory for testing without a real FS.
+
+    *dimension* arrives here from the action API's per-dimension routes
+    (a request path segment), so before any of the paths below are built it
+    is checked against :func:`is_known_dimension` -- the installed set
+    derived from ``compiled_dir``/``evaluators_dir`` -- whenever *options*
+    supplies at least one of those directories. An unknown dimension is
+    treated exactly like a dimension with no matching file: this returns
+    ``None``, same as every other "nothing found" branch below. When neither
+    directory is configured (e.g. a caller testing file-resolution logic in
+    isolation) the check is skipped, preserving prior behaviour.
     """
     opts = options or _ResolveOptions()
     _exists = opts.exists_fn
     _stat = opts.stat_fn
     compiled_dir = opts.compiled_dir
+    evaluators_dir = opts.evaluators_dir
+    if (compiled_dir or evaluators_dir) and not is_known_dimension(
+        dimension, compiled_dir, evaluators_dir,
+    ):
+        _logger.warning("Rejected unknown dimension for eval resolution: %r", dimension)
+        return None
     dkeys = _dismissed_keys(base.parent)
     delkeys = _deleted_keys(base.parent)
 

--- a/tests/core/test_dimension_path_guard.py
+++ b/tests/core/test_dimension_path_guard.py
@@ -1,0 +1,130 @@
+"""Path-traversal guard tests for compiled-standards dimension lookup.
+
+``_load_compiled_data`` (``core/standards/refs.py``) interpolates a
+request-supplied ``dimension`` string directly into a filesystem path
+(``Path(compiled_dir) / f"{dimension}.json"`` and the ``evaluators_dir``
+equivalent). These tests prove a traversal segment, an absolute path, and a
+null byte are all rejected before any file outside ``compiled_dir`` /
+``evaluators_dir`` is touched, and that every genuinely installed
+dimension -- including a custom, user-imported one -- still resolves.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.core.standards.refs import is_known_dimension, known_dimension_ids, load_compiled_refs
+
+
+def _write_compiled(directory: Path, dim: str, req_id: str = "S-1") -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    data = {
+        "id": dim,
+        "principles": [{
+            "name": "Principle",
+            "requirements": [{
+                "id": req_id,
+                "text": "Requirement text",
+                "refs": [{"source": "cwe", "id": "1", "url": "https://example.com/1"}],
+            }],
+        }],
+    }
+    (directory / f"{dim}.json").write_text(json.dumps(data))
+
+
+class TestKnownDimensionIds:
+    def test_lists_compiled_and_custom_ids(self, tmp_path):
+        compiled_dir = tmp_path / "compiled"
+        evaluators_dir = tmp_path / "evaluators"
+        _write_compiled(compiled_dir, "security")
+        _write_compiled(evaluators_dir, "my-custom-standard")
+
+        ids = known_dimension_ids(compiled_dir, evaluators_dir)
+
+        assert ids == {"security", "my-custom-standard"}
+
+    def test_missing_directories_yield_empty_set(self, tmp_path):
+        assert known_dimension_ids(tmp_path / "nope", None) == frozenset()
+
+
+class TestIsKnownDimensionCaseInsensitive:
+    """Dimension ids are compared case-insensitively everywhere else in this
+    codebase (core.standards.visibility.normalize_ids); older eval payloads
+    carry "Security" where a fresh compile writes security.json, and both
+    must be recognised as the same dimension."""
+
+    def test_mixed_case_dimension_matches_lowercase_file(self, tmp_path):
+        compiled_dir = tmp_path / "compiled"
+        _write_compiled(compiled_dir, "security")
+
+        assert is_known_dimension("Security", compiled_dir, None) is True
+
+    def test_traversal_value_is_not_known_regardless_of_case(self, tmp_path):
+        compiled_dir = tmp_path / "compiled"
+        _write_compiled(compiled_dir, "security")
+
+        assert is_known_dimension("../SECRET", compiled_dir, None) is False
+
+
+class TestLoadCompiledRefsRejectsTraversal:
+    """Each case proves the escape *would* succeed without the guard: the
+    target file genuinely exists and genuinely contains data the traversal
+    is reaching for."""
+
+    def test_dot_dot_segment_cannot_escape_compiled_dir(self, tmp_path):
+        compiled_dir = tmp_path / "compiled"
+        compiled_dir.mkdir()
+        outside = tmp_path / "outside"
+        _write_compiled(outside, "secret", req_id="LEAKED-1")
+
+        refs = load_compiled_refs(str(compiled_dir), "../outside/secret")
+
+        assert refs == {}
+        # The file "outside" is reaching for is untouched and still there --
+        # proof the guard rejected the lookup rather than the file being absent.
+        assert (outside / "secret.json").is_file()
+        assert list(compiled_dir.iterdir()) == []
+
+    def test_absolute_path_dimension_cannot_reach_arbitrary_file(self, tmp_path):
+        compiled_dir = tmp_path / "compiled"
+        compiled_dir.mkdir()
+        _write_compiled(tmp_path, "secret_target", req_id="LEAKED-2")
+        secret_json = tmp_path / "secret_target.json"
+        assert secret_json.is_file()
+
+        # dimension carries an absolute path; the code appends ".json" itself.
+        absolute_dimension = str(tmp_path / "secret_target")
+        refs = load_compiled_refs(str(compiled_dir), absolute_dimension)
+
+        assert refs == {}
+        assert secret_json.is_file()  # untouched, proves nothing leaked from it
+
+    def test_null_byte_in_dimension_is_rejected(self, tmp_path):
+        compiled_dir = tmp_path / "compiled"
+        _write_compiled(compiled_dir, "security")
+
+        refs = load_compiled_refs(str(compiled_dir), "security\0../../../etc/passwd")
+
+        assert refs == {}
+
+
+class TestLoadCompiledRefsValidDimensionsStillResolve:
+    def test_builtin_dimension_still_resolves(self, tmp_path):
+        compiled_dir = tmp_path / "compiled"
+        _write_compiled(compiled_dir, "security", req_id="S-CON-1")
+
+        refs = load_compiled_refs(str(compiled_dir), "security")
+
+        assert "S-CON-1" in refs
+
+    def test_custom_imported_dimension_still_resolves(self, tmp_path):
+        compiled_dir = tmp_path / "compiled"
+        compiled_dir.mkdir()
+        evaluators_dir = tmp_path / "evaluators"
+        _write_compiled(evaluators_dir, "my-custom-standard", req_id="C-1")
+
+        refs = load_compiled_refs(
+            str(compiled_dir), "my-custom-standard", evaluators_dir=evaluators_dir,
+        )
+
+        assert "C-1" in refs

--- a/tests/services/test_violations.py
+++ b/tests/services/test_violations.py
@@ -8,6 +8,7 @@ import pytest
 
 from quodeq.services.violations import (
     ViolationContext,
+    _ResolveOptions,
     aggregate_violations,
     resolve_dimension_eval,
 )
@@ -134,3 +135,120 @@ class TestAggregateUnknownSeverity:
         assert summary.minor == 2
         f = summary.files[0]
         assert f.critical + f.major + f.minor == f.count
+
+
+def _compiled_dir_with(tmp_path, *dims):
+    """Build a compiled-standards dir containing one empty <dim>.json per dim."""
+    compiled_dir = tmp_path / "compiled"
+    compiled_dir.mkdir()
+    for dim in dims:
+        (compiled_dir / f"{dim}.json").write_text("{}")
+    return compiled_dir
+
+
+class TestResolveDimensionEvalRejectsTraversal:
+    """dimension is a request path segment (action API "eval" routes). These
+    prove a traversal value is rejected before any of resolve_dimension_eval's
+    five path-construction sites run, and that the file it reaches for is
+    provably real (not merely absent) -- proof the guard, not luck, stopped it.
+    """
+
+    def test_dot_dot_segment_cannot_reach_eval_json_outside_run(self, tmp_path):
+        base = tmp_path / "run-1"
+        (base / "evaluation").mkdir(parents=True)
+        (base / "evidence").mkdir()
+        secret_dir = tmp_path / "secret"
+        secret_dir.mkdir()
+        (secret_dir / "leaked.json").write_text(
+            json.dumps({"dimension": "leaked", "overallGrade": "A", "principles": {}})
+        )
+        options = _ResolveOptions(compiled_dir=_compiled_dir_with(tmp_path, "security"))
+
+        result = resolve_dimension_eval(
+            base, "proj", "run-1", "../../secret/leaked", options=options,
+        )
+
+        assert result is None
+        assert (secret_dir / "leaked.json").is_file()  # untouched, genuinely reachable
+
+    def test_dot_dot_segment_cannot_reach_evidence_json_outside_run(self, tmp_path):
+        base = tmp_path / "run-1"
+        (base / "evaluation").mkdir(parents=True)
+        (base / "evidence").mkdir()
+        secret_dir = tmp_path / "secret"
+        secret_dir.mkdir()
+        (secret_dir / "leaked_evidence.json").write_text(
+            json.dumps({"principles": {"p1": {"violations": [{"file": "x.py", "reason": "leak"}]}}})
+        )
+        options = _ResolveOptions(compiled_dir=_compiled_dir_with(tmp_path, "security"))
+
+        result = resolve_dimension_eval(
+            base, "proj", "run-1", "../../secret/leaked", options=options,
+        )
+
+        assert result is None
+        assert (secret_dir / "leaked_evidence.json").is_file()
+
+    def test_absolute_path_dimension_cannot_reach_arbitrary_file(self, tmp_path):
+        base = tmp_path / "run-1"
+        (base / "evaluation").mkdir(parents=True)
+        (base / "evidence").mkdir()
+        secret_eval = tmp_path / "secret_eval.json"
+        secret_eval.write_text(json.dumps({"dimension": "secret_eval", "overallGrade": "A", "principles": {}}))
+        options = _ResolveOptions(compiled_dir=_compiled_dir_with(tmp_path, "security"))
+
+        absolute_dimension = str(tmp_path / "secret_eval")  # ".json" appended by the code
+        result = resolve_dimension_eval(
+            base, "proj", "run-1", absolute_dimension, options=options,
+        )
+
+        assert result is None
+        assert secret_eval.is_file()
+
+    def test_null_byte_in_dimension_is_rejected(self, tmp_path):
+        base = tmp_path / "run-1"
+        (base / "evaluation").mkdir(parents=True)
+        (base / "evidence").mkdir()
+        options = _ResolveOptions(compiled_dir=_compiled_dir_with(tmp_path, "security"))
+
+        result = resolve_dimension_eval(
+            base, "proj", "run-1", "security\0../../../etc/passwd", options=options,
+        )
+
+        assert result is None
+
+
+class TestResolveDimensionEvalValidDimensionsStillResolve:
+    def test_builtin_dimension_still_resolves(self, tmp_path):
+        base = tmp_path / "run-1"
+        eval_dir = base / "evaluation"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "security.json").write_text(
+            json.dumps({"dimension": "security", "overallGrade": "B", "principles": {}})
+        )
+        options = _ResolveOptions(compiled_dir=_compiled_dir_with(tmp_path, "security"))
+
+        result = resolve_dimension_eval(base, "proj", "run-1", "security", options=options)
+
+        assert result is not None
+
+    def test_custom_imported_dimension_still_resolves(self, tmp_path):
+        base = tmp_path / "run-1"
+        eval_dir = base / "evaluation"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "my-custom-standard.json").write_text(
+            json.dumps({"dimension": "my-custom-standard", "overallGrade": "C", "principles": {}})
+        )
+        evaluators_dir = tmp_path / "evaluators"
+        evaluators_dir.mkdir()
+        (evaluators_dir / "my-custom-standard.json").write_text("{}")
+        options = _ResolveOptions(
+            compiled_dir=_compiled_dir_with(tmp_path, "security"),
+            evaluators_dir=evaluators_dir,
+        )
+
+        result = resolve_dimension_eval(
+            base, "proj", "run-1", "my-custom-standard", options=options,
+        )
+
+        assert result is not None


### PR DESCRIPTION
## Summary

quodeq's own self-scan flagged three unguarded interpolations of a request-supplied `dimension` string into a filesystem path, reachable from the action API's per-dimension routes (`/api/projects/<project>/runs/<run_id>/dimensions/<dimension>/eval` and its `/api/shared/...` mirror). These are the findings a proposed scope-gate rule (the checks-path severity work in #1032) would have wrongly waived as covered-by-an-outer-guard: the outer route-level `validate_path_segment` call blocks `../` and `\0` at two of the known call sites, but the sink functions themselves had no defense of their own, and a bare absolute-path `dimension` defeats `Path.join` regardless (pathlib drops the left operand entirely when the right side is absolute).

Fix: dimension is a member of a closed, known set (built-in + custom standards actually installed), not free text. Added `known_dimension_ids` / `is_known_dimension` (`core/standards/refs.py`), derived at runtime from a directory listing of `compiled_dir` and `evaluators_dir` — not a hardcoded list, and not `visibility.py::DEFAULT_VISIBLE_STANDARDS` (that's a static six-item default selection, not the installed set; the docstring on that module says as much — quodeq ships more built-ins than the default shows, plus users import their own custom standards). Listing rather than joining is what actually closes the hole: a traversal segment or absolute path never matches a real directory entry, so there's nothing to sanitise.

Comparison is case-insensitive to match `core.standards.visibility.normalize_ids`, the existing convention for comparing dimension ids elsewhere in the codebase (an existing test fixture uses `"Security"` against a `security.json` file and depends on this).

## Sites found and fixed

Two guard insertion points cover every interpolation of this shape (grepped the whole tree for `{dimension` used in an f-string/path-join; everything outside these two functions is either already guarded — e.g. `assistant/tools/_read_tools.py::_validate_dimension`, `services/suppression.py::load_req_to_principle` (both call `validate_path_segment`/regex-check before use) — or derives `dimension` from an existing directory listing rather than request input, so it's not attacker-controlled):

**`src/quodeq/services/violations.py` — `resolve_dimension_eval`** (one guard, before any of these five paths are built):
- `base / "evaluation" / f"{dimension}.json"` — before: unguarded; after: rejected if `dimension` isn't installed
- `base / "evaluation" / f"{dimension}_eval.md"` — same (not explicitly named in the original report, same shape)
- `base / "evidence" / f"{dimension}_evidence.json"` — before: unguarded; after: rejected
- `base / "evidence" / f"{dimension}_evidence.jsonl"` — same
- `base / "evidence" / f"{dimension}_live.stream"` — same (not explicitly named in the original report, same shape)

**`src/quodeq/core/standards/refs.py` — `_load_compiled_data`** (one guard, before either path is built):
- `Path(compiled_dir) / f"{dimension}.json"` — before: unguarded; after: rejected
- `evaluators_dir / f"{dimension}.json"` — same

An unknown dimension is rejected the same way a dimension with no matching file already was (`return None`) — the action API's response shape (404 "Eval file not found", or 202 "waiting" for a run still in progress) is unchanged for every legitimate request.

## Test plan

- [x] For each of the two sinks: a traversal (`../`), an absolute path, and a null byte are proven rejected, with the target file demonstrated to genuinely exist first (so the test proves the guard stopped it, not that the file was merely absent)
- [x] A genuinely valid built-in dimension still resolves
- [x] A genuinely valid custom (user-imported) dimension still resolves
- [x] Case-insensitive comparison covered directly (`"Security"` vs. installed `security`)
- [x] Verified every new test FAILS on the pre-fix code (temporarily stashed the four source-file changes, confirmed 4 traversal/custom-dimension tests fail for real reasons — real escapes reaching a genuinely-existing target file — restored the fix, all pass)
- [x] Full suite green: `uv run pytest -m "not integration" -q` → 5839 passed, 1 skipped, 13 deselected

New/changed files: `src/quodeq/core/standards/refs.py`, `src/quodeq/core/standards/__init__.py`, `src/quodeq/services/violations.py`, `src/quodeq/services/_fs_reports.py`, `tests/core/test_dimension_path_guard.py`, `tests/services/test_violations.py`.

## Concerns

- One narrow, accepted behavior change: if a custom standard is later deleted, a historical run's per-dimension detail view for that now-uninstalled dimension will 404/return "waiting" instead of showing the old data (the dashboard/overview aggregate is unaffected — it reads run data by directory listing, not through this function). This wasn't in the requested test matrix and seemed like the right tradeoff for closing a real path-injection hole; flagging in case that's not the desired product behavior.