### PR TITLE
ci: manual dispatch trigger on the four PR-gating workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     # Weekly sweep catches newly published queries against unchanged code.
     - cron: '30 5 * * 1'
+  # Manual escape hatch when event delivery is down, see test.yml.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/enforce-main-source.yml
+++ b/.github/workflows/enforce-main-source.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
+  # Manual escape hatch when event delivery is down, see test.yml. This one
+  # matters most: check-source is the only REQUIRED context on main, so when
+  # no run is ever created the PR shows a lone "Expected - Waiting for status
+  # to be reported" row that nothing can ever satisfy. Dispatch against the
+  # release branch itself; the check run lands on that branch's head commit,
+  # which is the PR head.
+  workflow_dispatch:
 
 jobs:
   check-source:
@@ -13,8 +20,11 @@ jobs:
         # SOURCE is passed via env (not ${{ }} interpolation) so bash treats
         # the branch name as data — prevents script injection if a branch
         # name contains shell metacharacters.
+        # head_ref is set only for pull_request events; on a manual dispatch it
+        # is empty, which would fail the check against its own escape hatch.
+        # ref_name is the dispatched branch, so the same rule still applies.
         env:
-          SOURCE: ${{ github.head_ref }}
+          SOURCE: ${{ github.head_ref || github.ref_name }}
         run: |
           if [ "$SOURCE" = "develop" ] || [[ "$SOURCE" == release/* ]]; then
             echo "Source branch '$SOURCE' is allowed. OK."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,13 @@ on:
     branches: [develop, main]
   push:
     branches: [develop]
+  # Manual escape hatch. On 2026-08-06 a GitHub incident stopped delivering
+  # pull_request/push events to Actions: runs were never created, so a PR sat
+  # with zero checks and no way to produce them. Run creation and the runners
+  # themselves were fine, only event delivery was down. workflow_dispatch goes
+  # through the API instead of the event pipeline, and its check runs attach to
+  # the dispatched ref's head commit, which is where branch protection looks.
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -22,6 +22,10 @@ on:
       - '.github/workflows/wheel-smoke.yml'
   push:
     branches: [develop, main]
+  # Manual escape hatch when event delivery is down, see test.yml. Note
+  # workflow_dispatch ignores the paths filter above, so a manual run always
+  # builds the wheel rather than deciding it has nothing to do.
+  workflow_dispatch:
 
 jobs:
   smoke:


### PR DESCRIPTION
Adds `workflow_dispatch:` to Tests, CodeQL, Wheel smoke test and Enforce main source branch, so CI can be run by hand when GitHub is not delivering `pull_request`/`push` events.

## Why

During today's Actions incident, PR #1068 sat with **zero** check runs. Diagnosis:

| Trigger attempted | Result |
| --- | --- |
| PR opened | no runs created |
| Close + reopen | no runs created |
| Empty commit (`synchronize`) | no runs created |
| **Manual API dispatch** | **run created, runner picked it up, job completed** |

So run creation and the runners were both healthy. Only event delivery was down, which matches the incident's "webhook deliveries may be delayed" note.

The symptom is nastier than slow CI. Tests, CodeQL and wheel-smoke are not required contexts, so with no run created they do not render on the PR at all. The only visible row is `check-source` stuck at `Expected - Waiting for status to be reported`, which branch protection draws from the rule itself rather than from a job. Nothing on the repo side can satisfy it, and the PR reads as misconfigured when it is fine.

`workflow_dispatch` goes through the API instead of the event pipeline, and its check runs attach to the dispatched ref's head commit, which is where branch protection looks. Confirmed empirically: dispatching a workflow against `release/v1.9.0` moved that PR's `check-runs` count from 0 to 2.

## Behavioral change worth reviewing

`enforce-main-source.yml` read `${{ github.head_ref }}`, which is populated **only** for `pull_request` events. A dispatched run would have evaluated an empty branch name and failed its own escape hatch. It now reads `${{ github.head_ref || github.ref_name }}`. On a PR the value is unchanged; on a dispatch it is the dispatched branch, so the develop-or-release rule still applies. The env-var indirection that keeps branch names out of shell interpolation is untouched.

`wheel-smoke.yml` has a `paths:` filter, which `workflow_dispatch` ignores, so a manual run always builds rather than deciding it has nothing to do. Noted in a comment.

## Verification

`actionlint` locally: **0 errors across 15 workflows**. Note that CI on this PR will itself be empty until event delivery recovers, which is precisely the problem being fixed.