### PR TITLE
fix(ui): visible feedback while a navigation's target page renders

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -1298,6 +1298,12 @@ export default function App() {
               {!state.serverConnected && (
                 <ServerDisconnectedOverlay onReconnect={() => state.setServerConnected(true)} />
               )}
+              {/* Route pushes render the target page in a transition
+                  (useNavStack); this bar is the feedback while that render
+                  runs. Without it a heavy detail page (or a slow webview
+                  engine) leaves the click looking ignored — there is no
+                  yield point where a spinner could otherwise paint. */}
+              {state.navPending && <div className="nav-pending-bar" aria-hidden="true" />}
               <div className="tab-fade" key={activeTab}>
                 <MainContent activePage={activePage} props={contentProps} />
               </div>

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -70,7 +70,7 @@ function useProjects({ onNoProjects }) {
 
 function useAppNavigation() {
   const [serverConnected, setServerConnected, serverVersion] = useServerHealth();
-  const { navStack, activePage, navPush, navPop, navReplace, navGoTo, navSwapAt, navReset, navTab } = useNavStack();
+  const { navStack, activePage, navPending, navPush, navPop, navReplace, navGoTo, navSwapAt, navReset, navTab } = useNavStack();
   const projectBundle = useProjects({ onNoProjects: () => { /* wizard handles fresh-user UX in App.jsx */ } });
   const { selectedRun, setSelectedRun, handleRunChange } = projectBundle;
   const [historySelectedRun, setHistorySelectedRun] = useState('latest');
@@ -84,7 +84,7 @@ function useAppNavigation() {
     // repositories local/online tabs): history must not grow per flip.
     navReplace({ page, ...params });
   }
-  return { serverConnected, setServerConnected, serverVersion, navStack, activePage, navPush, navPop, navGoTo, navSwapAt, navReset, navTab, projectBundle, handleNavigate, handleNavigateReplace, handleRunChange, historySelectedRun, setHistorySelectedRun };
+  return { serverConnected, setServerConnected, serverVersion, navStack, activePage, navPending, navPush, navPop, navGoTo, navSwapAt, navReset, navTab, projectBundle, handleNavigate, handleNavigateReplace, handleRunChange, historySelectedRun, setHistorySelectedRun };
 }
 
 export function formatDayLabel(trend, currentOverviewRun, dailyRuns, overviewRunIndex) {
@@ -136,7 +136,7 @@ export function useOverviewReturnReconcile({ rootTab, selectedProject, selectedS
 
 export function useAppState() {
   const nav = useAppNavigation();
-  const { serverConnected, setServerConnected, serverVersion, navStack, activePage, navPop, navGoTo, navSwapAt, navReset, navTab, projectBundle, handleNavigate, handleNavigateReplace, handleRunChange, historySelectedRun, setHistorySelectedRun } = nav;
+  const { serverConnected, setServerConnected, serverVersion, navStack, activePage, navPending, navPop, navGoTo, navSwapAt, navReset, navTab, projectBundle, handleNavigate, handleNavigateReplace, handleRunChange, historySelectedRun, setHistorySelectedRun } = nav;
   const {
     projects, projectsLoaded, setProjects, selectedProject, selectedSource,
     selectedRun, setSelectedRun, loadProjects, handleProjectChange,
@@ -183,7 +183,7 @@ export function useAppState() {
   useOverviewReturnReconcile({ rootTab: navStack[0]?.page, selectedProject, selectedSource });
 
   return {
-    serverConnected, setServerConnected, serverVersion, navStack, activePage, navPop, navGoTo, navSwapAt, navTab,
+    serverConnected, setServerConnected, serverVersion, navStack, activePage, navPending, navPop, navGoTo, navSwapAt, navTab,
     projects, projectsLoaded, selectedProject, selectedSource, selectedRun, loadProjects, handleProjectChange, handleNavigate, handleNavigateReplace,
     handleDeleteProject, handleExportProject, handleRelocateProject, handleImportProject,
     dashboard, accumulated, latestAccumulated, rescoreLookup, loading, isFetching, scoresPending, error, availableRuns, dailyRuns: visibleDailyRuns, overviewRunIndex, sharedProjectInfo,

--- a/src/quodeq/ui/src/hooks/useNavStack.js
+++ b/src/quodeq/ui/src/hooks/useNavStack.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useTransition } from 'react';
 
 const DEFAULT_PAGE = 'overview';
 
@@ -53,7 +53,7 @@ function handlePopState(e, setNavStack, entriesByIndex) {
   });
 }
 
-function createNavActions(setNavStack, navStackRef, history, entriesByIndex) {
+function createNavActions(setNavStack, navStackRef, history, entriesByIndex, startNavTransition) {
   function rememberEntry(index, entry) {
     entriesByIndex.set(index, entry);
     // pushState/swap truncated the browser's forward history — entries past
@@ -65,7 +65,16 @@ function createNavActions(setNavStack, navStackRef, history, entriesByIndex) {
 
   function navPush(entry) {
     const next = [...navStackRef.current, entry];
-    setNavStack(next);
+    // Transition, not a plain set: a detail page can take hundreds of ms to
+    // render (pretext layout effects per card, and the WebKit webview is
+    // slower at it than Chromium), and a blocking render freezes the page
+    // with the click seemingly ignored. In a transition React time-slices
+    // the incoming page while the current one stays interactive, and the
+    // exposed navPending drives a visible progress bar — the user feedback
+    // a synchronous render can never paint.
+    startNavTransition(() => {
+      setNavStack(next);
+    });
     rememberEntry(next.length - 1, entry);
     history.pushState({ navIndex: next.length - 1, entry: toHistoryEntry(entry) }, '');
   }
@@ -122,7 +131,11 @@ function createNavActions(setNavStack, navStackRef, history, entriesByIndex) {
     // Spread params first so page/_tabKey stay authoritative and can't be
     // clobbered by a caller-supplied params key.
     const entry = { ...params, page, _tabKey: prevKey + 1 };
-    setNavStack([entry]);
+    // Same transition rationale as navPush: tab targets (Violations on a
+    // large project, the keyed tab-fade remount) render heavy too.
+    startNavTransition(() => {
+      setNavStack([entry]);
+    });
     rememberEntry(0, entry);
     if (stepsBack > 0) history.go(-stepsBack);
   }
@@ -138,18 +151,24 @@ export function useNavStack({ historyAdapter } = {}) {
   // Full entries (object payloads included) by stack index, for forward
   // restores — see toHistoryEntry for why history state can't hold them.
   const entriesByIndexRef = useRef(new Map([[0, { page: DEFAULT_PAGE }]]));
+  // navPending is true while a navigation's target page is still rendering
+  // in a transition — the caller's cue to show progress feedback.
+  const [navPending, startNavTransition] = useTransition();
 
   useEffect(() => {
     history.replaceState({ navIndex: 0, entry: { page: DEFAULT_PAGE } }, '');
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    const handler = (e) => handlePopState(e, setNavStack, entriesByIndexRef.current);
+    // Back/forward render the same heavy pages a push does; same transition.
+    const handler = (e) => startNavTransition(() => {
+      handlePopState(e, setNavStack, entriesByIndexRef.current);
+    });
     window.addEventListener('popstate', handler);
     return () => window.removeEventListener('popstate', handler);
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const { navPush, navPop, navReplace, navGoTo, navSwapAt, navReset, navTab } = createNavActions(setNavStack, navStackRef, history, entriesByIndexRef.current);
+  const { navPush, navPop, navReplace, navGoTo, navSwapAt, navReset, navTab } = createNavActions(setNavStack, navStackRef, history, entriesByIndexRef.current, startNavTransition);
   const activePage = navStack[navStack.length - 1];
 
   useEffect(() => {
@@ -161,5 +180,5 @@ export function useNavStack({ historyAdapter } = {}) {
     else window.scrollTo({ top: 0 });
   }, [activePage]);
 
-  return { navStack, activePage, navPush, navPop, navReplace, navGoTo, navSwapAt, navReset, navTab };
+  return { navStack, activePage, navPending, navPush, navPop, navReplace, navGoTo, navSwapAt, navReset, navTab };
 }

--- a/src/quodeq/ui/src/hooks/useNavStack.test.jsx
+++ b/src/quodeq/ui/src/hooks/useNavStack.test.jsx
@@ -325,6 +325,33 @@ describe('useNavStack navReplace (repositories tab flips must not grow history)'
   });
 });
 
+describe('useNavStack navPending', () => {
+  let historyAdapter;
+
+  beforeEach(() => {
+    historyAdapter = {
+      pushState: vi.fn(),
+      replaceState: vi.fn(),
+      back: vi.fn(),
+      go: vi.fn(),
+    };
+  });
+
+  it('exposes a boolean pending flag that settles false after a push', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+    expect(result.current.navPending).toBe(false);
+
+    act(() => { result.current.navPush({ page: 'evalprinciple' }); });
+
+    // act() flushes the transition; the navigation itself must have landed.
+    expect(result.current.navPending).toBe(false);
+    expect(result.current.navStack.at(-1).page).toBe('evalprinciple');
+  });
+});
+
 describe('useNavStack history-state payload stripping', () => {
   let historyAdapter;
 

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -9,6 +9,42 @@
   to { opacity: 1; }
 }
 
+/* ── Navigation pending bar ─────────────────────────────
+   Shown while a route transition's target page is still rendering
+   (useNavStack navPending). Sits at the top of the content column so a
+   heavy detail page (or a slow webview engine) never leaves a click
+   looking ignored. Fades in late: fast navigations never flash it. */
+.nav-pending-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  overflow: hidden;
+  z-index: 30;
+  pointer-events: none;
+  animation: nav-pending-appear 80ms ease-out 120ms both;
+}
+
+.nav-pending-bar::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  width: 40%;
+  background: var(--color-accent);
+  animation: nav-pending-slide 0.9s ease-in-out infinite;
+}
+
+@keyframes nav-pending-appear {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes nav-pending-slide {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(350%); }
+}
+
 /* ── Dashboard fade transitions ──────────────────────── */
 
 .dashboard-fade {

--- a/src/quodeq/ui/src/styles/dim-gauge-card.css
+++ b/src/quodeq/ui/src/styles/dim-gauge-card.css
@@ -21,6 +21,13 @@
   border-color: var(--color-accent);
 }
 
+/* Instant tactile acknowledgement: the pages a card opens can take a
+   beat to render (nav-pending-bar covers the wait) — the press itself
+   must react in the same frame. */
+.dim-gauge-card:active {
+  background: color-mix(in srgb, var(--color-accent) 8%, var(--color-surface));
+}
+
 /* corner brackets — match other terminal cards */
 .dim-gauge-card::before,
 .dim-gauge-card::after {

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1560,6 +1560,8 @@ button.term-sev-badge--clickable:focus-visible {
   min-width: 0;
   min-height: 0;
   overflow: hidden;
+  /* Anchors the absolutely-positioned .nav-pending-bar to this column. */
+  position: relative;
   /* Isolate the main column's layout + paint from the side-pane subtree
      and topbar so a pane-divider drag doesn't propagate reflow into the
      entire document. The column already clips its own overflow, so


### PR DESCRIPTION
## Problem (reported after #1060/#1063)

Clicking a principle card after the first one gave no feedback: the app "stops, then launches with the data". Measured on the production bundle: the target page's render is a single blocking pass (up to 1.5s on the first click; the native WKWebView is slower at the pretext layout effects than Chromium), and there is no yield point where any spinner could paint. The only loading UI on that path is the lazy-chunk Suspense boundary, which by construction fires once per session — so the first click "shows loading" and every later one looks ignored.

## Fix

Feedback becomes structural instead of accidental:

1. **Route changes render in a React transition** (`navPush`, `navTab`, back/forward in `useNavStack`). The current page stays visible and interactive while the incoming page renders time-sliced.
2. **`navPending` drives a slim indeterminate bar** at the top of the content column. It fades in after 120ms, so fast navigations never flash it.
3. **`.dim-gauge-card:active`** gives the press itself same-frame acknowledgment.

Behavior change worth noting: the first-ever principle click now keeps the current page up with the progress bar instead of dropping to the full-screen LoadingScreen while the lazy chunk loads. Every navigation now gives the same feedback.

## Verified live (isolated backend, real project data)

- The bar mounts during both the slow first click and subsequent clicks, and is gone once the page lands.
- Back/forward and drill-ins work unchanged; no console errors.

## Tests

- New: `navPending` exposure and post-push settling.
- All StrictMode purity tests (pushState/go called exactly once) still pass — the transition wraps only the state update.
- Full vitest suite: 1510 passed.