### PR TITLE
fix(ui): WCAG text contrast across all ten theme combos + automated guard

### DIFF
--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -19,8 +19,8 @@
   /* Gray (light-mode text) */
   --primitive-gray-900: #1a1816;
   --primitive-gray-700: #3d3a37;
-  --primitive-gray-500: #8a8279;
-  --primitive-gray-400: #a09890;
+  --primitive-gray-500: #726b63;
+  --primitive-gray-400: #90867d;
 
   /* Coral (accent) */
   --primitive-coral-700: #b5543a;
@@ -50,7 +50,7 @@
   --primitive-ifrit-900: #201614;
   --primitive-ifrit-800: #2c201c;
   --primitive-ifrit-700: #3e302a;
-  --primitive-ifrit-500: #9a7a68;
+  --primitive-ifrit-500: #a48777;
   --primitive-ifrit-200: #f0dcc8;
   --primitive-ifrit-accent-light: #c85a10;
   --primitive-ifrit-accent-dark: #e88030;
@@ -58,7 +58,7 @@
   --primitive-ifrit-100: #f0e8de;
   --primitive-ifrit-border-light: #dcc8b4;
   --primitive-ifrit-text-dark: #241810;
-  --primitive-ifrit-text-muted-light: #8a7060;
+  --primitive-ifrit-text-muted-light: #786153;
 
   /* Galadriel palette (nature greens, sage) */
   --primitive-galadriel-50:  #f4f7f4;
@@ -74,7 +74,7 @@
   --primitive-flynn-900: #111822;
   --primitive-flynn-800: #1a2230;
   --primitive-flynn-700: #2a3545;
-  --primitive-flynn-500: #6a8aaa;
+  --primitive-flynn-500: #708fae;
   --primitive-flynn-200: #d4e0f0;
   --primitive-flynn-accent: #00d4ff;
   --primitive-flynn-accent-hover: #33e0ff;
@@ -102,7 +102,7 @@
   --primitive-neo-900:  #111111;
   --primitive-neo-800:  #1a1a1a;
   --primitive-neo-700:  #282828;
-  --primitive-neo-500:  #608060;
+  --primitive-neo-500:  #6b8f6b;
   --primitive-neo-200:  #b0ffb0;
   --primitive-neo-accent: #00ff41;
   --primitive-neo-accent-dark: #008833;
@@ -216,7 +216,7 @@
   --primitive-deckard-100: #e8e4ee;
   --primitive-deckard-border-light: #c8c2d0;
   --primitive-deckard-text-dark: #18141e;
-  --primitive-deckard-text-muted-light: #7a7088;
+  --primitive-deckard-text-muted-light: #686074;
 
   /* Deckard severity — neon pink-red scale */
   --primitive-deckard-sev-critical-light: #e02050;
@@ -402,7 +402,7 @@
 
     --color-text:         var(--primitive-flynn-200);
     --color-text-muted:   var(--primitive-flynn-500);
-    --color-text-subtle:  #4a6a88;
+    --color-text-subtle:  #4f7292;
 
     --color-accent:       var(--primitive-flynn-accent);
     --color-accent-hover: var(--primitive-flynn-accent-hover);
@@ -532,7 +532,7 @@ html[data-theme="dark"]:root, [data-theme="dark"] {
 
   --color-text:         var(--primitive-flynn-200);
   --color-text-muted:   var(--primitive-flynn-500);
-  --color-text-subtle:  #4a6a88;
+  --color-text-subtle:  #4f7292;
 
   --color-accent:       var(--primitive-flynn-accent);
   --color-accent-hover: var(--primitive-flynn-accent-hover);
@@ -708,7 +708,7 @@ html[data-theme="ifrit-dark"]:root, [data-theme="ifrit-dark"] {
 
   --color-text:         var(--primitive-ifrit-200);
   --color-text-muted:   var(--primitive-ifrit-500);
-  --color-text-subtle:  #6a5448;
+  --color-text-subtle:  #856a5b;
 
   --color-accent:       var(--primitive-ifrit-accent-dark);
   --color-accent-hover: #f09040;
@@ -796,8 +796,8 @@ html[data-theme="galadriel-light"]:root, [data-theme="galadriel-light"] {
   --color-border-focus: #1b6b3a;
 
   --color-text:         #162016;
-  --color-text-muted:   #5a7a5a;
-  --color-text-subtle:  #7a9a7a;
+  --color-text-muted:   #4f6b4f;
+  --color-text-subtle:  #688968;
 
   --color-accent:       #1b6b3a;
   --color-accent-hover: #145228;
@@ -884,7 +884,7 @@ html[data-theme="neo-dark"]:root, [data-theme="neo-dark"] {
   --color-border-focus: var(--primitive-neo-accent);
   --color-text:         var(--primitive-neo-200);
   --color-text-muted:   var(--primitive-neo-500);
-  --color-text-subtle:  #405040;
+  --color-text-subtle:  #596f59;
   --color-accent:       var(--primitive-neo-accent);
   --color-accent-hover: #33ff66;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-neo-accent) 14%, transparent);
@@ -959,8 +959,8 @@ html[data-theme="neo-light"]:root, [data-theme="neo-light"] {
   --color-border:       var(--primitive-neo-border-light);
   --color-border-focus: var(--primitive-neo-accent-dark);
   --color-text:         var(--primitive-neo-text-dark);
-  --color-text-muted:   #5a7a5a;
-  --color-text-subtle:  #7a9a7a;
+  --color-text-muted:   #516e51;
+  --color-text-subtle:  #6a8b6a;
   --color-accent:       var(--primitive-neo-accent-dark);
   --color-accent-hover: #006622;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-neo-accent-dark) 8%, transparent);
@@ -1033,8 +1033,8 @@ html[data-theme="galadriel-dark"]:root, [data-theme="galadriel-dark"] {
   --color-border:       var(--primitive-galadriel-700-dark);
   --color-border-focus: var(--primitive-green-400);
   --color-text:         #c8d4c8;
-  --color-text-muted:   #5a7a5a;
-  --color-text-subtle:  #3a5a3a;
+  --color-text-muted:   #7a9d7a;
+  --color-text-subtle:  #548254;
   --color-accent:       var(--primitive-green-400);
   --color-accent-hover: #6ee7a0;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-green-400) 14%, transparent);
@@ -1111,7 +1111,7 @@ html[data-theme="ifrit-light"]:root, [data-theme="ifrit-light"] {
 
   --color-text:         var(--primitive-ifrit-text-dark);
   --color-text-muted:   var(--primitive-ifrit-text-muted-light);
-  --color-text-subtle:  #b0a090;
+  --color-text-subtle:  #917c67;
 
   --color-accent:       var(--primitive-ifrit-accent-light);
   --color-accent-hover: #a84a08;
@@ -1197,7 +1197,7 @@ html[data-theme="deckard-dark"]:root, [data-theme="deckard-dark"] {
 
   --color-text:         var(--primitive-deckard-200);
   --color-text-muted:   var(--primitive-deckard-500);
-  --color-text-subtle:  #58506a;
+  --color-text-subtle:  #706687;
 
   --color-accent:       var(--primitive-deckard-accent-dark);
   --color-accent-hover: #ff60d0;
@@ -1287,7 +1287,7 @@ html[data-theme="deckard-light"]:root, [data-theme="deckard-light"] {
 
   --color-text:         var(--primitive-deckard-text-dark);
   --color-text-muted:   var(--primitive-deckard-text-muted-light);
-  --color-text-subtle:  #9a90a8;
+  --color-text-subtle:  #857996;
 
   --color-accent:       var(--primitive-deckard-accent-light);
   --color-accent-hover: #b01888;

--- a/src/quodeq/ui/tools/token_contrast.mjs
+++ b/src/quodeq/ui/tools/token_contrast.mjs
@@ -1,0 +1,212 @@
+/**
+ * Token contrast audit — WCAG contrast of the text tokens against the
+ * surface tokens for EVERY shipped theme combination (5 families x 2 modes).
+ *
+ * The UX audit's headline finding was that only the default pair ever gets
+ * eyeballed while ten combinations ship; this makes the other eight fail in
+ * CI instead of in a user's screenshot. Pure functions over the tokens.css
+ * source text — no browser, no CSS engine. The parser understands exactly
+ * the shapes tokens.css uses (custom props, var() chains, hex/rgb colours,
+ * one level of @media nesting); anything fancier (color-mix) is skipped.
+ *
+ * Run directly for the full matrix:  node tools/token_contrast.mjs
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// Text tokens audited, with the minimum ratio each must hit against every
+// surface it can sit on. --color-text and --color-text-muted carry real
+// copy (body, labels, secondary text) -> WCAG AA normal-text 4.5. subtle is
+// pinned at 3.0: it is documented for decorative/tertiary use, but it still
+// ends up on timestamps and captions, so it must at least clear the
+// large-text/UI-component floor.
+export const TEXT_REQUIREMENTS = {
+  '--color-text': 4.5,
+  '--color-text-muted': 4.5,
+  '--color-text-subtle': 3.0,
+};
+
+export const SURFACE_TOKENS = ['--color-bg', '--color-surface', '--color-surface-alt'];
+
+const FAMILIES = ['neo', 'galadriel', 'ifrit', 'deckard'];
+
+// ---------------------------------------------------------------------------
+// parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Flatten tokens.css into blocks of { selector, media, decls } where decls
+ * only keeps custom properties. Handles one level of @media nesting, which
+ * is all tokens.css uses.
+ */
+export function parseBlocks(cssText) {
+  const src = cssText.replace(/\/\*[\s\S]*?\*\//g, '');
+  const blocks = [];
+  let i = 0;
+  const readBlock = (media) => {
+    const open = src.indexOf('{', i);
+    if (open === -1) { i = src.length; return; }
+    const selector = src.slice(i, open).trim();
+    if (selector.startsWith('@media')) {
+      i = open + 1;
+      const innerMedia = selector;
+      while (i < src.length) {
+        const next = src.slice(i).search(/\S/);
+        if (next === -1) { i = src.length; break; }
+        i += next;
+        if (src[i] === '}') { i += 1; break; }
+        readBlock(innerMedia);
+      }
+      return;
+    }
+    let depth = 1;
+    let j = open + 1;
+    while (j < src.length && depth > 0) {
+      if (src[j] === '{') depth += 1;
+      else if (src[j] === '}') depth -= 1;
+      j += 1;
+    }
+    const body = src.slice(open + 1, j - 1);
+    const decls = {};
+    for (const m of body.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+      decls[m[1]] = m[2].trim();
+    }
+    if (Object.keys(decls).length) blocks.push({ selector, media: media || null, decls });
+    i = j;
+  };
+  while (i < src.length) {
+    const next = src.slice(i).search(/\S/);
+    if (next === -1) break;
+    i += next;
+    if (src[i] === '}') { i += 1; continue; }
+    readBlock(null);
+  }
+  return blocks;
+}
+
+const isPlainRoot = (b) => !b.media && b.selector.includes(':root') && !b.selector.includes('data-theme');
+const inMediaDark = (b) => Boolean(b.media && b.media.includes('prefers-color-scheme: dark'));
+const hasExact = (name) => (b) => !b.media && b.selector.includes(`[data-theme="${name}"]`);
+const hasEndsDark = (b) => !b.media && b.selector.includes('[data-theme$="dark"]');
+
+/** Merge every matching block's declarations, in file order per matcher order. */
+function compose(blocks, matchers) {
+  const vars = {};
+  for (const match of matchers) {
+    for (const b of blocks) {
+      if (match(b)) Object.assign(vars, b.decls);
+    }
+  }
+  return vars;
+}
+
+/**
+ * The ten shipped combinations. Daruma is the default family: its light
+ * mode is the bare :root, its dark mode exists twice (system-preference
+ * media block, and the explicit data-theme="dark" the toggle sets).
+ */
+export function themeContexts(blocks) {
+  const themes = {
+    'daruma-light': compose(blocks, [isPlainRoot]),
+    'daruma-dark-system': compose(blocks, [isPlainRoot, inMediaDark]),
+    'daruma-dark': compose(blocks, [isPlainRoot, hasEndsDark, hasExact('dark')]),
+    'daruma-light-explicit': compose(blocks, [isPlainRoot, hasExact('light')]),
+  };
+  for (const f of FAMILIES) {
+    themes[`${f}-light`] = compose(blocks, [isPlainRoot, hasExact(`${f}-light`)]);
+    themes[`${f}-dark`] = compose(blocks, [isPlainRoot, hasEndsDark, hasExact(`${f}-dark`)]);
+  }
+  return themes;
+}
+
+// ---------------------------------------------------------------------------
+// colour math
+// ---------------------------------------------------------------------------
+
+export function resolveVar(vars, name, seen = new Set()) {
+  if (seen.has(name)) return null;
+  seen.add(name);
+  const raw = vars[name];
+  if (!raw) return null;
+  const ref = raw.match(/^var\((--[\w-]+)\s*(?:,\s*([^)]+))?\)$/);
+  if (ref) return resolveVar(vars, ref[1], seen) ?? (ref[2] ? ref[2].trim() : null);
+  return raw;
+}
+
+export function parseColor(value) {
+  if (!value) return null;
+  const v = value.trim().toLowerCase();
+  let m = v.match(/^#([0-9a-f]{6})([0-9a-f]{2})?$/);
+  if (m) {
+    const n = parseInt(m[1], 16);
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+  }
+  m = v.match(/^#([0-9a-f]{3})$/);
+  if (m) return [...m[1]].map((c) => parseInt(c + c, 16));
+  m = v.match(/^rgba?\(\s*(\d+)[\s,]+(\d+)[\s,]+(\d+)/);
+  if (m) return [Number(m[1]), Number(m[2]), Number(m[3])];
+  return null; // color-mix, named colours, anything exotic
+}
+
+function luminance([r, g, b]) {
+  const chan = (c) => {
+    const s = c / 255;
+    return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * chan(r) + 0.7152 * chan(g) + 0.0722 * chan(b);
+}
+
+export function contrastRatio(rgbA, rgbB) {
+  const la = luminance(rgbA);
+  const lb = luminance(rgbB);
+  const [hi, lo] = la >= lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// ---------------------------------------------------------------------------
+// audit
+// ---------------------------------------------------------------------------
+
+/**
+ * @returns {{results: Array, failures: Array}} one result per
+ *   theme x text-token x surface-token with the measured ratio; failures is
+ *   the subset under its required minimum.
+ */
+export function auditContrast(cssText) {
+  const blocks = parseBlocks(cssText);
+  const themes = themeContexts(blocks);
+  const results = [];
+  for (const [theme, vars] of Object.entries(themes)) {
+    for (const [textToken, min] of Object.entries(TEXT_REQUIREMENTS)) {
+      const fg = parseColor(resolveVar(vars, textToken));
+      if (!fg) continue;
+      for (const surfaceToken of SURFACE_TOKENS) {
+        const bg = parseColor(resolveVar(vars, surfaceToken));
+        if (!bg) continue;
+        const ratio = Math.round(contrastRatio(fg, bg) * 100) / 100;
+        results.push({
+          theme, textToken, surfaceToken, min, ratio,
+          fg: resolveVar(vars, textToken), bg: resolveVar(vars, surfaceToken),
+          ok: ratio >= min,
+        });
+      }
+    }
+  }
+  return { results, failures: results.filter((r) => !r.ok) };
+}
+
+export function defaultTokensPath() {
+  return join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'styles', 'tokens.css');
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (invokedDirectly) {
+  const { results, failures } = auditContrast(readFileSync(defaultTokensPath(), 'utf8'));
+  for (const r of results) {
+    const flag = r.ok ? '  ' : '!!';
+    console.log(`${flag} ${r.theme.padEnd(22)} ${r.textToken.padEnd(22)} on ${r.surfaceToken.padEnd(20)} ${String(r.ratio).padEnd(6)} (min ${r.min})  ${r.fg} / ${r.bg}`);
+  }
+  console.log(`\n${results.length} checks, ${failures.length} failures`);
+  process.exitCode = failures.length ? 1 : 0;
+}

--- a/src/quodeq/ui/tools/token_contrast.test.mjs
+++ b/src/quodeq/ui/tools/token_contrast.test.mjs
@@ -1,0 +1,54 @@
+/**
+ * Theme-matrix contrast guard.
+ *
+ * Every shipped theme combination (5 families x light/dark, plus the
+ * system-preference dark path) must keep its text tokens legible on every
+ * surface token. This exists because only the default pair ever gets
+ * eyeballed — the other eight combinations previously shipped with muted
+ * and subtle text as low as 1.9:1. A new theme family, or a tweak to any
+ * bg/surface/text value, re-runs the whole matrix here.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import {
+  auditContrast, themeContexts, parseBlocks, contrastRatio, parseColor, defaultTokensPath,
+} from './token_contrast.mjs';
+
+const css = readFileSync(defaultTokensPath(), 'utf8');
+
+test('parser sees every shipped theme combination', () => {
+  const themes = themeContexts(parseBlocks(css));
+  const names = Object.keys(themes);
+  for (const expected of [
+    'daruma-light', 'daruma-dark-system', 'daruma-dark', 'daruma-light-explicit',
+    'neo-light', 'neo-dark', 'galadriel-light', 'galadriel-dark',
+    'ifrit-light', 'ifrit-dark', 'deckard-light', 'deckard-dark',
+  ]) {
+    assert.ok(names.includes(expected), `missing theme context: ${expected}`);
+  }
+  // Each context must actually resolve its own surfaces — an empty context
+  // means a selector drifted and the audit below would vacuously pass.
+  for (const [name, vars] of Object.entries(themes)) {
+    assert.ok(vars['--color-bg'], `${name} resolved no --color-bg`);
+    assert.ok(vars['--color-text'], `${name} resolved no --color-text`);
+  }
+});
+
+test('contrastRatio matches known WCAG reference points', () => {
+  const white = parseColor('#ffffff');
+  const black = parseColor('#000000');
+  assert.equal(Math.round(contrastRatio(white, black)), 21);
+  assert.equal(Math.round(contrastRatio(white, white)), 1);
+});
+
+test('every text token clears its floor on every surface, in every theme', () => {
+  const { results, failures } = auditContrast(css);
+  // 12 contexts x 3 text tokens x 3 surfaces — if this shrinks, the parser
+  // stopped seeing part of the matrix and the guard is weaker than it looks.
+  assert.ok(results.length >= 100, `matrix shrank: only ${results.length} checks ran`);
+  const table = failures
+    .map((f) => `  ${f.theme}: ${f.textToken} ${f.fg} on ${f.surfaceToken} ${f.bg} = ${f.ratio} (min ${f.min})`)
+    .join('\n');
+  assert.equal(failures.length, 0, `contrast failures:\n${table}`);
+});


### PR DESCRIPTION
## What

From the design-system UX audit's finding *"Ten theme combinations, one really tested"*: measured every shipped theme combination (5 families x light/dark, plus the system-preference dark path) and **52 of 108 text-on-surface contrast checks failed** — every failure on `--color-text-muted` or `--color-text-subtle`. Worst offenders: galadriel-dark subtle at **1.9:1**, daruma-light muted at **3.4:1** (the audit's own headline numbers, confirmed).

## Fix

Minimal hue-and-saturation-preserving lightness shifts to 20 token values (7 primitives + 13 per-theme literals) — darker on light surfaces, lighter on dark — until the worst surface clears the floor with margin:

- `--color-text` / `--color-text-muted`: **4.5:1** (WCAG AA normal text)
- `--color-text-subtle`: **3.0:1** (documented as decorative, but it carries timestamps and captions)

Now **0 of 108 checks fail**. Theme character is preserved; verified visually in daruma light + dark.

## Guard

`tools/token_contrast.mjs` parses tokens.css directly (no browser), composes all twelve theme contexts (`:root` + shared-dark + per-theme blocks, including the `@media` system-dark path), resolves `var()` chains, and computes WCAG contrast for every text x surface pair. `token_contrast.test.mjs` runs the matrix in `npm test`, so a new theme family or a surface tweak fails CI instead of a user's screenshot.

Full table on demand:
```
node tools/token_contrast.mjs
```

## Testing

- New guard: 3 tests (matrix completeness, WCAG reference points, zero failures)
- Full node suite 456 passing, vitest suite 1547 passing
- Visual check in the running app, light + dark, no console errors

Related: #1087 (the Compare tab's dark-mode readability complaint was partly these same tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)