### PR TITLE
fix(ui): give grades a color channel severity does not use

### DIFF
--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -302,17 +302,22 @@
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
 
-  /* Grade tier colors — Daruma Fire: vivid gold top, warm gray high */
-  --color-grade-top-text:    #e0a800;
-  --color-grade-top-bg:      color-mix(in srgb, #e0a800 14%, transparent);
-  --color-grade-high-text:   #9ca0a8;
-  --color-grade-high-bg:     color-mix(in srgb, #9ca0a8 12%, transparent);
-  --color-grade-mid-text:    #c0502a;
-  --color-grade-mid-bg:      color-mix(in srgb, #c0502a 12%, transparent);
-  --color-grade-low-text:    var(--primitive-ired-900);
-  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-900) 12%, transparent);
-  --color-grade-bottom-text: var(--primitive-crimson-600);
-  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-600) 12%, transparent);
+  /* Grade tier colors. Every theme follows the same rule: grades are a
+     metallic shine ramp (gold A, silver B, then duller metal down to lead F)
+     in a hue band that theme's severity ramp does not use, so a bad grade
+     and a severe finding never share a color. Severity keeps the vivid
+     warm/danger channel; grades own the metal channel. Enforced by
+     tools/token_distinctness.mjs. */
+  --color-grade-top-text:    #a87e00;
+  --color-grade-top-bg:      color-mix(in srgb, #a87e00 14%, transparent);
+  --color-grade-high-text:   #566a82;
+  --color-grade-high-bg:     color-mix(in srgb, #566a82 12%, transparent);
+  --color-grade-mid-text:    #8a621e;
+  --color-grade-mid-bg:      color-mix(in srgb, #8a621e 12%, transparent);
+  --color-grade-low-text:    #63491a;
+  --color-grade-low-bg:      color-mix(in srgb, #63491a 12%, transparent);
+  --color-grade-bottom-text: #3e332c;
+  --color-grade-bottom-bg:   color-mix(in srgb, #3e332c 12%, transparent);
 
   /* Trend — default is light; dark themes override below */
   --color-trend-strong-up:   #e0a800;
@@ -359,10 +364,10 @@
   --logo-needle:         var(--primitive-crimson-300);
   --logo-needle-dark:    var(--primitive-crimson-700);
 
-  /* Compliance — rich gold */
-  --color-compliance:        #b08000;
-  --color-compliance-bg:     color-mix(in srgb, #b08000 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, #b08000 38%, transparent);
+  /* Compliance — deep emerald; gold now belongs to the grade ramp */
+  --color-compliance:        #157347;
+  --color-compliance-bg:     color-mix(in srgb, #157347 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #157347 38%, transparent);
 
   /* Warning */
   --color-warning:      var(--primitive-amber-700);
@@ -422,16 +427,16 @@
     --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-flynn-sev-minor-dark) 4%, transparent);
     --color-sev-minor-border:    color-mix(in srgb, var(--primitive-flynn-sev-minor-dark) 32%, transparent);
 
-    --color-grade-top-text:    var(--primitive-flynn-accent);
-    --color-grade-top-bg:      color-mix(in srgb, var(--primitive-flynn-accent) 12%, transparent);
-    --color-grade-high-text:   #8aafcc;
-    --color-grade-high-bg:     color-mix(in srgb, #8aafcc 12%, transparent);
-    --color-grade-mid-text:    var(--primitive-ired-300);
-    --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 12%, transparent);
-    --color-grade-low-text:    var(--primitive-ired-400);
-    --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-400) 13%, transparent);
-    --color-grade-bottom-text: var(--primitive-crimson-200);
-    --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
+    --color-grade-top-text:    #f2c14e;
+    --color-grade-top-bg:      color-mix(in srgb, #f2c14e 12%, transparent);
+    --color-grade-high-text:   var(--primitive-brand-300);
+    --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-300) 12%, transparent);
+    --color-grade-mid-text:    #c08c50;
+    --color-grade-mid-bg:      color-mix(in srgb, #c08c50 12%, transparent);
+    --color-grade-low-text:    #96805e;
+    --color-grade-low-bg:      color-mix(in srgb, #96805e 13%, transparent);
+    --color-grade-bottom-text: #76706a;
+    --color-grade-bottom-bg:   color-mix(in srgb, #76706a 12%, transparent);
 
     --color-warning:      var(--primitive-amber-400);
     --color-info:         var(--primitive-cyan-400);
@@ -442,9 +447,9 @@
     --color-danger-bg:     color-mix(in srgb, var(--primitive-red-300) 15%, transparent);
     --color-danger-border: color-mix(in srgb, var(--primitive-red-300) 30%, transparent);
 
-    --color-compliance:        var(--primitive-flynn-accent);
-    --color-compliance-bg:     color-mix(in srgb, var(--primitive-flynn-accent) 4%, transparent);
-    --color-compliance-border: color-mix(in srgb, var(--primitive-flynn-accent) 38%, transparent);
+    --color-compliance:        var(--primitive-compliance);
+    --color-compliance-bg:     color-mix(in srgb, var(--primitive-compliance) 4%, transparent);
+    --color-compliance-border: color-mix(in srgb, var(--primitive-compliance) 38%, transparent);
 
     --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
     --color-overlay-medium: rgba(0, 0, 0, 0.82);
@@ -552,16 +557,16 @@ html[data-theme="dark"]:root, [data-theme="dark"] {
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-flynn-sev-minor-dark) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-flynn-sev-minor-dark) 32%, transparent);
 
-  --color-grade-top-text:    var(--primitive-flynn-accent);
-  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-flynn-accent) 12%, transparent);
-  --color-grade-high-text:   #8aafcc;
-  --color-grade-high-bg:     color-mix(in srgb, #8aafcc 12%, transparent);
-  --color-grade-mid-text:    #ff8a8a;
-  --color-grade-mid-bg:      color-mix(in srgb, #ff8a8a 12%, transparent);
-  --color-grade-low-text:    var(--primitive-ired-400);
-  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-400) 13%, transparent);
-  --color-grade-bottom-text: #e6182a;
-  --color-grade-bottom-bg:   color-mix(in srgb, #e6182a 12%, transparent);
+  --color-grade-top-text:    #f2c14e;
+  --color-grade-top-bg:      color-mix(in srgb, #f2c14e 12%, transparent);
+  --color-grade-high-text:   var(--primitive-brand-300);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-300) 12%, transparent);
+  --color-grade-mid-text:    #c08c50;
+  --color-grade-mid-bg:      color-mix(in srgb, #c08c50 12%, transparent);
+  --color-grade-low-text:    #96805e;
+  --color-grade-low-bg:      color-mix(in srgb, #96805e 13%, transparent);
+  --color-grade-bottom-text: #76706a;
+  --color-grade-bottom-bg:   color-mix(in srgb, #76706a 12%, transparent);
 
   --color-warning:      var(--primitive-amber-400);
   --color-info:         var(--primitive-cyan-400);
@@ -572,10 +577,10 @@ html[data-theme="dark"]:root, [data-theme="dark"] {
   --color-danger-bg:     color-mix(in srgb, var(--primitive-red-300) 15%, transparent);
   --color-danger-border: color-mix(in srgb, var(--primitive-red-300) 30%, transparent);
 
-  /* Compliance — cool cyan */
-  --color-compliance:        var(--primitive-flynn-accent);
-  --color-compliance-bg:     color-mix(in srgb, var(--primitive-flynn-accent) 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, var(--primitive-flynn-accent) 38%, transparent);
+  /* Compliance — spring green, off the cyan accent */
+  --color-compliance:        var(--primitive-compliance);
+  --color-compliance-bg:     color-mix(in srgb, var(--primitive-compliance) 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, var(--primitive-compliance) 38%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
@@ -639,16 +644,16 @@ html[data-theme="light"]:root, [data-theme="light"] {
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
 
-  --color-grade-top-text:    #e0a800;
-  --color-grade-top-bg:      color-mix(in srgb, #e0a800 14%, transparent);
-  --color-grade-high-text:   #9ca0a8;
-  --color-grade-high-bg:     color-mix(in srgb, #9ca0a8 12%, transparent);
-  --color-grade-mid-text:    #c0502a;
-  --color-grade-mid-bg:      color-mix(in srgb, #c0502a 12%, transparent);
-  --color-grade-low-text:    var(--primitive-ired-900);
-  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-900) 12%, transparent);
-  --color-grade-bottom-text: var(--primitive-crimson-600);
-  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-600) 12%, transparent);
+  --color-grade-top-text:    #a87e00;
+  --color-grade-top-bg:      color-mix(in srgb, #a87e00 14%, transparent);
+  --color-grade-high-text:   #566a82;
+  --color-grade-high-bg:     color-mix(in srgb, #566a82 12%, transparent);
+  --color-grade-mid-text:    #8a621e;
+  --color-grade-mid-bg:      color-mix(in srgb, #8a621e 12%, transparent);
+  --color-grade-low-text:    #63491a;
+  --color-grade-low-bg:      color-mix(in srgb, #63491a 12%, transparent);
+  --color-grade-bottom-text: #3e332c;
+  --color-grade-bottom-bg:   color-mix(in srgb, #3e332c 12%, transparent);
 
   /* Warning */
   --color-warning:      var(--primitive-amber-700);
@@ -661,10 +666,10 @@ html[data-theme="light"]:root, [data-theme="light"] {
   --color-danger-bg:     var(--color-sev-critical-bg);
   --color-danger-border: var(--color-sev-critical-border);
 
-  /* Compliance — rich gold */
-  --color-compliance:        #b08000;
-  --color-compliance-bg:     color-mix(in srgb, #b08000 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, #b08000 38%, transparent);
+  /* Compliance — deep emerald; gold now belongs to the grade ramp */
+  --color-compliance:        #157347;
+  --color-compliance-bg:     color-mix(in srgb, #157347 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #157347 38%, transparent);
 
   /* Overlays */
   --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
@@ -728,17 +733,17 @@ html[data-theme="ifrit-dark"]:root, [data-theme="ifrit-dark"] {
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ifrit-sev-minor-dark) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ifrit-sev-minor-dark) 32%, transparent);
 
-  /* Grades — ember glow: gold → amber → orange → red */
-  --color-grade-top-text:    #f0b830;
-  --color-grade-top-bg:      color-mix(in srgb, #f0b830 12%, transparent);
-  --color-grade-high-text:   var(--primitive-ifrit-500);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-ifrit-500) 12%, transparent);
-  --color-grade-mid-text:    #f07030;
-  --color-grade-mid-bg:      color-mix(in srgb, #f07030 12%, transparent);
-  --color-grade-low-text:    #ff5030;
-  --color-grade-low-bg:      color-mix(in srgb, #ff5030 13%, transparent);
-  --color-grade-bottom-text: #ff2820;
-  --color-grade-bottom-bg:   color-mix(in srgb, #ff2820 4%, transparent);
+  /* Grades — bright gold cooling to ash; the fire band stays with severity */
+  --color-grade-top-text:    #f6d44c;
+  --color-grade-top-bg:      color-mix(in srgb, #f6d44c 12%, transparent);
+  --color-grade-high-text:   #cad0d6;
+  --color-grade-high-bg:     color-mix(in srgb, #cad0d6 12%, transparent);
+  --color-grade-mid-text:    #aab2ba;
+  --color-grade-mid-bg:      color-mix(in srgb, #aab2ba 12%, transparent);
+  --color-grade-low-text:    #8a929c;
+  --color-grade-low-bg:      color-mix(in srgb, #8a929c 13%, transparent);
+  --color-grade-bottom-text: #6a727c;
+  --color-grade-bottom-bg:   color-mix(in srgb, #6a727c 12%, transparent);
 
   --color-warning:      var(--primitive-amber-400);
   --color-info:         var(--primitive-cyan-400);
@@ -749,10 +754,10 @@ html[data-theme="ifrit-dark"]:root, [data-theme="ifrit-dark"] {
   --color-danger-bg:     color-mix(in srgb, #ff5030 15%, transparent);
   --color-danger-border: color-mix(in srgb, #ff5030 30%, transparent);
 
-  /* Compliance — warm gold */
-  --color-compliance:        #f0b830;
-  --color-compliance-bg:     color-mix(in srgb, #f0b830 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, #f0b830 38%, transparent);
+  /* Compliance — spring green, clear of the orange accent and gold grades */
+  --color-compliance:        var(--primitive-compliance);
+  --color-compliance-bg:     color-mix(in srgb, var(--primitive-compliance) 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, var(--primitive-compliance) 38%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
@@ -820,16 +825,17 @@ html[data-theme="galadriel-light"]:root, [data-theme="galadriel-light"] {
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-galadriel-sev-minor-light) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-galadriel-sev-minor-light) 30%, transparent);
 
-  --color-grade-top-text:    var(--primitive-galadriel-800);
-  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-galadriel-800) 12%, transparent);
-  --color-grade-high-text:   var(--primitive-galadriel-500);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-galadriel-500) 10%, transparent);
-  --color-grade-mid-text:    var(--primitive-ired-800);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-800) 10%, transparent);
-  --color-grade-low-text:    var(--primitive-ired-900);
-  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-900) 10%, transparent);
-  --color-grade-bottom-text: var(--primitive-crimson-600);
-  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-600) 12%, transparent);
+  /* Grades — gold withering through sage and dry gray down to lead */
+  --color-grade-top-text:    #9c7400;
+  --color-grade-top-bg:      color-mix(in srgb, #9c7400 12%, transparent);
+  --color-grade-high-text:   #607668;
+  --color-grade-high-bg:     color-mix(in srgb, #607668 10%, transparent);
+  --color-grade-mid-text:    #62684a;
+  --color-grade-mid-bg:      color-mix(in srgb, #62684a 10%, transparent);
+  --color-grade-low-text:    #565349;
+  --color-grade-low-bg:      color-mix(in srgb, #565349 10%, transparent);
+  --color-grade-bottom-text: #35342e;
+  --color-grade-bottom-bg:   color-mix(in srgb, #35342e 12%, transparent);
 
   --color-warning:      var(--primitive-brown-500);
   --color-info:         var(--primitive-cyan-700);
@@ -840,10 +846,10 @@ html[data-theme="galadriel-light"]:root, [data-theme="galadriel-light"] {
   --color-danger-bg:     var(--color-sev-critical-bg);
   --color-danger-border: var(--color-sev-critical-border);
 
-  /* Compliance — forest green */
-  --color-compliance:        #1b6b3a;
-  --color-compliance-bg:     color-mix(in srgb, #1b6b3a 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, #1b6b3a 38%, transparent);
+  /* Compliance — blue-teal, off the forest-green accent */
+  --color-compliance:        #0c7a86;
+  --color-compliance-bg:     color-mix(in srgb, #0c7a86 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #0c7a86 38%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
   --color-overlay-medium: rgba(0, 0, 0, 0.5);
@@ -900,16 +906,17 @@ html[data-theme="neo-dark"]:root, [data-theme="neo-dark"] {
   --color-sev-minor-text:      #b47850;
   --color-sev-minor-bg:        color-mix(in srgb, #b47850 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, #b47850 32%, transparent);
-  --color-grade-top-text:    var(--primitive-neo-accent);
-  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-neo-accent) 12%, transparent);
-  --color-grade-high-text:   #80ff80;
-  --color-grade-high-bg:     color-mix(in srgb, #80ff80 10%, transparent);
-  --color-grade-mid-text:    #ff6432;
-  --color-grade-mid-bg:      color-mix(in srgb, #ff6432 12%, transparent);
-  --color-grade-low-text:    #ff4040;
-  --color-grade-low-bg:      color-mix(in srgb, #ff4040 13%, transparent);
-  --color-grade-bottom-text: #ff2020;
-  --color-grade-bottom-bg:   color-mix(in srgb, #ff2020 4%, transparent);
+  /* Grades — phosphor fading from bright mint to dead-pixel gray */
+  --color-grade-top-text:    #b4ffc8;
+  --color-grade-top-bg:      color-mix(in srgb, #b4ffc8 12%, transparent);
+  --color-grade-high-text:   #86d89e;
+  --color-grade-high-bg:     color-mix(in srgb, #86d89e 10%, transparent);
+  --color-grade-mid-text:    #64a67c;
+  --color-grade-mid-bg:      color-mix(in srgb, #64a67c 12%, transparent);
+  --color-grade-low-text:    #869286;
+  --color-grade-low-bg:      color-mix(in srgb, #869286 13%, transparent);
+  --color-grade-bottom-text: #6a726a;
+  --color-grade-bottom-bg:   color-mix(in srgb, #6a726a 4%, transparent);
   --color-warning:      var(--primitive-amber-400);
   --color-info:         var(--primitive-cyan-400);
   --color-warning-text: var(--primitive-amber-400);
@@ -918,10 +925,10 @@ html[data-theme="neo-dark"]:root, [data-theme="neo-dark"] {
   --color-danger-bg:     color-mix(in srgb, #ff4040 15%, transparent);
   --color-danger-border: color-mix(in srgb, #ff4040 30%, transparent);
 
-  /* Compliance — matrix green */
-  --color-compliance:        #00ff41;
-  --color-compliance-bg:     color-mix(in srgb, #00ff41 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, #00ff41 38%, transparent);
+  /* Compliance — teal, off the matrix-green accent */
+  --color-compliance:        var(--primitive-teal-400);
+  --color-compliance-bg:     color-mix(in srgb, var(--primitive-teal-400) 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, var(--primitive-teal-400) 38%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.92);
   --color-overlay-medium: rgba(0, 0, 0, 0.85);
@@ -976,16 +983,17 @@ html[data-theme="neo-light"]:root, [data-theme="neo-light"] {
   --color-sev-minor-text:      var(--primitive-neo-sev-minor-light);
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-neo-sev-minor-light) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-neo-sev-minor-light) 30%, transparent);
-  --color-grade-top-text:    #006622;
-  --color-grade-top-bg:      color-mix(in srgb, #006622 12%, transparent);
-  --color-grade-high-text:   #338844;
-  --color-grade-high-bg:     color-mix(in srgb, #338844 10%, transparent);
-  --color-grade-mid-text:    var(--primitive-ired-800);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-800) 10%, transparent);
-  --color-grade-low-text:    var(--primitive-ired-900);
-  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-900) 10%, transparent);
-  --color-grade-bottom-text: var(--primitive-crimson-600);
-  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-600) 12%, transparent);
+  /* Grades — phosphor fading from deep green to dead-pixel gray */
+  --color-grade-top-text:    #0a4a1e;
+  --color-grade-top-bg:      color-mix(in srgb, #0a4a1e 12%, transparent);
+  --color-grade-high-text:   #5c8068;
+  --color-grade-high-bg:     color-mix(in srgb, #5c8068 10%, transparent);
+  --color-grade-mid-text:    #646e64;
+  --color-grade-mid-bg:      color-mix(in srgb, #646e64 10%, transparent);
+  --color-grade-low-text:    #4e5048;
+  --color-grade-low-bg:      color-mix(in srgb, #4e5048 10%, transparent);
+  --color-grade-bottom-text: #2f2e28;
+  --color-grade-bottom-bg:   color-mix(in srgb, #2f2e28 12%, transparent);
   --color-warning:      var(--primitive-amber-700);
   --color-info:         var(--primitive-cyan-700);
   --color-warning-text: var(--primitive-amber-700);
@@ -994,10 +1002,10 @@ html[data-theme="neo-light"]:root, [data-theme="neo-light"] {
   --color-danger-bg:     var(--color-sev-critical-bg);
   --color-danger-border: var(--color-sev-critical-border);
 
-  /* Compliance — deep green */
-  --color-compliance:        #008833;
-  --color-compliance-bg:     color-mix(in srgb, #008833 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, #008833 38%, transparent);
+  /* Compliance — deep teal, off the green accent */
+  --color-compliance:        #0c7a70;
+  --color-compliance-bg:     color-mix(in srgb, #0c7a70 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #0c7a70 38%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
   --color-overlay-medium: rgba(0, 0, 0, 0.5);
@@ -1050,16 +1058,17 @@ html[data-theme="galadriel-dark"]:root, [data-theme="galadriel-dark"] {
   --color-sev-minor-text:      var(--primitive-galadriel-sev-minor-dark);
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-galadriel-sev-minor-dark) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-galadriel-sev-minor-dark) 32%, transparent);
-  --color-grade-top-text:    var(--primitive-green-400);
-  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-green-400) 12%, transparent);
-  --color-grade-high-text:   #6a9678;
-  --color-grade-high-bg:     color-mix(in srgb, #6a9678 12%, transparent);
-  --color-grade-mid-text:    var(--primitive-ired-300);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 12%, transparent);
-  --color-grade-low-text:    var(--primitive-ired-400);
-  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-400) 13%, transparent);
-  --color-grade-bottom-text: var(--primitive-crimson-200);
-  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
+  /* Grades — gold withering through sage and dry gray down to lead */
+  --color-grade-top-text:    #ecc44e;
+  --color-grade-top-bg:      color-mix(in srgb, #ecc44e 12%, transparent);
+  --color-grade-high-text:   #a8c8b0;
+  --color-grade-high-bg:     color-mix(in srgb, #a8c8b0 12%, transparent);
+  --color-grade-mid-text:    #86a05e;
+  --color-grade-mid-bg:      color-mix(in srgb, #86a05e 12%, transparent);
+  --color-grade-low-text:    #8a8890;
+  --color-grade-low-bg:      color-mix(in srgb, #8a8890 13%, transparent);
+  --color-grade-bottom-text: #6a746a;
+  --color-grade-bottom-bg:   color-mix(in srgb, #6a746a 4%, transparent);
   --color-warning:      var(--primitive-amber-400);
   --color-info:         var(--primitive-cyan-400);
   --color-warning-text: var(--primitive-amber-400);
@@ -1068,10 +1077,10 @@ html[data-theme="galadriel-dark"]:root, [data-theme="galadriel-dark"] {
   --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-200) 15%, transparent);
   --color-danger-border: color-mix(in srgb, var(--primitive-crimson-200) 30%, transparent);
 
-  /* Compliance — bright sage */
-  --color-compliance:        #4caf7d;
-  --color-compliance-bg:     color-mix(in srgb, #4caf7d 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, #4caf7d 38%, transparent);
+  /* Compliance — bright teal, off the sage-green accent */
+  --color-compliance:        var(--primitive-teal-400);
+  --color-compliance-bg:     color-mix(in srgb, var(--primitive-teal-400) 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, var(--primitive-teal-400) 38%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
@@ -1131,17 +1140,17 @@ html[data-theme="ifrit-light"]:root, [data-theme="ifrit-light"] {
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ifrit-sev-minor-light) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ifrit-sev-minor-light) 30%, transparent);
 
-  /* Grades — ember glow: gold → warm gray → orange → red */
-  --color-grade-top-text:    #c08000;
-  --color-grade-top-bg:      color-mix(in srgb, #c08000 14%, transparent);
-  --color-grade-high-text:   var(--primitive-ifrit-text-muted-light);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-ifrit-text-muted-light) 10%, transparent);
-  --color-grade-mid-text:    #c05020;
-  --color-grade-mid-bg:      color-mix(in srgb, #c05020 10%, transparent);
-  --color-grade-low-text:    #b82010;
-  --color-grade-low-bg:      color-mix(in srgb, #b82010 10%, transparent);
-  --color-grade-bottom-text: #a01008;
-  --color-grade-bottom-bg:   color-mix(in srgb, #a01008 12%, transparent);
+  /* Grades — gold cooling to ash; the fire band stays with severity */
+  --color-grade-top-text:    #9c7c00;
+  --color-grade-top-bg:      color-mix(in srgb, #9c7c00 14%, transparent);
+  --color-grade-high-text:   #6e7a8c;
+  --color-grade-high-bg:     color-mix(in srgb, #6e7a8c 10%, transparent);
+  --color-grade-mid-text:    #585e66;
+  --color-grade-mid-bg:      color-mix(in srgb, #585e66 10%, transparent);
+  --color-grade-low-text:    #42464c;
+  --color-grade-low-bg:      color-mix(in srgb, #42464c 10%, transparent);
+  --color-grade-bottom-text: #2b2d32;
+  --color-grade-bottom-bg:   color-mix(in srgb, #2b2d32 12%, transparent);
 
   --color-warning:      var(--primitive-amber-700);
   --color-info:         var(--primitive-cyan-700);
@@ -1152,10 +1161,10 @@ html[data-theme="ifrit-light"]:root, [data-theme="ifrit-light"] {
   --color-danger-bg:     var(--color-sev-critical-bg);
   --color-danger-border: var(--color-sev-critical-border);
 
-  /* Compliance — deep amber */
-  --color-compliance:        #c08000;
-  --color-compliance-bg:     color-mix(in srgb, #c08000 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, #c08000 38%, transparent);
+  /* Compliance — deep green, clear of the orange accent and gold grades */
+  --color-compliance:        #1a7a42;
+  --color-compliance-bg:     color-mix(in srgb, #1a7a42 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #1a7a42 38%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
   --color-overlay-medium: rgba(0, 0, 0, 0.5);
@@ -1217,17 +1226,17 @@ html[data-theme="deckard-dark"]:root, [data-theme="deckard-dark"] {
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-deckard-sev-minor-dark) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-deckard-sev-minor-dark) 32%, transparent);
 
-  /* Grades — neon spectrum: violet → purple-gray → pink → red */
+  /* Grades — violet chrome dimming to dull slate-violet; pink stays severity's */
   --color-grade-top-text:    #b040ff;
   --color-grade-top-bg:      color-mix(in srgb, #b040ff 12%, transparent);
-  --color-grade-high-text:   #a098b8;
-  --color-grade-high-bg:     color-mix(in srgb, #a098b8 12%, transparent);
-  --color-grade-mid-text:    var(--primitive-deckard-accent-dark);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-deckard-accent-dark) 12%, transparent);
-  --color-grade-low-text:    #ff4060;
-  --color-grade-low-bg:      color-mix(in srgb, #ff4060 13%, transparent);
-  --color-grade-bottom-text: #ff2040;
-  --color-grade-bottom-bg:   color-mix(in srgb, #ff2040 4%, transparent);
+  --color-grade-high-text:   #d4c4fc;
+  --color-grade-high-bg:     color-mix(in srgb, #d4c4fc 12%, transparent);
+  --color-grade-mid-text:    #b092ec;
+  --color-grade-mid-bg:      color-mix(in srgb, #b092ec 12%, transparent);
+  --color-grade-low-text:    #9278c8;
+  --color-grade-low-bg:      color-mix(in srgb, #9278c8 13%, transparent);
+  --color-grade-bottom-text: #7a66a2;
+  --color-grade-bottom-bg:   color-mix(in srgb, #7a66a2 4%, transparent);
 
   /* Compliance — neon cyan */
   --color-compliance:        #00dce0;
@@ -1307,17 +1316,17 @@ html[data-theme="deckard-light"]:root, [data-theme="deckard-light"] {
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-deckard-sev-minor-light) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-deckard-sev-minor-light) 30%, transparent);
 
-  /* Grades — neon spectrum: purple → gray → magenta → red */
+  /* Grades — violet chrome dimming to dull slate-violet; pink stays severity's */
   --color-grade-top-text:    #8020d0;
   --color-grade-top-bg:      color-mix(in srgb, #8020d0 12%, transparent);
-  --color-grade-high-text:   var(--primitive-deckard-text-muted-light);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-deckard-text-muted-light) 10%, transparent);
-  --color-grade-mid-text:    var(--primitive-deckard-accent-light);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-deckard-accent-light) 10%, transparent);
-  --color-grade-low-text:    #e03060;
-  --color-grade-low-bg:      color-mix(in srgb, #e03060 10%, transparent);
-  --color-grade-bottom-text: #c02040;
-  --color-grade-bottom-bg:   color-mix(in srgb, #c02040 12%, transparent);
+  --color-grade-high-text:   #8274bc;
+  --color-grade-high-bg:     color-mix(in srgb, #8274bc 10%, transparent);
+  --color-grade-mid-text:    #6858a4;
+  --color-grade-mid-bg:      color-mix(in srgb, #6858a4 10%, transparent);
+  --color-grade-low-text:    #4f4280;
+  --color-grade-low-bg:      color-mix(in srgb, #4f4280 10%, transparent);
+  --color-grade-bottom-text: #37305c;
+  --color-grade-bottom-bg:   color-mix(in srgb, #37305c 12%, transparent);
 
   /* Compliance — teal-cyan */
   --color-compliance:        #0098a8;

--- a/src/quodeq/ui/tools/token_distinctness.mjs
+++ b/src/quodeq/ui/tools/token_distinctness.mjs
@@ -1,0 +1,251 @@
+/**
+ * Token distinctness audit — perceptual separation between the grade ramp,
+ * the severity ramp, and the interactive accent for EVERY shipped theme
+ * combination (5 families x 2 modes).
+ *
+ * The UX audit found the two ramps colliding: grade-bottom and sev-critical
+ * resolved to the same red, and in several dark themes accent, compliance and
+ * grade-top were one identical color meaning three different things. This
+ * guard makes that class of regression fail in CI. Pure functions over the
+ * tokens.css source text, same approach as token_contrast.mjs: no browser,
+ * no CSS engine, and anything the tiny parser cannot resolve (color-mix) is
+ * skipped rather than guessed.
+ *
+ * Distances are CIE76 delta-E in Lab. Thresholds are calibrated so the
+ * audit's real findings fail while deliberate same-family lightness steps
+ * (neo's all-green world) pass.
+ *
+ * Run directly for the full matrix:  node tools/token_distinctness.mjs
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+export const GRADE_TOKENS = [
+  '--color-grade-top-text',
+  '--color-grade-high-text',
+  '--color-grade-mid-text',
+  '--color-grade-low-text',
+  '--color-grade-bottom-text',
+];
+
+export const SEV_TOKENS = [
+  '--color-sev-critical-text',
+  '--color-sev-major-text',
+  '--color-sev-minor-text',
+];
+
+// Minimum CIE76 delta-E between…
+export const MIN_GRADE_VS_SEV = 20;      // any grade color and any severity color
+export const MIN_GRADE_VS_ACCENT = 20;   // any grade color and the accent
+export const MIN_COMPLIANCE_VS_ACCENT = 20; // compliance and the accent
+export const MIN_GRADE_STEP = 10;        // any two grade steps (mutual legibility)
+
+// Grade text sits in chips/gauges over every surface; hold it to the WCAG
+// UI-component floor so no theme ships an unreadable tier.
+export const MIN_GRADE_CONTRAST = 3.0;
+export const SURFACE_TOKENS = ['--color-bg', '--color-surface', '--color-surface-alt'];
+
+const FAMILIES = ['neo', 'galadriel', 'ifrit', 'deckard'];
+
+// ---------------------------------------------------------------------------
+// parsing (same shapes token_contrast.mjs understands)
+// ---------------------------------------------------------------------------
+
+export function parseBlocks(cssText) {
+  const src = cssText.replace(/\/\*[\s\S]*?\*\//g, '');
+  const blocks = [];
+  let i = 0;
+  const readBlock = (media) => {
+    const open = src.indexOf('{', i);
+    if (open === -1) { i = src.length; return; }
+    const selector = src.slice(i, open).trim();
+    if (selector.startsWith('@media')) {
+      i = open + 1;
+      const innerMedia = selector;
+      while (i < src.length) {
+        const next = src.slice(i).search(/\S/);
+        if (next === -1) { i = src.length; break; }
+        i += next;
+        if (src[i] === '}') { i += 1; break; }
+        readBlock(innerMedia);
+      }
+      return;
+    }
+    let depth = 1;
+    let j = open + 1;
+    while (j < src.length && depth > 0) {
+      if (src[j] === '{') depth += 1;
+      else if (src[j] === '}') depth -= 1;
+      j += 1;
+    }
+    const body = src.slice(open + 1, j - 1);
+    const decls = {};
+    for (const m of body.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+      decls[m[1]] = m[2].trim();
+    }
+    if (Object.keys(decls).length) blocks.push({ selector, media: media || null, decls });
+    i = j;
+  };
+  while (i < src.length) {
+    const next = src.slice(i).search(/\S/);
+    if (next === -1) break;
+    i += next;
+    if (src[i] === '}') { i += 1; continue; }
+    readBlock(null);
+  }
+  return blocks;
+}
+
+const isPlainRoot = (b) => !b.media && b.selector.includes(':root') && !b.selector.includes('data-theme');
+const inMediaDark = (b) => Boolean(b.media && b.media.includes('prefers-color-scheme: dark'));
+const hasExact = (name) => (b) => !b.media && b.selector.includes(`[data-theme="${name}"]`);
+const hasEndsDark = (b) => !b.media && b.selector.includes('[data-theme$="dark"]');
+
+function compose(blocks, matchers) {
+  const vars = {};
+  for (const match of matchers) {
+    for (const b of blocks) {
+      if (match(b)) Object.assign(vars, b.decls);
+    }
+  }
+  return vars;
+}
+
+export function themeContexts(blocks) {
+  const themes = {
+    'daruma-light': compose(blocks, [isPlainRoot]),
+    'daruma-dark-system': compose(blocks, [isPlainRoot, inMediaDark]),
+    'daruma-dark': compose(blocks, [isPlainRoot, hasEndsDark, hasExact('dark')]),
+    'daruma-light-explicit': compose(blocks, [isPlainRoot, hasExact('light')]),
+  };
+  for (const f of FAMILIES) {
+    themes[`${f}-light`] = compose(blocks, [isPlainRoot, hasExact(`${f}-light`)]);
+    themes[`${f}-dark`] = compose(blocks, [isPlainRoot, hasEndsDark, hasExact(`${f}-dark`)]);
+  }
+  return themes;
+}
+
+// ---------------------------------------------------------------------------
+// colour math
+// ---------------------------------------------------------------------------
+
+export function resolveVar(vars, name, seen = new Set()) {
+  if (seen.has(name)) return null;
+  seen.add(name);
+  const raw = vars[name];
+  if (!raw) return null;
+  const ref = raw.match(/^var\((--[\w-]+)\s*(?:,\s*([^)]+))?\)$/);
+  if (ref) return resolveVar(vars, ref[1], seen) ?? (ref[2] ? ref[2].trim() : null);
+  return raw;
+}
+
+export function parseColor(value) {
+  if (!value) return null;
+  const v = value.trim().toLowerCase();
+  let m = v.match(/^#([0-9a-f]{6})([0-9a-f]{2})?$/);
+  if (m) {
+    const n = parseInt(m[1], 16);
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+  }
+  m = v.match(/^#([0-9a-f]{3})$/);
+  if (m) return [...m[1]].map((c) => parseInt(c + c, 16));
+  m = v.match(/^rgba?\(\s*(\d+)[\s,]+(\d+)[\s,]+(\d+)/);
+  if (m) return [Number(m[1]), Number(m[2]), Number(m[3])];
+  return null;
+}
+
+function srgbToLinear(c) {
+  const s = c / 255;
+  return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+}
+
+function rgbToLab([r, g, b]) {
+  const [lr, lg, lb] = [srgbToLinear(r), srgbToLinear(g), srgbToLinear(b)];
+  // sRGB D65
+  let x = (0.4124564 * lr + 0.3575761 * lg + 0.1804375 * lb) / 0.95047;
+  let y = (0.2126729 * lr + 0.7151522 * lg + 0.0721750 * lb) / 1.0;
+  let z = (0.0193339 * lr + 0.1191920 * lg + 0.9503041 * lb) / 1.08883;
+  const f = (t) => (t > 0.008856 ? Math.cbrt(t) : 7.787 * t + 16 / 116);
+  [x, y, z] = [f(x), f(y), f(z)];
+  return [116 * y - 16, 500 * (x - y), 200 * (y - z)];
+}
+
+export function deltaE(rgbA, rgbB) {
+  const [l1, a1, b1] = rgbToLab(rgbA);
+  const [l2, a2, b2] = rgbToLab(rgbB);
+  return Math.hypot(l1 - l2, a1 - a2, b1 - b2);
+}
+
+export function contrastRatio(rgbA, rgbB) {
+  const lum = ([r, g, b]) => 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b);
+  const la = lum(rgbA);
+  const lb = lum(rgbB);
+  const [hi, lo] = la >= lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// ---------------------------------------------------------------------------
+// audit
+// ---------------------------------------------------------------------------
+
+/**
+ * @returns {{results: Array, failures: Array}} one result per rule per theme;
+ *   failures is the subset under its required minimum. Unresolvable tokens
+ *   (color-mix and friends) are skipped, matching token_contrast.mjs.
+ */
+export function auditDistinctness(cssText) {
+  const blocks = parseBlocks(cssText);
+  const themes = themeContexts(blocks);
+  const results = [];
+  const push = (theme, rule, a, b, value, min, kind) => {
+    results.push({ theme, rule, a, b, value: Math.round(value * 10) / 10, min, kind, ok: value >= min });
+  };
+  for (const [theme, vars] of Object.entries(themes)) {
+    const color = (token) => parseColor(resolveVar(vars, token));
+    const grades = GRADE_TOKENS.map((t) => [t, color(t)]).filter(([, c]) => c);
+    const sevs = SEV_TOKENS.map((t) => [t, color(t)]).filter(([, c]) => c);
+    const accent = color('--color-accent');
+    const compliance = color('--color-compliance');
+
+    for (const [g, gc] of grades) {
+      for (const [s, sc] of sevs) {
+        push(theme, 'grade-vs-severity', g, s, deltaE(gc, sc), MIN_GRADE_VS_SEV, 'deltaE');
+      }
+      if (accent) {
+        push(theme, 'grade-vs-accent', g, '--color-accent', deltaE(gc, accent), MIN_GRADE_VS_ACCENT, 'deltaE');
+      }
+      for (const surface of SURFACE_TOKENS) {
+        const bg = color(surface);
+        if (bg) push(theme, 'grade-contrast', g, surface, contrastRatio(gc, bg), MIN_GRADE_CONTRAST, 'contrast');
+      }
+    }
+    for (let i = 0; i < grades.length; i += 1) {
+      for (let j = i + 1; j < grades.length; j += 1) {
+        push(theme, 'grade-step', grades[i][0], grades[j][0], deltaE(grades[i][1], grades[j][1]), MIN_GRADE_STEP, 'deltaE');
+      }
+    }
+    if (accent && compliance) {
+      push(theme, 'compliance-vs-accent', '--color-compliance', '--color-accent', deltaE(compliance, accent), MIN_COMPLIANCE_VS_ACCENT, 'deltaE');
+    }
+  }
+  return { results, failures: results.filter((r) => !r.ok) };
+}
+
+export function defaultTokensPath() {
+  return join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'styles', 'tokens.css');
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (invokedDirectly) {
+  const tokensPath = process.argv.slice(2).find((a) => !a.startsWith('--')) || defaultTokensPath();
+  const { results, failures } = auditDistinctness(readFileSync(tokensPath, 'utf8'));
+  const failuresOnly = process.argv.includes('--failures');
+  for (const r of results) {
+    if (failuresOnly && r.ok) continue;
+    const flag = r.ok ? '  ' : '!!';
+    console.log(`${flag} ${r.theme.padEnd(22)} ${r.rule.padEnd(22)} ${r.a.padEnd(28)} vs ${r.b.padEnd(28)} ${String(r.value).padEnd(7)} (min ${r.min} ${r.kind})`);
+  }
+  console.log(`\n${results.length} checks, ${failures.length} failures`);
+  process.exitCode = failures.length ? 1 : 0;
+}

--- a/src/quodeq/ui/tools/token_distinctness.test.mjs
+++ b/src/quodeq/ui/tools/token_distinctness.test.mjs
@@ -1,0 +1,59 @@
+/**
+ * Theme-matrix distinctness guard.
+ *
+ * The design-system UX audit found the grade ramp and the severity ramp
+ * colliding (an F-grade file and a critical finding shared the same red),
+ * and several dark themes resolving accent, compliance, and grade-top to
+ * one identical color. This suite keeps every shipped theme combination
+ * honest: grade colors must stay perceptually apart from severity colors
+ * and the accent, grade steps must stay mutually legible, and grade text
+ * must clear the WCAG UI-component contrast floor on every surface.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import {
+  auditDistinctness, themeContexts, parseBlocks, deltaE, parseColor, defaultTokensPath,
+} from './token_distinctness.mjs';
+
+const css = readFileSync(defaultTokensPath(), 'utf8');
+
+test('parser sees every shipped theme combination', () => {
+  const themes = themeContexts(parseBlocks(css));
+  const names = Object.keys(themes);
+  for (const expected of [
+    'daruma-light', 'daruma-dark-system', 'daruma-dark', 'daruma-light-explicit',
+    'neo-light', 'neo-dark', 'galadriel-light', 'galadriel-dark',
+    'ifrit-light', 'ifrit-dark', 'deckard-light', 'deckard-dark',
+  ]) {
+    assert.ok(names.includes(expected), `missing theme context: ${expected}`);
+  }
+  // Each context must actually resolve grades and severity — an empty
+  // context means a selector drifted and the audit would vacuously pass.
+  for (const [name, vars] of Object.entries(themes)) {
+    assert.ok(vars['--color-grade-top-text'], `${name} resolved no --color-grade-top-text`);
+    assert.ok(vars['--color-sev-critical-text'], `${name} resolved no --color-sev-critical-text`);
+  }
+});
+
+test('deltaE matches known reference points', () => {
+  const white = parseColor('#ffffff');
+  const black = parseColor('#000000');
+  assert.equal(Math.round(deltaE(white, black)), 100);
+  assert.equal(Math.round(deltaE(white, white)), 0);
+  // The audit's headline finding: grade-bottom and sev-critical were both
+  // this exact red in daruma light. Identical colors must measure as such.
+  assert.equal(deltaE(parseColor('#b00a14'), parseColor('#b00a14')), 0);
+});
+
+test('grades, severity, accent, and compliance stay apart in every theme', () => {
+  const { results, failures } = auditDistinctness(css);
+  // 12 contexts x (15 grade-vs-sev + 5 grade-vs-accent + 15 contrast +
+  // 10 grade-step + 1 compliance) — if this shrinks, the parser stopped
+  // seeing part of the matrix and the guard is weaker than it looks.
+  assert.ok(results.length >= 500, `matrix shrank: only ${results.length} checks ran`);
+  const table = failures
+    .map((f) => `  ${f.theme}: ${f.rule} ${f.a} vs ${f.b} = ${f.value} (min ${f.min} ${f.kind})`)
+    .join('\n');
+  assert.equal(failures.length, 0, `distinctness failures:\n${table}`);
+});


### PR DESCRIPTION
## Problem

The design-system UX audit found the severity ramp and the grade ramp colliding, so a critical finding and an F-grade file were indistinguishable at a glance:

- daruma light: grade-bottom = sev-critical, both `#b00a14`; grade-mid `#c0502a` vs sev-major `#c05030`
- neo dark: grade-low = sev-critical `#ff4040`, grade-mid = sev-major `#ff6432`
- ifrit: grade-low = sev-critical in both modes
- deckard dark: grade-mid = accent = sev-major, all `#ff40c0`; grade-high = sev-minor
- four dark themes resolved accent, compliance, and grade-top to one color (flynn cyan `#00d4ff`, neo green `#00ff41`, galadriel sage `#4caf7d`, plus ifrit compliance = grade-top gold)

## Fix

One rule applied to all 5 families x 2 modes: **grades are a metallic shine ramp** (bright precious tone for A fading through silver and bronze tones to dull lead for F) in a hue band that theme's severity ramp does not use. Severity keeps the vivid warm danger channel untouched, per the audit's direction.

- daruma: gold / silver / bronze / tarnish / lead
- ifrit: gold cooling to ash (the fire band stays with severity)
- galadriel: gold withering through sage and dry gray to lead
- neo: phosphor fading from bright mint (dark) or deep green (light) to dead-pixel gray
- deckard: violet chrome dimming to slate-violet (pink stays severity's)

Compliance moves off the accent where they collided: spring green (daruma dark, ifrit) and teal (neo, galadriel), which also puts the long-unused `--primitive-compliance` primitive to work. The three-layer token pipeline and all token names are unchanged, so no component CSS moves.

## Guard

New `tools/token_distinctness.mjs` + test (picked up by the existing `npm test` glob) enforce the invariant across the 10-combo matrix with CIE76 deltaE floors: every grade color vs every severity color >= 20, every grade color vs the accent >= 20, compliance vs accent >= 20, grade steps pairwise >= 10, plus a 3.0:1 contrast floor for grade text on every surface (daruma's old grade-top/high shipped at 2.0 and 2.5). On the old tokens it reports 79 failures; on this branch 0 of 552 checks fail.

## Verification

- `npm test`: 456 pass, 0 fail
- PR #1088's `token_contrast.mjs` run against this branch's tokens.css reports only develop's pre-existing text-token baseline (the set #1088 itself fixes); no token overlaps with that PR, both can merge in either order
- Visually verified in daruma light + dark with the vite dev server against a live API: grade chips, severity chips, accent, compliance, and warning all read as distinct families side by side

Known accepted adjacency, unchanged from what already ships: gold grade-A sits near the amber warning color in some themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)