### PR TITLE
feat(ui): cache the explorer's dimension data in react-query

### DIFF
--- a/src/quodeq/ui/src/api/queryKeys.js
+++ b/src/quodeq/ui/src/api/queryKeys.js
@@ -33,6 +33,13 @@ export const projectKeys = {
   dashboard: (projectId, run, source = "local") => ["project", projectId, source, "dashboard", run || "latest"],
   runs: (projectId, source = "local") => ["project", projectId, source, "runs"],
   info: (projectId, source = "local") => ["project", projectId, source, "info"],
+  // Explorer (dimension detail) queries. Distinct from `scores`: that one is
+  // GET /projects/<p>/scores?as_of= (full payload incl. trend/availableRuns),
+  // runScores is the slim GET /projects/<p>/scores/<run> used for the rescore
+  // merge. Both sit inside the project subtree on purpose, so every existing
+  // mutation invalidation (dismiss/delete/formula reconcile) reaches them.
+  runScores: (projectId, run, source = "local") => ["project", projectId, source, "runScores", run || "latest"],
+  dimensionEval: (projectId, run, dimension, source = "local") => ["project", projectId, source, "dimensionEval", run || "latest", dimension],
 };
 
 /**

--- a/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.js
+++ b/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.js
@@ -1,5 +1,7 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useApi } from '../../../api/ApiContext.jsx';
+import { projectKeys, samePlaceholderScope } from '../../../api/queryKeys.js';
 import { buildTopOffendingFiles } from '../../../utils/explorerUtils.js';
 import { countBySeverity } from '../../../utils/severity.js';
 
@@ -86,18 +88,6 @@ function mergeRescoreIntoEval(prev, dimData) {
   };
 }
 
-async function fetchAndRescore(project, runId, dimension, getDimensionEval, getRunScores) {
-  const [data, rescored] = await Promise.all([
-    getDimensionEval(project, runId, dimension),
-    getRunScores(project, runId).catch(() => null),
-  ]);
-  if (rescored) {
-    const dimData = (rescored.dimensions || []).find((d) => d.dimension === dimension);
-    return dimData ? mergeRescoreIntoEval(data, dimData) : data;
-  }
-  return data;
-}
-
 /**
  * @param {string} project
  * @param {string} dimension
@@ -106,64 +96,72 @@ async function fetchAndRescore(project, runId, dimension, getDimensionEval, getR
  * @param {'local'|'shared'} [selectedSource='local'] - picks the shared-repo
  *   mirror fetchers (sharedGetDimensionEval/sharedGetRunScores) instead of
  *   the local ones when the selected project is a shared-repo project.
+ *
+ * Both queries live in the react-query cache under the project subtree, so
+ * re-entering the page (Back from a principle/file detail) renders instantly
+ * from cache instead of refetching behind a full-screen LoadingScreen — the
+ * cost that used to make every Back out of a principle a multi-second hop.
+ * Every dismiss/delete/formula mutation already invalidates the
+ * projectKeys.project() prefix (see refreshDashboard/scheduleDashboardReconcile
+ * in useDashboard.js), which marks these stale too, so the cached page
+ * refetches after user actions exactly like the Overview does.
  */
 export function useExplorerData(project, dimension, runId, refreshSignal, selectedSource = 'local') {
   const { getDimensionEval, getRunScores, sharedGetDimensionEval, sharedGetRunScores } = useApi();
   const fetchDimensionEval = selectedSource === 'shared' ? sharedGetDimensionEval : getDimensionEval;
   const fetchRunScores = selectedSource === 'shared' ? sharedGetRunScores : getRunScores;
-  const [evalData, setEvalData] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [isFetching, setIsFetching] = useState(false);
-  const [error, setError] = useState(null);
+  const queryClient = useQueryClient();
+  const projectKey = project || '_none_';
+  // Reuse the previous payload only within this project+source subtree —
+  // run-navigator swaps keep the page up with an isFetching dim, a project
+  // switch drops to the real LoadingScreen (see samePlaceholderScope).
+  const keepInScope = useCallback(
+    (prev, prevQuery) => (samePlaceholderScope(prevQuery, projectKey, selectedSource) ? prev : undefined),
+    [projectKey, selectedSource],
+  );
 
-  useEffect(() => {
-    // First load shows the LoadingScreen; subsequent run-switches keep
-    // the previous run's data on screen and toggle isFetching so the
-    // caller can dim the page during the background refetch (matches
-    // the Overview placeholderData behaviour).
-    // The stale flag drops responses that resolve after a newer request
-    // (run-navigator clicks re-fire this effect); without it a slow earlier
-    // response could park another run's findings under the current header.
-    let stale = false;
-    setIsFetching(true);
-    fetchAndRescore(project, runId, dimension, fetchDimensionEval, fetchRunScores)
-      .then((data) => {
-        if (stale) return;
-        setEvalData(data); setLoading(false); setIsFetching(false);
-      })
-      .catch((err) => {
-        if (stale) return;
-        setError(err.message); setLoading(false); setIsFetching(false);
-      });
-    return () => { stale = true; };
-  }, [project, dimension, runId, fetchDimensionEval, fetchRunScores]);
+  const evalQuery = useQuery({
+    queryKey: projectKeys.dimensionEval(projectKey, runId, dimension, selectedSource),
+    queryFn: () => fetchDimensionEval(project, runId, dimension),
+    enabled: !!project && !!dimension,
+    staleTime: 60_000,
+    placeholderData: keepInScope,
+  });
 
+  // The rescore side. Non-fatal by design: if it errors, the page renders
+  // the unrescored eval (the old fetchAndRescore caught and dropped scores
+  // errors the same way).
+  const scoresQuery = useQuery({
+    queryKey: projectKeys.runScores(projectKey, runId, selectedSource),
+    queryFn: () => fetchRunScores(project, runId),
+    enabled: !!project,
+    staleTime: 60_000,
+    placeholderData: keepInScope,
+  });
+
+  const evalData = useMemo(() => {
+    const data = evalQuery.data ?? null;
+    if (!data) return null;
+    const dimData = (scoresQuery.data?.dimensions || []).find((d) => d.dimension === dimension);
+    return dimData ? mergeRescoreIntoEval(data, dimData) : data;
+  }, [evalQuery.data, scoresQuery.data, dimension]);
+
+  // refreshSignal (the dashboard payload identity) flips after external
+  // changes; re-pull the rescore data then, like the old effect did.
   const initialRef = useRef(refreshSignal);
   useEffect(() => {
     if (refreshSignal === initialRef.current) return;
-    if (!evalData || !project || !runId) return;
-    fetchRunScores(project, runId).then((rescored) => {
-      const dimData = (rescored.dimensions || []).find((d) => d.dimension === dimension);
-      if (dimData) setEvalData((prev) => mergeRescoreIntoEval(prev, dimData));
-    }).catch((err) => {
-      // Non-blocking: the explorer keeps the previous scores on screen, but
-      // log the failure so the silent-stale state is diagnosable.
-      console.warn('Rescore refresh failed:', err);
-    });
+    if (!project || !runId) return;
+    queryClient.invalidateQueries({ queryKey: projectKeys.runScores(projectKey, runId, selectedSource) });
   }, [refreshSignal]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Live updates after a dismiss arrive synchronously in the dismiss HTTP
-  // response. Callers fold the rescored payload back into this hook via
-  // ``applyRescoredPayload`` so the page re-renders with the new scores
-  // without a follow-up GET. (Previously this was an SSE subscription, which
-  // turned out to be broken for completed runs — see the long-form
-  // commit message for the architectural history.)
-  const applyRescoredPayload = useCallback((payload) => {
-    if (!payload) return;
-    const dimData = (payload.dimensions || []).find((d) => d.dimension === dimension);
-    if (!dimData) return;
-    setEvalData((prev) => mergeRescoreIntoEval(prev, dimData));
-  }, [dimension]);
+  // Loading gates on BOTH queries so the first paint never shows pre-rescore
+  // grades that visibly correct themselves a beat later (the old code
+  // Promise.all'd the two fetches for the same reason). isLoading is false
+  // once cached data exists, so Back-navigation skips the LoadingScreen.
+  const loading = evalQuery.isLoading || scoresQuery.isLoading;
+  const isFetching = evalQuery.isFetching || scoresQuery.isFetching;
+  const error = evalQuery.isError ? (evalQuery.error?.message || String(evalQuery.error)) : null;
 
   const overallGrade = useMemo(() => (evalData?.principleGrades || []).find((pg) => pg.isOverall || pg.principle?.includes('Overall')), [evalData]);
   const principleGrades = useMemo(() => (evalData?.principleGrades || []).filter((pg) => !pg.isOverall && !pg.principle?.includes('Overall')), [evalData]);
@@ -176,7 +174,6 @@ export function useExplorerData(project, dimension, runId, refreshSignal, select
     // report.
     waiting: !!evalData?.waiting,
     overallGrade, principleGrades, allViolations,
-    applyRescoredPayload,
     ...stats,
   };
 }

--- a/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.test.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.test.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
 import { ApiProvider } from '../../../api/ApiContext.jsx';
+import { withStableQueryApi } from '../../../test-utils/withQueryClient.jsx';
 import { usePrincipleData, useExplorerData } from './explorerDataHooks.js';
 
 // ---------------------------------------------------------------------------
@@ -136,7 +139,7 @@ describe('useExplorerData source-aware fetch selection', () => {
     const fakeApi = makeFakeExplorerApi();
     const { result } = renderHook(
       () => useExplorerData('proj', 'security', 'r1', null),
-      { wrapper: ({ children }) => <ApiProvider value={fakeApi}>{children}</ApiProvider> },
+      { wrapper: withStableQueryApi(fakeApi) },
     );
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(fakeApi.getDimensionEval).toHaveBeenCalledWith('proj', 'r1', 'security');
@@ -149,7 +152,7 @@ describe('useExplorerData source-aware fetch selection', () => {
     const fakeApi = makeFakeExplorerApi();
     const { result } = renderHook(
       () => useExplorerData('proj', 'security', 'r1', null, 'shared'),
-      { wrapper: ({ children }) => <ApiProvider value={fakeApi}>{children}</ApiProvider> },
+      { wrapper: withStableQueryApi(fakeApi) },
     );
     await waitFor(() => expect(result.current.evalData?.marker).toBe('shared'));
     expect(fakeApi.sharedGetDimensionEval).toHaveBeenCalledWith('proj', 'r1', 'security');
@@ -161,9 +164,9 @@ describe('useExplorerData source-aware fetch selection', () => {
 
 describe('useExplorerData response handling', () => {
   it('ignores a stale response that resolves after a newer request', async () => {
-    // Run-navigator clicks re-fire the fetch with no cancellation; a slow
-    // earlier response resolving last used to park another run's findings
-    // under the current header.
+    // Run-navigator clicks re-key the query; a slow earlier response
+    // resolving last must land in ITS OWN cache entry, never under the
+    // current run's header.
     const resolvers = {};
     const fakeApi = {
       getDimensionEval: vi.fn((p, r) => new Promise((res) => { resolvers[r] = res; })),
@@ -173,13 +176,12 @@ describe('useExplorerData response handling', () => {
     };
     const { result, rerender } = renderHook(
       ({ runId }) => useExplorerData('proj', 'security', runId, null),
-      {
-        initialProps: { runId: 'r1' },
-        wrapper: ({ children }) => <ApiProvider value={fakeApi}>{children}</ApiProvider>,
-      },
+      { initialProps: { runId: 'r1' }, wrapper: withStableQueryApi(fakeApi) },
     );
     rerender({ runId: 'r2' });
     await act(async () => { resolvers.r2({ dimension: 'security', marker: 'r2' }); });
+    await waitFor(() => expect(result.current.evalData?.marker).toBe('r2'));
+    // The stale r1 response must land in its own cache entry, not on screen.
     await act(async () => { resolvers.r1({ dimension: 'security', marker: 'r1' }); });
     expect(result.current.evalData?.marker).toBe('r2');
   });
@@ -196,9 +198,66 @@ describe('useExplorerData response handling', () => {
     };
     const { result } = renderHook(
       () => useExplorerData('proj', 'security', 'r1', null),
-      { wrapper: ({ children }) => <ApiProvider value={fakeApi}>{children}</ApiProvider> },
+      { wrapper: withStableQueryApi(fakeApi) },
     );
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.waiting).toBe(true);
+  });
+
+  it('re-enters from cache without a loading pass (the Back-nav path)', async () => {
+    // Back from a principle detail remounts ExplorerPage. With the queries
+    // in the shared cache the remount renders data immediately — loading
+    // must stay false from the first render or the page flashes the
+    // full-screen LoadingScreen it used to show on every Back.
+    // withStableQueryApi's client uses gcTime: 0, which drops the cache the
+    // moment the first mount unmounts — exactly the continuity this test is
+    // about — so it needs a client with a real gcTime.
+    const fakeApi = makeFakeExplorerApi();
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 300_000, staleTime: 60_000 } },
+    });
+    const wrapper = ({ children }) => (
+      <QueryClientProvider client={client}>
+        <ApiProvider value={fakeApi}>{children}</ApiProvider>
+      </QueryClientProvider>
+    );
+    const first = renderHook(() => useExplorerData('proj', 'security', 'r1', null), { wrapper });
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+    first.unmount();
+
+    const second = renderHook(() => useExplorerData('proj', 'security', 'r1', null), { wrapper });
+    expect(second.result.current.loading).toBe(false);
+    expect(second.result.current.evalData).toBeTruthy();
+  });
+
+  it('merges the rescored per-dimension grades over the raw eval payload', async () => {
+    const fakeApi = {
+      getDimensionEval: vi.fn(async () => ({
+        dimension: 'security',
+        principleGrades: [
+          { principle: 'Input Validation', score: '8.0/10', grade: 'B' },
+          { principle: 'Overall', score: '8.0/10', grade: 'B', isOverall: true },
+        ],
+        violations: [],
+      })),
+      getRunScores: vi.fn(async () => ({
+        dimensions: [{
+          dimension: 'security',
+          overallScore: '6.0/10',
+          overallGrade: 'C',
+          principles: [{ principle: 'Input Validation', score: '6.5/10', grade: 'C+' }],
+        }],
+      })),
+      sharedGetDimensionEval: vi.fn(),
+      sharedGetRunScores: vi.fn(),
+    };
+    const { result } = renderHook(
+      () => useExplorerData('proj', 'security', 'r1', null),
+      { wrapper: withStableQueryApi(fakeApi) },
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const pg = result.current.principleGrades.find((p) => p.principle === 'Input Validation');
+    expect(pg.score).toBe('6.5/10');
+    expect(result.current.overallGrade.score).toBe('6.0/10');
   });
 });


### PR DESCRIPTION
## Problem

`useExplorerData` fetched with plain `useState`/`useEffect`, so every entry to the dimension detail page refetched the dimension eval and run scores behind a full-screen LoadingScreen. Coming Back from a principle or file detail paid that cost every time — the slowest hop left in the drill-in loop after #1060.

## Fix

Both fetches become react-query queries with new factories `projectKeys.dimensionEval` / `projectKeys.runScores`, keyed inside the project subtree on purpose: every existing mutation invalidation (dismiss/delete/formula via `refreshDashboard` / `scheduleDashboardReconcile`) already targets that prefix, so the cached explorer pages go stale on user actions with no new wiring.

Preserved semantics, each pinned by a test:

- The rescore merge (`mergeRescoreIntoEval`) now runs in a memo over both payloads; `loading` gates on both queries so first paint never shows pre-rescore grades (the old code `Promise.all`'d for the same reason).
- `refreshSignal` invalidates the run-scores key (was: manual refetch+merge).
- Scores errors stay non-fatal (page renders unrescored).
- Stale responses can't land under the wrong run — each run is its own cache entry.
- `waiting` (202 sentinel) passes through.
- placeholderData is scoped with `samePlaceholderScope`, matching the Overview conventions: run swaps keep the page up with a dim, project switches drop to a real loading state.
- `applyRescoredPayload` is removed: it had no callers.

## Verified live (isolated backend, real 423MB project copy)

- Back from principle → explorer renders instantly, no LoadingScreen, zero refetches of the heavy endpoints.
- Dismiss on the principle page (281 → 280) propagates to the re-entered explorer with exactly one mutation-triggered refetch, no spinner, no console errors.

## Tests

New: re-enter from cache without a loading pass; rescore merge over the raw payload. Updated: stale-response and source-selection tests to the query wrapper. Full vitest suite: 1509 passed.