### PR TITLE
fix(scoring): re-derive projected grades when the grade math changes

### DIFF
--- a/src/quodeq/core/scoring/projector_scoring.py
+++ b/src/quodeq/core/scoring/projector_scoring.py
@@ -26,6 +26,19 @@ from quodeq.core.scoring.params import (
 )
 from quodeq.core.types.finding import Finding
 
+# Version of the grade math projected into each run's SQLite grade tables.
+# Bump it whenever a change here (or in the scoring internals this module
+# calls) alters the numbers an ALREADY-SCANNED run would produce — the
+# projector re-derives that run's grades on next contact instead of serving
+# the old math forever. Without the stamp, the clamp-order fix (floor no
+# longer beats ceiling) left projected runs on the old ordering while fresh
+# rescores used the new one: the same principle read 8.0 on one screen and
+# 7.3 on another. Same pattern as the ``algo`` salt in services/score_cache.
+#
+# 1: implicit pre-stamp state (any DB without the run_meta key).
+# 2: ceiling beats floor in the principle-score clamp.
+GRADE_ALGO_VERSION = 2
+
 
 def _finding_to_dict(f: Finding) -> dict[str, Any]:
     """Convert Finding to the dict shape scoring internals expect.

--- a/src/quodeq/data/projection/grade_projector.py
+++ b/src/quodeq/data/projection/grade_projector.py
@@ -19,6 +19,7 @@ from quodeq.data.sqlite._row_mappers import row_to_finding
 from quodeq.data.sqlite.connection import open_evaluation_db
 from quodeq.data.sqlite.state_store import SQLiteStateStore
 from quodeq.core.scoring.projector_scoring import (
+    GRADE_ALGO_VERSION,
     compute_dimension_score,
     compute_principle_grade,
 )
@@ -151,3 +152,6 @@ def recompute_grades(run_dir: Path, params: ScoringParams | None = None) -> None
 
     store = SQLiteStateStore(run_dir)
     store.batch_rewrite_grades(principle_rows, dimension_rows)
+    # Stamp the math these tables now embody, so ensure_projected can tell a
+    # run graded with older scoring apart from one that is merely unchanged.
+    store.save_grades_algo_version(GRADE_ALGO_VERSION)

--- a/src/quodeq/data/projection/projector.py
+++ b/src/quodeq/data/projection/projector.py
@@ -118,7 +118,16 @@ class Projector:
                 current_actions_size = actions_log.stat().st_size if actions_log.is_file() else 0
                 actions_changed = current_actions_size != last_actions_size
 
-            if not events_changed and not actions_changed:
+            # Grade tables embody the scoring math that computed them. When
+            # that math changes (see GRADE_ALGO_VERSION), a run whose logs are
+            # untouched still carries grades no fresh rescore would produce —
+            # the same principle read differently depending on which screen's
+            # read path served it. Re-derive from the already-projected
+            # findings; no event replay needed.
+            from quodeq.core.scoring.projector_scoring import GRADE_ALGO_VERSION  # noqa: PLC0415
+            grades_stale = store.get_grades_algo_version() != GRADE_ALGO_VERSION
+
+            if not events_changed and not actions_changed and not grades_stale:
                 return ProjectionResult(events_projected=0, rebuilt=False)
 
             # Project events first (so new findings exist before action events touch them).
@@ -132,9 +141,11 @@ class Projector:
             if actions_log is not None and (actions_changed or events_changed):
                 self._engine.update_actions(actions_log, run_dir, force=events_changed)
 
-            # Grade tables are derived from findings + dismissals. Recompute whenever
-            # either source changed.
-            if events_changed or actions_changed:
+            # Grade tables are derived from findings + dismissals. Recompute
+            # whenever either source changed, or when the stored grades were
+            # computed with an older version of the math (recompute_grades
+            # stamps the current one).
+            if events_changed or actions_changed or grades_stale:
                 from quodeq.data.projection.grade_projector import recompute_grades  # noqa: PLC0415
                 recompute_grades(run_dir)
 

--- a/src/quodeq/data/sqlite/state_store.py
+++ b/src/quodeq/data/sqlite/state_store.py
@@ -20,6 +20,7 @@ _logger = logging.getLogger(__name__)
 _CHECKPOINT_KEY = "projection_checkpoint"
 _PROJECTED_SIZE_KEY = "projection_event_log_size"
 _ACTIONS_SIZE_KEY = "actions_log_projected_size"
+_GRADES_ALGO_KEY = "grades_algo_version"
 
 _INSERT_FINDING = """
 INSERT OR IGNORE INTO findings (
@@ -156,6 +157,31 @@ class SQLiteStateStore:
             conn.execute(
                 "INSERT OR REPLACE INTO run_meta (key, value) VALUES (?, ?)",
                 (_ACTIONS_SIZE_KEY, str(size)),
+            )
+            conn.commit()
+
+    def get_grades_algo_version(self) -> int | None:
+        """Version of the grade math the stored grade tables were computed with.
+
+        None means the tables predate the stamp (or were never computed);
+        callers treat that as stale so pre-stamp DBs heal on first contact.
+        """
+        with self._db() as conn:
+            row = conn.execute(
+                "SELECT value FROM run_meta WHERE key = ?", (_GRADES_ALGO_KEY,)
+            ).fetchone()
+        if row is None:
+            return None
+        try:
+            return int(row[0])
+        except (TypeError, ValueError):
+            return None
+
+    def save_grades_algo_version(self, version: int) -> None:
+        with self._db() as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO run_meta (key, value) VALUES (?, ?)",
+                (_GRADES_ALGO_KEY, str(version)),
             )
             conn.commit()
 

--- a/tests/data/projection/test_ensure_projected.py
+++ b/tests/data/projection/test_ensure_projected.py
@@ -280,3 +280,69 @@ def test_ensure_projected_grade_updates_after_dismiss(tmp_path: Path) -> None:
     # All findings dismissed → no dimension rows.
     assert store.read_dimension_scores() == []
     assert store.read_principle_grades() == []
+
+
+# --- grade-algo version reconciliation ---------------------------------------
+#
+# The grade tables embody the scoring math that computed them. When that math
+# changes (clamp-order fix and successors), a run with untouched logs must
+# still get its grades re-derived once — otherwise the same principle reads
+# one number from SQL-backed screens and another from a fresh rescore.
+
+
+def test_stale_grade_algo_recomputes_once_then_no_ops(tmp_path: Path) -> None:
+    from unittest.mock import patch
+
+    from quodeq.core.scoring.projector_scoring import GRADE_ALGO_VERSION
+    from quodeq.data.sqlite.state_store import SQLiteStateStore
+
+    project_dir = tmp_path / "project"
+    run_dir = project_dir / "r1"
+    run_dir.mkdir(parents=True)
+    events_log = _seed_run_with_finding(run_dir, req="R1", file="a.py", line=10)
+    Projector().ensure_projected(events_log, run_dir, project_dir=project_dir)
+
+    store = SQLiteStateStore(run_dir)
+    assert store.get_grades_algo_version() == GRADE_ALGO_VERSION
+
+    # Simulate a DB graded by older math: same tables, older (or absent) stamp.
+    store.save_grades_algo_version(GRADE_ALGO_VERSION - 1)
+
+    with patch("quodeq.data.projection.grade_projector.recompute_grades") as spy:
+        Projector().ensure_projected(events_log, run_dir, project_dir=project_dir)
+        assert spy.call_count == 1
+
+    # The patched call above didn't restamp; run the real thing once.
+    Projector().ensure_projected(events_log, run_dir, project_dir=project_dir)
+    assert store.get_grades_algo_version() == GRADE_ALGO_VERSION
+
+    # Fresh logs + current stamp → full fast no-op, no recompute.
+    with patch("quodeq.data.projection.grade_projector.recompute_grades") as spy:
+        result = Projector().ensure_projected(events_log, run_dir, project_dir=project_dir)
+        assert result == ProjectionResult(events_projected=0, rebuilt=False)
+        assert spy.call_count == 0
+
+
+def test_pre_stamp_db_heals_on_first_contact(tmp_path: Path) -> None:
+    """A DB projected before the stamp existed (no run_meta key) re-derives grades."""
+    from quodeq.core.scoring.projector_scoring import GRADE_ALGO_VERSION
+    from quodeq.data.sqlite.connection import open_evaluation_db as _open
+    from quodeq.data.sqlite.state_store import SQLiteStateStore
+
+    project_dir = tmp_path / "project"
+    run_dir = project_dir / "r1"
+    run_dir.mkdir(parents=True)
+    events_log = _seed_run_with_finding(run_dir, req="R1", file="a.py", line=10)
+    Projector().ensure_projected(events_log, run_dir, project_dir=project_dir)
+
+    store = SQLiteStateStore(run_dir)
+    # Erase the stamp to reproduce a pre-stamp DB.
+    with _open(run_dir) as conn:
+        conn.execute("DELETE FROM run_meta WHERE key = 'grades_algo_version'")
+        conn.commit()
+    assert store.get_grades_algo_version() is None
+
+    Projector().ensure_projected(events_log, run_dir, project_dir=project_dir)
+
+    assert store.get_grades_algo_version() == GRADE_ALGO_VERSION
+    assert len(store.read_dimension_scores()) == 1

--- a/tests/data/test_projection_di_seams.py
+++ b/tests/data/test_projection_di_seams.py
@@ -37,6 +37,15 @@ class _FakeStore:
     def get_projected_size(self):
         return self.projected_size
 
+    def get_grades_algo_version(self):
+        # Report current so grades_stale stays False — these tests exercise
+        # the event/actions projection seams, not grade reconciliation.
+        from quodeq.core.scoring.projector_scoring import GRADE_ALGO_VERSION
+        return GRADE_ALGO_VERSION
+
+    def save_grades_algo_version(self, version):
+        pass
+
     def record_finding(self, payload):
         self.findings.append(payload)
 

--- a/tests/services/_scalar_fixtures.py
+++ b/tests/services/_scalar_fixtures.py
@@ -5,6 +5,7 @@ Mirrors tests/services/test_scoring_sql_overlay.py::_build_event_log_run.
 import json
 from pathlib import Path
 
+from quodeq.core.scoring.projector_scoring import GRADE_ALGO_VERSION
 from quodeq.data.sqlite.state_store import SQLiteStateStore
 
 
@@ -30,6 +31,10 @@ def build_projected_run(
     (run_dir / "events.jsonl").write_text("")
     store = SQLiteStateStore(run_dir)
     store.save_projected_size((run_dir / "events.jsonl").stat().st_size)
+    # Same freeze for the grade-algo stamp: without it ensure_projected treats
+    # the baked grades as computed-by-older-math and recomputes them — from
+    # this run's zero findings, wiping the very scores the tests bake in.
+    store.save_grades_algo_version(GRADE_ALGO_VERSION)
     for dim, (score, grade) in dims.items():
         store.record_dimension_score(dimension=dim, score=score, grade=grade)
 


### PR DESCRIPTION
## Problem

The clamp-order fix (91335d9e, ceiling beats floor) changed the numbers a rescore produces, but grades already projected into each run's SQLite grade tables kept the old math — the projector had no way to tell "unchanged run" from "run graded by older scoring". Result: the same principle could read 8.0 on a SQL-backed screen and 7.3 from a fresh rescore, and could appear to change spontaneously when a dismiss triggered one.

## Fix

- `GRADE_ALGO_VERSION` lives next to the scoring functions in `core/scoring/projector_scoring.py` (currently 2; 1 is the implicit pre-stamp state). Bump it whenever a change there alters the numbers an already-scanned run would produce — the same pattern as the `algo` salt in `services/score_cache.py`.
- `recompute_grades` stamps the version into `run_meta` on every write.
- `Projector.ensure_projected` treats a missing or older stamp as one more reason to recompute grades. That path is a re-derivation from the already-projected SQL findings (few ms per the grade projector's own docs), no event replay. Pre-stamp DBs heal lazily on first contact.

## Tests

- New: stale stamp recomputes once then fully no-ops; pre-stamp DB (no `run_meta` key) heals on first contact and gets stamped.
- `_scalar_fixtures.build_projected_run` freezes the stamp the same way it already froze `projected_size` (its baked grades have no backing findings, so a recompute would wipe them — synthetic-fixture state only, a real run's grades always coexist with projected findings).
- The DI-seam fake store grew the two new methods.
- Full local run: 2878 passed across data/core/services/api/integration/tools; the one unrelated failure (`tests/ci/test_cli_signals.py::test_normal_completion_writes_done`) reproduces on clean develop locally and is green in CI.