### PR TITLE
fix(dashboard): relaunch no longer kills the healthy running instance

### DIFF
--- a/src/quodeq/dashboard/_api_spawn.py
+++ b/src/quodeq/dashboard/_api_spawn.py
@@ -59,10 +59,10 @@ def spawn_action_api(
         stderr=None if verbose else subprocess.DEVNULL,
         **_popen_platform_kwargs(),
     )
-    record = json.dumps(
-        {"pid": proc.pid, "host": env[_ENV_ACTION_API_HOST], "port": port},
-    )
     try:
+        record = json.dumps(
+            {"pid": proc.pid, "host": env[_ENV_ACTION_API_HOST], "port": port},
+        )
         pid_file_path.write_text(record, encoding="utf-8")
     except (OSError, AttributeError, TypeError) as exc:
         log_warning(f"Could not write PID file: {exc}")

--- a/src/quodeq/dashboard/_api_spawn.py
+++ b/src/quodeq/dashboard/_api_spawn.py
@@ -59,15 +59,11 @@ def spawn_action_api(
         stderr=None if verbose else subprocess.DEVNULL,
         **_popen_platform_kwargs(),
     )
+    record = json.dumps(
+        {"pid": proc.pid, "host": env[_ENV_ACTION_API_HOST], "port": port},
+    )
     try:
-        pid_file_path.write_text(
-            json.dumps({
-                "pid": proc.pid,
-                "host": env[_ENV_ACTION_API_HOST],
-                "port": port,
-            }),
-            encoding="utf-8",
-        )
+        pid_file_path.write_text(record, encoding="utf-8")
     except (OSError, AttributeError, TypeError) as exc:
         log_warning(f"Could not write PID file: {exc}")
     return proc

--- a/src/quodeq/dashboard/_api_spawn.py
+++ b/src/quodeq/dashboard/_api_spawn.py
@@ -1,6 +1,7 @@
 """Action API subprocess spawning helpers."""
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -59,8 +60,15 @@ def spawn_action_api(
         **_popen_platform_kwargs(),
     )
     try:
-        pid_file_path.write_text(str(proc.pid), encoding="utf-8")
-    except (OSError, AttributeError) as exc:
+        pid_file_path.write_text(
+            json.dumps({
+                "pid": proc.pid,
+                "host": env[_ENV_ACTION_API_HOST],
+                "port": port,
+            }),
+            encoding="utf-8",
+        )
+    except (OSError, AttributeError, TypeError) as exc:
         log_warning(f"Could not write PID file: {exc}")
     return proc
 

--- a/src/quodeq/dashboard/_instance.py
+++ b/src/quodeq/dashboard/_instance.py
@@ -86,6 +86,49 @@ class InstanceController:
 
     # ── Public API ──
 
+    def probe_existing(self) -> bool:
+        """Return True if a live primary instance is already listening.
+
+        Unlike ``try_acquire`` this never binds, so the caller can leave the
+        socket free for a *child* process to own — which is what the native
+        path does: the webview window process is the one that must react to a
+        reload, so it owns the listener (see ``_server._serve_native``). A
+        socket/port file left behind by a crashed instance is removed here, so
+        the follow-up bind by that child still succeeds.
+        """
+        if _IS_WIN32:
+            return self._probe_tcp()
+        return self._probe_unix()
+
+    def _probe_unix(self) -> bool:
+        if not self._sock_path.exists():
+            return False
+        try:
+            probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            probe.settimeout(_SOCK_TIMEOUT)
+            self._connect_to_sock(probe)
+            probe.close()
+            return True
+        except (ConnectionRefusedError, OSError):
+            _logger.debug("Removing stale socket %s", self._sock_path)
+            self._sock_path.unlink(missing_ok=True)
+            return False
+
+    def _probe_tcp(self) -> bool:
+        if not self._port_file.exists():
+            return False
+        try:
+            port = int(self._port_file.read_text(encoding="utf-8").strip())
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+                probe.settimeout(_SOCK_TIMEOUT)
+                probe.connect((_TCP_LOCALHOST, port))
+            self._tcp_port = port
+            return True
+        except (ConnectionRefusedError, OSError, ValueError):
+            _logger.debug("Removing stale port file %s", self._port_file)
+            self._port_file.unlink(missing_ok=True)
+            return False
+
     def try_acquire(self) -> bool:
         """Try to become the primary instance. Return True if acquired."""
         if _IS_WIN32:
@@ -93,16 +136,8 @@ class InstanceController:
         return self._try_acquire_unix()
 
     def _try_acquire_unix(self) -> bool:
-        if self._sock_path.exists():
-            try:
-                probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-                probe.settimeout(_SOCK_TIMEOUT)
-                self._connect_to_sock(probe)
-                probe.close()
-                return False
-            except (ConnectionRefusedError, OSError):
-                _logger.debug("Removing stale socket %s", self._sock_path)
-                self._sock_path.unlink(missing_ok=True)
+        if self._probe_unix():
+            return False
 
         self._server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._bind_server_sock()
@@ -112,17 +147,8 @@ class InstanceController:
 
     def _try_acquire_tcp(self) -> bool:
         """Windows: use TCP localhost with port stored in a file."""
-        if self._port_file.exists():
-            try:
-                port = int(self._port_file.read_text(encoding="utf-8").strip())
-                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
-                    probe.settimeout(_SOCK_TIMEOUT)
-                    probe.connect((_TCP_LOCALHOST, port))
-                self._tcp_port = port
-                return False
-            except (ConnectionRefusedError, OSError, ValueError):
-                _logger.debug("Removing stale port file %s", self._port_file)
-                self._port_file.unlink(missing_ok=True)
+        if self._probe_tcp():
+            return False
 
         self._server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._server_sock.bind((_TCP_LOCALHOST, 0))
@@ -132,8 +158,23 @@ class InstanceController:
         self._port_file.write_text(str(self._tcp_port), encoding="utf-8")
         return True
 
-    def start_listening(self, on_reload: Callable[[str], None]) -> None:
-        """Start a background thread that listens for reload commands."""
+    def start_listening(self, on_reload: Callable[[str], None]) -> bool:
+        """Start a background thread that listens for reload commands.
+
+        Returns False (and starts nothing) when this controller never acquired
+        the socket. Without that guard every ``accept()`` raises
+        ``AttributeError`` on the ``None`` socket, the thread dies on the first
+        iteration, and the traceback is the only trace — which is exactly how
+        the reload channel stayed silently dead: the caller had no way to tell
+        listening from not-listening.
+        """
+        if self._server_sock is None:
+            _logger.warning(
+                "Not listening for reloads: socket was never acquired "
+                "(call try_acquire first)",
+            )
+            return False
+
         def _listen() -> None:
             while not self._shutdown_event.is_set():
                 try:
@@ -153,6 +194,7 @@ class InstanceController:
 
         self._listen_thread = threading.Thread(target=_listen, daemon=True)
         self._listen_thread.start()
+        return True
 
     def send_reload(self, url: str) -> None:
         """Send a reload command to the running instance."""
@@ -170,7 +212,15 @@ class InstanceController:
                 sock.sendall(f"{_RELOAD_PREFIX}{url}".encode("utf-8"))
 
     def shutdown(self) -> None:
-        """Stop listening and clean up."""
+        """Stop listening and clean up.
+
+        Only removes the socket/port file if this controller actually bound it.
+        A controller that merely probed (``probe_existing``) or lost the race
+        must not delete the live instance's socket — doing so would strip the
+        winner of its reload channel and leave the next launch unable to find
+        it.
+        """
+        owns_socket = self._server_sock is not None
         self._shutdown_event.set()
         if self._server_sock:
             try:
@@ -179,6 +229,8 @@ class InstanceController:
                 pass
         if self._listen_thread:
             self._listen_thread.join(timeout=0.5)
+        if not owns_socket:
+            return
         if _IS_WIN32:
             self._port_file.unlink(missing_ok=True)
         else:

--- a/src/quodeq/dashboard/_process.py
+++ b/src/quodeq/dashboard/_process.py
@@ -1,13 +1,14 @@
 """Process management — PID tracking, stale-process cleanup, and process waiting."""
 from __future__ import annotations
 
+import json
 import os
 import signal
 import subprocess
 import time
 from pathlib import Path
 
-from quodeq.dashboard._api_health import ApiConfig, spawn_and_wait
+from quodeq.dashboard._api_health import ApiConfig, action_api_healthy, spawn_and_wait
 from quodeq.dashboard._networking import _is_port_open
 from quodeq.shared.config_loader import get_default_host as _get_default_host
 from quodeq.shared.logging import log_debug
@@ -36,15 +37,62 @@ def _get_pid_file(env: dict[str, str] | None = None) -> Path:
     return run_dir / "action_api.pid"
 
 
+def _read_pid_record(pid_file: Path) -> dict | None:
+    """Return the recorded API endpoint as ``{pid, host, port}``, or None.
+
+    Tolerates the legacy bare-integer file written by older versions (and by a
+    differently-versioned quodeq sharing this run dir), reporting host/port as
+    None so the caller falls back to the endpoint it was about to use.
+    """
+    try:
+        raw = pid_file.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        log_debug(f"Could not read PID file: {exc}")
+        return None
+    if not raw:
+        return None
+    try:
+        record = json.loads(raw)
+    except ValueError:
+        log_debug(f"Unrecognized PID file contents: {raw!r}")
+        return None
+    # A bare integer is the legacy format — and note json.loads parses it
+    # happily, so it never reaches an int() fallback.
+    if _is_pid(record):
+        return {"pid": record, "host": None, "port": None}
+    if not isinstance(record, dict) or not _is_pid(record.get("pid")):
+        log_debug(f"Unrecognized PID file contents: {raw!r}")
+        return None
+    return record
+
+
+def _is_pid(value: object) -> bool:
+    """True for a plausible pid. Excludes bool, which is an int in Python."""
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
 def _kill_stale_action_api(host: str, port: int) -> None:
-    """Kill any lingering action API processes using PID file tracking."""
+    """Kill a *stale* action API recorded in the PID file.
+
+    An API that still answers /api/health is left alone. It used to be killed
+    unconditionally, which meant every launch executed the previous launch's
+    backend: the running window kept its dead Flask server, could never load
+    projects, and sat on the loading screen forever. The recorded endpoint is
+    health-checked rather than the requested one because ``_choose_ui_port``
+    has already skipped the port the live API holds, so the two differ in
+    exactly the case that matters.
+    """
     pid_file = _get_pid_file()
     if pid_file.exists():
-        try:
-            pid = int(pid_file.read_text(encoding="utf-8").strip())
-            _terminate_pid(pid)
-        except (ValueError, OSError) as exc:
-            log_debug(f"Could not kill stale action API (pid file): {exc}")
+        record = _read_pid_record(pid_file)
+        if record is not None and _recorded_api_healthy(record, host, port):
+            log_debug("Action API in PID file is healthy; leaving it running")
+            return
+        if record is not None:
+            try:
+                _terminate_pid(record["pid"])
+            except (ValueError, OSError) as exc:
+                log_debug(f"Could not kill stale action API (pid file): {exc}")
         try:
             pid_file.unlink(missing_ok=True)
         except OSError as exc:
@@ -52,6 +100,13 @@ def _kill_stale_action_api(host: str, port: int) -> None:
     deadline = time.monotonic() + _STALE_KILL_DEADLINE_S
     while _is_port_open(host, port) and time.monotonic() < deadline:
         time.sleep(_POLL_INTERVAL_S)
+
+
+def _recorded_api_healthy(record: dict, fallback_host: str, fallback_port: int) -> bool:
+    """Return True if the API named by *record* is serving a healthy endpoint."""
+    api_host = record.get("host") or fallback_host
+    api_port = record.get("port") or fallback_port
+    return action_api_healthy(f"http://{api_host}:{api_port}")
 
 
 def _spawn_and_wait_local(

--- a/src/quodeq/dashboard/_server.py
+++ b/src/quodeq/dashboard/_server.py
@@ -116,6 +116,16 @@ def _serve_and_wait(
     if hasattr(signal, "SIGTSTP"):
         signal.signal(signal.SIGTSTP, _handle_tstp)
 
+    def _handle_term(_signum, _frame) -> None:
+        # Without this the API child outlives a `kill`/logout of the dashboard
+        # and keeps holding its port, so the next launch scans past it and the
+        # orphan lingers until it's found by hand. Only KeyboardInterrupt and
+        # SIGTSTP used to reach _stop_children.
+        _stop_children()
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, _handle_term)
+
     if config.build.use_native and config.build.open_browser:
         _serve_native(action_api_url, action_api_process, _stop_children)
     elif config.build.open_browser:
@@ -161,16 +171,18 @@ def _serve_native(
 
     instance = InstanceController()
 
-    if not instance.try_acquire():
+    # Probe rather than acquire: the *window* process owns the reload socket,
+    # because it is the only one that can act on a reload. Binding it here
+    # would leave the child unable to bind, its listener dead, and every
+    # relaunch's reload dropped into a socket nobody reads.
+    if instance.probe_existing():
         try:
             instance.send_reload(action_api_url)
         except (ConnectionRefusedError, OSError):
+            # The instance answered the probe but died before the send. Fall
+            # through and open our own window; its try_acquire clears the
+            # now-stale socket.
             logging.getLogger(__name__).warning("Could not reach existing instance — opening new window")
-            instance.shutdown()
-            instance = InstanceController()
-            if not instance.try_acquire():
-                stop_children()
-                return
         else:
             stop_children()
             return

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -1161,7 +1161,17 @@ def main() -> None:
     window.events.loaded += _on_loaded
     window.events.closing += _make_on_closing(api, window)
 
-    instance.start_listening(on_reload=_on_reload)
+    # Own the reload socket here, not in the parent: this process holds the
+    # window, so it is the only one that can bring it forward on a relaunch.
+    # try_acquire is what binds the socket — without it start_listening has
+    # nothing to accept on.
+    if not instance.try_acquire():
+        _logger.warning(
+            "Another instance owns %s — this window will not answer reloads",
+            instance.sock_path,
+        )
+    else:
+        instance.start_listening(on_reload=_on_reload)
 
     storage_dir = str(_quodeq_dir() / "webview")
 

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -99,8 +99,7 @@ function useNativeTitlebarSync(effectiveDark) {
  * @param {{ serverHealth: Object, evaluation: Object, selectedProject: string, projects: Array, onGoToProjects: Function, onGoToSettings: Function, preselectDims: string[]|undefined }} props
  * @returns {JSX.Element}
  */
-function EvaluateCase({ serverHealth, evaluation, selectedProject, projects, onGoToProjects, onGoToSettings, preselectDims }) {
-  const { connected, setConnected } = serverHealth;
+function EvaluateCase({ evaluation, selectedProject, projects, onGoToProjects, onGoToSettings, preselectDims }) {
   const { job, jobError, liveViolations, handleStartEvaluation, handleEvalDismiss, cancelEvaluation, startedProject } = evaluation;
   const projectInfo = projects?.find(p => (p.id || p.name) === selectedProject) || null;
   // The in-progress card describes the running job's own project, which can
@@ -116,7 +115,6 @@ function EvaluateCase({ serverHealth, evaluation, selectedProject, projects, onG
     : null;
   return (
     <>
-      {!connected && <ServerDisconnectedOverlay onReconnect={() => setConnected(true)} />}
       <EvaluateScreen
         evaluation={{ job, jobError, liveViolations }}
         context={{ selectedProject, projectInfo, jobProjectInfo, startedProjectInfo, preselectDims }}
@@ -691,7 +689,7 @@ export const ROUTE_RENDERERS = {
     if (isSharedSource(props.navigation.selectedSource)) {
       return ROUTE_RENDERERS.overview(params, props);
     }
-    return <EvaluateCase serverHealth={props.serverHealth} evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} projects={props.navigation.projects} preselectDims={params.preselectDims} onGoToProjects={() => props.navigation.navTab('projects')} onGoToSettings={() => props.navigation.navTab('settings')} />;
+    return <EvaluateCase evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} projects={props.navigation.projects} preselectDims={params.preselectDims} onGoToProjects={() => props.navigation.navTab('projects')} onGoToSettings={() => props.navigation.navTab('settings')} />;
   },
   file: (params, props) => (
     <FileDetailPage
@@ -1291,6 +1289,14 @@ export default function App() {
           }
           content={
             <Suspense fallback={<LoadingScreen />}>
+              {/* Every route, not just Evaluate. A dead backend is the one
+                  failure no page can render around: the Overview's own wall
+                  falls back to a bare loading spinner that never resolves, so
+                  a killed server read as "quodeq won't start" with nothing
+                  on screen to say why or to retry from. */}
+              {!state.serverConnected && (
+                <ServerDisconnectedOverlay onReconnect={() => state.setServerConnected(true)} />
+              )}
               <div className="tab-fade" key={activeTab}>
                 <MainContent activePage={activePage} props={contentProps} />
               </div>

--- a/src/quodeq/ui/src/hooks/useServerHealth.js
+++ b/src/quodeq/ui/src/hooks/useServerHealth.js
@@ -2,8 +2,9 @@
  * useServerHealth — TanStack Query-based connectivity poll.
  *
  * Polls the server every 5s. When the primary endpoint is unreachable,
- * probes alternate quodeq ports (4180-4183) and redirects if the server
- * has moved. Otherwise reports disconnected.
+ * probes the ports a relaunched server can have moved to (see
+ * altPortCandidates) and redirects if it finds one. Otherwise reports
+ * disconnected, which raises the app-wide ServerDisconnectedOverlay.
  *
  * Returns [serverConnected, setServerConnected] for backward compatibility.
  * setServerConnected(true) lets the reconnect overlay optimistically clear
@@ -15,7 +16,14 @@ import { getHealth } from '../api/index.js';
 import { SERVER_BASE_URL } from '../config.js';
 import { systemKeys } from '../api/queryKeys.js';
 
-const DEFAULT_ALT_PORTS = [4180, 4181, 4182, 4183];
+// Where the server can have moved to. The dashboard walks *upward* from its
+// configured base port when one is taken (see dashboard/_networking.py), so a
+// relaunch while the old instance still held 7863 lands on 7864 and the open
+// window must follow it there. The previous list (4180-4183) predates the
+// current port scheme, so it probed ports quodeq never binds and this recovery
+// could not fire at all.
+const DASHBOARD_BASE_PORT = 7863; // shared/defaults.json -> dashboard_port
+const PORT_SCAN_SPAN = 5; // enough for a few stacked relaunches, not all 20 scan tries
 const HEALTH_CHECK_TIMEOUT_MS = 2000;
 const HEALTH_POLL_INTERVAL_MS = 5000;
 const HEALTH_ENDPOINT = '/api/health';
@@ -33,13 +41,26 @@ async function probeAltPort(port, baseUrl) {
   }
 }
 
+/**
+ * Ports to probe when the current one goes quiet: the base scan range plus the
+ * neighbourhood of wherever this window is actually pointed, so a
+ * QUODEQ_DASHBOARD_PORT override is covered too. Deduped; the caller drops the
+ * current port.
+ */
+export function altPortCandidates(currentPort) {
+  const span = (from) => Array.from({ length: PORT_SCAN_SPAN }, (_, i) => from + i);
+  const current = Number(currentPort);
+  const nearCurrent = Number.isInteger(current) && current > 0 ? span(current) : [];
+  return [...new Set([...span(DASHBOARD_BASE_PORT), ...nearCurrent])];
+}
+
 async function tryFindPort(candidates, baseUrl) {
   const results = await Promise.allSettled(candidates.map((p) => probeAltPort(p, baseUrl)));
   const found = results.find((r) => r.status === 'fulfilled' && r.value !== null);
   return found ? found.value : null;
 }
 
-export function useServerHealth({ altPorts = DEFAULT_ALT_PORTS, baseUrl = SERVER_BASE_URL } = {}) {
+export function useServerHealth({ altPorts, baseUrl = SERVER_BASE_URL } = {}) {
   // Local state is the source of truth for callers. The query side-effects
   // it on each poll resolution. setServerConnected(true) lets the reconnect
   // overlay optimistically clear the disconnected state until the next poll.
@@ -56,8 +77,9 @@ export function useServerHealth({ altPorts = DEFAULT_ALT_PORTS, baseUrl = SERVER
         return true;
       } catch {
         const currentPort = typeof window !== 'undefined' ? window.location.port : '';
+        const candidates = altPorts || altPortCandidates(currentPort);
         const foundPort = await tryFindPort(
-          altPorts.filter((p) => String(p) !== currentPort),
+          candidates.filter((p) => String(p) !== currentPort),
           baseUrl,
         );
         if (foundPort && typeof window !== 'undefined') {

--- a/src/quodeq/ui/src/hooks/useServerHealth.test.jsx
+++ b/src/quodeq/ui/src/hooks/useServerHealth.test.jsx
@@ -7,7 +7,7 @@ vi.mock('../api/index.js', () => ({
 }));
 
 import { getHealth } from '../api/index.js';
-import { useServerHealth } from './useServerHealth.js';
+import { useServerHealth, altPortCandidates } from './useServerHealth.js';
 
 describe('useServerHealth', () => {
   beforeEach(() => {
@@ -35,6 +35,18 @@ describe('useServerHealth', () => {
     await waitFor(() => {
       expect(result.current[0]).toBe(false);
     });
+  });
+
+  it('scans the ports the dashboard actually binds', () => {
+    // The dashboard walks upward from 7863 when the base port is taken
+    // (dashboard/_networking.py), so recovery must probe that range — the
+    // old 4180-4183 list pointed at ports quodeq never binds.
+    expect(altPortCandidates('')).toEqual([7863, 7864, 7865, 7866, 7867]);
+  });
+
+  it('also scans around the port this window is pointed at', () => {
+    const candidates = altPortCandidates('9100');
+    expect(candidates).toEqual(expect.arrayContaining([7863, 9100, 9101, 9104]));
   });
 
   it('exposes setServerConnected for optimistic reconnect', async () => {

--- a/tests/dashboard/test_instance.py
+++ b/tests/dashboard/test_instance.py
@@ -47,3 +47,72 @@ def test_shutdown_removes_socket(tmp_path: Path):
     ctrl.try_acquire()
     ctrl.shutdown()
     assert not sock_path.exists()
+
+
+def test_probe_does_not_bind_so_a_child_can_own_the_socket(tmp_path: Path):
+    """The launcher probes; the window process it spawns is what binds.
+
+    When the launcher bound instead, the child could never acquire, its
+    listener died on an unbound socket, and reloads went nowhere.
+    """
+    sock_path = tmp_path / "test.sock"
+    launcher = InstanceController(sock_path)
+
+    assert launcher.probe_existing() is False
+    assert not sock_path.exists()
+
+    window = InstanceController(sock_path)
+    assert window.try_acquire() is True
+    window.shutdown()
+
+
+def test_probe_detects_a_live_instance(tmp_path: Path):
+    sock_path = tmp_path / "test.sock"
+    owner = InstanceController(sock_path)
+    assert owner.try_acquire() is True
+    owner.start_listening(on_reload=lambda _url: None)
+
+    assert InstanceController(sock_path).probe_existing() is True
+    owner.shutdown()
+
+
+def test_probe_clears_a_stale_socket(tmp_path: Path):
+    sock_path = tmp_path / "test.sock"
+    sock_path.touch()  # left behind by a crashed instance
+
+    assert InstanceController(sock_path).probe_existing() is False
+    assert not sock_path.exists()
+
+
+def test_non_owner_shutdown_keeps_the_live_socket(tmp_path: Path):
+    """A controller that only probed must not delete the winner's socket."""
+    sock_path = tmp_path / "test.sock"
+    owner = InstanceController(sock_path)
+    owner.try_acquire()
+    owner.start_listening(on_reload=lambda _url: None)
+
+    loser = InstanceController(sock_path)
+    assert loser.try_acquire() is False
+    loser.shutdown()
+
+    assert sock_path.exists()
+    assert InstanceController(sock_path).probe_existing() is True
+    owner.shutdown()
+
+
+def test_start_listening_refuses_an_unacquired_socket(tmp_path: Path):
+    """Reported, not silently swallowed by a thread that dies on accept().
+
+    This is the failure that filled webview.log with AttributeError while the
+    reload channel looked installed.
+    """
+    ctrl = InstanceController(tmp_path / "test.sock")
+    assert ctrl.start_listening(on_reload=lambda _url: None) is False
+    assert ctrl._listen_thread is None
+
+
+def test_start_listening_reports_success_when_acquired(tmp_path: Path):
+    ctrl = InstanceController(tmp_path / "test.sock")
+    ctrl.try_acquire()
+    assert ctrl.start_listening(on_reload=lambda _url: None) is True
+    ctrl.shutdown()

--- a/tests/dashboard/test_process_coverage.py
+++ b/tests/dashboard/test_process_coverage.py
@@ -1,6 +1,7 @@
 """Tests for quodeq.dashboard._process — process management."""
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -37,6 +38,70 @@ class TestGetPidFile:
         from quodeq.dashboard._process import _get_pid_file
         with pytest.raises(ValueError, match="absolute"):
             _get_pid_file(env={"QUODEQ_RUN_DIR": "relative/path"})
+
+
+class TestKillStaleActionApi:
+    """The stale-kill must not execute a *live* API.
+
+    Killing it unconditionally is what stranded the open window: its Flask
+    server died under it, /api/projects never answered, and the app sat on the
+    loading screen forever.
+    """
+
+    @staticmethod
+    def _run(tmp_path, pid_file_body, *, healthy, request_port=7864):
+        pid_file = tmp_path / "action_api.pid"
+        pid_file.write_text(pid_file_body, encoding="utf-8")
+        with patch("quodeq.dashboard._process._get_pid_file", return_value=pid_file), \
+             patch("quodeq.dashboard._process.action_api_healthy", return_value=healthy) as health, \
+             patch("quodeq.dashboard._process._is_port_open", return_value=False), \
+             patch("quodeq.dashboard._process._terminate_pid") as kill:
+            from quodeq.dashboard._process import _kill_stale_action_api
+            _kill_stale_action_api("127.0.0.1", request_port)
+        return kill, health, pid_file
+
+    def test_healthy_api_is_left_alone(self, tmp_path):
+        kill, _health, pid_file = self._run(
+            tmp_path, json.dumps({"pid": 4242, "host": "127.0.0.1", "port": 7863}), healthy=True,
+        )
+        kill.assert_not_called()
+        # The record must survive too, or the next launch loses track of it.
+        assert json.loads(pid_file.read_text(encoding="utf-8"))["pid"] == 4242
+
+    def test_health_is_checked_on_the_recorded_port_not_the_requested_one(self, tmp_path):
+        """The two differ in exactly the case that matters.
+
+        _choose_ui_port has already skipped the port the live API holds, so the
+        launch asks for 7864 while the API to protect is on 7863.
+        """
+        _kill, health, _pid_file = self._run(
+            tmp_path, json.dumps({"pid": 4242, "host": "127.0.0.1", "port": 7863}),
+            healthy=True, request_port=7864,
+        )
+        health.assert_called_once_with("http://127.0.0.1:7863")
+
+    def test_unhealthy_api_is_killed_and_record_removed(self, tmp_path):
+        kill, _health, pid_file = self._run(
+            tmp_path, json.dumps({"pid": 4242, "host": "127.0.0.1", "port": 7863}), healthy=False,
+        )
+        kill.assert_called_once_with(4242)
+        assert not pid_file.exists()
+
+    def test_legacy_bare_pid_file_falls_back_to_requested_endpoint(self, tmp_path):
+        """Older versions wrote just the pid, with no endpoint to check."""
+        kill, health, _pid_file = self._run(tmp_path, "4242", healthy=True)
+        health.assert_called_once_with("http://127.0.0.1:7864")
+        kill.assert_not_called()
+
+    def test_legacy_bare_pid_file_unhealthy_is_killed(self, tmp_path):
+        kill, _health, _pid_file = self._run(tmp_path, "4242", healthy=False)
+        kill.assert_called_once_with(4242)
+
+    @pytest.mark.parametrize("body", ["", "   ", "not-a-pid", '{"host": "127.0.0.1"}', "[1, 2]"])
+    def test_unusable_record_kills_nothing(self, tmp_path, body):
+        kill, _health, pid_file = self._run(tmp_path, body, healthy=False)
+        kill.assert_not_called()
+        assert not pid_file.exists()
 
 
 class TestWaitForProcess:

--- a/tests/dashboard/test_server_coverage.py
+++ b/tests/dashboard/test_server_coverage.py
@@ -177,10 +177,10 @@ class TestServeNative:
     @patch("quodeq.dashboard._server._linux_webview_backend_available", return_value=True)
     @patch("quodeq.dashboard._server.subprocess.Popen")
     @patch("quodeq.dashboard._server.subprocess_cmd", return_value=["quodeq-webview"])
-    def test_acquires_and_launches(self, mock_cmd, mock_popen, mock_backend):
+    def test_cold_start_launches_window(self, mock_cmd, mock_popen, mock_backend):
         from quodeq.dashboard._server import _serve_native
         mock_instance = MagicMock()
-        mock_instance.try_acquire.return_value = True
+        mock_instance.probe_existing.return_value = False
         mock_instance._sock_path = Path("/tmp/test.sock")
 
         mock_proc = MagicMock()
@@ -195,10 +195,36 @@ class TestServeNative:
 
     @patch("quodeq.dashboard._server._linux_webview_backend_available", return_value=True)
     @patch("quodeq.dashboard._server.subprocess.Popen")
+    @patch("quodeq.dashboard._server.subprocess_cmd", return_value=["quodeq-webview"])
+    def test_parent_never_owns_the_reload_socket(self, mock_cmd, mock_popen, mock_backend):
+        """The window process owns the socket, so the parent must not bind it.
+
+        Binding here is what left the webview child unable to acquire: its
+        listener thread died on the unbound socket and every relaunch's reload
+        was dropped. Probing must also never unlink a live instance's socket.
+        """
+        from quodeq.dashboard._server import _serve_native
+        mock_instance = MagicMock()
+        mock_instance.probe_existing.return_value = False
+        mock_instance._sock_path = Path("/tmp/test.sock")
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 1234
+
+        with self._fake_webview_ctx(), \
+             patch("quodeq.dashboard._instance.InstanceController", return_value=mock_instance):
+            _serve_native("http://localhost:8000", mock_proc, MagicMock())
+
+        mock_instance.try_acquire.assert_not_called()
+        mock_instance.start_listening.assert_not_called()
+        mock_instance.shutdown.assert_not_called()
+
+    @patch("quodeq.dashboard._server._linux_webview_backend_available", return_value=True)
+    @patch("quodeq.dashboard._server.subprocess.Popen")
     def test_send_reload_to_existing(self, mock_popen, mock_backend):
         from quodeq.dashboard._server import _serve_native
         mock_instance = MagicMock()
-        mock_instance.try_acquire.return_value = False
+        mock_instance.probe_existing.return_value = True
         mock_instance.send_reload.return_value = None
         mock_stop = MagicMock()
 
@@ -221,48 +247,26 @@ class TestServeNative:
     @patch("quodeq.dashboard._server._linux_webview_backend_available", return_value=True)
     @patch("quodeq.dashboard._server.subprocess.Popen")
     @patch("quodeq.dashboard._server.subprocess_cmd", return_value=["quodeq-webview"])
-    def test_reload_fails_opens_new(self, mock_cmd, mock_popen, mock_backend):
+    @pytest.mark.parametrize("failure", [ConnectionRefusedError(), OSError("refused")])
+    def test_reload_failure_opens_own_window(self, mock_cmd, mock_popen, mock_backend, failure):
+        """An instance that answers the probe but dies before the send.
+
+        The launch must still produce a window rather than exiting silently —
+        the child's own try_acquire clears the now-stale socket.
+        """
         from quodeq.dashboard._server import _serve_native
-        mock_instance1 = MagicMock()
-        mock_instance1.try_acquire.return_value = False
-        mock_instance1.send_reload.side_effect = ConnectionRefusedError()
-        mock_instance1._sock_path = Path("/tmp/test.sock")
-
-        mock_instance2 = MagicMock()
-        mock_instance2.try_acquire.return_value = True
-        mock_instance2._sock_path = Path("/tmp/test.sock")
-
-        instances = [mock_instance1, mock_instance2]
+        mock_instance = MagicMock()
+        mock_instance.probe_existing.return_value = True
+        mock_instance.send_reload.side_effect = failure
+        mock_instance._sock_path = Path("/tmp/test.sock")
 
         mock_proc = MagicMock()
         mock_proc.pid = 999
         mock_stop = MagicMock()
 
         with self._fake_webview_ctx(), \
-             patch("quodeq.dashboard._instance.InstanceController", side_effect=instances):
+             patch("quodeq.dashboard._instance.InstanceController", return_value=mock_instance):
             _serve_native("http://localhost:8000", mock_proc, mock_stop)
 
-        mock_instance1.shutdown.assert_called_once()
         mock_popen.assert_called_once()
-
-    @patch("quodeq.dashboard._server._linux_webview_backend_available", return_value=True)
-    @patch("quodeq.dashboard._server.subprocess.Popen")
-    def test_reload_fails_second_acquire_fails(self, mock_popen, mock_backend):
-        """When reload fails and second acquire also fails, stop_children is called."""
-        from quodeq.dashboard._server import _serve_native
-        mock_instance1 = MagicMock()
-        mock_instance1.try_acquire.return_value = False
-        mock_instance1.send_reload.side_effect = OSError("refused")
-
-        mock_instance2 = MagicMock()
-        mock_instance2.try_acquire.return_value = False
-
-        instances = [mock_instance1, mock_instance2]
-        mock_stop = MagicMock()
-
-        with self._fake_webview_ctx(), \
-             patch("quodeq.dashboard._instance.InstanceController", side_effect=instances):
-            _serve_native("http://localhost:8000", MagicMock(), mock_stop)
-
-        mock_stop.assert_called_once()
-        mock_popen.assert_not_called()
+        mock_instance.shutdown.assert_not_called()


### PR DESCRIPTION
## Problem

Launching quodeq while an instance was already running killed that instance's backend. The open window sat on the loading screen forever with no error and no retry. Diagnosed on 2026-08-05: three independent defects stacked.

1. `_kill_stale_action_api` SIGTERMed whatever pid was in `action_api.pid` on every launch, healthy or not.
2. The single-instance reload channel never worked. The parent bound `dashboard.sock` but never listened; the webview child listened without acquiring, so its accept loop died instantly on a `None` socket (AttributeError spam in webview.log). A relaunch's reload landed in a dead backlog.
3. The frontend had no recovery: the disconnected overlay only existed on the Evaluate route, and the alt-port scan probed 4180-4183, ports quodeq never binds.

## Fix

- `action_api.pid` now records `{pid, host, port}`. The kill is gated on a failed health check of the recorded endpoint (legacy bare-int files fall back to the requested endpoint). A healthy API is left running.
- Socket ownership moved to the process that can act on it: the parent only probes (`probe_existing`, no bind), the webview window process acquires and listens. `start_listening` refuses an unacquired socket instead of spawning a doomed thread. A non-owner `shutdown` no longer deletes the live socket.
- UI: `ServerDisconnectedOverlay` renders on every route, and the alt-port recovery scans from the dashboard base port (7863) plus the neighbourhood of the current port, so a window can follow its server after a relaunch lands on the next port up.

## Tests

- `tests/dashboard/test_process_coverage.py`: healthy API left alone, health checked on the recorded (not requested) port, unhealthy killed, legacy pid-file fallbacks, unusable records kill nothing.
- `tests/dashboard/test_instance.py`: probe does not bind, probe detects live/clears stale, non-owner shutdown keeps the live socket, start_listening guards.
- `tests/dashboard/test_server_coverage.py` updated for the probe flow.
- `useServerHealth.test.jsx`: port candidate list.
- Full suites: 179 dashboard py, 1503 vitest, node tests, i18n ratchet, import layers.