### PR TITLE
feat(dashboard): hand a relaunch to the running window before spawning

### DIFF
--- a/src/quodeq/dashboard/_instance.py
+++ b/src/quodeq/dashboard/_instance.py
@@ -198,18 +198,32 @@ class InstanceController:
 
     def send_reload(self, url: str) -> None:
         """Send a reload command to the running instance."""
+        self._send(f"{_RELOAD_PREFIX}{url}")
+
+    def send_focus(self) -> None:
+        """Ask the running instance to surface the window it already has.
+
+        A relaunch must not hand the running window a *new* URL: the launch
+        that would supply one tears its own API down immediately afterwards,
+        so the window would be sent to a dead server. Encoded as a reload with
+        an empty URL, which older windows discard through their reload-URL
+        guard — a no-op there rather than a broken navigation.
+        """
+        self._send(_RELOAD_PREFIX)
+
+    def _send(self, payload: str) -> None:
         if _IS_WIN32:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(_SOCK_TIMEOUT)
             with sock:
                 sock.connect((_TCP_LOCALHOST, self._tcp_port))
-                sock.sendall(f"{_RELOAD_PREFIX}{url}".encode("utf-8"))
+                sock.sendall(payload.encode("utf-8"))
         else:
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             sock.settimeout(_SOCK_TIMEOUT)
             with sock:
                 self._connect_to_sock(sock)
-                sock.sendall(f"{_RELOAD_PREFIX}{url}".encode("utf-8"))
+                sock.sendall(payload.encode("utf-8"))
 
     def shutdown(self) -> None:
         """Stop listening and clean up.

--- a/src/quodeq/dashboard/_server.py
+++ b/src/quodeq/dashboard/_server.py
@@ -175,9 +175,14 @@ def _serve_native(
     # because it is the only one that can act on a reload. Binding it here
     # would leave the child unable to bind, its listener dead, and every
     # relaunch's reload dropped into a socket nobody reads.
+    # Focus, not send_reload(action_api_url): stop_children below kills the API
+    # that URL names, so handing it to the running window would point it at a
+    # server about to die. It keeps the backend it already has. (The runner's
+    # pre-spawn hand-off normally catches this case before any API exists;
+    # this is the late-race fallback for an instance that appeared since.)
     if instance.probe_existing():
         try:
-            instance.send_reload(action_api_url)
+            instance.send_focus()
         except (ConnectionRefusedError, OSError):
             # The instance answered the probe but died before the send. Fall
             # through and open our own window; its try_acquire clears the

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -857,16 +857,37 @@ def _make_on_reload(window: object) -> "Callable[[str], None]":
 
     Extracted from ``main()`` so the test suite can import and exercise the
     real implementation rather than a hand-rolled duplicate.
+
+    An empty URL is the "focus" case a plain relaunch sends (see
+    InstanceController.send_focus): stay on the page this window already has,
+    reloading it in place so a ``--dev`` relaunch picks up the rebuilt UI, and
+    raise the window either way.
     """
     def _on_reload(new_url: str) -> None:
-        if not _is_safe_reload_url(new_url):
+        if new_url and not _is_safe_reload_url(new_url):
             _logger.warning("Ignoring unsafe reload URL: %s", new_url)
             return
-        window.load_url(new_url)  # type: ignore[union-attr]
+        target = new_url or _current_url(window)
+        if target:
+            window.load_url(target)  # type: ignore[union-attr]
         window.on_top = True  # type: ignore[union-attr]
         window.on_top = False  # type: ignore[union-attr]
 
     return _on_reload
+
+
+def _current_url(window: object) -> str | None:
+    """The window's own URL, or None if the backend won't say.
+
+    Only used to reload in place, so an unavailable URL just means "raise the
+    window without refreshing" — never a reason to fail the focus request.
+    """
+    try:
+        url = window.get_current_url()  # type: ignore[union-attr]
+    except Exception:  # noqa: BLE001 — backend-specific; the window may be mid-teardown
+        _logger.debug("get_current_url failed; focusing without reload", exc_info=True)
+        return None
+    return url if isinstance(url, str) and _is_safe_reload_url(url) else None
 
 
 def _webview_user_agent() -> str:

--- a/src/quodeq/dashboard/runner.py
+++ b/src/quodeq/dashboard/runner.py
@@ -106,6 +106,34 @@ def _start_action_api(
     )
 
 
+def _handed_off_to_running_instance(config: DashboardConfig) -> bool:
+    """Give a relaunch to the window that is already open. True if handled.
+
+    Checked before the API starts, which is the only order that works: the
+    launch used to spawn a second backend, notice the running instance, and
+    terminate that backend on the way out — so the running window was competing
+    with a launch that had already killed a server on its behalf. Nothing is
+    spawned and no PID file is rewritten when this returns True.
+
+    Runs after the UI build so a ``--dev`` relaunch still rebuilds, and the
+    focused window reloads into the fresh bundle it serves.
+    """
+    if not (config.build.use_native and config.build.open_browser):
+        return False  # --browser / --no-open have no window to hand off to
+    from quodeq.dashboard._instance import InstanceController
+
+    instance = InstanceController()
+    if not instance.probe_existing():
+        return False
+    try:
+        instance.send_focus()
+    except (ConnectionRefusedError, OSError):
+        log_warning("Could not reach the running instance — starting a new one")
+        return False
+    log_info("quodeq is already running — brought its window to the front.")
+    return True
+
+
 def _kick_update_check() -> None:
     """Fire a throttled, non-blocking update check. Fail-silent — never delays launch."""
     try:
@@ -130,6 +158,9 @@ def run_dashboard(config: DashboardConfig, env: dict[str, str] | None = None) ->
         environ = os.environ
     if config.build.verbose:
         environ["QUODEQ_VERBOSE"] = "1"
+
+    if _handed_off_to_running_instance(config):
+        return 0
 
     log_info("Starting dashboard...")
     log_info(f"Reports: {config.reports_dir}")

--- a/tests/dashboard/conftest.py
+++ b/tests/dashboard/conftest.py
@@ -1,0 +1,21 @@
+"""Shared isolation for the dashboard suite.
+
+Every test here runs against a throwaway QUODEQ_RUN_DIR. Without it, any
+code path that resolves the default run dir (InstanceController's
+dashboard.sock, the action-API PID file) reaches into the developer's real
+~/.quodeq/run — probing, focusing, or killing whatever quodeq instance is
+live on the machine. That is exactly how running this suite next to an open
+dashboard popped its window to the front and failed
+test_run_dashboard_native_window: the relaunch hand-off probed the real
+socket, found the live instance, and handed the test's launch off to it.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_run_dir(tmp_path_factory, monkeypatch):
+    run_dir = tmp_path_factory.mktemp("quodeq-run")
+    monkeypatch.setenv("QUODEQ_RUN_DIR", str(run_dir))
+    return run_dir

--- a/tests/dashboard/test_dashboard_runner.py
+++ b/tests/dashboard/test_dashboard_runner.py
@@ -221,3 +221,97 @@ def test_run_dashboard_verbose_sets_env(tmp_path: Path, monkeypatch):
     # run_dashboard copies the env dict, so original is not mutated;
     # verify that os.environ is not polluted by verbose=True
     assert os.environ.get("QUODEQ_VERBOSE") != "1"
+
+
+class TestHandoffToRunningInstance:
+    """A relaunch must reach the open window without disturbing its backend.
+
+    The launch used to spawn a second action API, notice the running instance,
+    and terminate that API on the way out — after _kill_stale_action_api had
+    already killed the *running* instance's one. The open window was left with a
+    dead server and an unresolvable loading screen.
+    """
+
+    @staticmethod
+    def _config(tmp_path: Path, **build_overrides) -> DashboardConfig:
+        (tmp_path / "reports").mkdir(exist_ok=True)
+        static_dist = tmp_path / "ui/web/dist"
+        static_dist.mkdir(parents=True, exist_ok=True)
+        (static_dist / "index.html").write_text("ok")
+        build = {"open_browser": True, "no_build": True, "reinstall": False, "use_native": True}
+        build.update(build_overrides)
+        return _make_config(tmp_path, static_dist=static_dist, build=BuildConfig(**build))
+
+    @staticmethod
+    def _patch_launch_path(monkeypatch, instance):
+        """Stub everything past the handoff so a real launch is never attempted."""
+        calls = {"killed": False, "spawned": False}
+
+        def fake_kill(*_a, **_k):
+            calls["killed"] = True
+
+        def fake_ensure(*_a, **_k):
+            calls["spawned"] = True
+            return f"http://127.0.0.1:{_TEST_PORT}", DummyProcess()
+
+        monkeypatch.setattr(runner, "_kill_stale_action_api", fake_kill)
+        monkeypatch.setattr(runner, "_ensure_action_api", fake_ensure)
+        monkeypatch.setattr(runner, "maybe_build_ui", lambda *a, **k: None)
+        monkeypatch.setattr(runner._server_mod, "serve_and_wait", lambda *a, **k: None)
+        monkeypatch.setattr(
+            "quodeq.dashboard._instance.InstanceController", lambda *a, **k: instance,
+        )
+        return calls
+
+    def test_running_instance_is_focused_and_left_alone(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+        instance = MagicMock()
+        instance.probe_existing.return_value = True
+        calls = self._patch_launch_path(monkeypatch, instance)
+
+        config = self._config(tmp_path)
+        monkeypatch.setattr(runner, "maybe_build_ui", lambda *a, **k: config.static_dist)
+
+        assert run_dashboard(config) == 0
+        instance.send_focus.assert_called_once_with()
+        assert calls["killed"] is False, "the running instance's API must survive"
+        assert calls["spawned"] is False, "no second API should be spawned just to kill it"
+
+    def test_cold_start_proceeds_to_launch(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+        instance = MagicMock()
+        instance.probe_existing.return_value = False
+        calls = self._patch_launch_path(monkeypatch, instance)
+
+        config = self._config(tmp_path)
+        monkeypatch.setattr(runner, "maybe_build_ui", lambda *a, **k: config.static_dist)
+
+        assert run_dashboard(config) == 0
+        instance.send_focus.assert_not_called()
+        assert calls["spawned"] is True
+
+    def test_unreachable_instance_falls_back_to_launching(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+        instance = MagicMock()
+        instance.probe_existing.return_value = True
+        instance.send_focus.side_effect = ConnectionRefusedError()
+        calls = self._patch_launch_path(monkeypatch, instance)
+
+        config = self._config(tmp_path)
+        monkeypatch.setattr(runner, "maybe_build_ui", lambda *a, **k: config.static_dist)
+
+        assert run_dashboard(config) == 0
+        assert calls["spawned"] is True
+
+    def test_browser_mode_has_no_window_to_hand_off_to(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+        instance = MagicMock()
+        instance.probe_existing.return_value = True
+        calls = self._patch_launch_path(monkeypatch, instance)
+
+        config = self._config(tmp_path, use_native=False)
+        monkeypatch.setattr(runner, "maybe_build_ui", lambda *a, **k: config.static_dist)
+
+        assert run_dashboard(config) == 0
+        instance.send_focus.assert_not_called()
+        assert calls["spawned"] is True

--- a/tests/dashboard/test_instance_coverage.py
+++ b/tests/dashboard/test_instance_coverage.py
@@ -171,7 +171,11 @@ class TestConnectToSock:
 
 
 class TestDefaultPaths:
-    def test_default_sock_path(self):
+    def test_default_sock_path(self, monkeypatch):
+        # The suite-wide conftest points QUODEQ_RUN_DIR at a tmp dir (so no
+        # dashboard test can reach the developer's live instance); this test
+        # is specifically about the env-less fallback, so drop it again.
+        monkeypatch.delenv("QUODEQ_RUN_DIR", raising=False)
         from quodeq.dashboard._instance import _default_sock_path
         path = _default_sock_path()
         assert path.name == "dashboard.sock"

--- a/tests/dashboard/test_reload_url_guard.py
+++ b/tests/dashboard/test_reload_url_guard.py
@@ -82,3 +82,24 @@ class TestOnReloadGuard:
         on_reload, window = self._make_handler()
         on_reload("file:///etc/passwd")
         window.load_url.assert_not_called()
+
+    def test_focus_reloads_the_window_own_url(self):
+        """The empty-URL focus case reloads in place and never navigates away."""
+        on_reload, window = self._make_handler()
+        window.get_current_url.return_value = "http://127.0.0.1:7863/#/overview"
+        on_reload("")
+        window.load_url.assert_called_once_with("http://127.0.0.1:7863/#/overview")
+
+    def test_focus_still_raises_when_the_url_is_unavailable(self):
+        on_reload, window = self._make_handler()
+        window.get_current_url.side_effect = RuntimeError("no backend yet")
+        on_reload("")
+        window.load_url.assert_not_called()
+        assert window.on_top is False  # raised, then released
+
+    def test_focus_will_not_reload_an_unsafe_current_url(self):
+        """Defence in depth: even self-reported URLs go through the guard."""
+        on_reload, window = self._make_handler()
+        window.get_current_url.return_value = "http://evil.example.com/"
+        on_reload("")
+        window.load_url.assert_not_called()

--- a/tests/dashboard/test_server_coverage.py
+++ b/tests/dashboard/test_server_coverage.py
@@ -221,18 +221,24 @@ class TestServeNative:
 
     @patch("quodeq.dashboard._server._linux_webview_backend_available", return_value=True)
     @patch("quodeq.dashboard._server.subprocess.Popen")
-    def test_send_reload_to_existing(self, mock_popen, mock_backend):
+    def test_focuses_existing_instead_of_retargeting_it(self, mock_popen, mock_backend):
+        """The running window keeps its own backend.
+
+        stop_children kills the API this launch spawned, so sending that URL
+        would hand the window a server about to die.
+        """
         from quodeq.dashboard._server import _serve_native
         mock_instance = MagicMock()
         mock_instance.probe_existing.return_value = True
-        mock_instance.send_reload.return_value = None
+        mock_instance.send_focus.return_value = None
         mock_stop = MagicMock()
 
         with self._fake_webview_ctx(), \
              patch("quodeq.dashboard._instance.InstanceController", return_value=mock_instance):
             _serve_native("http://localhost:8000", MagicMock(), mock_stop)
 
-        mock_instance.send_reload.assert_called_once_with("http://localhost:8000")
+        mock_instance.send_focus.assert_called_once_with()
+        mock_instance.send_reload.assert_not_called()
         mock_stop.assert_called_once()
         mock_popen.assert_not_called()
 
@@ -248,7 +254,7 @@ class TestServeNative:
     @patch("quodeq.dashboard._server.subprocess.Popen")
     @patch("quodeq.dashboard._server.subprocess_cmd", return_value=["quodeq-webview"])
     @pytest.mark.parametrize("failure", [ConnectionRefusedError(), OSError("refused")])
-    def test_reload_failure_opens_own_window(self, mock_cmd, mock_popen, mock_backend, failure):
+    def test_focus_failure_opens_own_window(self, mock_cmd, mock_popen, mock_backend, failure):
         """An instance that answers the probe but dies before the send.
 
         The launch must still produce a window rather than exiting silently —
@@ -257,7 +263,7 @@ class TestServeNative:
         from quodeq.dashboard._server import _serve_native
         mock_instance = MagicMock()
         mock_instance.probe_existing.return_value = True
-        mock_instance.send_reload.side_effect = failure
+        mock_instance.send_focus.side_effect = failure
         mock_instance._sock_path = Path("/tmp/test.sock")
 
         mock_proc = MagicMock()


### PR DESCRIPTION
## Origin

This work was found half-applied in the main checkout with live conflict markers (an uncommitted extension to #1059 whose stash base predated that PR's CI fixes). Rescued as-is onto `wip/dashboard-handoff-rescue` (local branch, markers included), then rebuilt cleanly on current develop here. Only the coherent new pieces were taken; everything #1059 already merged (probe_existing, listener guards, non-owner shutdown) stays as merged.

## What it does

1. **Pre-spawn hand-off** (`runner._handed_off_to_running_instance`): a relaunch probes for a live instance before the API starts. If one answers, it gets focused and the launch exits — nothing spawned, no PID file rewritten. Runs after the UI build so a `--dev` relaunch still rebuilds. `--browser`/`--no-open` launches skip it (no window to hand off to).
2. **Focus, not retarget**: the `_serve_native` late-race fallback sends `send_focus()` (an empty-URL reload) instead of `send_reload(action_api_url)` — `stop_children` kills the API that URL names, so retargeting would point the running window at a dying server.
3. **Window side**: an empty reload URL means "reload your own page in place and come to the front" (`_make_on_reload` + `_current_url`, both under the existing safe-URL guard; older windows discard the empty URL as a no-op).
4. **Test isolation**: a new `tests/dashboard/conftest.py` pins `QUODEQ_RUN_DIR` to a tmp dir for the whole suite. Running these tests next to a live dashboard previously probed the real `dashboard.sock` and focused the developer's actual window (observed while assembling this PR).

## Tests

- New: `test_dashboard_runner.py` (hand-off happy path, probe-miss, focus-failure fallback, --browser skip), `test_reload_url_guard.py` focus cases (reload-in-place, unavailable URL, unsafe self-reported URL).
- Updated: `test_server_coverage.py` reload tests became focus tests (send_reload asserted never called).
- Suite: 247 passed (tests/dashboard + text-IO guard + tools).