### PR TITLE
feat(ui): map drill-down and violations sub-tabs live in the nav stack

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -312,6 +312,9 @@ export function buildNavigationBundle({ state, navTab, navStackLength, isEvaluat
     warmup: state.warmup,
     loadProjects: state.loadProjects,
     handleNavigate: state.handleNavigate, handleNavigateReplace: state.handleNavigateReplace, navPop: state.navPop, handleRunSelect: state.handleRunSelect,
+    // navStack + navGoTo let a route unwind history to an earlier entry of
+    // its own page (the map's drill-up) instead of pushing a duplicate.
+    navStack: state.navStack, navGoTo: state.navGoTo,
     handleProjectChange: state.handleProjectChange, navTab, navStackLength,
     handleDeleteProject: state.handleDeleteProject, handleExportProject: state.handleExportProject, handleRelocateProject: state.handleRelocateProject, handleImportProject: state.handleImportProject,
     historySelectedRun: state.historySelectedRun, setHistorySelectedRun: state.setHistorySelectedRun,
@@ -597,6 +600,12 @@ function ViolationsRoute({ params, props }) {
       }}
       isDirectNav={props.navigation.navStackLength === 1}
       tabKey={params._tabKey || 0}
+      // The by-dimension / by-file / dismissed flip is view state on the SAME
+      // screen: it lives in the route entry so back/forward and the crumb see
+      // it, but flipping replaces (never pushes) so history doesn't grow.
+      // Params are spread forward so _tabKey survives the flip.
+      subTab={params.subTab || 'dimension'}
+      onSubTabChange={(v) => props.navigation.handleNavigateReplace('violations', { ...params, subTab: v })}
     />
   );
 }
@@ -612,6 +621,25 @@ export const ROUTE_RENDERERS = {
   map: (params, props) => {
     const acc = props.dashboardData.latestAccumulated || props.dashboardData.accumulated;
     const isDirectNav = props.navigation.navStackLength === 1;
+    // The viz drill-down is a real nav-stack entry: drilling into a folder
+    // pushes (browser back climbs back out), and navigating up to a path
+    // that already sits in the trailing run of map entries unwinds history
+    // to it instead of stacking a duplicate. Mode/style toggles replace in
+    // place so flipping them never grows history. Params are spread forward
+    // on every hop so _tabKey (the fresh-tab-click reset signal) survives.
+    const handlePathChange = (path) => {
+      const current = params.path || '';
+      if (path === current) return;
+      const stack = props.navigation.navStack || [];
+      for (let i = stack.length - 2; i >= 0 && stack[i].page === 'map'; i--) {
+        if ((stack[i].path || '') === path) {
+          props.navigation.navGoTo(i);
+          return;
+        }
+      }
+      props.navigation.handleNavigate('map', { ...params, path });
+    };
+    const replaceView = (patch) => props.navigation.handleNavigateReplace('map', { ...params, ...patch });
     return <MapPage
       data={{
         accumulated: acc,
@@ -626,6 +654,16 @@ export const ROUTE_RENDERERS = {
         error: props.dashboardData.error,
       }}
       callbacks={{ onNavigate: props.navigation.handleNavigate, onRefresh: props.refreshDashboard, onRetry: props.dashboardData.onRetry }}
+      nav={{
+        path: params.path || '',
+        vizStyle: params.vizStyle,
+        viewMode: params.viewMode,
+        galaxyMode: params.galaxyMode,
+        onPathChange: handlePathChange,
+        onVizStyleChange: (v) => replaceView({ vizStyle: v }),
+        onViewModeChange: (v) => replaceView({ viewMode: v }),
+        onGalaxyModeChange: (v) => replaceView({ galaxyMode: v }),
+      }}
       isDirectNav={isDirectNav}
       tabKey={params._tabKey || 0}
     />;

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -700,6 +700,112 @@ describe('buildNavigationBundle', () => {
   });
 });
 
+// Same pattern as the compare tab's dimension drill-down (PR #1087): the
+// map's viz path and the violations sub-tab are route params, so the browser
+// back button and the breadcrumb see them. Drilling pushes, navigating up to
+// a path already in the trailing run of map entries unwinds history via
+// navGoTo, and view toggles replace in place so flipping never grows
+// history. Params must be spread forward on every hop or _tabKey (the
+// fresh-tab-click reset signal) silently drops and the page resets its
+// cached state mid-drill.
+describe('map/violations view state lives in the nav stack', () => {
+  function mapProps(navOverrides = {}) {
+    return {
+      dashboardData: {
+        latestAccumulated: null, accumulated: null, dashboard: null,
+        selectedDisplayName: 'p1', loading: false, isFetching: false,
+      },
+      navigation: {
+        selectedProject: 'p1', selectedSource: 'local', projects: [], projectsLoaded: true,
+        handleNavigate: vi.fn(), handleNavigateReplace: vi.fn(), navGoTo: vi.fn(),
+        navStack: [{ page: 'map', _tabKey: 3 }], navStackLength: 1,
+        ...navOverrides,
+      },
+      refreshDashboard: vi.fn(),
+    };
+  }
+
+  it('map: drilling to a new path pushes, with existing params spread forward', () => {
+    const props = mapProps();
+    const el = ROUTE_RENDERERS.map({ _tabKey: 3, vizStyle: 'riskmatrix' }, props);
+    el.props.nav.onPathChange('src');
+    expect(props.navigation.handleNavigate).toHaveBeenCalledWith('map', { _tabKey: 3, vizStyle: 'riskmatrix', path: 'src' });
+    expect(props.navigation.navGoTo).not.toHaveBeenCalled();
+    expect(props.navigation.handleNavigateReplace).not.toHaveBeenCalled();
+  });
+
+  it('map: navigating up to a path already in the trailing map trail unwinds via navGoTo, never pushes a duplicate', () => {
+    const props = mapProps({
+      navStack: [
+        { page: 'map', _tabKey: 3 },
+        { page: 'map', _tabKey: 3, path: 'src' },
+        { page: 'map', _tabKey: 3, path: 'src/app' },
+      ],
+      navStackLength: 3,
+    });
+    const el = ROUTE_RENDERERS.map({ _tabKey: 3, path: 'src/app' }, props);
+    el.props.nav.onPathChange('');
+    expect(props.navigation.navGoTo).toHaveBeenCalledWith(0);
+    expect(props.navigation.handleNavigate).not.toHaveBeenCalled();
+  });
+
+  it('map: the trail scan stops at the first non-map entry, so an older unrelated map entry is not a goTo target', () => {
+    const props = mapProps({
+      navStack: [
+        { page: 'map', _tabKey: 2, path: 'src' },
+        { page: 'overview' },
+        { page: 'map', _tabKey: 3, path: 'src/app' },
+      ],
+      navStackLength: 3,
+    });
+    const el = ROUTE_RENDERERS.map({ _tabKey: 3, path: 'src/app' }, props);
+    el.props.nav.onPathChange('src');
+    expect(props.navigation.navGoTo).not.toHaveBeenCalled();
+    expect(props.navigation.handleNavigate).toHaveBeenCalledWith('map', { _tabKey: 3, path: 'src' });
+  });
+
+  it('map: mode/style toggles replace the entry in place, params preserved', () => {
+    const props = mapProps();
+    const el = ROUTE_RENDERERS.map({ _tabKey: 3, path: 'src' }, props);
+    el.props.nav.onVizStyleChange('galaxy');
+    expect(props.navigation.handleNavigateReplace).toHaveBeenCalledWith('map', { _tabKey: 3, path: 'src', vizStyle: 'galaxy' });
+    el.props.nav.onGalaxyModeChange('standards');
+    expect(props.navigation.handleNavigateReplace).toHaveBeenCalledWith('map', { _tabKey: 3, path: 'src', galaxyMode: 'standards' });
+    expect(props.navigation.handleNavigate).not.toHaveBeenCalled();
+  });
+
+  it('violations: the sub-tab flip replaces the entry (history must not grow), _tabKey preserved', () => {
+    const props = {
+      dashboardData: { latestAccumulated: null, accumulated: null, selectedDisplayName: 'p1', loading: false, isFetching: false },
+      navigation: {
+        selectedProject: 'p1', selectedSource: 'local', projects: [], projectsLoaded: true,
+        handleNavigate: vi.fn(), handleNavigateReplace: vi.fn(), navStackLength: 1,
+      },
+      dismissRefreshKey: 0,
+      refreshDashboard: vi.fn(),
+      scheduleDashboardReconcile: vi.fn(),
+    };
+    const outer = ROUTE_RENDERERS.violations({ _tabKey: 2 }, props);
+    const inner = outer.type(outer.props);
+    expect(inner.props.subTab).toBe('dimension');
+    inner.props.onSubTabChange('file');
+    expect(props.navigation.handleNavigateReplace).toHaveBeenCalledWith('violations', { _tabKey: 2, subTab: 'file' });
+    expect(props.navigation.handleNavigate).not.toHaveBeenCalled();
+  });
+
+  it('buildNavigationBundle forwards navStack and navGoTo (the map drill-up dies without them)', () => {
+    const navStack = [{ page: 'map' }];
+    const navGoTo = vi.fn();
+    const bundle = buildNavigationBundle({
+      state: { navStack, navGoTo },
+      navTab: vi.fn(), navStackLength: 1,
+      isEvaluating: false, showToast: vi.fn(), setWizardEntry: vi.fn(),
+    });
+    expect(bundle.navStack).toBe(navStack);
+    expect(bundle.navGoTo).toBe(navGoTo);
+  });
+});
+
 // Teammate persona, one click deeper than the data pages: with zero LOCAL
 // projects, drill-in pages (file/finding/dimension detail...) must not wall
 // a shared selection behind the add-a-project tour. Same gate class as the

--- a/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.jsx
@@ -16,6 +16,13 @@ const PAGE_LABELS = {
 };
 
 export function labelFor(entry) {
+  // A map drill-down entry carries its folder path (see App.jsx's map
+  // renderer): the crumb shows the folder name, so the trail reads
+  // map / src / components. The root map entry (no path) falls through to
+  // its tab label.
+  if (entry.page === 'map' && entry.path) {
+    return entry.path.split('/').filter(Boolean).pop() || 'map';
+  }
   if (PAGE_LABELS[entry.page]) return PAGE_LABELS[entry.page];
   switch (entry.page) {
     case 'run':           return entry.label || entry.runId || 'run';

--- a/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.test.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.test.jsx
@@ -1,7 +1,30 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
-import NavBreadcrumb from './NavBreadcrumb.jsx';
+import NavBreadcrumb, { labelFor } from './NavBreadcrumb.jsx';
+
+// Map drill-down entries carry their folder path as a route param (see
+// App.jsx's map renderer); the crumb must read as the folder name so the
+// trail reads map / src / components instead of map / map / map.
+describe('labelFor — map drill-down entries', () => {
+  it('root map entry (no path) keeps the tab label', () => {
+    expect(labelFor({ page: 'map' })).toBe('map');
+    expect(labelFor({ page: 'map', path: '' })).toBe('map');
+  });
+
+  it('a drill-down entry shows the deepest folder name', () => {
+    expect(labelFor({ page: 'map', path: 'src' })).toBe('src');
+    expect(labelFor({ page: 'map', path: 'src/components' })).toBe('components');
+  });
+
+  it('tolerates trailing slashes in the path', () => {
+    expect(labelFor({ page: 'map', path: 'src/app/' })).toBe('app');
+  });
+
+  it('violations entries keep their tab label regardless of the sub-tab param', () => {
+    expect(labelFor({ page: 'violations', subTab: 'dismissed' })).toBe('violations');
+  });
+});
 
 describe('NavBreadcrumb project crumb', () => {
   const stack = [{ page: 'violations' }];

--- a/src/quodeq/ui/src/features/map/components/MapPage.test.jsx
+++ b/src/quodeq/ui/src/features/map/components/MapPage.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
+import { useState } from 'react';
 import MapPage from './MapPage.jsx';
 
 // Final whole-branch review: Critical 1 (evaluate CTA gating for shared
@@ -113,6 +114,92 @@ describe('MapPage — error state + retry feedback (P4-T2)', () => {
       error: 'Failed to load',
     }));
     expect(screen.queryByText("Couldn't load this project")).toBeNull();
+  });
+});
+
+/* Mimics the App wiring (see ROUTE_RENDERERS.map): path/vizStyle/viewMode/
+   galaxyMode are route params — drilling into a folder pushes a nav-stack
+   entry, navigating up to a path already in the trail unwinds to it, and
+   mode/style toggles replace in place. The harness keeps a tiny stack plus
+   an action log so the push/replace/unwind contract is exercised, not just
+   that the view flipped. */
+function NavHarness({ data, log }) {
+  const [stack, setStack] = useState([{}]);
+  const top = stack[stack.length - 1];
+  const replaceTop = (patch) => setStack((s) => s.slice(0, -1).concat([{ ...s[s.length - 1], ...patch }]));
+  const nav = {
+    path: top.path || '',
+    vizStyle: top.vizStyle,
+    viewMode: top.viewMode,
+    galaxyMode: top.galaxyMode,
+    onPathChange: (path) => setStack((s) => {
+      for (let i = s.length - 2; i >= 0; i--) {
+        if ((s[i].path || '') === path) { log.push(['goTo', i]); return s.slice(0, i + 1); }
+      }
+      log.push(['push', path]);
+      return s.concat([{ ...s[s.length - 1], path }]);
+    }),
+    onVizStyleChange: (v) => { log.push(['replace', 'vizStyle', v]); replaceTop({ vizStyle: v }); },
+    onViewModeChange: (v) => { log.push(['replace', 'viewMode', v]); replaceTop({ viewMode: v }); },
+    onGalaxyModeChange: (v) => { log.push(['replace', 'galaxyMode', v]); replaceTop({ galaxyMode: v }); },
+  };
+  return <MapPage data={data} callbacks={{}} nav={nav} />;
+}
+
+describe('MapPage — drill-down and toggles live in the nav stack', () => {
+  // Two top-level entries so collapseSingleChildren keeps `src` as a
+  // distinct drillable folder.
+  const DIMS = [{
+    dimension: 'security',
+    violations: [
+      { file: 'src/a.py', severity: 'minor', principle: 'P1' },
+      { file: 'src/b.py', severity: 'major', principle: 'P1' },
+      { file: 'main.py', severity: 'minor', principle: 'P2' },
+    ],
+    compliance: [],
+  }];
+  const data = () => ({
+    accumulated: { dimensions: DIMS },
+    dashboard: null,
+    projectName: 'proj',
+    projects: [{ id: 'p1', name: 'p1' }],
+    projectsLoaded: true,
+    selectedProject: 'p1',
+    selectedSource: 'local',
+    loading: false,
+    isFetching: false,
+  });
+
+  it('style toggle replaces, folder drill pushes, breadcrumb-up unwinds to the trail entry', () => {
+    const log = [];
+    const { container } = render(<NavHarness data={data()} log={log} />);
+
+    // Switch to the risk-matrix style: a replace, not a push.
+    fireEvent.click(screen.getByRole('button', { name: 'Risk Matrix' }));
+    expect(log).toEqual([['replace', 'vizStyle', 'riskmatrix']]);
+
+    // Drill into the `src` folder circle: a push.
+    const circle = container.querySelector('circle[role="button"]');
+    expect(circle).not.toBeNull();
+    fireEvent.click(circle);
+    expect(log[1]).toEqual(['push', 'src']);
+    // The controlled path round-tripped: breadcrumb now shows the folder.
+    expect(screen.getAllByText('src').length).toBeGreaterThan(0);
+
+    // Breadcrumb back to the project root: unwinds to the earlier entry
+    // (the browser-back equivalent), never a fresh push.
+    fireEvent.click(screen.getByRole('button', { name: 'proj' }));
+    expect(log[2]).toEqual(['goTo', 0]);
+    // The unwound entry still carries the style set by the replace.
+    expect(screen.getByRole('button', { name: 'Risk Matrix' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('view-mode toggle on the circle pack replaces in place', () => {
+    const log = [];
+    render(<NavHarness data={data()} log={log} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Violations' }));
+    expect(log).toEqual([['replace', 'viewMode', 'violations']]);
+    expect(screen.getByRole('button', { name: 'Violations' })).toHaveAttribute('aria-pressed', 'true');
   });
 });
 

--- a/src/quodeq/ui/src/features/map/components/useMapPageState.js
+++ b/src/quodeq/ui/src/features/map/components/useMapPageState.js
@@ -38,8 +38,26 @@ function buildBreadcrumbPath(root, path) {
   return crumbs;
 }
 
-export default function useMapPageState({ data, callbacks, tabKey = 0 }) {
+export default function useMapPageState({ data, callbacks, nav, tabKey = 0 }) {
   const selectedProject = data?.projectName || data?.selectedProject || '__map__';
+
+  // Drill path and mode/style toggles live in the nav-stack entry (route
+  // params), not component state — drilling pushes a history entry, toggling
+  // replaces one (see App.jsx's map renderer), and browser back/forward and
+  // the breadcrumb restore them. Defaults apply when a fresh tab entry
+  // carries no params yet. Standalone renders (tests) may pass no nav
+  // bundle; the setters then no-op.
+  const {
+    path: currentPath = '',
+    vizStyle = 'zoompack',
+    viewMode = 'health',
+    galaxyMode = 'filesystem',
+    onPathChange, onVizStyleChange, onViewModeChange, onGalaxyModeChange,
+  } = nav || {};
+  const setCurrentPath = (p) => onPathChange?.(p);
+  const setVizStyle = (v) => onVizStyleChange?.(v);
+  const setViewMode = (v) => onViewModeChange?.(v);
+  const setGalaxyMode = (v) => onGalaxyModeChange?.(v);
 
   // Fresh tab click drops the cache; round-tripping through a detail view
   // does not change tabKey, so cached state survives unmount/remount.
@@ -50,10 +68,6 @@ export default function useMapPageState({ data, callbacks, tabKey = 0 }) {
   }
 
   const cached = readCachedState('map', selectedProject, {
-    currentPath: '',
-    vizStyle: 'zoompack',
-    viewMode: 'health',
-    galaxyMode: 'filesystem',
     selectedDimensionsArr: [],
   });
 
@@ -86,12 +100,6 @@ export default function useMapPageState({ data, callbacks, tabKey = 0 }) {
   }, []);
 
   const allDimensions = data?.accumulated?.dimensions || data?.dashboard?.dimensions || [];
-  const [viewMode, _setViewMode] = useState(cached.viewMode);
-  const setViewMode = (v) => { writeCachedState('map', selectedProject, { viewMode: v }); _setViewMode(v); };
-  const [vizStyle, _setVizStyle] = useState(cached.vizStyle);
-  const setVizStyle = (v) => { writeCachedState('map', selectedProject, { vizStyle: v }); _setVizStyle(v); };
-  const [galaxyMode, _setGalaxyMode] = useState(cached.galaxyMode);
-  const setGalaxyMode = (v) => { writeCachedState('map', selectedProject, { galaxyMode: v }); _setGalaxyMode(v); };
   const [showLabels, _setShowLabels] = useState(() => { try { const v = localStorage.getItem(MAP_LABELS_KEY); return v === null ? true : v === '1'; } catch { return true; } });
   const setShowLabels = (v) => { _setShowLabels(v); try { localStorage.setItem(MAP_LABELS_KEY, v ? '1' : '0'); } catch {} };
   const appIsDark = useThemeIsDark();
@@ -106,18 +114,9 @@ export default function useMapPageState({ data, callbacks, tabKey = 0 }) {
     if (appIsDark) { _setDarkMode(true); }
     else { try { const v = localStorage.getItem(MAP_DARK_KEY); _setDarkMode(v === null ? false : v === '1'); } catch { _setDarkMode(false); } }
   }, [appIsDark]);
-  const [currentPath, _setCurrentPath] = useState(cached.currentPath);
-  const setCurrentPath = (p) => { writeCachedState('map', selectedProject, { currentPath: p }); _setCurrentPath(p); };
-
-  // Animate back to root when tab is re-clicked while already on map
-  const prevTabKey = useRef(tabKey);
-  useEffect(() => {
-    if (tabKey !== prevTabKey.current) {
-      prevTabKey.current = tabKey;
-      setCurrentPath('');
-      callbacks?.onRefresh?.();
-    }
-  }, [tabKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Tab re-click needs no path reset here anymore: navTab creates a fresh
+  // entry with no path param, so the controlled currentPath above is already
+  // '' (and the refresh-on-tabKey effect above covers the data refresh).
 
   // Get visible standards and available dimension names
   const visibleIds = useMemo(() => new Set(readVisibleStandardIds()), [allDimensions]);

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -99,12 +99,7 @@ function FileSubTab({ dimensions, onFileClick, currentPath, setCurrentPath }) {
   );
 }
 
-function useViolationsData({ accumulatedDimensions, selectedProject, onRefresh, onReconcile, initialSubTab, initialFilePath, dismissRefreshKey, selectedSource }) {
-  const [activeSubTab, _setActiveSubTab] = useState(initialSubTab);
-  const setActiveSubTab = (v) => {
-    writeCachedState('violations', selectedProject, { activeSubTab: v });
-    _setActiveSubTab(v);
-  };
+function useViolationsData({ accumulatedDimensions, selectedProject, onRefresh, onReconcile, initialFilePath, dismissRefreshKey, selectedSource }) {
   const [fileCurrentPath, _setFileCurrentPath] = useState(initialFilePath);
   const setFileCurrentPath = (v) => {
     writeCachedState('violations', selectedProject, { fileCurrentPath: v });
@@ -137,7 +132,7 @@ function useViolationsData({ accumulatedDimensions, selectedProject, onRefresh, 
   );
 
   return {
-    activeSubTab, setActiveSubTab, dismissed,
+    dismissed,
     handleRestore, handleRestoreAll, handleDelete, handleDeleteAll,
     restoreError, visibleDimensions,
     summary, topFilesCount, uniquePrinciples,
@@ -192,15 +187,23 @@ export function ViolationsSubTabContent(props) {
   return null;
 }
 
-export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 0 }) {
+export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 0, subTab = 'dimension', onSubTabChange }) {
   const { accumulatedDimensions = [], selectedProject, dismissRefreshKey = 0, selectedSource = 'local' } = data;
   const { projects = [], projectsLoaded, projectName, loading, isFetching, error } = data;
   const { onNavigate, onRefresh, onReconcile, onRetry } = callbacks;
 
-  // Fresh tab click (tabKey changed) drops the cached navigation state so
-  // the user lands at the default sub-tab / root path. Round-tripping
-  // through a file detail does NOT change tabKey, so the cache survives
-  // unmount and the page resumes where it was.
+  // The active sub-tab lives in the nav-stack entry, not component state:
+  // `subTab` arrives as a route param and flipping it replaces the entry in
+  // place (see App.jsx's ViolationsRoute), so back/forward restore it while
+  // history never grows per flip. A fresh tab click creates an entry with no
+  // subTab param, which lands on the default just like the old cache reset.
+  const activeSubTab = subTab;
+  const setActiveSubTab = (v) => onSubTabChange?.(v);
+
+  // Fresh tab click (tabKey changed) drops the cached file-tree path so the
+  // user lands at the root. Round-tripping through a file detail does NOT
+  // change tabKey, so the cache survives unmount and the tree resumes where
+  // it was.
   const lastTabKeyRef = useRef(tabKey);
   if (lastTabKeyRef.current !== tabKey) {
     resetCachedScope('violations', selectedProject);
@@ -208,7 +211,6 @@ export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 
   }
 
   const cached = readCachedState('violations', selectedProject, {
-    activeSubTab: 'dimension',
     fileCurrentPath: '',
   });
 
@@ -223,7 +225,7 @@ export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 
   }, [tabKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const {
-    activeSubTab, setActiveSubTab, dismissed,
+    dismissed,
     handleRestore, handleRestoreAll, handleDelete, handleDeleteAll,
     restoreError, visibleDimensions,
     summary, topFilesCount, uniquePrinciples,
@@ -233,7 +235,6 @@ export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 
     selectedProject,
     onRefresh,
     onReconcile,
-    initialSubTab: cached.activeSubTab,
     initialFilePath: cached.fileCurrentPath,
     dismissRefreshKey,
     selectedSource,

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
+import { useState } from 'react';
 import ViolationsPage, { ViolationsSubTabContent } from './ViolationsPage.jsx';
 import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
 
@@ -214,6 +215,86 @@ describe('ViolationsPage — error state + retry feedback (P4-T2)', () => {
       error: 'Failed to load',
     }));
     expect(screen.queryByText("Couldn't load this project")).toBeNull();
+  });
+});
+
+/* Mimics the App wiring (see ViolationsRoute): `subTab` is a route param and
+   flipping it REPLACES the nav entry in place — history must not grow per
+   flip, so the harness stack length is part of the assertions. */
+function SubTabNavHarness({ data, log }) {
+  const [stack, setStack] = useState([{}]);
+  const top = stack[stack.length - 1];
+  return (
+    <ViolationsPage
+      data={data}
+      callbacks={{}}
+      subTab={top.subTab || 'dimension'}
+      onSubTabChange={(v) => {
+        setStack((s) => {
+          log.push(['replace', v, s.length]);
+          return s.slice(0, -1).concat([{ ...s[s.length - 1], subTab: v }]);
+        });
+      }}
+    />
+  );
+}
+
+describe('ViolationsPage — sub-tab lives in the nav entry (replace, not push)', () => {
+  const DIMS = [{
+    dimension: 'security',
+    violations: [
+      { file: 'src/a.py', severity: 'minor', principle: 'P1' },
+      { file: 'lib/b.py', severity: 'major', principle: 'P2' },
+    ],
+    compliance: [],
+  }];
+  const data = () => ({
+    accumulatedDimensions: DIMS,
+    selectedProject: 'p1',
+    projects: [{ id: 'p1', name: 'p1' }],
+    projectsLoaded: true,
+    projectName: 'p1',
+    loading: false,
+    isFetching: false,
+    dismissRefreshKey: 0,
+    selectedSource: 'local',
+  });
+
+  function renderHarness(log) {
+    const QC = withQueryClient();
+    return render(
+      <QC>
+        <SubTabNavHarness data={data()} log={log} />
+      </QC>
+    );
+  }
+
+  it('flipping to by-file and dismissed replaces the entry in place; the view follows the param', async () => {
+    const log = [];
+    renderHarness(log);
+    // Default sub-tab renders the dimension grid.
+    expect(await screen.findByText('security')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('by-file'));
+    // Replace with the stack still at length 1 — a push would report 2 next.
+    expect(log).toEqual([['replace', 'file', 1]]);
+    // The controlled param round-tripped into the file tree view.
+    expect(await screen.findByText('src')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('dismissed'));
+    expect(log).toEqual([['replace', 'file', 1], ['replace', 'dismissed', 1]]);
+    expect(await screen.findByText('No dismissed violations.')).toBeInTheDocument();
+  });
+
+  it('renders the sub-tab the route param dictates without any interaction', () => {
+    const QC = withQueryClient();
+    render(
+      <QC>
+        <ViolationsPage data={data()} callbacks={{}} subTab="file" onSubTabChange={() => {}} />
+      </QC>
+    );
+    expect(screen.getByText('src')).toBeInTheDocument();
+    expect(screen.getByText('lib')).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
Applies the compare tab's nav-param pattern (#1087) to the remaining internal-state view switches, so the browser back button and the breadcrumb see them.

## Map (`MapPage` / `useMapPageState`)
- The viz drill path and the `vizStyle` / `viewMode` / `galaxyMode` toggles are route params on the `map` entry.
- Drilling into a folder **pushes** a nav entry; browser Back climbs back out.
- Navigating up (in-page breadcrumb, circle-pack zoom-out) to a path that already sits in the trailing run of map entries **unwinds history to it via `navGoTo`** instead of pushing a duplicate, so zoom-out is equivalent to pressing Back. A target not in the trail (the circle pack can jump levels) pushes normally.
- Mode/style toggles **replace** in place; flipping never grows history.
- `buildNavigationBundle` now forwards `navStack` + `navGoTo` for the drill-up.

## Violations (`ViolationsPage`)
- The by-dimension / by-file / dismissed sub-tab is a `subTab` route param, flipped via `handleNavigateReplace` (replace, not push). The file-tree path inside the by-file view stays in the page cache.

## Shared details
- Every hop spreads the existing params forward so `_tabKey` (the fresh-tab-click reset signal) survives; dropping it would silently reset cached page state mid-drill (test pins this).
- The pageStateCache keys these params replace were removed: a fresh `navTab` entry with no params reproduces the old tab-reclick reset, and back/round-trip resume now comes from the entry itself.
- `labelFor` renders a map drill entry as its folder name, so the crumb trail reads `map / src / components`.

## Tests
- NavHarness tests mirroring `ComparePage.test.jsx`: toggle→replace, drill→push, breadcrumb-up→unwind (style surviving the unwind), violations flips pinned to stack length 1.
- Producer×consumer pins in `App.test.jsx` for the route wiring, param spreading, and the trail-scan stopping at the first non-map entry.
- Full suite: 1573 vitest + 476 node tests green, strings lint clean, build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)