### PR TITLE
fix: startup hang after upgrade (spinner forever, duplicated cache recompute)

### DIFF
--- a/src/quodeq/services/_projects_cache.py
+++ b/src/quodeq/services/_projects_cache.py
@@ -7,6 +7,7 @@ to the camelCase wire shape happens at the route.
 """
 from __future__ import annotations
 
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -27,17 +28,26 @@ class ProjectsCache:
         self._ttl_s = ttl_s
         self._payload: dict[str, Any] | None = None
         self._stamp: float = 0.0
+        self._lock = threading.Lock()
 
     def list(self, reports_dir: str) -> dict[str, Any]:
         if self._is_fresh():
             return self._payload  # type: ignore[return-value]
-        projects = _fs_projects.build_project_list(Path(reports_dir))
-        # Entities, not wire dicts: the route serializes per request (WS6).
-        # The cached part is the expensive disk walk; camelCase mapping is
-        # cheap and belongs at the boundary.
-        self._payload = {"projects": projects}
-        self._stamp = time.monotonic()
-        return self._payload
+        # Single-flight: requests racing a cold cache wait for the one build
+        # in progress instead of each starting their own. The client retries
+        # a slow startup request, and the build can take minutes right after
+        # an upgrade invalidates the score caches — without this lock those
+        # retries multiplied the whole recompute.
+        with self._lock:
+            if self._is_fresh():
+                return self._payload  # type: ignore[return-value]
+            projects = _fs_projects.build_project_list(Path(reports_dir))
+            # Entities, not wire dicts: the route serializes per request (WS6).
+            # The cached part is the expensive disk walk; camelCase mapping is
+            # cheap and belongs at the boundary.
+            self._payload = {"projects": projects}
+            self._stamp = time.monotonic()
+            return self._payload
 
     def invalidate(self) -> None:
         """Drop the cached payload; next ``list`` call re-reads from disk."""

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import logging
 import sqlite3
+import threading
 from contextlib import contextmanager
 from contextvars import ContextVar
 from pathlib import Path
@@ -137,18 +138,27 @@ def _init(path: Path) -> sqlite3.Connection:
     return conn
 
 
+# Serializes _init (and the corrupt-db rebuild). Concurrent first-opens of a
+# fresh DB race the schema DDL; the loser's lock error is indistinguishable
+# from corruption here, so the rebuild path would unlink the file out from
+# under the winner's live WAL connection (observed as a SIGBUS on the mmap'd
+# -shm). Only open/rebuild is serialized — yielded connections stay concurrent.
+_OPEN_LOCK = threading.Lock()
+
+
 @contextmanager
 def open_score_cache() -> Iterator[sqlite3.Connection]:
     """Open the score cache DB (WAL). Rebuilds from scratch if corrupt/older-schema."""
     override = _CACHE_PATH_OVERRIDE.get()
     path = Path(override) if override else Path(get_score_cache_path())
     path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        conn = _init(path)
-    except sqlite3.DatabaseError:
-        _logger.warning("score cache at %s unreadable; rebuilding", path)
-        path.unlink(missing_ok=True)
-        conn = _init(path)
+    with _OPEN_LOCK:
+        try:
+            conn = _init(path)
+        except sqlite3.DatabaseError:
+            _logger.warning("score cache at %s unreadable; rebuilding", path)
+            path.unlink(missing_ok=True)
+            conn = _init(path)
     try:
         yield conn
     finally:
@@ -429,6 +439,31 @@ def per_run_versions(
     return out
 
 
+# In-flight computes by (kind, project, version). Concurrent misses on the
+# same key must share ONE compute: these computes walk a project's full run
+# history and can take minutes right after an upgrade invalidates every
+# cached row, and the client re-requests while the first compute is still
+# running. The registry entry is dropped once no thread holds the key's lock;
+# a waiter that raced the cleanup at worst recomputes (idempotent write).
+_INFLIGHT_GUARD = threading.Lock()
+_INFLIGHT: dict[tuple[str, str, str], threading.Lock] = {}
+
+
+@contextmanager
+def _single_flight(kind: str, project: str, version: str) -> Iterator[None]:
+    key = (kind, project, version)
+    with _INFLIGHT_GUARD:
+        lock = _INFLIGHT.setdefault(key, threading.Lock())
+    lock.acquire()
+    try:
+        yield
+    finally:
+        lock.release()
+        with _INFLIGHT_GUARD:
+            if not lock.locked() and _INFLIGHT.get(key) is lock:
+                del _INFLIGHT[key]
+
+
 def cached_accumulated(
     project: str, version: str, compute: Callable[[], dict],
     cacheable: Callable[[dict], bool] | None = None,
@@ -437,6 +472,7 @@ def cached_accumulated(
 
     Hit -> return the deserialized cached payload. Miss (or kill switch / cache
     error) -> call *compute*, cache the result best-effort, return it.
+    Concurrent misses on one (project, version) share a single compute.
 
     *cacheable*, when given, is called with the computed result before it is
     persisted; returning False serves the result without caching it. This lets
@@ -453,15 +489,24 @@ def cached_accumulated(
             return cached
     except sqlite3.Error:
         return compute()
-    result = compute()
-    if cacheable is not None and not cacheable(result):
+    with _single_flight("accumulated", project, version):
+        # Re-check: a caller we waited on may have computed and cached it.
+        try:
+            with open_score_cache() as conn:
+                cached = read_cached_accumulated(conn, project, version)
+            if cached is not None:
+                return cached
+        except sqlite3.Error:
+            pass
+        result = compute()
+        if cacheable is not None and not cacheable(result):
+            return result
+        try:
+            with open_score_cache() as conn:
+                write_cached_accumulated(conn, project, version, result)
+        except sqlite3.Error:
+            pass
         return result
-    try:
-        with open_score_cache() as conn:
-            write_cached_accumulated(conn, project, version, result)
-    except sqlite3.Error:
-        pass
-    return result
 
 
 def read_cached_project_summary(
@@ -515,13 +560,22 @@ def cached_project_summary(
             return hit
     except sqlite3.Error:
         return compute()
-    result = compute()
-    try:
-        with open_score_cache() as conn:
-            write_cached_project_summary(conn, project, version, result)
-    except sqlite3.Error:
-        pass
-    return result
+    with _single_flight("summary", project, version):
+        # Re-check: a caller we waited on may have computed and cached it.
+        try:
+            with open_score_cache() as conn:
+                hit = read_cached_project_summary(conn, project, version)
+            if hit is not None:
+                return hit
+        except sqlite3.Error:
+            pass
+        result = compute()
+        try:
+            with open_score_cache() as conn:
+                write_cached_project_summary(conn, project, version, result)
+        except sqlite3.Error:
+            pass
+        return result
 
 
 def make_cache_backed_fetcher(

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -18,6 +18,7 @@ const ViolationsPage = lazy(() => import('./features/violations/components/Viola
 const MapPage = lazy(() => import('./features/map/components/MapPage.jsx'));
 const HelpPage = lazy(() => import('./features/help/components/HelpPage.jsx'));
 const OnboardingWizard = lazy(() => import('./features/onboarding/components/OnboardingWizard.jsx'));
+import EmptyState from './components/EmptyState.jsx';
 import EmptyStateWithTour from './features/onboarding/components/EmptyStateWithTour.jsx';
 import ServerDisconnectedOverlay from './components/ServerDisconnectedOverlay.jsx';
 import { useQueryClient } from '@tanstack/react-query';
@@ -287,6 +288,8 @@ export function buildDashboardDataBundle({ state, sharedHasContent = false }) {
   return {
     selectedProject: state.selectedProject, selectedSource: state.selectedSource, selectedRun: state.selectedRun, projects: state.projects,
     projectsLoaded: state.projectsLoaded,
+    projectsLoadFailed: state.projectsLoadFailed,
+    onProjectsRetry: state.retryLoadProjects,
     dashboard: state.dashboard, accumulated: state.accumulated, latestAccumulated: state.latestAccumulated, loading: state.loading, isFetching: state.isFetching, error: state.error,
     onRetry: state.refreshDashboardActive,
     scoresPending: state.scoresPending,
@@ -302,6 +305,8 @@ export function buildNavigationBundle({ state, navTab, navStackLength, isEvaluat
   return {
     selectedProject: state.selectedProject, selectedSource: state.selectedSource, selectedRun: state.selectedRun, projects: state.projects,
     projectsLoaded: state.projectsLoaded,
+    projectsLoadFailed: state.projectsLoadFailed,
+    retryLoadProjects: state.retryLoadProjects,
     loadProjects: state.loadProjects,
     handleNavigate: state.handleNavigate, handleNavigateReplace: state.handleNavigateReplace, handleRunSelect: state.handleRunSelect,
     handleProjectChange: state.handleProjectChange, navTab, navStackLength,
@@ -599,7 +604,7 @@ function ViolationsRoute({ params, props }) {
 // ROUTE_RENDERERS.file(params, props) just builds the React element tree; it
 // doesn't render, so the returned element's props can be asserted on directly.
 export const ROUTE_RENDERERS = {
-  overview: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate, onRunSelect: props.navigation.handleRunSelect, onProjectsReload: props.navigation.loadProjects, onRetry: props.dashboardData.onRetry }} runMode={false} />,
+  overview: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate, onRunSelect: props.navigation.handleRunSelect, onProjectsReload: props.navigation.loadProjects, onRetry: props.dashboardData.onRetry, onProjectsRetry: props.dashboardData.onProjectsRetry }} runMode={false} />,
   violations: (params, props) => <ViolationsRoute params={params} props={props} />,
   map: (params, props) => {
     const acc = props.dashboardData.latestAccumulated || props.dashboardData.accumulated;
@@ -622,7 +627,7 @@ export const ROUTE_RENDERERS = {
       tabKey={params._tabKey || 0}
     />;
   },
-  run: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate, onRetry: props.dashboardData.onRetry }} runMode={true} />,
+  run: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate, onRetry: props.dashboardData.onRetry, onProjectsRetry: props.dashboardData.onProjectsRetry }} runMode={true} />,
   history: (params, props) => {
     const trend = props.dashboardData.dashboard?.trend || [];
     const runs = props.dashboardData.availableRuns || [];
@@ -844,7 +849,21 @@ export function buildAssistantActionAppliedHandler({
 function MainContent({ activePage, props }) {
   const { page, ...params } = activePage;
   if (shouldWallEmptyProjects({ page, projects: props.navigation?.projects, selectedSource: props.navigation?.selectedSource })) {
-    if (!props.navigation?.projectsLoaded) return <LoadingScreen />;
+    if (!props.navigation?.projectsLoaded) {
+      // Mirror of DashboardPage's gate: a failed startup load must offer a
+      // retry instead of an unrecoverable fullscreen spinner.
+      if (props.navigation?.projectsLoadFailed) {
+        return (
+          <EmptyState
+            title={t('overview.projectsLoadFailedTitle')}
+            description={t('overview.projectsLoadFailedDesc')}
+            actionLabel={t('overview.retry')}
+            onAction={() => props.navigation.retryLoadProjects?.()}
+          />
+        );
+      }
+      return <LoadingScreen />;
+    }
     return (
       <EmptyStateWithTour
         onAdd={() => props.navigation.onAddProject()}

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -887,3 +887,44 @@ describe('history route onRunDeleted wiring', () => {
     expect(props.scheduleDashboardReconcile).toHaveBeenCalledTimes(1);
   });
 });
+
+// v1.9.0 startup-spinner regression: the failure state and its retry action
+// must survive both explicit bundle whitelists (see buildDashboardDataBundle's
+// docstring -- an unforwarded field silently arrives as undefined and the
+// feature never activates).
+describe('projects-load failure threading', () => {
+  it('buildDashboardDataBundle forwards projectsLoadFailed and the retry action', () => {
+    const state = { projectsLoadFailed: true, retryLoadProjects: vi.fn() };
+    const bundle = buildDashboardDataBundle({ state });
+    expect(bundle.projectsLoadFailed).toBe(true);
+    expect(bundle.onProjectsRetry).toBe(state.retryLoadProjects);
+  });
+
+  it('buildNavigationBundle forwards projectsLoadFailed and retryLoadProjects', () => {
+    const state = { projectsLoadFailed: true, retryLoadProjects: vi.fn() };
+    const bundle = buildNavigationBundle({
+      state, navTab: vi.fn(), navStackLength: 1, isEvaluating: false,
+      showToast: vi.fn(), setWizardEntry: vi.fn(),
+    });
+    expect(bundle.projectsLoadFailed).toBe(true);
+    expect(bundle.retryLoadProjects).toBe(state.retryLoadProjects);
+  });
+
+  it('the overview route threads onProjectsRetry into DashboardPage callbacks', () => {
+    const props = {
+      dashboardData: { projectsLoaded: false, projectsLoadFailed: true, onProjectsRetry: vi.fn() },
+      navigation: { handleNavigate: vi.fn(), handleRunSelect: vi.fn(), loadProjects: vi.fn() },
+    };
+    const el = ROUTE_RENDERERS.overview({}, props);
+    expect(el.props.callbacks.onProjectsRetry).toBe(props.dashboardData.onProjectsRetry);
+  });
+
+  it('the run route threads onProjectsRetry into DashboardPage callbacks', () => {
+    const props = {
+      dashboardData: { projectsLoaded: false, projectsLoadFailed: true, onProjectsRetry: vi.fn() },
+      navigation: { handleNavigate: vi.fn() },
+    };
+    const el = ROUTE_RENDERERS.run({}, props);
+    expect(el.props.callbacks.onProjectsRetry).toBe(props.dashboardData.onProjectsRetry);
+  });
+});

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -37,9 +37,16 @@ export function getHealth() {
 
 // ── Projects ────────────────────────────────────────────────────────────
 
+// First startup after an upgrade can invalidate the backend's score caches,
+// making the first /projects response take minutes, not seconds. The default
+// 30s abort turned that into an abandon-and-re-request loop that multiplied
+// the backend's recompute; the server single-flights the build now, and this
+// wider window lets one request wait it out instead of churning.
+const PROJECTS_LIST_TIMEOUT_MS = 120000;
+
 /** @returns {Promise<import('../models/project.js').Project[]>} */
 export async function listProjects() {
-  const data = await request('/projects');
+  const data = await request('/projects', { timeout: PROJECTS_LIST_TIMEOUT_MS });
   const list = data?.projects ?? data ?? [];
   return Array.isArray(list) ? list.map(createProject) : [];
 }

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -291,8 +291,25 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
     setNoRunsEmptySticky({ scopeKey: noRunsScopeKey, active: showNoRunsEmpty });
   }
 
-  const { projectsLoaded } = data;
-  if (!projectsLoaded) return <LoadingScreen />;
+  const { projectsLoaded, projectsLoadFailed } = data;
+  if (!projectsLoaded) {
+    // The startup projects load exhausted its retries: offer a retry instead
+    // of an unrecoverable spinner (this early return sits above every other
+    // error branch, so without this the page spins forever even after the
+    // backend recovered). No hooks in either branch — the hook count across
+    // the false -> true flip is pinned by tests.
+    if (projectsLoadFailed) {
+      return (
+        <EmptyState
+          title={t('overview.projectsLoadFailedTitle')}
+          description={t('overview.projectsLoadFailedDesc')}
+          actionLabel={t('overview.retry')}
+          onAction={() => callbacks.onProjectsRetry?.()}
+        />
+      );
+    }
+    return <LoadingScreen />;
+  }
   if (projects.length === 0 && selectedSource !== 'shared') {
     // Zero local projects. When the connected shared repo has published
     // content, the useful next step is browsing it (read-only until pulled)

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -905,3 +905,42 @@ describe('selectDashboardProjectInfo', () => {
     expect(info).toBeNull();
   });
 });
+
+// v1.9.0 regression: when the startup projects fetch exhausted its retries the
+// page sat on the fullscreen LoadingScreen forever -- projectsLoaded stayed
+// false with no error branch above this gate and nothing left to re-fire the
+// load. The gate must surface a retry instead of an unrecoverable spinner.
+describe('projects-load failure gate (startup infinite spinner)', () => {
+  it('renders a retry action instead of a LoadingScreen when the projects load failed', () => {
+    const onProjectsRetry = vi.fn();
+    const { container } = render(
+      <DashboardPage
+        data={{ projectsLoaded: false, projectsLoadFailed: true }}
+        callbacks={{ onProjectsRetry }}
+        runMode={false}
+      />,
+    );
+    expect(container.querySelector('.loading-screen')).toBeNull();
+    const btn = container.querySelector('.empty-state-btn');
+    expect(btn).toBeTruthy();
+    fireEvent.click(btn);
+    expect(onProjectsRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the LoadingScreen while the load is still in flight (not failed)', () => {
+    const { container } = render(
+      <DashboardPage data={{ projectsLoaded: false, projectsLoadFailed: false }} callbacks={{}} runMode={false} />,
+    );
+    expect(container.querySelector('.loading-screen')).toBeTruthy();
+    expect(container.querySelector('.empty-state-btn')).toBeNull();
+  });
+
+  it('does not change hook count across the failed -> loaded transition', () => {
+    const { rerender } = render(
+      <DashboardPage data={{ projectsLoaded: false, projectsLoadFailed: true }} callbacks={{}} runMode={false} />,
+    );
+    expect(() => {
+      rerender(<DashboardPage data={overviewLoading} callbacks={{}} runMode={false} />);
+    }).not.toThrow();
+  });
+});

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -72,6 +72,18 @@ function useAppNavigation() {
   const [serverConnected, setServerConnected, serverVersion] = useServerHealth();
   const { navStack, activePage, navPending, navPush, navPop, navReplace, navGoTo, navSwapAt, navReset, navTab } = useNavStack();
   const projectBundle = useProjects({ onNoProjects: () => { /* wizard handles fresh-user UX in App.jsx */ } });
+  // Re-arm a failed projects load when connectivity returns. Without this the
+  // manual Retry button is the only way out of the startup failure state after
+  // the backend comes back (the health poll recovers on its own; the projects
+  // load, a one-shot effect, does not).
+  const prevConnectedRef = useRef(serverConnected);
+  useEffect(() => {
+    const wasConnected = prevConnectedRef.current;
+    prevConnectedRef.current = serverConnected;
+    if (serverConnected && !wasConnected && projectBundle.projectsLoadFailed) {
+      projectBundle.retryLoadProjects();
+    }
+  }, [serverConnected]); // eslint-disable-line react-hooks/exhaustive-deps
   const { selectedRun, setSelectedRun, handleRunChange } = projectBundle;
   const [historySelectedRun, setHistorySelectedRun] = useState('latest');
   function handleNavigate(page, params = {}) {
@@ -138,7 +150,7 @@ export function useAppState() {
   const nav = useAppNavigation();
   const { serverConnected, setServerConnected, serverVersion, navStack, activePage, navPending, navPop, navGoTo, navSwapAt, navReset, navTab, projectBundle, handleNavigate, handleNavigateReplace, handleRunChange, historySelectedRun, setHistorySelectedRun } = nav;
   const {
-    projects, projectsLoaded, setProjects, selectedProject, selectedSource,
+    projects, projectsLoaded, projectsLoadFailed, retryLoadProjects, setProjects, selectedProject, selectedSource,
     selectedRun, setSelectedRun, loadProjects, handleProjectChange,
     selectProjectAndRun, handleDeleteProject, handleExportProject, handleRelocateProject, handleImportProject,
   } = projectBundle;
@@ -184,7 +196,7 @@ export function useAppState() {
 
   return {
     serverConnected, setServerConnected, serverVersion, navStack, activePage, navPending, navPop, navGoTo, navSwapAt, navTab,
-    projects, projectsLoaded, selectedProject, selectedSource, selectedRun, loadProjects, handleProjectChange, handleNavigate, handleNavigateReplace,
+    projects, projectsLoaded, projectsLoadFailed, retryLoadProjects, selectedProject, selectedSource, selectedRun, loadProjects, handleProjectChange, handleNavigate, handleNavigateReplace,
     handleDeleteProject, handleExportProject, handleRelocateProject, handleImportProject,
     dashboard, accumulated, latestAccumulated, rescoreLookup, loading, isFetching, scoresPending, error, availableRuns, dailyRuns: visibleDailyRuns, overviewRunIndex, sharedProjectInfo,
     currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect, prefetchHandlers,

--- a/src/quodeq/ui/src/hooks/useAppState.test.jsx
+++ b/src/quodeq/ui/src/hooks/useAppState.test.jsx
@@ -22,8 +22,11 @@ vi.mock('../features/evaluation/hooks/useEvaluation.js', () => ({
   useEvaluation: () => evaluationState,
   LOCAL_API_PROVIDERS: new Set(['ollama', 'llamacpp', 'omlx']),
 }));
+// Mutable so the reconnect re-arm regression below can flip connectivity;
+// defaults to connected for every other test.
+const healthState = { connected: true };
 vi.mock('./useServerHealth.js', () => ({
-  useServerHealth: () => [true, vi.fn(), null],
+  useServerHealth: () => [healthState.connected, vi.fn(), null],
 }));
 
 // Task 2 (stacked on Task 1's scheduleDashboardReconcile): the Overview's
@@ -410,5 +413,50 @@ describe('useAppState eval-completion: single refetch path (P5-T1)', () => {
     await waitFor(() => expect(fakeApi.getProjectScores.mock.calls.length).toBeGreaterThan(scoresCallsBefore));
     await waitFor(() => expect(result.current.accumulated).toEqual({ score: 95 }));
     await waitFor(() => expect(result.current.availableRuns.some((r) => r.runId === 'run-2')).toBe(true));
+  });
+});
+
+// v1.9.0 startup-spinner regression, third recovery lane: if the projects load
+// exhausted its retries while the backend was unreachable, a later reconnect
+// (health poll coming back) must re-fire the load -- otherwise the only way
+// out is the manual Retry button.
+describe('useAppState projects-load re-arm on server reconnect', () => {
+  beforeEach(() => {
+    evaluationState.job = null;
+    healthState.connected = true;
+    localStorage.setItem('quodeq_selected_project', 'project-a');
+    localStorage.setItem('quodeq_selected_source', 'local');
+  });
+  afterEach(() => {
+    healthState.connected = true;
+    localStorage.removeItem('quodeq_selected_project');
+    localStorage.removeItem('quodeq_selected_source');
+  });
+
+  it('reloads the project list when connectivity returns after the load failed', async () => {
+    const fakeApi = makeAppStateFakeApi();
+    fakeApi.listProjects.mockRejectedValue(new Error('backend still starting'));
+    healthState.connected = false;
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+    });
+    const { result, rerender } = renderHook(() => useAppState(), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={client}>
+          <ApiProvider value={fakeApi}>{children}</ApiProvider>
+        </QueryClientProvider>
+      ),
+    });
+
+    await waitFor(() => expect(result.current.projectsLoadFailed).toBe(true), { timeout: 5000 });
+    const callsWhileDown = fakeApi.listProjects.mock.calls.length;
+
+    fakeApi.listProjects.mockResolvedValue([{ id: 'project-a', name: 'Project A' }]);
+    healthState.connected = true;
+    rerender();
+
+    await waitFor(() => expect(result.current.projectsLoaded).toBe(true), { timeout: 5000 });
+    expect(fakeApi.listProjects.mock.calls.length).toBeGreaterThan(callsWhileDown);
+    expect(result.current.projectsLoadFailed).toBe(false);
   });
 });

--- a/src/quodeq/ui/src/hooks/useProjectState.js
+++ b/src/quodeq/ui/src/hooks/useProjectState.js
@@ -74,6 +74,7 @@ export function useProjectState({
   const { listProjects } = useApi();
   const [projects, setProjects] = useState([]);
   const [projectsLoaded, setProjectsLoaded] = useState(false);
+  const [projectsLoadFailed, setProjectsLoadFailed] = useState(false);
   const [selectedProject, setSelectedProject] = useState(() => readStoredProject(storage));
   const [selectedSource, setSelectedSource] = useState(() => readStoredSource(storage));
   const [selectedRun, setSelectedRun] = useState(DEFAULT_RUN);
@@ -82,10 +83,13 @@ export function useProjectState({
   // during a startup/reload race) must NOT be mistaken for "no projects" —
   // that used to strand the user in the onboarding wizard even though their
   // projects were fine. Retry a few times; on genuine exhaustion return null
-  // so the caller skips onboarding and the app keeps its loading state (which
-  // recovers on the next successful load / reconnect). A successful fetch that
-  // returns an empty array is still a real "fresh user" -> onboarding.
+  // so the caller skips onboarding, and raise projectsLoadFailed so the UI
+  // can offer a retry instead of spinning forever (retries used to exhaust
+  // silently, leaving a permanent LoadingScreen even after the backend
+  // recovered). A successful fetch that returns an empty array is still a
+  // real "fresh user" -> onboarding.
   const loadProjects = useCallback(function load(attempt = 0) {
+    if (attempt === 0) setProjectsLoadFailed(false);
     return listProjects()
       .then((data) => {
         const list = Array.isArray(data) ? data : (data?.projects || []);
@@ -99,9 +103,20 @@ export function useProjectState({
             .then(() => load(attempt + 1));
         }
         console.warn('Failed to load projects after retries:', err);
+        setProjectsLoadFailed(true);
         return null;
       });
   }, [listProjects, maxRetries, retryDelayMs]);
+
+  // Same load + boot-time selection resolution as the mount effect, for the
+  // failure-state Retry action (and the reconnect re-arm): a retry that
+  // succeeds must also migrate a stale stored selection, exactly like boot.
+  function retryLoadProjects() {
+    return loadProjects().then((list) => {
+      if (list) resolveInitialProject(list, selectedProject, selectedSource, handleProjectChange, onNoProjects, storage);
+      return list;
+    });
+  }
 
   useEffect(() => {
     loadProjects().then((list) => {
@@ -128,6 +143,8 @@ export function useProjectState({
   return {
     projects,
     projectsLoaded,
+    projectsLoadFailed,
+    retryLoadProjects,
     setProjects,
     selectedProject,
     selectedSource,

--- a/src/quodeq/ui/src/hooks/useProjectState.test.jsx
+++ b/src/quodeq/ui/src/hooks/useProjectState.test.jsx
@@ -55,6 +55,45 @@ describe('useProjectState — resilience to a transient projects-fetch failure',
   });
 });
 
+describe('useProjectState — recoverable failure state (v1.9.0 infinite spinner)', () => {
+  it('exposes projectsLoadFailed=true after retries exhaust', async () => {
+    listProjects.mockRejectedValue(new DOMException('aborted', 'AbortError'));
+    const { result } = renderHook(() =>
+      useProjectState({ onNoProjects: vi.fn(), storage: noStorage, retryDelayMs: 0, maxRetries: 1 }));
+
+    await waitFor(() => expect(result.current.projectsLoadFailed).toBe(true));
+    expect(result.current.projectsLoaded).toBe(false);
+  });
+
+  it('retryLoadProjects clears the failure, reloads, and resolves the initial selection', async () => {
+    listProjects.mockRejectedValue(new DOMException('aborted', 'AbortError'));
+    const { result } = renderHook(() =>
+      useProjectState({ onNoProjects: vi.fn(), storage: noStorage, retryDelayMs: 0, maxRetries: 0 }));
+
+    await waitFor(() => expect(result.current.projectsLoadFailed).toBe(true));
+
+    listProjects.mockResolvedValue([{ id: 'p1', name: 'proj1' }]);
+    await act(async () => { await result.current.retryLoadProjects(); });
+
+    expect(result.current.projectsLoaded).toBe(true);
+    expect(result.current.projectsLoadFailed).toBe(false);
+    expect(result.current.selectedProject).toBe('p1');
+  });
+
+  it('a failed retry raises the failure flag again', async () => {
+    listProjects.mockRejectedValue(new DOMException('aborted', 'AbortError'));
+    const { result } = renderHook(() =>
+      useProjectState({ onNoProjects: vi.fn(), storage: noStorage, retryDelayMs: 0, maxRetries: 0 }));
+
+    await waitFor(() => expect(result.current.projectsLoadFailed).toBe(true));
+
+    await act(async () => { await result.current.retryLoadProjects(); });
+
+    expect(result.current.projectsLoadFailed).toBe(true);
+    expect(result.current.projectsLoaded).toBe(false);
+  });
+});
+
 function makeMemoryStorage(initial = {}) {
   const store = { ...initial };
   return {

--- a/src/quodeq/ui/src/strings/en.json
+++ b/src/quodeq/ui/src/strings/en.json
@@ -668,6 +668,8 @@
   "overview.lastEvaluated": "last_evaluated · {date}",
   "overview.loadFailed": "Failed to load dashboard data. Please try again.",
   "overview.loadProjectFailedTitle": "Couldn't load this project",
+  "overview.projectsLoadFailedTitle": "Couldn't load your projects",
+  "overview.projectsLoadFailedDesc": "The server took too long to respond. It may still be preparing data after an update. Retrying is safe.",
   "overview.loadRunFailedDesc": "This run's data didn't come back. Try refreshing.",
   "overview.loadRunFailedTitle": "Couldn't load this run",
   "overview.loading": "loading…",

--- a/tests/services/test_projects_cache_entities.py
+++ b/tests/services/test_projects_cache_entities.py
@@ -53,6 +53,46 @@ def test_invalidate_forces_a_reread(tmp_path):
     assert spy.call_count == 2
 
 
+def test_concurrent_cold_reads_share_one_build(tmp_path):
+    """Requests racing a cold cache must share ONE disk walk.
+
+    Regression (v1.9.0 startup storm): the client re-requests /api/projects
+    while the first build is still running; without an in-flight lock every
+    request started its own full build_project_list, multiplying minutes of
+    post-upgrade recompute by the number of piled-up requests.
+    """
+    import threading
+    import time as _time
+
+    calls = []
+
+    def slow_build(_root):
+        calls.append(1)
+        _time.sleep(0.05)
+        return [_entry()]
+
+    with patch(
+        "quodeq.services._projects_cache._fs_projects.build_project_list",
+        side_effect=slow_build,
+    ):
+        cache = ProjectsCache()
+        barrier = threading.Barrier(4)
+        results = [None] * 4
+
+        def hit(i):
+            barrier.wait()
+            results[i] = cache.list(str(tmp_path))
+
+        threads = [threading.Thread(target=hit, args=(i,)) for i in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    assert len(calls) == 1, "concurrent cold reads must collapse into one build"
+    assert all(r == results[0] for r in results)
+
+
 def test_service_module_does_no_serialization():
     """The declared WS6 wire-boundary entry is retired: no to_camel_dict here."""
     import quodeq.services._projects_cache as mod

--- a/tests/services/test_score_cache_single_flight.py
+++ b/tests/services/test_score_cache_single_flight.py
@@ -1,0 +1,124 @@
+"""Concurrent misses on the read-through score caches must compute once.
+
+Regression (v1.9.0 startup storm): after an upgrade invalidates every cached
+row, the piled-up startup requests all miss the same (project, version) key
+and each ran the full multi-minute recompute in parallel. The caches must
+single-flight the compute so N concurrent misses cost one compute.
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from quodeq.services.score_cache import (
+    cached_accumulated,
+    cached_project_summary,
+    open_score_cache,
+)
+
+
+def _race(n: int, call):
+    """Run *call(i)* on n threads released together; return the results list."""
+    barrier = threading.Barrier(n)
+    results = [None] * n
+    errors = []
+
+    def run(i):
+        barrier.wait()
+        try:
+            results[i] = call(i)
+        except BaseException as exc:  # noqa: BLE001 — surfaced to the test
+            errors.append(exc)
+
+    threads = [threading.Thread(target=run, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return results, errors
+
+
+def test_concurrent_accumulated_misses_compute_once(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    calls = []
+
+    def compute():
+        calls.append(1)
+        time.sleep(0.05)
+        return {"summary": {"x": 1}}
+
+    results, errors = _race(3, lambda _i: cached_accumulated("proj", "v1", compute))
+
+    assert not errors
+    assert calls == [1], "concurrent misses on one key must share one compute"
+    assert results == [{"summary": {"x": 1}}] * 3
+
+
+def test_concurrent_summary_misses_compute_once(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    calls = []
+
+    def compute():
+        calls.append(1)
+        time.sleep(0.05)
+        return {"grade": "B"}
+
+    results, errors = _race(3, lambda _i: cached_project_summary("proj", "v1", compute))
+
+    assert not errors
+    assert calls == [1]
+    assert results == [{"grade": "B"}] * 3
+
+
+def test_distinct_keys_still_compute_independently(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    calls = []
+
+    def make_compute(tag):
+        def compute():
+            calls.append(tag)
+            return {"summary": {"tag": tag}}
+        return compute
+
+    results, errors = _race(
+        2, lambda i: cached_accumulated(f"proj-{i}", "v1", make_compute(i)),
+    )
+
+    assert not errors
+    assert sorted(calls) == [0, 1], "different projects must not share a compute"
+    assert results[0] != results[1]
+
+
+def test_concurrent_first_open_initializes_safely(tmp_path, monkeypatch):
+    """Racing first-opens of a fresh cache DB must not corrupt or crash.
+
+    Regression: concurrent ``_init`` DDL on a brand-new file could raise a
+    lock error that the rebuild path misread as corruption, unlinking the DB
+    out from under another thread's live WAL connection (SIGBUS).
+    """
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+
+    def touch(_i):
+        with open_score_cache() as conn:
+            return conn.execute("SELECT count(*) FROM cache_meta").fetchone()[0]
+
+    results, errors = _race(4, touch)
+
+    assert not errors
+    assert all(isinstance(r, int) for r in results)
+
+
+def test_failed_compute_does_not_wedge_the_key(tmp_path, monkeypatch):
+    """A compute that raises must release the in-flight key for the next caller."""
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+
+    def boom():
+        raise RuntimeError("compute failed")
+
+    with pytest.raises(RuntimeError):
+        cached_accumulated("proj", "v1", boom)
+
+    out = cached_accumulated("proj", "v1", lambda: {"summary": {"ok": True}})
+    assert out == {"summary": {"ok": True}}


### PR DESCRIPTION
Fixes the 1.9.0 startup hang: the dashboard sat on the loading spinner forever while the backend pegged ~300% CPU for minutes.

## What happened

First launch after upgrading to 1.9.0 invalidates every score-cache row (algo 5→6 bump plus the new `rules` key in the version hash), so the first `/api/projects` recomputes every project's accumulated payload from raw evaluations. Three defects turned that one-time cost into a hang:

1. **No dedup.** The client aborts at 30s and re-requests. `ProjectsCache` (5s TTL, no lock) and the read-through accumulated/summary caches each started a full recompute per piled-up request. Six concurrent requests meant six copies of the same minutes-long compute fighting over the GIL.
2. **No way out of the spinner.** `projectsLoaded` only flips on a successful `/api/projects`. After the hand-rolled retry loop exhausted (~2 min), it gave up silently. The gate in `DashboardPage` renders `LoadingScreen` above every error branch, so the page spun forever even after the backend recovered.
3. **Latent crash.** `open_score_cache` treats any `DatabaseError` as corruption and unlinks the DB. Concurrent first-opens of a fresh DB race the schema DDL; the loser's lock error unlinks the file under the winner's live WAL connection. Reproduced as a SIGBUS in the new test.

## Changes

Backend:
- `ProjectsCache.list` takes an in-flight lock: concurrent cold reads share one `build_project_list`.
- `cached_accumulated` / `cached_project_summary` single-flight per (project, version) with a cache re-check after the wait.
- `open_score_cache` serializes init/rebuild (yielded connections stay concurrent).

UI:
- `useProjectState` exposes `projectsLoadFailed` and `retryLoadProjects` (retry re-runs the boot-time selection resolution).
- The `DashboardPage` and `MainContent` gates render "Couldn't load your projects" with a Retry button instead of an endless spinner once the load has failed.
- A health-poll reconnect re-fires a failed load automatically.
- `listProjects` timeout raised to 120s: with the server single-flighting the rebuild, one waiting request beats an abandon-and-re-request loop.

## Result

Post-upgrade rebuild runs once instead of N times. If it still outlasts the client's patience, the user gets an explicit retry instead of a dead spinner, and a reconnect recovers on its own.

## Tests

- `test_score_cache_single_flight.py`: concurrent misses compute once, distinct keys stay independent, a failed compute releases the key, racing first-opens no longer SIGBUS (crashed the interpreter before the fix).
- `test_projects_cache_entities.py`: concurrent cold reads share one build.
- UI: failure state, retry, reconnect re-arm, bundle threading (both whitelists), gate rendering, and hook-count stability across the failed→loaded flip.

Full suite green: pytest 5,892 passed, vitest 1,521 passed, node tests, strings lint, vite build.
