### PR TITLE
fix(runs): dry-run marks dimension states done

### DIFF
--- a/src/quodeq/analysis/_pipeline.py
+++ b/src/quodeq/analysis/_pipeline.py
@@ -7,7 +7,12 @@ from datetime import datetime, timedelta, timezone
 
 from quodeq.analysis._dim_estimates import compute_dim_estimates, write_dim_estimates
 from quodeq.analysis._analysis_context import load_analysis_context as _load_ctx
-from quodeq.analysis._loops import run_incremental_loop, run_per_dimension_loop
+from quodeq.analysis._loops import (
+    _run_dir_for,
+    _safe_write_dim_state,
+    run_incremental_loop,
+    run_per_dimension_loop,
+)
 from quodeq.analysis._types import RunConfig, _AnalysisContext
 from quodeq.analysis.dimension_runner import DimensionRunner, _log_dimension_result
 from quodeq.analysis.errors import EvaluationError as EvaluationError  # re-export
@@ -15,6 +20,7 @@ from quodeq.analysis.subagents.runner import process_consolidated_dimensions
 from quodeq.analysis._provider_cache import get_provider_configs
 from quodeq.analysis.subprocess import _get_provider_type
 from quodeq.core.evidence.model import Evidence
+from quodeq.data.fs.dimensions_state_store import DimState
 from quodeq.core.evidence.merge import merge_evidence
 from quodeq.analysis._runner_markers import emit_marker
 from quodeq.shared.logging import log_info, log_warning
@@ -66,7 +72,12 @@ def _run_dry_run(
     result: dict[str, Evidence] = {}
     date_str = datetime.now(timezone.utc).isoformat(timespec="seconds")
     evidence_dir = config.work_dir or config.src
+    run_dir = _run_dir_for(config)
     for idx, dimension in enumerate(dimensions, 1):
+        # Dim states must move to DONE here just like the real loops: the
+        # lifecycle flips anything still pending at exit to INCOMPLETE and
+        # stamps the run exit_reason=incomplete_dimensions.
+        _safe_write_dim_state(run_dir, dimension, DimState.RUNNING)
         log_info(f"→ [{idx}/{ctx.total}] Dry-run: skipping AI call for {dimension}")
         emit_marker("analyzing", dimension=dimension)
         ev = Evidence(
@@ -85,6 +96,7 @@ def _run_dry_run(
             jsonl_path.touch()
         emit_marker("scoring", dimension=dimension)
         result[dimension] = ev
+        _safe_write_dim_state(run_dir, dimension, DimState.DONE)
         if on_dimension_done:
             on_dimension_done(dimension, ev)
     return result

--- a/tests/analysis/test_dry_run.py
+++ b/tests/analysis/test_dry_run.py
@@ -293,6 +293,42 @@ class TestDryRunPipeline:
             jsonl_path = evidence_dir / f"{dim}_evidence.jsonl"
             assert jsonl_path.exists(), f"Expected evidence file {jsonl_path} to exist"
 
+    def test_dim_states_marked_done(self, tmp_path):
+        """Dry-run must close out dim states like the real loops do.
+
+        The lifecycle flips any dim still pending/running at exit to
+        INCOMPLETE and stamps the run exit_reason=incomplete_dimensions.
+        A dry run completes every dimension, so each must end at DONE or
+        the run reads as truncated.
+        """
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        (tmp_path / "evidence").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "src").mkdir(parents=True, exist_ok=True)
+        config = RunConfig(
+            src=tmp_path / "src",
+            language="python",
+            work_dir=tmp_path / "evidence",
+            run_dir=run_dir,
+            dimensions_data=_make_dims_data("security", "reliability"),
+            options=AnalysisOptions(dry_run=True),
+        )
+
+        with patch("quodeq.analysis._pipeline.emit_marker"), \
+             patch("quodeq.analysis._pipeline.load_analysis_context") as mock_ctx:
+            dims = ["security", "reliability"]
+            ctx = MagicMock()
+            ctx.total = 2
+            mock_ctx.return_value = (dims, ctx)
+
+            from quodeq.analysis._pipeline import run_per_dimension
+            run_per_dimension(config)
+
+        from quodeq.data.fs.dimensions_state_store import read_dimensions
+        entries = read_dimensions(run_dir).get("dimensions", {})
+        states = {dim: entry.get("state") for dim, entry in entries.items()}
+        assert states == {"security": "done", "reliability": "done"}
+
     def test_does_not_raise_zero_findings_error(self, tmp_path):
         """Dry-run with source files present must not raise zero-findings EvaluationError."""
         config = RunConfig(


### PR DESCRIPTION
## Problem

Every completed dry-run finalizes as `exit_reason=incomplete_dimensions` instead of a clean done. Regression from df1a6727: the lifecycle now flips any dim still pending at exit to INCOMPLETE, but `_run_dry_run` never wrote dim states. The real loops mark each dim RUNNING then DONE, dry-run skipped that entirely.

It landed silently because the covering test (`tests/ci/test_cli_signals.py::test_normal_completion_writes_done`) only runs in the nightly non-blocking integration lane, red since Aug 5 on both ubuntu and windows. PR CI runs `-m "not integration"`.

## Fix

`_run_dry_run` records RUNNING before and DONE after each dimension, using the same `_safe_write_dim_state` / `_run_dir_for` helpers as the real loops.

New unit test `test_dim_states_marked_done` asserts dry-run dims end at done. Deliberately not integration-marked so the blocking lane guards this contract from now on.

## Verification

- `tests/ci/test_cli_signals.py::test_normal_completion_writes_done` passes again
- `tests/ci -m integration`: 6 passed
- Full non-integration suite: 5873 passed, 13 skipped
- Import-layer baseline unchanged