### PR TITLE
fix(ui): missed i18n loader string and cancel-failure detail

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -457,7 +457,7 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
           the wait legible instead of looking like the page hung. runMode only
           -- the Overview shows the OverviewSkeleton (inside .dashboard-page,
           see showOverviewSkeleton) instead. */}
-      {isLoading && runMode && <LoadingScreen variant="inline" message={projectName ? `Loading ${projectName}…` : undefined} />}
+      {isLoading && runMode && <LoadingScreen variant="inline" message={projectName ? t('overview.loadingProjectMsg', { name: projectName }) : undefined} />}
       <div className={`dashboard-page dashboard-fade ${isDimmed ? 'dashboard-loading' : `dashboard-ready${dashboardAppearClass}`}${isRefreshing ? ' dashboard-refreshing' : ''}`}>
         <IncompleteSetupCard projectInfo={projectInfo} onComplete={handleSetupComplete} />
         {error && <p className="inline-error">{t('overview.loadFailed')}</p>}

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -273,7 +273,11 @@ export function useEvaluation() {
       // racing the ~33s server-side kill path) must KEEP the job: clearing
       // it hid a still-running scan and let a second concurrent scan start
       // on the same project.
-      setJobError(t("evaluate.cancelFailed"));
+      // Keep the backend's sentence as a detail suffix: a 409 ("already
+      // finished") and a 500 are different situations for the user, and the
+      // translated summary alone flattened them into one. Same policy as
+      // apiErrorMessage, which preserves err.message for unmapped codes.
+      setJobError(err?.message ? `${t("evaluate.cancelFailed")} (${err.message})` : t("evaluate.cancelFailed"));
       if (err?.status !== 409 && err?.status !== 404) return;
       const id = jobId;
       if (id) queryClient.removeQueries({ queryKey: evaluationKeys.evaluation(id) });


### PR DESCRIPTION
Two small frictions found while auditing UI changes since v1.8.1.

1. `DashboardPage` runMode loader still rendered a raw `Loading X…` template literal. Its two sibling call sites were migrated to `overview.loadingProjectMsg` in the i18n sweep; this branch was missed (it renders untranslated in any future locale and is invisible to the string ratchet).
2. Cancelling an evaluation collapsed every failure to the generic `evaluate.cancelFailed` sentence. A 409 (job already finished) and a 500 read identically to the user. The backend sentence now rides along as a suffix, matching the documented `apiErrorMessage` policy of preserving `err.message` for unmapped codes.

Tests: evaluation + dashboard suites (371), string ratchet clean.