### PR TITLE
fix(ui): principle card click no longer freezes the app for seconds

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -671,6 +671,7 @@ export const ROUTE_RENDERERS = {
       dimension={params.dimension}
       runId={params.runId}
       dateLabel={params.dateLabel}
+      sourceTab={params.sourceTab}
       selectedSource={props.navigation.selectedSource}
       onNavigate={props.navigation.handleNavigate}
       refreshSignal={props.dashboardData.dashboard}

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -61,6 +61,7 @@ export default function ExplorerPage({
   dimension,
   runId,
   dateLabel,
+  sourceTab,
   selectedSource = 'local',
   onNavigate,
   refreshSignal,
@@ -141,7 +142,11 @@ export default function ExplorerPage({
   const dim = String(d.evalData.dimension || '').toLowerCase();
   const radialPrinciples = buildRadialPrinciples(d.principleGrades);
   const enrichedPrinciples = buildEnrichedPrinciples(d.principleGrades, d.allViolations, d.complianceByPrinciple);
-  const onPrincipleClick = (name) => onNavigate?.('evalprinciple', { evalPrincipal: buildEvalPrincipal(name) });
+  // Thread sourceTab through: without it a principle click from a
+  // Violations-tab drill-in falls back to the Overview tab, force-remounting
+  // the whole content subtree (App.jsx keys it on activeTab) and jumping the
+  // sidebar highlight.
+  const onPrincipleClick = (name) => onNavigate?.('evalprinciple', { evalPrincipal: buildEvalPrincipal(name), sourceTab });
 
   const overallScoreNum = parseFloat(d.overallGrade?.score);
   const sev = d.severityCounts;
@@ -161,7 +166,7 @@ export default function ExplorerPage({
   const handleCardNavigate = (kind) => {
     if (!onNavigate) return;
     const severityFilter = kind === 'violations' ? 'all' : kind;
-    onNavigate('file', { file: dimFile, severityFilter, runId: activeRunId, dateLabel: activeDateLabel });
+    onNavigate('file', { file: dimFile, severityFilter, runId: activeRunId, dateLabel: activeDateLabel, sourceTab });
   };
   const onSeverityBadge = (level) => () => handleCardNavigate(level);
 
@@ -250,7 +255,7 @@ export default function ExplorerPage({
         </div>
         <TopOffendingFilesTable
           files={d.topFiles}
-          onFileClick={(f) => onNavigate?.('file', { file: f, runId: activeRunId, dateLabel: activeDateLabel })}
+          onFileClick={(f) => onNavigate?.('file', { file: f, runId: activeRunId, dateLabel: activeDateLabel, sourceTab })}
         />
       </section>
     </div>

--- a/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
@@ -1,5 +1,4 @@
-import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
-import { useVirtualizer } from '@tanstack/react-virtual';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { buildFilePlanText } from '../../../utils/planTextBuilders.js';
 import { buildFileReport } from '../../../utils/reportBuilder.js';
 import { SEVERITY_ORDER, parseFileRef, complianceRatio } from '../../../utils/formatters.js';
@@ -12,6 +11,7 @@ import { TermHeader, StatStrip, Stat, SevBadge } from '../../../components/termi
 import { VerifiedChip } from '../../violations/components/VerifiedChip.jsx';
 import { useRegisterWindowSpec, ReportContent, useSidePane, violationFixPlanSpec } from '../../side-pane/index.js';
 import { isLowConfidence } from '../../violations/components/LowConfidenceGroup.jsx';
+import VirtualList, { useDashboardScrollElement } from './VirtualList.jsx';
 import { t } from '../../../strings/index.js';
 import { severityLabel, scopeGateRuleLabel } from '../../../strings/labels.js';
 
@@ -170,68 +170,34 @@ function LowConfidenceToggle({ count, expanded, onToggle }) {
   );
 }
 
-// Virtualizer extracted into its own component so the parent can remount it
-// (via `key={activeFilter}`) when the filter changes. A fresh virtualizer
-// starts with empty measurement caches, sidestepping the class of bugs
-// where stale heights at recycled indices cause row overlap.
-function VirtualList({ items, scrollElement, renderItem }) {
-  const virtualizer = useVirtualizer({
-    count: items.length,
-    getScrollElement: () => scrollElement,
-    estimateSize: (i) => {
-      const item = items[i];
-      if (!item) return 140;
-      if (item.kind === 'sev-header' || item.kind === 'compliance-header') return 36;
-      if (item.kind === 'low-conf-toggle') return 36;
-      return 160;
-    },
-    overscan: 6,
-    getItemKey: (i) => {
-      const item = items[i];
-      if (!item) return i;
-      if (item.kind === 'sev-header') return `h-${item.sev}`;
-      if (item.kind === 'compliance-header') return 'h-compliance';
-      if (item.kind === 'low-conf-toggle') return 'h-lowconf';
-      if (item.kind === 'violation') {
-        return `v-${item.v.dimension || ''}:${item.v.file || ''}:${item.v.line ?? ''}:${item.v.principle || ''}:${item.v.title || ''}`;
-      }
-      if (item.kind === 'low-conf-row') {
-        return `lc-${item.v.dimension || ''}:${item.v.file || ''}:${item.v.line ?? ''}:${item.v.principle || ''}:${item.v.title || ''}`;
-      }
-      if (item.kind === 'compliance') {
-        return `c-${item.c.dimension || ''}:${item.c.file || ''}:${item.c.line ?? ''}:${item.c.principle || ''}`;
-      }
-      return i;
-    },
-  });
+function estimateItemSize(items) {
+  return (i) => {
+    const item = items[i];
+    if (!item) return 140;
+    if (item.kind === 'sev-header' || item.kind === 'compliance-header') return 36;
+    if (item.kind === 'low-conf-toggle') return 36;
+    return 160;
+  };
+}
 
-  const totalSize = virtualizer.getTotalSize();
-  const virtualItems = virtualizer.getVirtualItems();
-
-  return (
-    <div className="vlive-violations-virtual" style={{ position: 'relative', width: '100%', height: totalSize }}>
-      {virtualItems.map((virtualRow) => {
-        const item = items[virtualRow.index];
-        if (!item) return null;
-        return (
-          <div
-            key={virtualRow.key}
-            data-index={virtualRow.index}
-            ref={virtualizer.measureElement}
-            style={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              width: '100%',
-              transform: `translateY(${virtualRow.start}px)`,
-            }}
-          >
-            {renderItem(item)}
-          </div>
-        );
-      })}
-    </div>
-  );
+function itemKey(items) {
+  return (i) => {
+    const item = items[i];
+    if (!item) return i;
+    if (item.kind === 'sev-header') return `h-${item.sev}`;
+    if (item.kind === 'compliance-header') return 'h-compliance';
+    if (item.kind === 'low-conf-toggle') return 'h-lowconf';
+    if (item.kind === 'violation') {
+      return `v-${item.v.dimension || ''}:${item.v.file || ''}:${item.v.line ?? ''}:${item.v.principle || ''}:${item.v.title || ''}`;
+    }
+    if (item.kind === 'low-conf-row') {
+      return `lc-${item.v.dimension || ''}:${item.v.file || ''}:${item.v.line ?? ''}:${item.v.principle || ''}:${item.v.title || ''}`;
+    }
+    if (item.kind === 'compliance') {
+      return `c-${item.c.dimension || ''}:${item.c.file || ''}:${item.c.line ?? ''}:${item.c.principle || ''}`;
+    }
+    return i;
+  };
 }
 
 const FileDetailPage = memo(function FileDetailPage({ file, runId, dateLabel, onDismiss, severityFilter }) {
@@ -302,12 +268,7 @@ const FileDetailPage = memo(function FileDetailPage({ file, runId, dateLabel, on
     return arr;
   }, [showViolations, showCompliance, activeFilter, highConfidenceBySeverity, lowConfidenceViolations, lowConfExpanded, file.compliance, totalCompliance]);
 
-  // The dashboard's main column owns vertical scroll; tanstack-virtual needs
-  // a ref to that ancestor to track scroll position.
-  const [scrollElement, setScrollElement] = useState(null);
-  useLayoutEffect(() => {
-    setScrollElement(document.querySelector('.app-shell__main-column > .dashboard'));
-  }, []);
+  const scrollElement = useDashboardScrollElement();
 
   // Snap to top whenever the filter changes so a giant list doesn't dump the
   // user mid-scroll into a freshly-mounted virtualizer.
@@ -394,7 +355,14 @@ const FileDetailPage = memo(function FileDetailPage({ file, runId, dateLabel, on
         />
       )}
 
-      <VirtualList key={virtualKey} items={items} scrollElement={scrollElement} renderItem={renderItem} />
+      <VirtualList
+        key={virtualKey}
+        items={items}
+        scrollElement={scrollElement}
+        estimateSize={estimateItemSize(items)}
+        getItemKey={itemKey(items)}
+        renderItem={renderItem}
+      />
     </>
   );
 });

--- a/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -1,4 +1,4 @@
-import { memo, useState, useMemo } from 'react';
+import { memo, useMemo, useEffect } from 'react';
 import { buildPrinciplePlanText } from '../../../utils/planTextBuilders.js';
 import { buildPrincipleReport } from '../../../utils/reportBuilder.js';
 import { SEVERITY_ORDER as EVAL_SEVERITY_ORDER, gradeLetter } from '../../../utils/formatters.js';
@@ -8,6 +8,7 @@ import { TermHeader, StatStrip, Stat, SevBadge, SectionLabel } from '../../../co
 import { useRegisterWindowSpec, ReportContent } from '../../side-pane/index.js';
 import { useStandardDescriptions } from '../hooks/useStandardDescriptions.js';
 import { usePrincipleData } from './explorerDataHooks.js';
+import VirtualList, { useDashboardScrollElement } from './VirtualList.jsx';
 import { t } from '../../../strings/index.js';
 
 function filterTitleSuffix(filter) {
@@ -15,51 +16,45 @@ function filterTitleSuffix(filter) {
   return ` (${filter})`;
 }
 
-// Off-screen rows skip layout/paint via CSS `content-visibility: auto` on
-// `.vdetail-row` (see styles/explorer.css), so no JS virtualizer or
-// "Show all" pagination is needed. Rows render naturally inside the app's
-// existing scroll container.
+// Rows are virtualized (same VirtualList as FileDetailPage): a principle can
+// carry hundreds of findings, and each card runs pretext measurement layout
+// effects on mount — rendering them all before first paint froze the page for
+// seconds with no spinner. React now holds ~30 row instances at once.
 
-export function ViolationListSection({ violationsBySeverity, principle, onDismiss }) {
-  return EVAL_SEVERITY_ORDER.map((sev) => {
-    const vs = violationsBySeverity[sev];
-    if (!vs || vs.length === 0) return null;
-    return (
-      <div key={sev}>
-        <SectionLabel>{sev.toUpperCase()} · {vs.length}</SectionLabel>
-        <div className="vlive-violations-group">
-          {vs.map((v, idx) => (
-            <EvalViolationCard
-              key={`${v.file || 'nofile'}:${v.line ?? 'noline'}:${idx}`}
-              v={v}
-              principle={principle}
-              index={idx}
-              onDismiss={onDismiss}
-            />
-          ))}
-        </div>
-      </div>
-    );
-  });
+function buildListItems({ displayedBySeverity, compliance, activeSevFilter }) {
+  const arr = [];
+  if (activeSevFilter !== 'compliance') {
+    for (const sev of EVAL_SEVERITY_ORDER) {
+      const vs = displayedBySeverity[sev];
+      if (!vs || vs.length === 0) continue;
+      arr.push({ kind: 'sev-header', sev, count: vs.length });
+      vs.forEach((v, idx) => arr.push({ kind: 'violation', v, idx }));
+    }
+  }
+  if ((!activeSevFilter || activeSevFilter === 'all' || activeSevFilter === 'compliance') && compliance.length > 0) {
+    arr.push({ kind: 'compliance-header', count: compliance.length });
+    compliance.forEach((c, idx) => arr.push({ kind: 'compliance', c, idx }));
+  }
+  return arr;
 }
 
-function ComplianceListSection({ compliance, principle }) {
-  if (compliance.length === 0) return null;
-  return (
-    <div>
-      <SectionLabel>{t('overview.statCompliance')} · {compliance.length}</SectionLabel>
-      <div className="vlive-violations-group">
-        {compliance.map((c, idx) => (
-          <ComplianceCard
-            key={`${c.file || 'nofile'}:${c.line ?? 'noline'}:${idx}`}
-            c={c}
-            principle={principle}
-            index={idx}
-          />
-        ))}
-      </div>
-    </div>
-  );
+function estimateItemSize(items) {
+  return (i) => {
+    const item = items[i];
+    if (!item) return 160;
+    return item.kind === 'sev-header' || item.kind === 'compliance-header' ? 36 : 160;
+  };
+}
+
+function itemKey(items) {
+  return (i) => {
+    const item = items[i];
+    if (!item) return i;
+    if (item.kind === 'sev-header') return `h-${item.sev}`;
+    if (item.kind === 'compliance-header') return 'h-compliance';
+    if (item.kind === 'violation') return `v-${item.v.file || ''}:${item.v.line ?? ''}:${item.idx}`;
+    return `c-${item.c.file || ''}:${item.c.line ?? ''}:${item.idx}`;
+  };
 }
 
 function SevBadgeRow({ sevCounts }) {
@@ -232,6 +227,48 @@ const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, s
   }, [principle, dimension, runId, filteredViolations, principleData, activeSevFilter]);
   useRegisterWindowSpec('fixplan', fixPlanSpec);
 
+  const items = useMemo(
+    () => buildListItems({ displayedBySeverity, compliance, activeSevFilter }),
+    [displayedBySeverity, compliance, activeSevFilter],
+  );
+
+  const scrollElement = useDashboardScrollElement();
+
+  // Snap to top whenever the filter changes so a giant list doesn't dump the
+  // user mid-scroll into a freshly-mounted virtualizer.
+  useEffect(() => {
+    if (scrollElement) scrollElement.scrollTop = 0;
+  }, [activeSevFilter, scrollElement]);
+
+  // Remount the virtualizer whenever the items collection changes shape so
+  // stale cached row heights can't misplace recycled rows.
+  const virtualKey = `${activeSevFilter ?? 'all'}-${filteredViolations.length}-${principle}`;
+
+  // handleDismiss (from usePrincipleData) is always a stable, callable
+  // no-op-safe function regardless of whether the caller passed a
+  // real onDismiss — that contract lets callers omit onDismiss without
+  // usePrincipleData throwing. But EvalViolationCard's dismiss button
+  // gates on *this* prop being truthy, so passing handleDismiss
+  // unconditionally would keep the button visible for shared projects
+  // (where App.jsx passes onDismiss={undefined}). Gate on the
+  // original onDismiss here so the button actually vanishes.
+  const cardDismiss = onDismiss ? handleDismiss : undefined;
+
+  const renderItem = (item) => {
+    switch (item.kind) {
+      case 'sev-header':
+        return <SectionLabel>{item.sev.toUpperCase()} · {item.count}</SectionLabel>;
+      case 'compliance-header':
+        return <SectionLabel>{t('overview.statCompliance')} · {item.count}</SectionLabel>;
+      case 'violation':
+        return <EvalViolationCard v={item.v} principle={principle} index={item.idx} onDismiss={cardDismiss} />;
+      case 'compliance':
+        return <ComplianceCard c={item.c} principle={principle} index={item.idx} />;
+      default:
+        return null;
+    }
+  };
+
   return (
     <>
       <PrincipleHeader
@@ -246,24 +283,14 @@ const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, s
           onFilterChange={setActiveSevFilter}
         />
       )}
-      {activeSevFilter !== 'compliance' && (
-        <ViolationListSection
-          violationsBySeverity={displayedBySeverity}
-          principle={principle}
-          // handleDismiss (from usePrincipleData) is always a stable, callable
-          // no-op-safe function regardless of whether the caller passed a
-          // real onDismiss — that contract lets callers omit onDismiss without
-          // usePrincipleData throwing. But EvalViolationCard's dismiss button
-          // gates on *this* prop being truthy, so passing handleDismiss
-          // unconditionally would keep the button visible for shared projects
-          // (where App.jsx passes onDismiss={undefined}). Gate on the
-          // original onDismiss here so the button actually vanishes.
-          onDismiss={onDismiss ? handleDismiss : undefined}
-        />
-      )}
-      {(!activeSevFilter || activeSevFilter === 'all' || activeSevFilter === 'compliance') && (
-        <ComplianceListSection compliance={compliance} principle={principle} />
-      )}
+      <VirtualList
+        key={virtualKey}
+        items={items}
+        scrollElement={scrollElement}
+        estimateSize={estimateItemSize(items)}
+        getItemKey={itemKey(items)}
+        renderItem={renderItem}
+      />
     </>
   );
 });

--- a/src/quodeq/ui/src/features/explorer/components/VirtualList.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/VirtualList.jsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+
+/**
+ * The dashboard's main column owns vertical scroll; tanstack-virtual needs a
+ * ref to that ancestor to track scroll position. The scroller is rendered by
+ * the app shell outside the tab-keyed subtree, so it exists before any detail
+ * page mounts — resolving it synchronously in the state initializer means the
+ * first render already virtualizes instead of committing an empty (or worse,
+ * complete) list for one frame.
+ */
+export function useDashboardScrollElement() {
+  const [scrollElement] = useState(() =>
+    typeof document !== 'undefined'
+      ? document.querySelector('.app-shell__main-column > .dashboard')
+      : null,
+  );
+  return scrollElement;
+}
+
+/**
+ * Absolutely-positioned virtual list over a flattened items array (headers
+ * and rows mixed in one list, so one scroller virtualizes the whole page).
+ *
+ * Remount it (via `key`) when the items collection changes shape: a fresh
+ * useVirtualizer call begins with no cached heights, so the row wrappers
+ * re-measure from scratch — eliminating overlap caused by stale measurements
+ * lingering from a previous filter or dismiss state.
+ *
+ * Without a scroll container (no `.dashboard` ancestor in the DOM — a moved
+ * shell or a jsdom test) it degrades to a plain fully-rendered list rather
+ * than rendering nothing.
+ */
+export default function VirtualList({ items, scrollElement, estimateSize, getItemKey, renderItem, overscan = 6 }) {
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => scrollElement,
+    estimateSize,
+    overscan,
+    getItemKey,
+  });
+
+  if (!scrollElement) {
+    return (
+      <div className="vlive-violations-virtual">
+        {items.map((item, i) => (
+          <div key={getItemKey(i)}>{renderItem(item)}</div>
+        ))}
+      </div>
+    );
+  }
+
+  const totalSize = virtualizer.getTotalSize();
+  const virtualItems = virtualizer.getVirtualItems();
+
+  return (
+    <div className="vlive-violations-virtual" style={{ position: 'relative', width: '100%', height: totalSize }}>
+      {virtualItems.map((virtualRow) => {
+        const item = items[virtualRow.index];
+        if (!item) return null;
+        return (
+          <div
+            key={virtualRow.key}
+            data-index={virtualRow.index}
+            ref={virtualizer.measureElement}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              transform: `translateY(${virtualRow.start}px)`,
+            }}
+          >
+            {renderItem(item)}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/hooks/useNavStack.js
+++ b/src/quodeq/ui/src/hooks/useNavStack.js
@@ -15,24 +15,59 @@ const defaultHistoryAdapter = {
  *
  * Returns { navStack, activePage, navPush, navPop, navReplace, navGoTo, navSwapAt, navReset, navTab }.
  */
-function handlePopState(e, setNavStack) {
+function isScalar(v) {
+  return v == null || typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean';
+}
+
+/**
+ * History state carries only scalars (and arrays of scalars, e.g.
+ * preselectDims); object payloads stay in React state and `entriesByIndex`.
+ * pushState structured-clones its argument synchronously on the main thread,
+ * and entries like evalprinciple/file carry a run's whole findings graph —
+ * cloning that inside the click handler froze navigation for seconds before
+ * React could even schedule a render (and risks the browser's history-state
+ * size cap, which would abort the handler mid-click).
+ */
+function toHistoryEntry(entry) {
+  const light = {};
+  for (const [k, v] of Object.entries(entry)) {
+    if (isScalar(v) || (Array.isArray(v) && v.every(isScalar))) light[k] = v;
+  }
+  return light;
+}
+
+function handlePopState(e, setNavStack, entriesByIndex) {
   const targetIndex = e.state?.navIndex ?? 0;
   setNavStack((prev) => {
     if (targetIndex < prev.length - 1) {
       return prev.slice(0, targetIndex + 1);
     }
     if (targetIndex >= prev.length && e.state?.entry) {
-      return [...prev.slice(0, targetIndex), e.state.entry];
+      // Forward: the full entry (with its object payload) lives in
+      // entriesByIndex; the history-state copy is the scalar-only fallback
+      // for entries pushed before a reload.
+      const entry = entriesByIndex.get(targetIndex) || e.state.entry;
+      return [...prev.slice(0, targetIndex), entry];
     }
     return prev;
   });
 }
 
-function createNavActions(setNavStack, navStackRef, history) {
+function createNavActions(setNavStack, navStackRef, history, entriesByIndex) {
+  function rememberEntry(index, entry) {
+    entriesByIndex.set(index, entry);
+    // pushState/swap truncated the browser's forward history — entries past
+    // this index are unreachable now.
+    for (const k of [...entriesByIndex.keys()]) {
+      if (k > index) entriesByIndex.delete(k);
+    }
+  }
+
   function navPush(entry) {
     const next = [...navStackRef.current, entry];
     setNavStack(next);
-    history.pushState({ navIndex: next.length - 1, entry }, '');
+    rememberEntry(next.length - 1, entry);
+    history.pushState({ navIndex: next.length - 1, entry: toHistoryEntry(entry) }, '');
   }
 
   function navPop() {
@@ -47,7 +82,8 @@ function createNavActions(setNavStack, navStackRef, history) {
     const prev = navStackRef.current;
     const next = [...prev.slice(0, -1), entry];
     setNavStack(next);
-    history.replaceState({ navIndex: next.length - 1, entry }, '');
+    entriesByIndex.set(next.length - 1, entry);
+    history.replaceState({ navIndex: next.length - 1, entry: toHistoryEntry(entry) }, '');
   }
 
   function navGoTo(index) {
@@ -68,12 +104,14 @@ function createNavActions(setNavStack, navStackRef, history) {
       return;
     }
     setNavStack([...prev.slice(0, index), entry]);
+    rememberEntry(index, entry);
     history.go(-stepsBack);
   }
 
   function navReset() {
     const stepsBack = navStackRef.current.length - 1;
     setNavStack([{ page: DEFAULT_PAGE }]);
+    rememberEntry(0, { page: DEFAULT_PAGE });
     if (stepsBack > 0) history.go(-stepsBack);
   }
 
@@ -83,8 +121,9 @@ function createNavActions(setNavStack, navStackRef, history) {
     const prevKey = prev.length === 1 && prev[0].page === page ? (prev[0]._tabKey || 0) : 0;
     // Spread params first so page/_tabKey stay authoritative and can't be
     // clobbered by a caller-supplied params key.
-    const next = [{ ...params, page, _tabKey: prevKey + 1 }];
-    setNavStack(next);
+    const entry = { ...params, page, _tabKey: prevKey + 1 };
+    setNavStack([entry]);
+    rememberEntry(0, entry);
     if (stepsBack > 0) history.go(-stepsBack);
   }
 
@@ -96,18 +135,21 @@ export function useNavStack({ historyAdapter } = {}) {
   const [navStack, setNavStack] = useState([{ page: DEFAULT_PAGE }]);
   const navStackRef = useRef(navStack);
   navStackRef.current = navStack;
+  // Full entries (object payloads included) by stack index, for forward
+  // restores — see toHistoryEntry for why history state can't hold them.
+  const entriesByIndexRef = useRef(new Map([[0, { page: DEFAULT_PAGE }]]));
 
   useEffect(() => {
     history.replaceState({ navIndex: 0, entry: { page: DEFAULT_PAGE } }, '');
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    const handler = (e) => handlePopState(e, setNavStack);
+    const handler = (e) => handlePopState(e, setNavStack, entriesByIndexRef.current);
     window.addEventListener('popstate', handler);
     return () => window.removeEventListener('popstate', handler);
   }, []);
 
-  const { navPush, navPop, navReplace, navGoTo, navSwapAt, navReset, navTab } = createNavActions(setNavStack, navStackRef, history);
+  const { navPush, navPop, navReplace, navGoTo, navSwapAt, navReset, navTab } = createNavActions(setNavStack, navStackRef, history, entriesByIndexRef.current);
   const activePage = navStack[navStack.length - 1];
 
   useEffect(() => {

--- a/src/quodeq/ui/src/hooks/useNavStack.test.jsx
+++ b/src/quodeq/ui/src/hooks/useNavStack.test.jsx
@@ -324,3 +324,115 @@ describe('useNavStack navReplace (repositories tab flips must not grow history)'
     expect(result.current.navStack[0].page).toBe('overview');
   });
 });
+
+describe('useNavStack history-state payload stripping', () => {
+  let historyAdapter;
+
+  beforeEach(() => {
+    historyAdapter = {
+      pushState: vi.fn(),
+      replaceState: vi.fn(),
+      back: vi.fn(),
+      go: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // pushState structured-clones its state argument synchronously on the main
+  // thread. Entries like evalprinciple/file carry a run's whole findings
+  // graph (megabytes of violation text), so cloning it inside the click
+  // handler froze navigation before React could render anything.
+  it('keeps object payloads out of history state, scalars and scalar arrays in', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    const heavy = {
+      page: 'evalprinciple',
+      sourceTab: 'violations',
+      severity: 'major',
+      preselectDims: ['security', 'usability'],
+      evalPrincipal: { principle: 'p', dimViolations: [{ file: 'a.py', reason: 'x'.repeat(100) }] },
+    };
+    act(() => { result.current.navPush(heavy); });
+
+    const [state] = historyAdapter.pushState.mock.calls[0];
+    expect(state.entry).toEqual({
+      page: 'evalprinciple',
+      sourceTab: 'violations',
+      severity: 'major',
+      preselectDims: ['security', 'usability'],
+    });
+    // The React stack keeps the full entry.
+    expect(result.current.navStack.at(-1).evalPrincipal).toBe(heavy.evalPrincipal);
+  });
+
+  it('restores the full entry (payload included) on forward popstate', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    const payload = { principle: 'p', dimViolations: [{ file: 'a.py' }] };
+    act(() => { result.current.navPush({ page: 'evalprinciple', evalPrincipal: payload }); });
+
+    // Back to root…
+    act(() => {
+      window.dispatchEvent(Object.assign(new Event('popstate'), { state: { navIndex: 0 } }));
+    });
+    expect(result.current.navStack).toHaveLength(1);
+
+    // …then Forward: the browser hands back the stripped entry, the hook
+    // must recover the full one from memory.
+    act(() => {
+      window.dispatchEvent(Object.assign(new Event('popstate'), {
+        state: { navIndex: 1, entry: { page: 'evalprinciple' } },
+      }));
+    });
+    expect(result.current.navStack).toHaveLength(2);
+    expect(result.current.navStack.at(-1).evalPrincipal).toBe(payload);
+  });
+
+  it('falls back to the history-state entry when memory has no record (post-reload forward)', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    act(() => {
+      window.dispatchEvent(Object.assign(new Event('popstate'), {
+        state: { navIndex: 1, entry: { page: 'explorer', dimension: 'security' } },
+      }));
+    });
+    expect(result.current.navStack).toHaveLength(2);
+    expect(result.current.navStack.at(-1)).toEqual({ page: 'explorer', dimension: 'security' });
+  });
+
+  it('a push after back overwrites the remembered forward entry', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    const first = { page: 'evalprinciple', evalPrincipal: { principle: 'first' } };
+    const second = { page: 'evalprinciple', evalPrincipal: { principle: 'second' } };
+    act(() => { result.current.navPush(first); });
+    act(() => {
+      window.dispatchEvent(Object.assign(new Event('popstate'), { state: { navIndex: 0 } }));
+    });
+    act(() => { result.current.navPush(second); });
+    act(() => {
+      window.dispatchEvent(Object.assign(new Event('popstate'), { state: { navIndex: 0 } }));
+    });
+    act(() => {
+      window.dispatchEvent(Object.assign(new Event('popstate'), {
+        state: { navIndex: 1, entry: { page: 'evalprinciple' } },
+      }));
+    });
+    expect(result.current.navStack.at(-1).evalPrincipal.principle).toBe('second');
+  });
+});


### PR DESCRIPTION
## Problem

Selecting a principle on the dimension detail page froze the app, and no loading screen appeared. Measured on freemium-app-android, maintainability > Analyzability (281 violations), dev build:

- ~5.7s of synchronous main-thread work per click (long tasks: 500 + 2956 + 1958 + 320 ms)
- 416 violation cards committed to the DOM before first paint, each running two layout-effect text measurements
- 3.05 MB structured-cloned into history.pushState inside the click handler

The missing loading screen is inherent to the freeze: the only loading UI on this path is the lazy-chunk Suspense boundary, which fires once per session. After that the entire cost is synchronous, so nothing can paint until it's over. The click path is unchanged since v1.8.1; the cost grew with data size.

## Fix

Three independent pieces:

1. **History state carries only scalars.** Full nav entries (with findings payloads) live in an in-memory map keyed by stack index; Forward restores the complete payload from memory, entries pushed before a reload fall back to the stripped copy.
2. **PrincipleDetailPage is virtualized** with the same tanstack virtualizer as FileDetailPage, extracted into a shared `VirtualList`. Scroll container resolved synchronously (no empty first frame); degrades to a plain list when no scroll container exists (jsdom).
3. **sourceTab threads through explorer drill-ins**, so a principle/file click from a Violations drill-in no longer flips the active tab to Overview and force-remounts the content subtree.

## After (same data, same machine, dev build)

- ~0.44s total long tasks per click, 9 DOM rows
- history.state: 47 bytes
- Verified in the browser against a real 423MB project copy: scrolling deep into the list keeps 9 rows with no overlap, severity filters snap to top and filter correctly, Back/Forward restore the full page, no console errors.

## Tests

- useNavStack: history-state stripping, forward restore from memory, post-reload fallback, push-after-back overwrite (plus all existing purity tests).
- Explorer suite (incl. PrincipleDetailPage dismiss gating) passes against the virtualized list via the VirtualList static fallback.
- Full suites: 1505 vitest, 453 node, i18n ratchet clean.