### PR TITLE
fix(core): warn when path resolution skips a symlinked directory

### DIFF
--- a/src/quodeq/core/utils/io.py
+++ b/src/quodeq/core/utils/io.py
@@ -7,9 +7,12 @@ the evidence parser and standards loader can use them without reaching into
 from __future__ import annotations
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import IO, Any
+
+_logger = logging.getLogger(__name__)
 
 TEXT_ENCODING = "utf-8"
 """Standard text encoding used across the codebase for file I/O."""
@@ -65,6 +68,11 @@ def resolve_child_dir(root: str | Path, name: str) -> str | None:
     which would return ``root/escape`` for a link pointing out of the tree and
     hand the caller an escape hatch. Listing-based resolution is only safe
     when the entry is a real directory, so this asks for that explicitly.
+    A matching entry that IS a symlinked directory logs a warning before the
+    None: an owner who relocated a data dir and symlinked it back would
+    otherwise see their project silently render as empty, with nothing
+    anywhere saying why (the policy plus the fix for that silence is this
+    function; the decision record is PR #1062).
 
     Prefer this over ``contained_path(root / name, root)`` whenever *name*
     comes from a request and names something that must already exist. Reach
@@ -79,8 +87,27 @@ def resolve_child_dir(root: str | Path, name: str) -> str | None:
     try:
         with os.scandir(root) as entries:
             for entry in entries:
-                if entry.name == name and entry.is_dir(follow_symlinks=False):
+                if entry.name != name:
+                    continue
+                if entry.is_dir(follow_symlinks=False):
                     return entry.path
+                if entry.is_symlink() and entry.is_dir():
+                    # The exact case a user hits after relocating a data dir
+                    # and leaving a symlink behind: the name they asked for is
+                    # right there in the listing, but resolution refuses it.
+                    # Without this line the refusal is indistinguishable from
+                    # "no such project/run" — the UI just renders empty.
+                    _logger.warning(
+                        "Not following symlinked directory %s -> %s: symlinks "
+                        "are excluded from path resolution by policy. Replace "
+                        "the symlink with a real directory (or move the data "
+                        "back) to make %r visible again.",
+                        os.path.join(str(root), name),
+                        os.path.realpath(entry.path),
+                        name,
+                    )
+                # Names are unique within a directory — nothing else can match.
+                return None
     except OSError:
         return None
     return None

--- a/tests/core/test_contained_path.py
+++ b/tests/core/test_contained_path.py
@@ -8,6 +8,7 @@ this module pins the return-value contract, which is the part a well-meaning
 """
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 
@@ -142,3 +143,44 @@ def test_resolve_child_dir_refuses_a_symlink_even_to_a_real_directory(tmp_path: 
 
 def test_resolve_child_dir_on_a_missing_root_is_none(tmp_path: Path) -> None:
     assert resolve_child_dir(tmp_path / "no-such-root", "anything") is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_skipped_symlinked_dir_warns_instead_of_failing_silently(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Refusing a symlinked dir must be diagnosable.
+
+    An owner who relocates a project dir and symlinks it back sees the name
+    in every listing while the app renders the project empty. The refusal
+    stands (policy), but it has to say so: one warning naming the link and
+    its target.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "moved-project").symlink_to(outside)
+
+    with caplog.at_level(logging.WARNING, logger="quodeq.core.utils.io"):
+        assert resolve_child_dir(root, "moved-project") is None
+
+    assert any(
+        "moved-project" in rec.getMessage() and "symlink" in rec.getMessage().lower()
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_symlink_to_a_file_stays_silent(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Only the relocated-directory case warns; a link to a file is just absent."""
+    target = tmp_path / "afile"
+    target.write_text("x")
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "filelink").symlink_to(target)
+
+    with caplog.at_level(logging.WARNING, logger="quodeq.core.utils.io"):
+        assert resolve_child_dir(root, "filelink") is None
+
+    assert not caplog.records


### PR DESCRIPTION
## Decision

Follow-up to the since-v1.8.1 audit. `resolve_child_dir` refuses symlinked directories by design, and this PR keeps that policy: request-driven resolution must not follow links (a link out of the tree is an escape hatch, and shared-repo clones can carry attacker-authored links). What it fixes is the observability of the refusal.

## Problem

A user who relocates a project or evaluations dir and leaves a symlink behind sees the name in every directory listing while the app renders the project empty: `list_runs` returns `[]`, the Overview shows "No completed evaluation yet", and nothing in any log says why. The refusal is indistinguishable from "no such project".

## Fix

When the requested name matches a listing entry that is a symlinked directory, the resolver logs one warning naming the link, its real target, and the remediation (replace the symlink with a real directory). A matching symlink to a file stays silent as before, and the docstring records the trade-off. `resolve_child_dir` is the single choke point (only `follow_symlinks=False` site in src), so this covers project and run resolution everywhere.

## Tests

- New: skipped symlinked dir emits the warning; symlink-to-file stays silent.
- tests/core + tests/data + tests/api + tests/tools: 1693 passed.