### PR TITLE
Duel trend lines drop their per-point dots

### DIFF
--- a/src/quodeq/ui/src/features/compare/components/CompareDuelTrend.jsx
+++ b/src/quodeq/ui/src/features/compare/components/CompareDuelTrend.jsx
@@ -47,21 +47,32 @@ export default function CompareDuelTrend({ a, b }) {
   const ticks = [];
   for (let v = v0; v <= v1; v += 1) ticks.push(v);
 
+  /* Lines stay clean: no per-point dots. A lone-point series still gets a
+     visible dot (a dotless single point would vanish), and every point
+     keeps an invisible, slightly larger circle as the tooltip hit
+     target. */
   const line = (series, variant) => series.length > 0 && (
     <g key={variant}>
-      {series.length > 1 && (
+      {series.length > 1 ? (
         <polyline
           className={`compare-duel-trend__line compare-duel-trend__line--${variant}`}
           points={series.map((e) => `${x(e.dateISO).toFixed(1)},${y(e.value).toFixed(1)}`).join(' ')}
+        />
+      ) : (
+        <circle
+          className={`compare-duel-trend__dot compare-duel-trend__dot--${variant}`}
+          cx={x(series[0].dateISO).toFixed(1)}
+          cy={y(series[0].value).toFixed(1)}
+          r="4"
         />
       )}
       {series.map((e) => (
         <circle
           key={e.dateISO}
-          className={`compare-duel-trend__dot compare-duel-trend__dot--${variant}`}
+          className="compare-duel-trend__hit"
           cx={x(e.dateISO).toFixed(1)}
           cy={y(e.value).toFixed(1)}
-          r="4"
+          r="7"
         >
           <title>
             {t('compare.duelPointTip', { date: shortDate(Date.parse(e.dateISO)), score: e.value.toFixed(1) })}

--- a/src/quodeq/ui/src/styles/compare.css
+++ b/src/quodeq/ui/src/styles/compare.css
@@ -1008,6 +1008,10 @@
 .compare-duel-trend__dot--a { fill: var(--color-duel-a); }
 .compare-duel-trend__dot--b { fill: var(--color-duel-b); }
 
+/* Invisible per-point tooltip hit targets: the lines carry no visible
+   dots, but hovering a point still names its date and score. */
+.compare-duel-trend__hit { fill: transparent; }
+
 .compare-duel-trend__ticks { position: absolute; inset: 0; pointer-events: none; }
 
 .compare-duel-trend__tick {


### PR DESCRIPTION
Per user feedback on the duel screen: the per-run dots cluttered the trend lines. The lines render clean now; every point keeps an invisible, slightly larger circle as the tooltip hit target so hovering still names the date and score, and a single-point series still shows a visible dot (a dotless lone point would vanish entirely).

Verified: compare suite 14/14, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)