### PR TITLE
History bars keep the absolute 0-10 scale; only the line zooms

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -87,6 +87,7 @@ function ScoreBars({ data, hoveredIndex, selectedRunId }) {
   // they reach the chart-level onClick handler.
   return (
     <Bar
+      yAxisId="abs"
       dataKey="numericAverage"
       radius={[0, 0, 0, 0]}
       maxBarSize={28}
@@ -143,17 +144,21 @@ function ScoreHistoryChart({ data, interaction }) {
             clean edge-to-edge bars with just the accent-coloured trend line
             on top. Labels live in the banner (MIN / MAX / AVG). */}
         <XAxis dataKey="dateLabel" hide />
-        <YAxis domain={domain} hide />
+        {/* Two hidden Y axes on purpose. Bars keep the absolute 0-10 scale
+            so a 7 always fills 70% of the chart (a zoomed bar reads as a
+            smaller score). The line rides the data-fitted domain so the
+            trend's shape stays visible instead of flattening at the top. */}
+        <YAxis yAxisId="abs" domain={[0, 10]} hide />
+        <YAxis yAxisId="shape" domain={domain} hide />
         <Tooltip cursor={false} isAnimationActive={false} offset={20} content={<RunHistoryTooltip />} />
-        {/* Soft horizontal reference lines at the domain bounds and quarter
-            divisions — subtle grid anchors even though numeric ticks are
-            hidden. Bounds are drawn a touch stronger. */}
+        {/* Soft horizontal reference lines framing the line's domain —
+            subtle grid anchors even though numeric ticks are hidden. */}
         {refLineValues(domain).map((y, i) => (
-          <ReferenceLine key={y} y={y} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={i % 2 ? 0.2 : 0.3} />
+          <ReferenceLine key={y} yAxisId="shape" y={y} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={i % 2 ? 0.2 : 0.3} />
         ))}
-        <Area dataKey="numericAverage" type="monotone" fill="url(#scoreAreaGrad)" stroke="none" isAnimationActive={false} />
+        <Area yAxisId="shape" dataKey="numericAverage" type="monotone" fill="url(#scoreAreaGrad)" stroke="none" isAnimationActive={false} />
         <ScoreBars data={data} hoveredIndex={hoveredIndex} selectedRunId={selectedRunId} />
-        <Line isAnimationActive={false} dataKey="numericAverage" type="monotone" stroke={cssVar('--color-accent')} strokeOpacity={0.9} strokeWidth={2} dot={<SelectedDot selectedRunId={selectedRunId} />} activeDot={false} />
+        <Line yAxisId="shape" isAnimationActive={false} dataKey="numericAverage" type="monotone" stroke={cssVar('--color-accent')} strokeOpacity={0.9} strokeWidth={2} dot={<SelectedDot selectedRunId={selectedRunId} />} activeDot={false} />
       </ComposedChart>
     </ResponsiveContainer>
   );

--- a/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
@@ -93,13 +93,16 @@ function DimensionHistoryChart({ data, selectedRunId, hoveredIndex, setHoveredIn
           </linearGradient>
         </defs>
         <XAxis dataKey="dateLabel" hide />
-        <YAxis domain={domain} hide />
+        {/* Bars stay absolute (0-10: a 7 fills 70%); only the line and its
+            grid ride the data-fitted domain so the shape stays visible. */}
+        <YAxis yAxisId="abs" domain={[0, 10]} hide />
+        <YAxis yAxisId="shape" domain={domain} hide />
         <Tooltip cursor={false} isAnimationActive={false} offset={20} content={<DimensionTooltip />} />
         {refLineValues(domain).map((y, i) => (
-          <ReferenceLine key={y} y={y} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={i % 2 ? 0.2 : 0.3} />
+          <ReferenceLine key={y} yAxisId="shape" y={y} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={i % 2 ? 0.2 : 0.3} />
         ))}
-        <Area dataKey="numericAverage" type="monotone" fill="url(#dimScoreAreaGrad)" stroke="none" isAnimationActive={false} />
-        <Bar dataKey="numericAverage" radius={[0, 0, 0, 0]} maxBarSize={28} isAnimationActive={false}>
+        <Area yAxisId="shape" dataKey="numericAverage" type="monotone" fill="url(#dimScoreAreaGrad)" stroke="none" isAnimationActive={false} />
+        <Bar yAxisId="abs" dataKey="numericAverage" radius={[0, 0, 0, 0]} maxBarSize={28} isAnimationActive={false}>
           {data.map((entry, i) => (
             <Cell
               key={entry.runId ?? i}
@@ -111,6 +114,7 @@ function DimensionHistoryChart({ data, selectedRunId, hoveredIndex, setHoveredIn
           ))}
         </Bar>
         <Line
+          yAxisId="shape"
           isAnimationActive={false}
           dataKey="numericAverage"
           type="monotone"

--- a/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
@@ -94,12 +94,16 @@ function ScoreHistoryChart({ data, interaction }) {
         style={onBarClick ? { cursor: 'pointer' } : undefined}
       >
         <XAxis dataKey="dateLabel" hide />
-        <YAxis domain={domain} hide />
+        {/* Bars stay absolute (0-10: a 7 fills 70%); only the line and its
+            grid ride the data-fitted domain so the shape stays visible. */}
+        <YAxis yAxisId="abs" domain={[0, 10]} hide />
+        <YAxis yAxisId="shape" domain={domain} hide />
         <Tooltip cursor={false} isAnimationActive={false} offset={20} content={<RunHistoryTooltip />} />
         {refLineValues(domain).map((y, i) => (
-          <ReferenceLine key={y} y={y} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={i % 2 ? 0.2 : 0.3} />
+          <ReferenceLine key={y} yAxisId="shape" y={y} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={i % 2 ? 0.2 : 0.3} />
         ))}
         <Bar
+          yAxisId="abs"
           dataKey="numericAverage"
           radius={[0, 0, 0, 0]}
           maxBarSize={32}
@@ -116,6 +120,7 @@ function ScoreHistoryChart({ data, interaction }) {
           ))}
         </Bar>
         <Line
+          yAxisId="shape"
           isAnimationActive={false}
           dataKey="numericAverage"
           type="monotone"


### PR DESCRIPTION
## What

Follow-up to #1095, from the report that "a seven shows like a 5": fitting the whole chart to the data range made bar height relative, so a 7.0 rendered as a half-full bar. That traded one lie for another.

Bars and the line now ride two hidden Y axes. Bars are back on the absolute 0-10 scale, so a 7 always fills 70% of the chart and bar height means score again. The trend line, its area fill, and the grid lines keep the data-fitted domain from #1095, so the shape stays visible instead of flattening at the top. Applied to all three score charts (Overview, History, Explorer dimension panel).

## Verified

- 1594/1594 UI tests, build clean
- Browser-verified on Overview: bars at 75-81% for scores 7.5-8.1, line showing its descent within the zoomed frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)