### PR TITLE
Daruma grade ramp: caution descent instead of bronze

### DIFF
--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -302,22 +302,24 @@
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
 
-  /* Grade tier colors. Every theme follows the same rule: grades are a
-     metallic shine ramp (gold A, silver B, then duller metal down to lead F)
-     in a hue band that theme's severity ramp does not use, so a bad grade
-     and a severe finding never share a color. Severity keeps the vivid
-     warm/danger channel; grades own the metal channel. Enforced by
-     tools/token_distinctness.mjs. */
+  /* Grade tier colors. Every theme follows the same rule: grades live in
+     a hue band that theme's severity ramp does not use, so a bad grade and
+     a severe finding never share a color (enforced by
+     tools/token_distinctness.mjs). Daruma's ramp: gold A and silver B,
+     then a CAUTION descent (ochre -> deep orange -> brick) instead of dull
+     metal, because bronze reads as gold at gauge size and a bad grade must
+     not look decorated. The caution hexes are hue-shifted off the severity
+     pinks/reds to keep the channels apart. */
   --color-grade-top-text:    #a87e00;
   --color-grade-top-bg:      color-mix(in srgb, #a87e00 14%, transparent);
   --color-grade-high-text:   #566a82;
   --color-grade-high-bg:     color-mix(in srgb, #566a82 12%, transparent);
-  --color-grade-mid-text:    #8a621e;
-  --color-grade-mid-bg:      color-mix(in srgb, #8a621e 12%, transparent);
-  --color-grade-low-text:    #63491a;
-  --color-grade-low-bg:      color-mix(in srgb, #63491a 12%, transparent);
-  --color-grade-bottom-text: #3e332c;
-  --color-grade-bottom-bg:   color-mix(in srgb, #3e332c 12%, transparent);
+  --color-grade-mid-text:    #9a5a20;
+  --color-grade-mid-bg:      color-mix(in srgb, #9a5a20 12%, transparent);
+  --color-grade-low-text:    #84431c;
+  --color-grade-low-bg:      color-mix(in srgb, #84431c 12%, transparent);
+  --color-grade-bottom-text: #62342a;
+  --color-grade-bottom-bg:   color-mix(in srgb, #62342a 12%, transparent);
 
   /* Trend — default is light; dark themes override below */
   --color-trend-strong-up:   #e0a800;
@@ -431,12 +433,12 @@
     --color-grade-top-bg:      color-mix(in srgb, #f2c14e 12%, transparent);
     --color-grade-high-text:   var(--primitive-brand-300);
     --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-300) 12%, transparent);
-    --color-grade-mid-text:    #c08c50;
-    --color-grade-mid-bg:      color-mix(in srgb, #c08c50 12%, transparent);
-    --color-grade-low-text:    #96805e;
-    --color-grade-low-bg:      color-mix(in srgb, #96805e 13%, transparent);
-    --color-grade-bottom-text: #76706a;
-    --color-grade-bottom-bg:   color-mix(in srgb, #76706a 12%, transparent);
+    --color-grade-mid-text:    #ce7e3c;
+    --color-grade-mid-bg:      color-mix(in srgb, #ce7e3c 12%, transparent);
+    --color-grade-low-text:    #c26648;
+    --color-grade-low-bg:      color-mix(in srgb, #c26648 13%, transparent);
+    --color-grade-bottom-text: #aa5858;
+    --color-grade-bottom-bg:   color-mix(in srgb, #aa5858 12%, transparent);
 
     --color-warning:      var(--primitive-amber-400);
     --color-info:         var(--primitive-cyan-400);
@@ -561,12 +563,12 @@ html[data-theme="dark"]:root, [data-theme="dark"] {
   --color-grade-top-bg:      color-mix(in srgb, #f2c14e 12%, transparent);
   --color-grade-high-text:   var(--primitive-brand-300);
   --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-300) 12%, transparent);
-  --color-grade-mid-text:    #c08c50;
-  --color-grade-mid-bg:      color-mix(in srgb, #c08c50 12%, transparent);
-  --color-grade-low-text:    #96805e;
-  --color-grade-low-bg:      color-mix(in srgb, #96805e 13%, transparent);
-  --color-grade-bottom-text: #76706a;
-  --color-grade-bottom-bg:   color-mix(in srgb, #76706a 12%, transparent);
+  --color-grade-mid-text:    #ce7e3c;
+  --color-grade-mid-bg:      color-mix(in srgb, #ce7e3c 12%, transparent);
+  --color-grade-low-text:    #c26648;
+  --color-grade-low-bg:      color-mix(in srgb, #c26648 13%, transparent);
+  --color-grade-bottom-text: #aa5858;
+  --color-grade-bottom-bg:   color-mix(in srgb, #aa5858 12%, transparent);
 
   --color-warning:      var(--primitive-amber-400);
   --color-info:         var(--primitive-cyan-400);
@@ -648,12 +650,12 @@ html[data-theme="light"]:root, [data-theme="light"] {
   --color-grade-top-bg:      color-mix(in srgb, #a87e00 14%, transparent);
   --color-grade-high-text:   #566a82;
   --color-grade-high-bg:     color-mix(in srgb, #566a82 12%, transparent);
-  --color-grade-mid-text:    #8a621e;
-  --color-grade-mid-bg:      color-mix(in srgb, #8a621e 12%, transparent);
-  --color-grade-low-text:    #63491a;
-  --color-grade-low-bg:      color-mix(in srgb, #63491a 12%, transparent);
-  --color-grade-bottom-text: #3e332c;
-  --color-grade-bottom-bg:   color-mix(in srgb, #3e332c 12%, transparent);
+  --color-grade-mid-text:    #9a5a20;
+  --color-grade-mid-bg:      color-mix(in srgb, #9a5a20 12%, transparent);
+  --color-grade-low-text:    #84431c;
+  --color-grade-low-bg:      color-mix(in srgb, #84431c 12%, transparent);
+  --color-grade-bottom-text: #62342a;
+  --color-grade-bottom-bg:   color-mix(in srgb, #62342a 12%, transparent);
 
   /* Warning */
   --color-warning:      var(--primitive-amber-700);


### PR DESCRIPTION
## What

Direct response to the report that the overview's ADEQUATE tier "looks gold": the metallic ramp's bronze (#c08c50) reads as gold at gauge-ring size on dark surfaces, so a 5.9 looked rewarded, and the bronze/leather tiers blurred into one warm glow. This is daruma-specific — the other families' low tiers are greens, slates, and purples and never had the problem.

Gold stays exclusive to EXEMPLARY and silver to GOOD. Below that, daruma's ramp now descends through caution hues — ochre, deep orange, brick — so a worse grade looks warmer and more *wrong*, restoring the pre-#1090 feel of the bars without restoring its bug: the new hexes are hue-shifted off the severity pinks/reds (deltaE >= 20 everywhere), so the grade-red = severity-red collision #1090 fixed stays fixed.

| tier | light | dark |
|---|---|---|
| ADEQUATE | #8a621e -> #9a5a20 | #c08c50 -> #ce7e3c |
| POOR | #63491a -> #84431c | #96805e -> #c26648 |
| BAD | #3e332c -> #62342a | #76706a -> #aa5858 |

## Verified

- token_distinctness 552 checks / token_contrast 108 checks, 0 failures (severity distance, tier steps, surface contrast, accent clearance)
- 1588/1588 UI tests, build clean
- Browser-verified in daruma dark and light: 6.9 dimensions/gauges read warning-orange, 7.1-7.4 silver, gold only at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)