### PR TITLE
refactor(services): split score_cache and dashboard into focused modules

### DIFF
--- a/src/quodeq/api/assistant_routes.py
+++ b/src/quodeq/api/assistant_routes.py
@@ -56,8 +56,13 @@ def _try_claim_turn(sid: str) -> bool:
 
 
 def _release_turn(sid: str) -> None:
+    """Free the per-session turn slot and drop the turn's cancel token.
+
+    Workspace actions never register a token, so the pop is a no-op for them;
+    the slot is exclusive, so it can only ever drop this turn's own token."""
     with _running_lock:
         _running_turns.discard(sid)
+        _cancel_tokens.pop(sid, None)
 
 
 def _api_provider(provider_id: str) -> dict | None:
@@ -76,6 +81,94 @@ def _known_provider(provider_id: str) -> dict | None:
     return get_provider_configs().get(provider_id)
 
 
+def _shared_source_error() -> tuple[Response, int] | None:
+    """The shared-clone gate for a new session: the 409 body when no shared
+    repository is configured or its local clone state is unusable, else None."""
+    settings = read_settings()
+    if not settings.url:
+        return jsonify({"error": "no shared repository configured"}), 409
+    state = read_state(settings.url)
+    if state not in ("ok", "empty"):
+        return jsonify({"error": f"shared repository unavailable: {state}"}), 409
+    return None
+
+
+def _resolve_session_scope(source: str, body: dict) -> tuple[str | None, str | None, str]:
+    """``(run_dir, repo_root, repo_reason)`` for a new session.
+
+    Plan 1 mapping: runDir → run_id column, repoRoot → project_uuid column.
+    Client-supplied runDir/repoRoot are NOT honored: they'd flow to the MCP
+    subprocess's --run-dir/--repo-root with no path jail, giving a remote
+    API-key caller arbitrary server-side file access. The real UI never sends
+    these — it sends {projectId, runId} and the server resolves
+    run_dir/repo_root itself via the jailed resolver.
+
+    Three shapes:
+    - shared: never attaches a repo (the clone has no working copy); data reads
+      resolve against the clone's evaluations root in build_tool_context.
+    - local + specific runId: binds that one run.
+    - local overview (projectId, no runId): stays run-unscoped, so the detail
+      tools read the accumulated (per-dimension-latest) composition from
+      project_id + reports_dir.
+    """
+    project_id = body.get("projectId")
+    if source == "shared":
+        run_dir = None
+        if project_id and body.get("runId"):
+            run_dir = _assistant_helpers.resolve_shared_run_location(
+                str(project_id), str(body["runId"]))
+        return run_dir, None, "online_project"
+    if not project_id:
+        return None, None, "no_project"
+    repo_root, repo_reason = _assistant_helpers.repo_attach_info(str(project_id))
+    run_dir = None
+    if body.get("runId"):
+        run_dir, _ = _assistant_helpers.resolve_run_location(
+            str(project_id), str(body["runId"]),
+        )
+    return run_dir, repo_root, repo_reason
+
+
+def _turn_endpoint(provider: str, body: dict, provider_cfg: dict) -> tuple[str, str | None]:
+    """``(api_base, api_key)`` for a turn — the trust boundary for both.
+
+    api_base is ALWAYS the server's catalog value, never the request body: a
+    caller-supplied apiBase would redirect the turn (and its tool calls) at an
+    arbitrary host (SSRF into internal services / cloud metadata). The UI never
+    sends one — provider endpoints live in ai_providers.json. api_key may still
+    come from the request for genuinely caller-defined providers
+    (custom/openrouter) — it's a credential the caller supplies, not a fetch
+    target — falling back to server config; fixed-endpoint local providers need
+    none.
+    """
+    catalog_cfg = _known_provider(provider)
+    # CLI providers (claude/codex/gemini) have no HTTP endpoint to pin or
+    # override — the orchestrator's run_turn dispatches them internally
+    # (spawning the CLI subprocess), so apiBase/apiKey are meaningless here and
+    # left unset.
+    if catalog_cfg is not None and catalog_cfg.get("type") == "cli":
+        return "", None
+    if provider in _FIXED_ENDPOINT_PROVIDERS:
+        return provider_cfg.get("api_base", ""), None
+    return provider_cfg.get("api_base", ""), body.get("apiKey") or provider_cfg.get("api_key")
+
+
+def _start_turn_worker(sid: str, turn: TurnRequest, repo, tool_ctx, cancel: CancelToken) -> None:
+    """Run the turn on a daemon thread, freeing the session's turn slot when it
+    ends however it ends."""
+    def _worker():
+        try:
+            if tool_ctx.score_cache_path is not None:
+                with score_cache_path_override(tool_ctx.score_cache_path):
+                    run_turn(turn, repository=repo, tool_ctx=tool_ctx, cancel=cancel)
+            else:
+                run_turn(turn, repository=repo, tool_ctx=tool_ctx, cancel=cancel)
+        finally:
+            _release_turn(sid)
+
+    threading.Thread(target=_worker, daemon=True).start()
+
+
 def register_assistant_routes(app: Flask) -> None:
     register_assistant_workspace_routes(app)
 
@@ -92,40 +185,11 @@ def register_assistant_routes(app: Flask) -> None:
         if source not in ("local", "shared"):
             return jsonify({"error": "invalid source"}), 400
         if source == "shared":
-            settings = read_settings()
-            if not settings.url:
-                return jsonify({"error": "no shared repository configured"}), 409
-            state = read_state(settings.url)
-            if state not in ("ok", "empty"):
-                return jsonify(
-                    {"error": f"shared repository unavailable: {state}"}), 409
+            shared_error = _shared_source_error()
+            if shared_error is not None:
+                return shared_error
         session_id = uuid.uuid4().hex
-        # Plan 1 mapping: runDir → run_id column, repoRoot → project_uuid column.
-        # Client-supplied runDir/repoRoot are NOT honored: they'd flow to the
-        # MCP subprocess's --run-dir/--repo-root with no path jail, giving a
-        # remote API-key caller arbitrary server-side file access. The real UI
-        # never sends these — it sends {projectId, runId} and the server
-        # resolves run_dir/repo_root itself via the jailed resolver.
-        run_dir, repo_root, repo_reason = None, None, "no_project"
-        if source == "shared":
-            # Shared sessions never attach a repo (the clone has no working
-            # copy); data reads resolve against the clone's evaluations root
-            # in build_tool_context.
-            repo_reason = "online_project"
-            if body.get("projectId") and body.get("runId"):
-                run_dir = _assistant_helpers.resolve_shared_run_location(
-                    str(body["projectId"]), str(body["runId"]))
-        elif body.get("projectId"):
-            repo_root, repo_reason = _assistant_helpers.repo_attach_info(
-                str(body["projectId"]))
-            # Only bind a single run when the UI selected a SPECIFIC run. On
-            # the overview it sends projectId with no runId → the session
-            # stays run-unscoped and the detail tools read the accumulated
-            # (per-dimension-latest) composition from project_id + reports_dir.
-            if body.get("runId"):
-                run_dir, _ = _assistant_helpers.resolve_run_location(
-                    str(body["projectId"]), str(body["runId"]),
-                )
+        run_dir, repo_root, repo_reason = _resolve_session_scope(source, body)
         project_id = body.get("projectId")
         get_repository(app).create_session(
             session_id=session_id, provider=body["provider"],
@@ -185,28 +249,7 @@ def register_assistant_routes(app: Flask) -> None:
         # to this session 409s permanently.
         try:
             provider_cfg = _api_provider(session["provider"]) or {}
-            catalog_cfg = _known_provider(session["provider"])
-            # CLI providers (claude/codex/gemini) have no HTTP endpoint to pin or
-            # override — the orchestrator's run_turn dispatches them internally
-            # (spawning the CLI subprocess), so apiBase/apiKey are meaningless
-            # here and left unset.
-            if catalog_cfg is not None and catalog_cfg.get("type") == "cli":
-                api_base = ""
-                api_key = None
-            # api_base is ALWAYS the server's catalog value, never the request
-            # body: a caller-supplied apiBase would redirect the turn (and its
-            # tool calls) at an arbitrary host (SSRF into internal services /
-            # cloud metadata). The UI never sends one — provider endpoints live
-            # in ai_providers.json. api_key may still come from the request for
-            # genuinely caller-defined providers (custom/openrouter) — it's a
-            # credential the caller supplies, not a fetch target — falling back
-            # to server config; fixed-endpoint local providers need none.
-            elif session["provider"] in _FIXED_ENDPOINT_PROVIDERS:
-                api_base = provider_cfg.get("api_base", "")
-                api_key = None
-            else:
-                api_base = provider_cfg.get("api_base", "")
-                api_key = body.get("apiKey") or provider_cfg.get("api_key")
+            api_base, api_key = _turn_endpoint(session["provider"], body, provider_cfg)
             turn = TurnRequest(
                 session_id=sid, text=text, ui_state=body.get("uiState"),
                 api_base=api_base,
@@ -217,29 +260,12 @@ def register_assistant_routes(app: Flask) -> None:
                                and (session.get("source") or "local") == "local"),
             )
             tool_ctx = build_tool_context(app, session)
-
-            def _worker():
-                try:
-                    if tool_ctx.score_cache_path is not None:
-                        with score_cache_path_override(tool_ctx.score_cache_path):
-                            run_turn(turn, repository=repo, tool_ctx=tool_ctx, cancel=cancel)
-                    else:
-                        run_turn(turn, repository=repo, tool_ctx=tool_ctx, cancel=cancel)
-                finally:
-                    with _running_lock:
-                        _running_turns.discard(sid)
-                        _cancel_tokens.pop(sid, None)
-
-            threading.Thread(target=_worker, daemon=True).start()
+            _start_turn_worker(sid, turn, repo, tool_ctx, cancel)
         except SharedSourceUnavailable as exc:
-            with _running_lock:
-                _running_turns.discard(sid)
-                _cancel_tokens.pop(sid, None)
+            _release_turn(sid)
             return jsonify({"error": str(exc)}), 409
         except Exception:
-            with _running_lock:
-                _running_turns.discard(sid)
-                _cancel_tokens.pop(sid, None)
+            _release_turn(sid)
             raise
         return jsonify({"accepted": True}), 202
 

--- a/src/quodeq/services/_dashboard_cache.py
+++ b/src/quodeq/services/_dashboard_cache.py
@@ -1,0 +1,103 @@
+"""Run-dimension cache configuration and fetcher factory for the dashboard.
+
+Split out of ``dashboard``: the caching concern (env-tuned sizes, the
+process-wide LRU, its invalidation hook) is independent of run resolution and
+payload assembly, and ``services.scoring`` reaches into the fetcher factory
+directly. ``dashboard`` re-exports everything here, so the historical import
+path still resolves.
+"""
+from __future__ import annotations
+
+import os
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from quodeq.core.types import DimensionResult
+from quodeq.services._cache import make_lru_dimension_fetcher
+
+
+@dataclass
+class DashboardCacheConfig:
+    """Optional cache overrides for build_dashboard (mirrors AccumulatedCacheConfig)."""
+    cache: OrderedDict[tuple, list[DimensionResult]] | None = None
+    lock: threading.Lock | None = None
+    max_size: int | None = None
+
+
+_DEFAULT_RUN_DIM_CACHE_MAX = 256
+
+
+def _run_dim_cache_max(override: int | None = None, env: dict[str, str] | None = None) -> int:
+    """Return the run-dimension cache size limit. *override* bypasses env for testing."""
+    if override is not None:
+        return override
+    try:
+        return int((env or os.environ).get("QUODEQ_RUN_DIM_CACHE_MAX", str(_DEFAULT_RUN_DIM_CACHE_MAX)))
+    except (ValueError, TypeError):
+        return _DEFAULT_RUN_DIM_CACHE_MAX
+
+
+# Module-level shared cache for run-dimension data. Without this, every
+# dashboard request used a fresh cache (created in _make_run_dimension_fetcher
+# below), so re-fetching the same project's history (which collect_stale_dimensions
+# / _collect_previous_scores / build_accumulated_trend all walk) cost ~750ms
+# per request even on warm calls. The shared cache eliminates the cross-request
+# I/O without compromising the per-request consistency guarantees (the cache
+# is keyed by (reports_root, project, run_id, suppression_version) so a
+# dismiss/delete produces a new key and never serves a pre-suppression score,
+# and runs are immutable once finalized).
+#
+# Tests that need isolation can pass an explicit DashboardCacheConfig.
+_SHARED_RUN_DIM_CACHE, _SHARED_RUN_DIM_LOCK = OrderedDict(), threading.Lock()
+
+
+def create_dimension_cache() -> tuple[OrderedDict[tuple, list[DimensionResult]], threading.Lock]:
+    """Create the default run-dimension LRU cache and its lock.
+
+    Override this factory to plug in a shared backend (e.g. a Redis-backed
+    OrderedDict wrapper) for multi-worker deployments.  The returned
+    ordered-dict must support ``move_to_end``, ``popitem(last=False)``,
+    and standard ``__getitem__``/``__setitem__``/``__contains__``.
+    """
+    return OrderedDict(), threading.Lock()
+
+
+def clear_shared_dimension_cache() -> None:
+    """Drop all cached run-dimension data (e.g. after a formula change)."""
+    with _SHARED_RUN_DIM_LOCK:
+        _SHARED_RUN_DIM_CACHE.clear()
+
+
+def _make_run_dimension_fetcher(
+    reports_root: Path,
+    project: str,
+    cache: OrderedDict[tuple, list[DimensionResult]] | None = None,
+    lock: threading.Lock | None = None,
+    max_size: int | None = None,
+    version: str = "",
+) -> Callable[[str], list[DimensionResult]]:
+    """Return a cached fetcher for run dimension data (LRU, bounded).
+
+    Defaults to the module-level shared cache so reads of the same run's
+    dimensions across requests reuse work. *version* scopes the cache key to the
+    project's suppression state so a dismiss/delete invalidates it. Tests pass
+    explicit cache/lock to isolate state.
+    """
+    return make_lru_dimension_fetcher(
+        reports_root,
+        project,
+        cache if cache is not None else _SHARED_RUN_DIM_CACHE,
+        lock if lock is not None else _SHARED_RUN_DIM_LOCK,
+        max_size if max_size is not None else _run_dim_cache_max(),
+        version=version,
+    )
+
+
+__all__ = [
+    "DashboardCacheConfig",
+    "clear_shared_dimension_cache",
+    "create_dimension_cache",
+]

--- a/src/quodeq/services/_dashboard_history.py
+++ b/src/quodeq/services/_dashboard_history.py
@@ -1,0 +1,181 @@
+"""History-dependent parts of the dashboard response.
+
+Split out of ``dashboard``: everything here walks the project's *older* runs
+(previous scores, stale dimensions, the trend series) to build context for the
+selected run. ``dashboard`` owns the selected run itself and re-exports these
+helpers, so the historical import path still resolves.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Callable
+
+from quodeq.core.scoring.params import DEFAULT_PARAMS, ScoringParams
+from quodeq.core.types import DimensionResult, DimensionSummary
+
+from quodeq.data.fs.report_parser.grades import calculate_trend
+from quodeq.data.fs.report_parser.runs import RunInfo
+from quodeq.services._dashboard_cache import DashboardCacheConfig, _make_run_dimension_fetcher
+from quodeq.services._dashboard_stale import collect_stale_dimensions
+from quodeq.services._dashboard_trend import build_accumulated_trend
+from quodeq.services._trend_fetcher import make_trend_fetcher
+from quodeq.services.scoring_view import select_trend_runs
+
+_SKIP_GRADES = {"NA", "N/A", "INSUFFICIENT"}
+
+# Maximum number of historical runs scanned for trend, previous scores, and
+# stale dimensions. The full run list is still returned in availableRuns (metadata
+# only, no disk reads) so users can navigate to older runs directly.
+_DEFAULT_MAX_HISTORY_RUNS = 100
+
+
+def _max_history_runs(env: dict[str, str] | None = None) -> int:
+    """Return the history-scan ceiling, honouring QUODEQ_MAX_HISTORY_RUNS."""
+    raw = (env or os.environ).get("QUODEQ_MAX_HISTORY_RUNS")
+    if not raw:
+        return _DEFAULT_MAX_HISTORY_RUNS
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_MAX_HISTORY_RUNS
+    return value if value > 0 else _DEFAULT_MAX_HISTORY_RUNS
+
+
+def _collect_previous_scores(
+    runs: list[RunInfo], selected_index: int, selected_dim_names: set[str],
+    get_run_dimensions: Callable[[str], list[DimensionResult]],
+) -> dict[str, DimensionResult]:
+    """Find the most recent previous score for each dimension in the selected run."""
+    previous_by_dimension: dict[str, DimensionResult] = {}
+    for older_idx in range(selected_index + 1, len(runs)):
+        run_dimensions = get_run_dimensions(runs[older_idx].run_id)
+        for dim in run_dimensions:
+            dim_name = dim.dimension
+            if not dim_name or dim_name not in selected_dim_names:
+                continue
+            grade = dim.overall_grade
+            if not grade or str(grade).upper() in _SKIP_GRADES:
+                continue
+            if dim_name not in previous_by_dimension:
+                previous_by_dimension[dim_name] = replace(dim, run_id=runs[older_idx].run_id)
+    return previous_by_dimension
+
+
+def _enrich_dimensions_with_trend(
+    selected_dimensions: list[DimensionResult], previous_by_dimension: dict[str, DimensionResult]
+) -> list[DimensionResult]:
+    """Attach trend and previous-run data to each selected dimension."""
+    result: list[DimensionResult] = []
+    for dim in selected_dimensions:
+        previous = previous_by_dimension.get(dim.dimension or "")
+        trend = calculate_trend(dim.overall_score, previous.overall_score if previous else None)
+        result.append(
+            replace(
+                dim,
+                trend=trend,
+                previous_run_id=previous.run_id if previous else None,
+                previous_score=previous.overall_score if previous else None,
+            )
+        )
+    return result
+
+
+@dataclass
+class _DashboardPayload:
+    """Pre-computed parts for the dashboard response."""
+    selected_summary: DimensionSummary
+    trend: list[dict[str, Any]]
+    dimensions_with_trend: list[DimensionResult]
+    previous_by_dimension: dict[str, DimensionResult]
+    stale_previous_by_dimension: dict[str, DimensionResult]
+    stale_dimensions: list[DimensionResult]
+
+
+@dataclass(frozen=True)
+class _SelectedRunContext:
+    """Pre-resolved data for the selected run in a dashboard request."""
+    run: RunInfo
+    index: int
+    dimensions: list[DimensionResult]
+    summary: DimensionSummary
+
+
+def _compute_dashboard_payload(
+    reports_root: Path, project: str, runs: list[RunInfo],
+    ctx: _SelectedRunContext, cc: DashboardCacheConfig,
+    params: ScoringParams = DEFAULT_PARAMS,
+) -> _DashboardPayload:
+    """Compute history-dependent parts of the dashboard response."""
+    selected_dim_names = {d.dimension for d in ctx.dimensions}
+    # Shared trend rule (scoring_view.select_trend_runs): cancelled/failed
+    # runs are excluded — misleading history points. They remain visible in
+    # availableRuns for the UI.
+    scoreable_runs = select_trend_runs(runs)
+    # Re-find the selected run's index inside scoreable_runs. ctx.index is
+    # the index in the full unfiltered run list, which can exceed
+    # len(history_runs) when cancelled/failed runs sit above the selected
+    # run. Passing the wrong index to collect_stale_dimensions /
+    # _collect_previous_scores caused IndexError on history_runs[newer_idx].
+    selected_in_scoreable = next(
+        (i for i, r in enumerate(scoreable_runs) if r.run_id == ctx.run.run_id),
+        None,
+    )
+    max_history = _max_history_runs()
+    if selected_in_scoreable is None:
+        # Selected run was cancelled/failed (so it's not in scoreable_runs).
+        # Treat the entire scoreable history as "older" runs relative to it.
+        history_runs = scoreable_runs[:max_history]
+        history_index = len(history_runs)
+    else:
+        history_runs = scoreable_runs[:max(max_history, selected_in_scoreable + 1)]
+        history_index = selected_in_scoreable
+    # History fetcher: cache-backed, dismiss-adjusted, SCALAR-only -- the same
+    # fetcher the /scores endpoint uses. The three consumers below
+    # (_collect_previous_scores, collect_stale_dimensions, build_accumulated_trend)
+    # read only per-run scalars (dimension + overallScore + overallGrade), not
+    # the full violations. Reading + rescoring FULL data for every history run
+    # (up to _max_history_runs()) was the ~2s cost this replaces.
+    #
+    # In-progress freshness is preserved: the fast path re-reads each request
+    # (fresh per-call cache), and the heavy path's cacheable_run_ids guard makes
+    # in-progress runs compute-through without persisting a partial set. Stale-
+    # partial detection is preserved inside read_run_scalars, which falls back to
+    # full read_run_data whenever the SQL scalar projection disagrees with the
+    # on-disk evaluation/*.json count -- the same self-heal the old status-aware
+    # fetcher did via _count_eval_files. The dismiss-adjustment (Bug B) stays;
+    # it is now cached rather than recomputed on every request.
+    cacheable_run_ids = {r.run_id for r in history_runs if r.status == "complete"}
+    # Key the in-memory dimension cache by the project's suppression state so a
+    # dismiss/delete (or a formula change) invalidates warmed entries and no
+    # read path can serve a pre-dismiss score. ``score_cache_version`` already
+    # hashes dismissed + deleted keys + params. This fetcher is SHARED across the
+    # whole history window (previous-scores, stale-dimensions, and the trend all
+    # iterate many runs through it), so we keep the global project-scoped version
+    # here rather than a per-run scoped one -- per-run scoping only makes sense
+    # when a single run is in play, which this path is not.
+    from quodeq.services.score_cache import score_cache_version  # noqa: PLC0415
+    dim_cache_version = score_cache_version(reports_root / project, params)
+    get_run_dimensions = make_trend_fetcher(
+        reports_root, project, params=params, cacheable_run_ids=cacheable_run_ids,
+        max_history=max_history,
+        base_fetcher_factory=lambda rr, proj: _make_run_dimension_fetcher(
+            rr, proj, cache=cc.cache, lock=cc.lock, max_size=cc.max_size,
+            version=dim_cache_version,
+        ),
+    )
+    previous_by_dimension = _collect_previous_scores(
+        history_runs, history_index, selected_dim_names, get_run_dimensions,
+    )
+    stale_dimensions, stale_previous_by_dimension = collect_stale_dimensions(
+        history_runs, history_index, selected_dim_names, get_run_dimensions,
+    )
+    return _DashboardPayload(
+        selected_summary=ctx.summary,
+        trend=build_accumulated_trend(history_runs, get_run_dimensions, params=params),
+        dimensions_with_trend=_enrich_dimensions_with_trend(ctx.dimensions, previous_by_dimension),
+        previous_by_dimension=previous_by_dimension,
+        stale_previous_by_dimension=stale_previous_by_dimension,
+        stale_dimensions=stale_dimensions,
+    )

--- a/src/quodeq/services/_dashboard_response.py
+++ b/src/quodeq/services/_dashboard_response.py
@@ -1,0 +1,146 @@
+"""Serialization of the dashboard response.
+
+Split out of ``dashboard``: this is the wire boundary — everything here turns
+already-computed domain objects into the camelCase dict the UI consumes, and
+nothing here reads history or resolves runs. Declared in
+``tests/tools/test_serialization_boundary.py``.
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from quodeq.core.types import DimensionResult, to_camel_dict
+
+from quodeq.data.fs.report_parser.runs import RunInfo
+from quodeq.services._dashboard_history import _DashboardPayload
+
+
+def _read_run_exit_reason(reports_root: Path, project: str, run_id: str) -> str | None:
+    """Return the run's ``status.json`` ``exit_reason``, or ``None`` if absent.
+
+    Used by the dashboard to surface deadline-truncated runs to the UI:
+    the "Partial" badge on each DimensionGaugeCard fires when the run
+    didn't complete naturally (e.g. ``exit_reason="deadline"`` from a
+    timeout, or ``"failure_streak"`` from repeated failures).
+    """
+    import json as _json  # noqa: PLC0415
+    status_path = reports_root / project / run_id / "status.json"
+    if not status_path.is_file():
+        return None
+    try:
+        with status_path.open("r", encoding="utf-8") as fp:
+            data = _json.load(fp)
+    except (OSError, ValueError):
+        return None
+    reason = data.get("exit_reason")
+    return reason if isinstance(reason, str) else None
+
+
+def _attach_exit_reason_to_dim(
+    dim_dict: dict[str, Any], run_exit_reason: str | None,
+) -> dict[str, Any]:
+    """Add ``exitReason`` to a serialized dimension dict.
+
+    Preference order: per-dim exit_reason (if present on the dim) wins over
+    the run-level value. Either way, the chosen reason is exposed to the UI
+    as ``exitReason``. Falls back to no key when both are absent (legacy).
+    """
+    per_dim = dim_dict.get("exit_reason") or dim_dict.get("exitReason")
+    chosen = per_dim or run_exit_reason
+    if chosen is None:
+        # Drop the snake_case key if present, to keep the response clean.
+        if "exit_reason" in dim_dict:
+            out = dict(dim_dict)
+            out.pop("exit_reason", None)
+            return out
+        return dim_dict
+    out = dict(dim_dict)
+    out.pop("exit_reason", None)
+    out["exitReason"] = chosen
+    return out
+
+
+def _attach_dismissed_count_to_dim(
+    dim_dict: dict[str, Any], dismissed_counts: dict[str, int],
+    suppressed_counts: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    """Add ``dismissedCount`` / ``suppressedCount`` to a dimension dict when > 0.
+
+    Both explain the gap between "what the scan found" and "what the view
+    shows". ``dismissedCount`` covers the dismissed filter alone;
+    ``suppressedCount`` covers dismissals *and* deletions, so it is the total
+    the UI reports. They differ sharply on projects with a triage history:
+    deletions suppress a whole principle across a file and accumulate over
+    many runs, so a scan can re-find several times what the report displays.
+    Omitted when nothing was filtered, mirroring the exitReason convention.
+    """
+    key = dim_dict.get("dimension") or ""
+    out = dim_dict
+    count = dismissed_counts.get(key, 0)
+    if count > 0:
+        out = {**out, "dismissedCount": count}
+    total = (suppressed_counts or {}).get(key, 0)
+    if total > 0:
+        out = {**out, "suppressedCount": total}
+    return out
+
+
+def _slim_history_dim(dim: DimensionResult) -> dict[str, Any]:
+    """Serialize a history-context dimension without its finding bodies.
+
+    The previousByDimension / stalePreviousByDimension / staleDimensions keys
+    exist to carry scores, grades, and provenance (run id, dates) for trend
+    context; the UI reads only the scalar fields inlined on each selected-run
+    dimension (previousScore, trend, stale, fromRunId). No consumer reads the
+    violations/compliance arrays from these keys, yet on large projects they
+    dominated the payload: for a 201-run project, an old run's dashboard was
+    19.9 MB of which these three keys carried 18.6 MB of finding bodies.
+    Totals keep the counts; only the bodies are dropped.
+    """
+    return to_camel_dict(replace(dim, violations=[], compliance=[]))
+
+
+def _build_dashboard_result(
+    project: str,
+    runs: list[RunInfo],
+    selected_run: RunInfo,
+    payload: _DashboardPayload,
+    *,
+    exit_reason: str | None = None,
+    dismissed_counts: dict[str, int] | None = None,
+    suppressed_counts: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    """Assemble the final dashboard response dict from pre-computed parts."""
+    dim_dicts = [
+        _attach_dismissed_count_to_dim(
+            _attach_exit_reason_to_dim(to_camel_dict(d), exit_reason),
+            dismissed_counts or {},
+            suppressed_counts or {},
+        )
+        for d in payload.dimensions_with_trend
+    ]
+    return {
+        "project": project,
+        "availableRuns": [
+            {"runId": item.run_id, "dateISO": item.date_iso, "dateLabel": item.date_label, "status": item.status}
+            for item in runs
+        ],
+        "selectedRun": {
+            "runId": selected_run.run_id,
+            "dateISO": selected_run.date_iso,
+            "dateLabel": selected_run.date_label,
+            "exitReason": exit_reason,
+        },
+        "summary": {
+            **to_camel_dict(payload.selected_summary),
+            "dateISO": selected_run.date_iso,
+            "dateLabel": selected_run.date_label,
+        },
+        "trend": payload.trend,
+        "dimensions": dim_dicts,
+        "previousByDimension": {k: _slim_history_dim(v) for k, v in payload.previous_by_dimension.items()},
+        "stalePreviousByDimension": {k: _slim_history_dim(v) for k, v in payload.stale_previous_by_dimension.items()},
+        "staleDimensions": [_slim_history_dim(d) for d in payload.stale_dimensions],
+    }

--- a/src/quodeq/services/_score_cache_db.py
+++ b/src/quodeq/services/_score_cache_db.py
@@ -1,0 +1,131 @@
+"""Score-cache DB plumbing: path resolution, schema, and corrupt-db repair.
+
+Disposable/best-effort by design: a corrupt or older-schema db is unlinked and
+rebuilt instead of surfacing an error to the caller.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+from contextlib import contextmanager
+from contextvars import ContextVar
+from pathlib import Path
+from typing import Iterator
+
+from quodeq.services._score_cache_epoch import CACHE_WRITER_EPOCH
+from quodeq.shared._env import get_score_cache_path
+
+_logger = logging.getLogger(__name__)
+_BUSY_TIMEOUT_MS = 5000
+
+# Shared-root isolation seam (Phase 2): when serving read endpoints from a
+# second (shared) clone, the score cache must not mix rows with the local
+# clone's cache. Unset (None) in every normal code path, so the default
+# behavior below is byte-identical to before this seam existed.
+_CACHE_PATH_OVERRIDE: ContextVar[str | None] = ContextVar(
+    "score_cache_path_override", default=None
+)
+
+
+@contextmanager
+def score_cache_path_override(path: str | Path) -> Iterator[None]:
+    """Route score-cache reads/writes to *path* instead of the default DB.
+
+    Active only for the duration of the ``with`` block (and any code it
+    calls, via contextvars' task-local propagation); always restored,
+    including when the block raises.
+    """
+    token = _CACHE_PATH_OVERRIDE.set(str(path))
+    try:
+        yield
+    finally:
+        _CACHE_PATH_OVERRIDE.reset(token)
+
+
+_SCHEMA = (
+    "CREATE TABLE IF NOT EXISTS run_scalars ("
+    " project TEXT NOT NULL, run_id TEXT NOT NULL, version TEXT NOT NULL,"
+    " dimension TEXT NOT NULL, overall_score TEXT, overall_grade TEXT,"
+    " updated_at TEXT NOT NULL DEFAULT (datetime('now')),"
+    " PRIMARY KEY (project, run_id, dimension, version));"
+    "CREATE INDEX IF NOT EXISTS idx_run_scalars_lookup ON run_scalars(project, version);"
+    "CREATE TABLE IF NOT EXISTS accumulated_cache ("
+    " project TEXT NOT NULL, version TEXT NOT NULL, payload TEXT NOT NULL,"
+    " updated_at TEXT NOT NULL DEFAULT (datetime('now')),"
+    " PRIMARY KEY (project, version));"
+    "CREATE TABLE IF NOT EXISTS project_summary_cache ("
+    " project TEXT PRIMARY KEY, version TEXT NOT NULL, payload TEXT NOT NULL);"
+    "CREATE TABLE IF NOT EXISTS run_keys ("
+    " project TEXT NOT NULL, run_id TEXT NOT NULL,"
+    " dismiss_keys TEXT NOT NULL, class_keys TEXT NOT NULL,"
+    " PRIMARY KEY (project, run_id));"
+    "CREATE TABLE IF NOT EXISTS cache_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
+)
+
+
+def _purge_run_keys_on_epoch_change(conn: sqlite3.Connection) -> None:
+    """One-time purge of the non-version-keyed run_keys table on epoch bump.
+
+    ``run_scalars`` / ``accumulated_cache`` / ``project_summary_cache`` embed the
+    epoch in their version hash and self-invalidate, but ``run_keys`` rows are not
+    version-keyed, so a partial snapshot persisted by a prior writer would survive
+    a bump and stay frozen. Clearing the table once forces a fresh read.
+    """
+    try:
+        row = conn.execute(
+            "SELECT value FROM cache_meta WHERE key='writer_epoch'"
+        ).fetchone()
+        if row is not None and row[0] == CACHE_WRITER_EPOCH:
+            return
+        conn.execute("DELETE FROM run_keys")
+        conn.execute(
+            "INSERT OR REPLACE INTO cache_meta (key, value) VALUES ('writer_epoch', ?)",
+            (CACHE_WRITER_EPOCH,),
+        )
+        conn.commit()
+    except sqlite3.Error:
+        _logger.warning("run_keys epoch purge failed", exc_info=True)
+
+
+def _init(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
+        conn.executescript(_SCHEMA)
+        conn.commit()
+        _purge_run_keys_on_epoch_change(conn)
+    except sqlite3.DatabaseError:
+        # Close before re-raising so the caller's rebuild path can unlink the
+        # file with no open handle (Windows raises PermissionError otherwise).
+        conn.close()
+        raise
+    return conn
+
+
+# Serializes _init (and the corrupt-db rebuild). Concurrent first-opens of a
+# fresh DB race the schema DDL; the loser's lock error is indistinguishable
+# from corruption here, so the rebuild path would unlink the file out from
+# under the winner's live WAL connection (observed as a SIGBUS on the mmap'd
+# -shm). Only open/rebuild is serialized — yielded connections stay concurrent.
+_OPEN_LOCK = threading.Lock()
+
+
+@contextmanager
+def open_score_cache() -> Iterator[sqlite3.Connection]:
+    """Open the score cache DB (WAL). Rebuilds from scratch if corrupt/older-schema."""
+    override = _CACHE_PATH_OVERRIDE.get()
+    path = Path(override) if override else Path(get_score_cache_path())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with _OPEN_LOCK:
+        try:
+            conn = _init(path)
+        except sqlite3.DatabaseError:
+            _logger.warning("score cache at %s unreadable; rebuilding", path)
+            path.unlink(missing_ok=True)
+            conn = _init(path)
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/src/quodeq/services/_score_cache_epoch.py
+++ b/src/quodeq/services/_score_cache_epoch.py
@@ -1,0 +1,35 @@
+"""Writer-epoch salt for the score cache.
+
+Its own leaf module because the two consumers must not import each other: the
+version hashes in ``score_cache`` and the ``run_keys`` purge in
+``_score_cache_db``.
+"""
+from __future__ import annotations
+
+# Bumped when the cache *writer* semantics change in a way that could have
+# produced bad rows, to invalidate everything written by the prior writer.
+# "2": earlier writers persisted in-progress runs' partial scalar sets (e.g. 1
+# of 6 dims), which the content-hash version could never invalidate; the
+# write-guard now persists only completed runs, and this bump rebuilds the
+# stranded partial rows once.
+# "3": accumulated / project-summary payloads written before configured-dim
+# scoping carried stale dimensions (e.g. clean-architecture) that the project
+# no longer evaluates; the run-fingerprint could never invalidate them, so this
+# bump rebuilds them once against the latest run's configured-dimension set.
+# "4": earlier writers persisted in-progress runs' PARTIAL run_keys sets (the
+# per-run version path had no completeness gate), which load_run_keys froze
+# forever; the gate now persists only terminal runs, and this bump purges the
+# non-version-keyed run_keys table once so stranded partial snapshots rebuild.
+# "5": dismiss/delete rescoring switched basis from the legacy report-JSON
+# formula to the run's own evidence jsonl (services/evidence_rescore), so
+# scores cached by the prior writer differ for the SAME suppression state and
+# params; this bump rebuilds them on the evidence basis once.
+# "6": three scoring read paths built their run-dimension fetcher without the
+# staleness guards (in-progress bypass + eval-file-count validation), so a
+# request landing mid-run could freeze a partial dim list in the process LRU;
+# later writes built from it persisted half-rescored accumulated payloads and
+# partial scalar sets whose version hash can never self-invalidate. The guards
+# now live in the shared fetcher and the accumulated writer refuses
+# partial-coverage payloads; this bump rebuilds rows the prior writer may have
+# poisoned.
+CACHE_WRITER_EPOCH = "6"

--- a/src/quodeq/services/_score_cache_fetch.py
+++ b/src/quodeq/services/_score_cache_fetch.py
@@ -1,0 +1,182 @@
+"""Read-through wrappers over the score-cache tables.
+
+Each one is hit -> return cached, miss -> compute + persist best-effort. The
+kill switch (``QUODEQ_DISABLE_SCORE_CACHE``) and any SQLite error degrade to a
+plain recompute, so no caller has to handle cache failure.
+"""
+from __future__ import annotations
+
+import sqlite3
+import threading
+from contextlib import contextmanager
+from typing import Callable, Iterator
+
+from quodeq.core.types import DimensionResult
+from quodeq.services._score_cache_db import open_score_cache
+from quodeq.services._score_cache_store import (
+    read_cached_accumulated,
+    read_cached_project_summary,
+    write_cached_accumulated,
+    write_cached_project_summary,
+    write_cached_rows,
+)
+from quodeq.shared._env import score_cache_disabled
+
+# In-flight computes by (kind, project, version). Concurrent misses on the
+# same key must share ONE compute: these computes walk a project's full run
+# history and can take minutes right after an upgrade invalidates every
+# cached row, and the client re-requests while the first compute is still
+# running. The registry entry is dropped once no thread holds the key's lock;
+# a waiter that raced the cleanup at worst recomputes (idempotent write).
+_INFLIGHT_GUARD = threading.Lock()
+_INFLIGHT: dict[tuple[str, str, str], threading.Lock] = {}
+
+
+@contextmanager
+def _single_flight(kind: str, project: str, version: str) -> Iterator[None]:
+    key = (kind, project, version)
+    with _INFLIGHT_GUARD:
+        lock = _INFLIGHT.setdefault(key, threading.Lock())
+    lock.acquire()
+    try:
+        yield
+    finally:
+        lock.release()
+        with _INFLIGHT_GUARD:
+            if not lock.locked() and _INFLIGHT.get(key) is lock:
+                del _INFLIGHT[key]
+
+
+def cached_accumulated(
+    project: str, version: str, compute: Callable[[], dict],
+    cacheable: Callable[[dict], bool] | None = None,
+) -> dict:
+    """Read-through cache for the accumulated payload.
+
+    Hit -> return the deserialized cached payload. Miss (or kill switch / cache
+    error) -> call *compute*, cache the result best-effort, return it.
+    Concurrent misses on one (project, version) share a single compute.
+
+    *cacheable*, when given, is called with the computed result before it is
+    persisted; returning False serves the result without caching it. This lets
+    the caller withhold payloads it knows are incomplete (e.g. a rescore that
+    covered only part of the dimensions), which would otherwise freeze under a
+    version hash that cannot self-invalidate.
+    """
+    if score_cache_disabled():
+        return compute()
+    try:
+        with open_score_cache() as conn:
+            cached = read_cached_accumulated(conn, project, version)
+        if cached is not None:
+            return cached
+    except sqlite3.Error:
+        return compute()
+    with _single_flight("accumulated", project, version):
+        # Re-check: a caller we waited on may have computed and cached it.
+        try:
+            with open_score_cache() as conn:
+                cached = read_cached_accumulated(conn, project, version)
+            if cached is not None:
+                return cached
+        except sqlite3.Error:
+            pass
+        result = compute()
+        if cacheable is not None and not cacheable(result):
+            return result
+        try:
+            with open_score_cache() as conn:
+                write_cached_accumulated(conn, project, version, result)
+        except sqlite3.Error:
+            pass
+        return result
+
+
+def cached_project_summary(
+    project: str, version: str, compute: Callable[[], dict],
+) -> dict:
+    """Read-through cache for the project-card summary (mirrors cached_accumulated)."""
+    if score_cache_disabled():
+        return compute()
+    try:
+        with open_score_cache() as conn:
+            hit = read_cached_project_summary(conn, project, version)
+        if hit is not None:
+            return hit
+    except sqlite3.Error:
+        return compute()
+    with _single_flight("summary", project, version):
+        # Re-check: a caller we waited on may have computed and cached it.
+        try:
+            with open_score_cache() as conn:
+                hit = read_cached_project_summary(conn, project, version)
+            if hit is not None:
+                return hit
+        except sqlite3.Error:
+            pass
+        result = compute()
+        try:
+            with open_score_cache() as conn:
+                write_cached_project_summary(conn, project, version, result)
+        except sqlite3.Error:
+            pass
+        return result
+
+
+def make_cache_backed_fetcher(
+    project: str, version_for: Callable[[str], str],
+    base_fetcher: Callable[[str], list[DimensionResult]],
+    is_cacheable: Callable[[str], bool] | None = None,
+) -> Callable[[str], list[DimensionResult]]:
+    """Wrap *base_fetcher* with the read-through cache, versioned PER RUN.
+
+    *version_for(run_id)* returns that run's scoped version (params + the
+    suppressions touching it). Bulk-loads every cached row for *project* keyed by
+    (run_id, version); a hit requires the row's version to equal the run's
+    current version, so a dismiss/delete only misses the runs it touches. Misses
+    compute via *base_fetcher*, cache scalars at the run's version (only when
+    ``is_cacheable``), and return them. Kill switch -> *base_fetcher* unchanged.
+
+    ``is_cacheable`` gates *persistence* per run: only terminal (complete) runs
+    are safe. An in-progress run's scalar set grows as dimensions finish, and the
+    version hash can't see that, so persisting its partial set would strand a
+    stale row -- so opening History mid-scan would leave the trend showing one
+    dimension forever while run-detail shows all six. Non-cacheable runs
+    compute-through and are served for the current build but never written to
+    disk. Defaults to "always cacheable" for backward compatibility.
+    """
+    if score_cache_disabled():
+        return base_fetcher
+
+    by_run_version: dict[tuple[str, str], list[DimensionResult]] = {}
+    try:
+        with open_score_cache() as conn:
+            for rid, ver, dim, score, grade in conn.execute(
+                "SELECT run_id, version, dimension, overall_score, overall_grade "
+                "FROM run_scalars WHERE project=? ORDER BY run_id, dimension",
+                (project,),
+            ):
+                by_run_version.setdefault((rid, ver), []).append(
+                    DimensionResult(dimension=dim, overall_score=score, overall_grade=grade))
+    except sqlite3.Error:
+        by_run_version = {}
+
+    def fetch(run_id: str) -> list[DimensionResult]:
+        version = version_for(run_id)
+        hit = by_run_version.get((run_id, version))
+        if hit is not None:
+            return hit
+        dims = base_fetcher(run_id)
+        scalars = [DimensionResult(dimension=d.dimension, overall_score=d.overall_score,
+                                   overall_grade=d.overall_grade)
+                   for d in dims if d.dimension]
+        by_run_version[(run_id, version)] = scalars
+        if is_cacheable is None or is_cacheable(run_id):
+            try:
+                with open_score_cache() as conn:
+                    write_cached_rows(conn, project, run_id, version, scalars)
+            except sqlite3.Error:
+                pass
+        return scalars
+
+    return fetch

--- a/src/quodeq/services/_score_cache_store.py
+++ b/src/quodeq/services/_score_cache_store.py
@@ -1,0 +1,180 @@
+"""Row-level reads/writes for the score-cache tables.
+
+One function per (table, direction). Every write is best-effort: it logs and
+returns on any SQLite/serialization error, because the caller already holds the
+computed value and the cache is disposable. Every read returns None/empty on
+error so the caller falls through to recompute.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+
+from quodeq.core.types import DimensionResult
+
+_logger = logging.getLogger(__name__)
+
+
+def read_cached_rows(
+    conn: sqlite3.Connection, project: str, run_id: str, version: str,
+) -> list[DimensionResult] | None:
+    """Return cached scalar dims for (project, run_id, version), or None on miss/error."""
+    try:
+        rows = conn.execute(
+            "SELECT dimension, overall_score, overall_grade FROM run_scalars "
+            "WHERE project=? AND run_id=? AND version=? ORDER BY dimension",
+            (project, run_id, version),
+        ).fetchall()
+    except sqlite3.Error:
+        return None
+    if not rows:
+        return None
+    return [DimensionResult(dimension=r[0], overall_score=r[1], overall_grade=r[2]) for r in rows]
+
+
+def write_cached_rows(
+    conn: sqlite3.Connection, project: str, run_id: str, version: str,
+    dims: list[DimensionResult],
+) -> None:
+    """Replace all cached rows for (project, run_id) with *dims* at *version*.
+
+    Best-effort: logs and returns on any SQLite error (the caller still has the
+    computed result).
+    """
+    try:
+        conn.execute("DELETE FROM run_scalars WHERE project=? AND run_id=?", (project, run_id))
+        conn.executemany(
+            "INSERT OR REPLACE INTO run_scalars "
+            "(project, run_id, version, dimension, overall_score, overall_grade) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [(project, run_id, version, d.dimension, d.overall_score, d.overall_grade)
+             for d in dims if d.dimension],
+        )
+        conn.commit()
+    except sqlite3.Error:
+        _logger.warning("score cache write failed for %s/%s", project, run_id, exc_info=True)
+
+
+def read_cached_accumulated(
+    conn: sqlite3.Connection, project: str, version: str,
+) -> dict | None:
+    """Return the cached accumulated payload for (project, version), or None."""
+    try:
+        row = conn.execute(
+            "SELECT payload FROM accumulated_cache WHERE project=? AND version=?",
+            (project, version),
+        ).fetchone()
+    except sqlite3.Error:
+        return None
+    if row is None:
+        return None
+    try:
+        return json.loads(row[0])
+    except (ValueError, TypeError):
+        return None
+
+
+def write_cached_accumulated(
+    conn: sqlite3.Connection, project: str, version: str, payload: dict,
+) -> None:
+    """Replace the cached accumulated payload for *project* at *version*.
+
+    Single-slot per project: the DELETE clears any prior version first, so the
+    table holds at most one accumulated payload per project. The default
+    dashboard uses ``as_of=None`` (one version), so this is stable; rapidly
+    alternating distinct ``as_of`` historical views would each miss + overwrite.
+
+    Best-effort: logs and returns on any SQLite/serialization error.
+    """
+    try:
+        blob = json.dumps(payload)
+    except (TypeError, ValueError):
+        _logger.warning("accumulated payload for %s not serializable; skipping cache", project)
+        return
+    try:
+        conn.execute("DELETE FROM accumulated_cache WHERE project=?", (project,))
+        conn.execute(
+            "INSERT OR REPLACE INTO accumulated_cache (project, version, payload) VALUES (?, ?, ?)",
+            (project, version, blob),
+        )
+        conn.commit()
+    except sqlite3.Error:
+        _logger.warning("accumulated cache write failed for %s", project, exc_info=True)
+
+
+def read_cached_project_summary(
+    conn: sqlite3.Connection, project: str, version: str,
+) -> dict | None:
+    """Return the cached project-card summary for (project, version), or None."""
+    try:
+        row = conn.execute(
+            "SELECT payload FROM project_summary_cache WHERE project=? AND version=?",
+            (project, version),
+        ).fetchone()
+    except sqlite3.Error:
+        return None
+    if row is None:
+        return None
+    try:
+        return json.loads(row[0])
+    except (ValueError, TypeError):
+        return None
+
+
+def write_cached_project_summary(
+    conn: sqlite3.Connection, project: str, version: str, payload: dict,
+) -> None:
+    """Single-slot-per-project write for the project-card summary."""
+    try:
+        blob = json.dumps(payload)
+    except (TypeError, ValueError):
+        return
+    try:
+        conn.execute("DELETE FROM project_summary_cache WHERE project=?", (project,))
+        conn.execute(
+            "INSERT OR REPLACE INTO project_summary_cache (project, version, payload) VALUES (?, ?, ?)",
+            (project, version, blob),
+        )
+        conn.commit()
+    except sqlite3.Error:
+        _logger.warning("project summary cache write failed for %s", project, exc_info=True)
+
+
+def store_run_keys(
+    conn: sqlite3.Connection, project: str, run_id: str,
+    dismiss_keys: set[tuple], class_keys: set[tuple],
+) -> None:
+    """Persist a run's key sets (best-effort)."""
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO run_keys (project, run_id, dismiss_keys, class_keys) "
+            "VALUES (?, ?, ?, ?)",
+            (project, run_id,
+             json.dumps(sorted(list(k) for k in dismiss_keys)),
+             json.dumps(sorted(list(k) for k in class_keys))),
+        )
+        conn.commit()
+    except sqlite3.Error:
+        _logger.warning("run_keys write failed for %s/%s", project, run_id, exc_info=True)
+
+
+def load_run_keys(
+    conn: sqlite3.Connection, project: str,
+) -> dict[str, tuple[set[tuple], set[tuple]]]:
+    """Return ``{run_id: (dismiss_keys, class_keys)}`` for *project* (empty on error)."""
+    out: dict[str, tuple[set[tuple], set[tuple]]] = {}
+    try:
+        rows = conn.execute(
+            "SELECT run_id, dismiss_keys, class_keys FROM run_keys WHERE project=?",
+            (project,),
+        ).fetchall()
+    except sqlite3.Error:
+        return {}
+    for run_id, dj, cj in rows:
+        try:
+            out[run_id] = ({tuple(k) for k in json.loads(dj)},
+                           {tuple(k) for k in json.loads(cj)})
+        except (ValueError, TypeError):
+            continue
+    return out

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -1,166 +1,61 @@
-"""Dashboard and accumulated-view logic, split from action_provider_fs."""
+"""Dashboard and accumulated-view logic, split from action_provider_fs.
+
+This module owns the *selected run*: resolving which run the request means,
+rescoring its dimensions against project-wide suppressions, and driving the
+three collaborators that do the rest.
+
+- ``_dashboard_cache``    — run-dimension LRU config, shared cache, fetchers
+- ``_dashboard_history``  — previous scores, stale dimensions, trend series
+- ``_dashboard_response`` — camelCase serialization of the response
+
+Their symbols are re-exported below so existing import paths keep resolving.
+"""
 from __future__ import annotations
 
-import logging
-import os
 import threading
 from collections import OrderedDict
-from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Callable
 
-from quodeq.core.scoring.params import DEFAULT_PARAMS, ScoringParams
-from quodeq.core.types import DimensionResult, DimensionSummary, to_camel_dict
+from quodeq.core.scoring.params import ScoringParams
+from quodeq.core.types import DimensionResult
 
-from quodeq.data.fs.report_parser.grades import calculate_trend, summarize_dimensions
+from quodeq.data.fs.report_parser.grades import summarize_dimensions
 from quodeq.data.fs.report_parser.runs import RunInfo, list_runs, read_run_data
-from quodeq.services._cache import make_lru_dimension_fetcher
-from quodeq.services._dashboard_stale import collect_stale_dimensions
-from quodeq.services._dashboard_trend import build_accumulated_trend
-from quodeq.services._trend_fetcher import make_trend_fetcher
-from quodeq.services.scoring_view import is_eligible_for_default_view, select_trend_runs
+from quodeq.services.scoring_view import is_eligible_for_default_view
 from quodeq.services.dismissed import filter_dismissed_from_dimensions
 from quodeq.shared.validation import validate_path_segment
 from quodeq.data.fs.suppression_rules import load_suppression_rules
 
-_logger = logging.getLogger(__name__)
+from quodeq.services._dashboard_cache import (  # noqa: F401
+    DashboardCacheConfig,
+    _DEFAULT_RUN_DIM_CACHE_MAX,
+    _make_run_dimension_fetcher,
+    _run_dim_cache_max,
+    _SHARED_RUN_DIM_CACHE,
+    _SHARED_RUN_DIM_LOCK,
+    clear_shared_dimension_cache,
+    create_dimension_cache,
+)
+from quodeq.services._dashboard_history import (  # noqa: F401
+    _DashboardPayload,
+    _DEFAULT_MAX_HISTORY_RUNS,
+    _SKIP_GRADES,
+    _SelectedRunContext,
+    _collect_previous_scores,
+    _compute_dashboard_payload,
+    _enrich_dimensions_with_trend,
+    _max_history_runs,
+)
+from quodeq.services._dashboard_response import (  # noqa: F401
+    _attach_dismissed_count_to_dim,
+    _attach_exit_reason_to_dim,
+    _build_dashboard_result,
+    _read_run_exit_reason,
+    _slim_history_dim,
+)
 
-
-@dataclass
-class DashboardCacheConfig:
-    """Optional cache overrides for build_dashboard (mirrors AccumulatedCacheConfig)."""
-    cache: OrderedDict[tuple, list[DimensionResult]] | None = None
-    lock: threading.Lock | None = None
-    max_size: int | None = None
-
-
-_SKIP_GRADES = {"NA", "N/A", "INSUFFICIENT"}
-
-# Maximum number of historical runs scanned for trend, previous scores, and
-# stale dimensions. The full run list is still returned in availableRuns (metadata
-# only, no disk reads) so users can navigate to older runs directly.
 _LATEST_RUN = "latest"
-_DEFAULT_MAX_HISTORY_RUNS = 100
-
-
-def _max_history_runs(env: dict[str, str] | None = None) -> int:
-    """Return the history-scan ceiling, honouring QUODEQ_MAX_HISTORY_RUNS."""
-    raw = (env or os.environ).get("QUODEQ_MAX_HISTORY_RUNS")
-    if not raw:
-        return _DEFAULT_MAX_HISTORY_RUNS
-    try:
-        value = int(raw)
-    except ValueError:
-        return _DEFAULT_MAX_HISTORY_RUNS
-    return value if value > 0 else _DEFAULT_MAX_HISTORY_RUNS
-
-
-_DEFAULT_RUN_DIM_CACHE_MAX = 256
-
-
-def _run_dim_cache_max(override: int | None = None, env: dict[str, str] | None = None) -> int:
-    """Return the run-dimension cache size limit. *override* bypasses env for testing."""
-    if override is not None:
-        return override
-    try:
-        return int((env or os.environ).get("QUODEQ_RUN_DIM_CACHE_MAX", str(_DEFAULT_RUN_DIM_CACHE_MAX)))
-    except (ValueError, TypeError):
-        return _DEFAULT_RUN_DIM_CACHE_MAX
-
-
-# Module-level shared cache for run-dimension data. Without this, every
-# dashboard request used a fresh cache (created in _make_run_dimension_fetcher
-# below), so re-fetching the same project's history (which collect_stale_dimensions
-# / _collect_previous_scores / build_accumulated_trend all walk) cost ~750ms
-# per request even on warm calls. The shared cache eliminates the cross-request
-# I/O without compromising the per-request consistency guarantees (the cache
-# is keyed by (reports_root, project, run_id, suppression_version) so a
-# dismiss/delete produces a new key and never serves a pre-suppression score,
-# and runs are immutable once finalized).
-#
-# Tests that need isolation can pass an explicit DashboardCacheConfig.
-_SHARED_RUN_DIM_CACHE, _SHARED_RUN_DIM_LOCK = OrderedDict(), threading.Lock()
-
-
-def create_dimension_cache() -> tuple[OrderedDict[tuple, list[DimensionResult]], threading.Lock]:
-    """Create the default run-dimension LRU cache and its lock.
-
-    Override this factory to plug in a shared backend (e.g. a Redis-backed
-    OrderedDict wrapper) for multi-worker deployments.  The returned
-    ordered-dict must support ``move_to_end``, ``popitem(last=False)``,
-    and standard ``__getitem__``/``__setitem__``/``__contains__``.
-    """
-    return OrderedDict(), threading.Lock()
-
-
-def clear_shared_dimension_cache() -> None:
-    """Drop all cached run-dimension data (e.g. after a formula change)."""
-    with _SHARED_RUN_DIM_LOCK:
-        _SHARED_RUN_DIM_CACHE.clear()
-
-
-def _collect_previous_scores(
-    runs: list[RunInfo], selected_index: int, selected_dim_names: set[str],
-    get_run_dimensions: Callable[[str], list[DimensionResult]],
-) -> dict[str, DimensionResult]:
-    """Find the most recent previous score for each dimension in the selected run."""
-    previous_by_dimension: dict[str, DimensionResult] = {}
-    for older_idx in range(selected_index + 1, len(runs)):
-        run_dimensions = get_run_dimensions(runs[older_idx].run_id)
-        for dim in run_dimensions:
-            dim_name = dim.dimension
-            if not dim_name or dim_name not in selected_dim_names:
-                continue
-            grade = dim.overall_grade
-            if not grade or str(grade).upper() in _SKIP_GRADES:
-                continue
-            if dim_name not in previous_by_dimension:
-                previous_by_dimension[dim_name] = replace(dim, run_id=runs[older_idx].run_id)
-    return previous_by_dimension
-
-
-def _enrich_dimensions_with_trend(
-    selected_dimensions: list[DimensionResult], previous_by_dimension: dict[str, DimensionResult]
-) -> list[DimensionResult]:
-    """Attach trend and previous-run data to each selected dimension."""
-    result: list[DimensionResult] = []
-    for dim in selected_dimensions:
-        previous = previous_by_dimension.get(dim.dimension or "")
-        trend = calculate_trend(dim.overall_score, previous.overall_score if previous else None)
-        result.append(
-            replace(
-                dim,
-                trend=trend,
-                previous_run_id=previous.run_id if previous else None,
-                previous_score=previous.overall_score if previous else None,
-            )
-        )
-    return result
-
-
-def _make_run_dimension_fetcher(
-    reports_root: Path,
-    project: str,
-    cache: OrderedDict[tuple, list[DimensionResult]] | None = None,
-    lock: threading.Lock | None = None,
-    max_size: int | None = None,
-    version: str = "",
-) -> Callable[[str], list[DimensionResult]]:
-    """Return a cached fetcher for run dimension data (LRU, bounded).
-
-    Defaults to the module-level shared cache so reads of the same run's
-    dimensions across requests reuse work. *version* scopes the cache key to the
-    project's suppression state so a dismiss/delete invalidates it. Tests pass
-    explicit cache/lock to isolate state.
-    """
-    return make_lru_dimension_fetcher(
-        reports_root,
-        project,
-        cache if cache is not None else _SHARED_RUN_DIM_CACHE,
-        lock if lock is not None else _SHARED_RUN_DIM_LOCK,
-        max_size if max_size is not None else _run_dim_cache_max(),
-        version=version,
-    )
 
 
 def _rescore_run_dimensions(
@@ -231,146 +126,6 @@ def _make_status_aware_fetcher(
     return fetch
 
 
-@dataclass
-class _DashboardPayload:
-    """Pre-computed parts for the dashboard response."""
-    selected_summary: DimensionSummary
-    trend: list[dict[str, Any]]
-    dimensions_with_trend: list[DimensionResult]
-    previous_by_dimension: dict[str, DimensionResult]
-    stale_previous_by_dimension: dict[str, DimensionResult]
-    stale_dimensions: list[DimensionResult]
-
-
-def _read_run_exit_reason(reports_root: Path, project: str, run_id: str) -> str | None:
-    """Return the run's ``status.json`` ``exit_reason``, or ``None`` if absent.
-
-    Used by the dashboard to surface deadline-truncated runs to the UI:
-    the "Partial" badge on each DimensionGaugeCard fires when the run
-    didn't complete naturally (e.g. ``exit_reason="deadline"`` from a
-    timeout, or ``"failure_streak"`` from repeated failures).
-    """
-    import json as _json  # noqa: PLC0415
-    status_path = reports_root / project / run_id / "status.json"
-    if not status_path.is_file():
-        return None
-    try:
-        with status_path.open("r", encoding="utf-8") as fp:
-            data = _json.load(fp)
-    except (OSError, ValueError):
-        return None
-    reason = data.get("exit_reason")
-    return reason if isinstance(reason, str) else None
-
-
-def _attach_exit_reason_to_dim(
-    dim_dict: dict[str, Any], run_exit_reason: str | None,
-) -> dict[str, Any]:
-    """Add ``exitReason`` to a serialized dimension dict.
-
-    Preference order: per-dim exit_reason (if present on the dim) wins over
-    the run-level value. Either way, the chosen reason is exposed to the UI
-    as ``exitReason``. Falls back to no key when both are absent (legacy).
-    """
-    per_dim = dim_dict.get("exit_reason") or dim_dict.get("exitReason")
-    chosen = per_dim or run_exit_reason
-    if chosen is None:
-        # Drop the snake_case key if present, to keep the response clean.
-        if "exit_reason" in dim_dict:
-            out = dict(dim_dict)
-            out.pop("exit_reason", None)
-            return out
-        return dim_dict
-    out = dict(dim_dict)
-    out.pop("exit_reason", None)
-    out["exitReason"] = chosen
-    return out
-
-
-def _attach_dismissed_count_to_dim(
-    dim_dict: dict[str, Any], dismissed_counts: dict[str, int],
-    suppressed_counts: dict[str, int] | None = None,
-) -> dict[str, Any]:
-    """Add ``dismissedCount`` / ``suppressedCount`` to a dimension dict when > 0.
-
-    Both explain the gap between "what the scan found" and "what the view
-    shows". ``dismissedCount`` covers the dismissed filter alone;
-    ``suppressedCount`` covers dismissals *and* deletions, so it is the total
-    the UI reports. They differ sharply on projects with a triage history:
-    deletions suppress a whole principle across a file and accumulate over
-    many runs, so a scan can re-find several times what the report displays.
-    Omitted when nothing was filtered, mirroring the exitReason convention.
-    """
-    key = dim_dict.get("dimension") or ""
-    out = dim_dict
-    count = dismissed_counts.get(key, 0)
-    if count > 0:
-        out = {**out, "dismissedCount": count}
-    total = (suppressed_counts or {}).get(key, 0)
-    if total > 0:
-        out = {**out, "suppressedCount": total}
-    return out
-
-
-def _slim_history_dim(dim: DimensionResult) -> dict[str, Any]:
-    """Serialize a history-context dimension without its finding bodies.
-
-    The previousByDimension / stalePreviousByDimension / staleDimensions keys
-    exist to carry scores, grades, and provenance (run id, dates) for trend
-    context; the UI reads only the scalar fields inlined on each selected-run
-    dimension (previousScore, trend, stale, fromRunId). No consumer reads the
-    violations/compliance arrays from these keys, yet on large projects they
-    dominated the payload: for a 201-run project, an old run's dashboard was
-    19.9 MB of which these three keys carried 18.6 MB of finding bodies.
-    Totals keep the counts; only the bodies are dropped.
-    """
-    return to_camel_dict(replace(dim, violations=[], compliance=[]))
-
-
-def _build_dashboard_result(
-    project: str,
-    runs: list[RunInfo],
-    selected_run: RunInfo,
-    payload: _DashboardPayload,
-    *,
-    exit_reason: str | None = None,
-    dismissed_counts: dict[str, int] | None = None,
-    suppressed_counts: dict[str, int] | None = None,
-) -> dict[str, Any]:
-    """Assemble the final dashboard response dict from pre-computed parts."""
-    dim_dicts = [
-        _attach_dismissed_count_to_dim(
-            _attach_exit_reason_to_dim(to_camel_dict(d), exit_reason),
-            dismissed_counts or {},
-            suppressed_counts or {},
-        )
-        for d in payload.dimensions_with_trend
-    ]
-    return {
-        "project": project,
-        "availableRuns": [
-            {"runId": item.run_id, "dateISO": item.date_iso, "dateLabel": item.date_label, "status": item.status}
-            for item in runs
-        ],
-        "selectedRun": {
-            "runId": selected_run.run_id,
-            "dateISO": selected_run.date_iso,
-            "dateLabel": selected_run.date_label,
-            "exitReason": exit_reason,
-        },
-        "summary": {
-            **to_camel_dict(payload.selected_summary),
-            "dateISO": selected_run.date_iso,
-            "dateLabel": selected_run.date_label,
-        },
-        "trend": payload.trend,
-        "dimensions": dim_dicts,
-        "previousByDimension": {k: _slim_history_dim(v) for k, v in payload.previous_by_dimension.items()},
-        "stalePreviousByDimension": {k: _slim_history_dim(v) for k, v in payload.stale_previous_by_dimension.items()},
-        "staleDimensions": [_slim_history_dim(d) for d in payload.stale_dimensions],
-    }
-
-
 # Fallback order for the "latest" default run when none is complete. Each
 # tier is tried newest-first; a failed run is only headlined when nothing
 # else remains (handled after this list). Complete mirrors the Overview's
@@ -423,94 +178,6 @@ def _resolve_selected_run(runs: list[RunInfo], run: str) -> tuple[RunInfo, int]:
     if selected_index is None:
         raise RuntimeError(f"Run {selected_run.run_id!r} disappeared from the run list unexpectedly.")
     return selected_run, selected_index
-
-
-@dataclass(frozen=True)
-class _SelectedRunContext:
-    """Pre-resolved data for the selected run in a dashboard request."""
-    run: RunInfo
-    index: int
-    dimensions: list[DimensionResult]
-    summary: DimensionSummary
-
-
-def _compute_dashboard_payload(
-    reports_root: Path, project: str, runs: list[RunInfo],
-    ctx: _SelectedRunContext, cc: DashboardCacheConfig,
-    params: ScoringParams = DEFAULT_PARAMS,
-) -> _DashboardPayload:
-    """Compute history-dependent parts of the dashboard response."""
-    selected_dim_names = {d.dimension for d in ctx.dimensions}
-    # Shared trend rule (scoring_view.select_trend_runs): cancelled/failed
-    # runs are excluded — misleading history points. They remain visible in
-    # availableRuns for the UI.
-    scoreable_runs = select_trend_runs(runs)
-    # Re-find the selected run's index inside scoreable_runs. ctx.index is
-    # the index in the full unfiltered run list, which can exceed
-    # len(history_runs) when cancelled/failed runs sit above the selected
-    # run. Passing the wrong index to collect_stale_dimensions /
-    # _collect_previous_scores caused IndexError on history_runs[newer_idx].
-    selected_in_scoreable = next(
-        (i for i, r in enumerate(scoreable_runs) if r.run_id == ctx.run.run_id),
-        None,
-    )
-    max_history = _max_history_runs()
-    if selected_in_scoreable is None:
-        # Selected run was cancelled/failed (so it's not in scoreable_runs).
-        # Treat the entire scoreable history as "older" runs relative to it.
-        history_runs = scoreable_runs[:max_history]
-        history_index = len(history_runs)
-    else:
-        history_runs = scoreable_runs[:max(max_history, selected_in_scoreable + 1)]
-        history_index = selected_in_scoreable
-    # History fetcher: cache-backed, dismiss-adjusted, SCALAR-only -- the same
-    # fetcher the /scores endpoint uses. The three consumers below
-    # (_collect_previous_scores, collect_stale_dimensions, build_accumulated_trend)
-    # read only per-run scalars (dimension + overallScore + overallGrade), not
-    # the full violations. Reading + rescoring FULL data for every history run
-    # (up to _max_history_runs()) was the ~2s cost this replaces.
-    #
-    # In-progress freshness is preserved: the fast path re-reads each request
-    # (fresh per-call cache), and the heavy path's cacheable_run_ids guard makes
-    # in-progress runs compute-through without persisting a partial set. Stale-
-    # partial detection is preserved inside read_run_scalars, which falls back to
-    # full read_run_data whenever the SQL scalar projection disagrees with the
-    # on-disk evaluation/*.json count -- the same self-heal the old status-aware
-    # fetcher did via _count_eval_files. The dismiss-adjustment (Bug B) stays;
-    # it is now cached rather than recomputed on every request.
-    cacheable_run_ids = {r.run_id for r in history_runs if r.status == "complete"}
-    # Key the in-memory dimension cache by the project's suppression state so a
-    # dismiss/delete (or a formula change) invalidates warmed entries and no
-    # read path can serve a pre-dismiss score. ``score_cache_version`` already
-    # hashes dismissed + deleted keys + params. This fetcher is SHARED across the
-    # whole history window (previous-scores, stale-dimensions, and the trend all
-    # iterate many runs through it), so we keep the global project-scoped version
-    # here rather than a per-run scoped one -- per-run scoping only makes sense
-    # when a single run is in play, which this path is not.
-    from quodeq.services.score_cache import score_cache_version  # noqa: PLC0415
-    dim_cache_version = score_cache_version(reports_root / project, params)
-    get_run_dimensions = make_trend_fetcher(
-        reports_root, project, params=params, cacheable_run_ids=cacheable_run_ids,
-        max_history=max_history,
-        base_fetcher_factory=lambda rr, proj: _make_run_dimension_fetcher(
-            rr, proj, cache=cc.cache, lock=cc.lock, max_size=cc.max_size,
-            version=dim_cache_version,
-        ),
-    )
-    previous_by_dimension = _collect_previous_scores(
-        history_runs, history_index, selected_dim_names, get_run_dimensions,
-    )
-    stale_dimensions, stale_previous_by_dimension = collect_stale_dimensions(
-        history_runs, history_index, selected_dim_names, get_run_dimensions,
-    )
-    return _DashboardPayload(
-        selected_summary=ctx.summary,
-        trend=build_accumulated_trend(history_runs, get_run_dimensions, params=params),
-        dimensions_with_trend=_enrich_dimensions_with_trend(ctx.dimensions, previous_by_dimension),
-        previous_by_dimension=previous_by_dimension,
-        stale_previous_by_dimension=stale_previous_by_dimension,
-        stale_dimensions=stale_dimensions,
-    )
 
 
 def build_dashboard(
@@ -586,3 +253,11 @@ def build_dashboard(
         exit_reason=exit_reason, dismissed_counts=dismissed_counts,
         suppressed_counts=suppressed_counts,
     )
+
+
+__all__ = [
+    "DashboardCacheConfig",
+    "build_dashboard",
+    "clear_shared_dimension_cache",
+    "create_dimension_cache",
+]

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -3,253 +3,49 @@
 Keyed by a content-hash version of the project's dismissals/deletions + grade
 params, so any change auto-invalidates. Disposable/best-effort: a corrupt or
 older-schema db is rebuilt, and any cache error falls through to recompute.
+
+This module owns the version hashes (the cache's invalidation contract) and is
+the facade every caller imports. The mechanics live in three submodules:
+``_score_cache_db`` (connection/schema), ``_score_cache_store`` (per-table
+reads/writes) and ``_score_cache_fetch`` (read-through wrappers).
 """
 from __future__ import annotations
 
 import hashlib
 import json
-import logging
 import sqlite3
-import threading
-from contextlib import contextmanager
-from contextvars import ContextVar
 from pathlib import Path
-from typing import Callable, Iterator
 
 from quodeq.core.scoring.params import ScoringParams
-from quodeq.core.types import DimensionResult
 from quodeq.services.deleted import deleted_keys
 from quodeq.services.dismissed import dismissed_keys
-from quodeq.shared._env import get_score_cache_path, score_cache_disabled
+from quodeq.services._score_cache_epoch import CACHE_WRITER_EPOCH as _CACHE_WRITER_EPOCH
 from quodeq.data.fs.suppression_rules import load_suppression_rules
 
-_logger = logging.getLogger(__name__)
-_BUSY_TIMEOUT_MS = 5000
-# Bumped when the cache *writer* semantics change in a way that could have
-# produced bad rows, to invalidate everything written by the prior writer.
-# "2": earlier writers persisted in-progress runs' partial scalar sets (e.g. 1
-# of 6 dims), which the content-hash version could never invalidate; the
-# write-guard now persists only completed runs, and this bump rebuilds the
-# stranded partial rows once.
-# "3": accumulated / project-summary payloads written before configured-dim
-# scoping carried stale dimensions (e.g. clean-architecture) that the project
-# no longer evaluates; the run-fingerprint could never invalidate them, so this
-# bump rebuilds them once against the latest run's configured-dimension set.
-# "4": earlier writers persisted in-progress runs' PARTIAL run_keys sets (the
-# per-run version path had no completeness gate), which load_run_keys froze
-# forever; the gate now persists only terminal runs, and this bump purges the
-# non-version-keyed run_keys table once so stranded partial snapshots rebuild.
-# "5": dismiss/delete rescoring switched basis from the legacy report-JSON
-# formula to the run's own evidence jsonl (services/evidence_rescore), so
-# scores cached by the prior writer differ for the SAME suppression state and
-# params; this bump rebuilds them on the evidence basis once.
-# "6": three scoring read paths built their run-dimension fetcher without the
-# staleness guards (in-progress bypass + eval-file-count validation), so a
-# request landing mid-run could freeze a partial dim list in the process LRU;
-# later writes built from it persisted half-rescored accumulated payloads and
-# partial scalar sets whose version hash can never self-invalidate. The guards
-# now live in the shared fetcher and the accumulated writer refuses
-# partial-coverage payloads; this bump rebuilds rows the prior writer may have
-# poisoned.
-_CACHE_WRITER_EPOCH = "6"
-
-# Shared-root isolation seam (Phase 2): when serving read endpoints from a
-# second (shared) clone, the score cache must not mix rows with the local
-# clone's cache. Unset (None) in every normal code path, so the default
-# behavior below is byte-identical to before this seam existed.
-_CACHE_PATH_OVERRIDE: ContextVar[str | None] = ContextVar(
-    "score_cache_path_override", default=None
+# ---------------------------------------------------------------------------
+# Decomposed submodules. Every moved name is re-exported here so external
+# callers and test patch targets keep working against this module.
+# ---------------------------------------------------------------------------
+from quodeq.services._score_cache_db import (  # noqa: F401 — facade re-export
+    open_score_cache,
+    score_cache_path_override,
 )
-
-
-@contextmanager
-def score_cache_path_override(path: str | Path) -> Iterator[None]:
-    """Route score-cache reads/writes to *path* instead of the default DB.
-
-    Active only for the duration of the ``with`` block (and any code it
-    calls, via contextvars' task-local propagation); always restored,
-    including when the block raises.
-    """
-    token = _CACHE_PATH_OVERRIDE.set(str(path))
-    try:
-        yield
-    finally:
-        _CACHE_PATH_OVERRIDE.reset(token)
-
-
-_SCHEMA = (
-    "CREATE TABLE IF NOT EXISTS run_scalars ("
-    " project TEXT NOT NULL, run_id TEXT NOT NULL, version TEXT NOT NULL,"
-    " dimension TEXT NOT NULL, overall_score TEXT, overall_grade TEXT,"
-    " updated_at TEXT NOT NULL DEFAULT (datetime('now')),"
-    " PRIMARY KEY (project, run_id, dimension, version));"
-    "CREATE INDEX IF NOT EXISTS idx_run_scalars_lookup ON run_scalars(project, version);"
-    "CREATE TABLE IF NOT EXISTS accumulated_cache ("
-    " project TEXT NOT NULL, version TEXT NOT NULL, payload TEXT NOT NULL,"
-    " updated_at TEXT NOT NULL DEFAULT (datetime('now')),"
-    " PRIMARY KEY (project, version));"
-    "CREATE TABLE IF NOT EXISTS project_summary_cache ("
-    " project TEXT PRIMARY KEY, version TEXT NOT NULL, payload TEXT NOT NULL);"
-    "CREATE TABLE IF NOT EXISTS run_keys ("
-    " project TEXT NOT NULL, run_id TEXT NOT NULL,"
-    " dismiss_keys TEXT NOT NULL, class_keys TEXT NOT NULL,"
-    " PRIMARY KEY (project, run_id));"
-    "CREATE TABLE IF NOT EXISTS cache_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
+from quodeq.services._score_cache_store import (  # noqa: F401 — facade re-export
+    load_run_keys,
+    read_cached_accumulated,
+    read_cached_project_summary,
+    read_cached_rows,
+    store_run_keys,
+    write_cached_accumulated,
+    write_cached_project_summary,
+    write_cached_rows,
 )
-
-
-def _purge_run_keys_on_epoch_change(conn: sqlite3.Connection) -> None:
-    """One-time purge of the non-version-keyed run_keys table on epoch bump.
-
-    ``run_scalars`` / ``accumulated_cache`` / ``project_summary_cache`` embed the
-    epoch in their version hash and self-invalidate, but ``run_keys`` rows are not
-    version-keyed, so a partial snapshot persisted by a prior writer would survive
-    a bump and stay frozen. Clearing the table once forces a fresh read.
-    """
-    try:
-        row = conn.execute(
-            "SELECT value FROM cache_meta WHERE key='writer_epoch'"
-        ).fetchone()
-        if row is not None and row[0] == _CACHE_WRITER_EPOCH:
-            return
-        conn.execute("DELETE FROM run_keys")
-        conn.execute(
-            "INSERT OR REPLACE INTO cache_meta (key, value) VALUES ('writer_epoch', ?)",
-            (_CACHE_WRITER_EPOCH,),
-        )
-        conn.commit()
-    except sqlite3.Error:
-        _logger.warning("run_keys epoch purge failed", exc_info=True)
-
-
-def _init(path: Path) -> sqlite3.Connection:
-    conn = sqlite3.connect(path)
-    try:
-        conn.execute("PRAGMA journal_mode = WAL")
-        conn.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
-        conn.executescript(_SCHEMA)
-        conn.commit()
-        _purge_run_keys_on_epoch_change(conn)
-    except sqlite3.DatabaseError:
-        # Close before re-raising so the caller's rebuild path can unlink the
-        # file with no open handle (Windows raises PermissionError otherwise).
-        conn.close()
-        raise
-    return conn
-
-
-# Serializes _init (and the corrupt-db rebuild). Concurrent first-opens of a
-# fresh DB race the schema DDL; the loser's lock error is indistinguishable
-# from corruption here, so the rebuild path would unlink the file out from
-# under the winner's live WAL connection (observed as a SIGBUS on the mmap'd
-# -shm). Only open/rebuild is serialized — yielded connections stay concurrent.
-_OPEN_LOCK = threading.Lock()
-
-
-@contextmanager
-def open_score_cache() -> Iterator[sqlite3.Connection]:
-    """Open the score cache DB (WAL). Rebuilds from scratch if corrupt/older-schema."""
-    override = _CACHE_PATH_OVERRIDE.get()
-    path = Path(override) if override else Path(get_score_cache_path())
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with _OPEN_LOCK:
-        try:
-            conn = _init(path)
-        except sqlite3.DatabaseError:
-            _logger.warning("score cache at %s unreadable; rebuilding", path)
-            path.unlink(missing_ok=True)
-            conn = _init(path)
-    try:
-        yield conn
-    finally:
-        conn.close()
-
-
-def read_cached_rows(
-    conn: sqlite3.Connection, project: str, run_id: str, version: str,
-) -> list[DimensionResult] | None:
-    """Return cached scalar dims for (project, run_id, version), or None on miss/error."""
-    try:
-        rows = conn.execute(
-            "SELECT dimension, overall_score, overall_grade FROM run_scalars "
-            "WHERE project=? AND run_id=? AND version=? ORDER BY dimension",
-            (project, run_id, version),
-        ).fetchall()
-    except sqlite3.Error:
-        return None
-    if not rows:
-        return None
-    return [DimensionResult(dimension=r[0], overall_score=r[1], overall_grade=r[2]) for r in rows]
-
-
-def write_cached_rows(
-    conn: sqlite3.Connection, project: str, run_id: str, version: str,
-    dims: list[DimensionResult],
-) -> None:
-    """Replace all cached rows for (project, run_id) with *dims* at *version*.
-
-    Best-effort: logs and returns on any SQLite error (the caller still has the
-    computed result).
-    """
-    try:
-        conn.execute("DELETE FROM run_scalars WHERE project=? AND run_id=?", (project, run_id))
-        conn.executemany(
-            "INSERT OR REPLACE INTO run_scalars "
-            "(project, run_id, version, dimension, overall_score, overall_grade) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            [(project, run_id, version, d.dimension, d.overall_score, d.overall_grade)
-             for d in dims if d.dimension],
-        )
-        conn.commit()
-    except sqlite3.Error:
-        _logger.warning("score cache write failed for %s/%s", project, run_id, exc_info=True)
-
-
-def read_cached_accumulated(
-    conn: sqlite3.Connection, project: str, version: str,
-) -> dict | None:
-    """Return the cached accumulated payload for (project, version), or None."""
-    try:
-        row = conn.execute(
-            "SELECT payload FROM accumulated_cache WHERE project=? AND version=?",
-            (project, version),
-        ).fetchone()
-    except sqlite3.Error:
-        return None
-    if row is None:
-        return None
-    try:
-        return json.loads(row[0])
-    except (ValueError, TypeError):
-        return None
-
-
-def write_cached_accumulated(
-    conn: sqlite3.Connection, project: str, version: str, payload: dict,
-) -> None:
-    """Replace the cached accumulated payload for *project* at *version*.
-
-    Single-slot per project: the DELETE clears any prior version first, so the
-    table holds at most one accumulated payload per project. The default
-    dashboard uses ``as_of=None`` (one version), so this is stable; rapidly
-    alternating distinct ``as_of`` historical views would each miss + overwrite.
-
-    Best-effort: logs and returns on any SQLite/serialization error.
-    """
-    try:
-        blob = json.dumps(payload)
-    except (TypeError, ValueError):
-        _logger.warning("accumulated payload for %s not serializable; skipping cache", project)
-        return
-    try:
-        conn.execute("DELETE FROM accumulated_cache WHERE project=?", (project,))
-        conn.execute(
-            "INSERT OR REPLACE INTO accumulated_cache (project, version, payload) VALUES (?, ?, ?)",
-            (project, version, blob),
-        )
-        conn.commit()
-    except sqlite3.Error:
-        _logger.warning("accumulated cache write failed for %s", project, exc_info=True)
+from quodeq.services._score_cache_fetch import (  # noqa: F401 — facade re-export
+    cached_accumulated,
+    cached_project_summary,
+    make_cache_backed_fetcher,
+)
+from quodeq.shared._env import get_score_cache_path  # noqa: F401 — facade re-export
 
 
 def _params_fingerprint(params: ScoringParams) -> str:
@@ -307,45 +103,6 @@ def run_scoped_version(
         "params": _params_fingerprint(params),
     }, sort_keys=True)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
-
-
-def store_run_keys(
-    conn: sqlite3.Connection, project: str, run_id: str,
-    dismiss_keys: set[tuple], class_keys: set[tuple],
-) -> None:
-    """Persist a run's key sets (best-effort)."""
-    try:
-        conn.execute(
-            "INSERT OR REPLACE INTO run_keys (project, run_id, dismiss_keys, class_keys) "
-            "VALUES (?, ?, ?, ?)",
-            (project, run_id,
-             json.dumps(sorted(list(k) for k in dismiss_keys)),
-             json.dumps(sorted(list(k) for k in class_keys))),
-        )
-        conn.commit()
-    except sqlite3.Error:
-        _logger.warning("run_keys write failed for %s/%s", project, run_id, exc_info=True)
-
-
-def load_run_keys(
-    conn: sqlite3.Connection, project: str,
-) -> dict[str, tuple[set[tuple], set[tuple]]]:
-    """Return ``{run_id: (dismiss_keys, class_keys)}`` for *project* (empty on error)."""
-    out: dict[str, tuple[set[tuple], set[tuple]]] = {}
-    try:
-        rows = conn.execute(
-            "SELECT run_id, dismiss_keys, class_keys FROM run_keys WHERE project=?",
-            (project,),
-        ).fetchall()
-    except sqlite3.Error:
-        return {}
-    for run_id, dj, cj in rows:
-        try:
-            out[run_id] = ({tuple(k) for k in json.loads(dj)},
-                           {tuple(k) for k in json.loads(cj)})
-        except (ValueError, TypeError):
-            continue
-    return out
 
 
 def accumulated_cache_version(
@@ -437,201 +194,3 @@ def per_run_versions(
         out.append(
             (rid, status, run_scoped_version(params, keys[0], keys[1], dismissed, deleted)))
     return out
-
-
-# In-flight computes by (kind, project, version). Concurrent misses on the
-# same key must share ONE compute: these computes walk a project's full run
-# history and can take minutes right after an upgrade invalidates every
-# cached row, and the client re-requests while the first compute is still
-# running. The registry entry is dropped once no thread holds the key's lock;
-# a waiter that raced the cleanup at worst recomputes (idempotent write).
-_INFLIGHT_GUARD = threading.Lock()
-_INFLIGHT: dict[tuple[str, str, str], threading.Lock] = {}
-
-
-@contextmanager
-def _single_flight(kind: str, project: str, version: str) -> Iterator[None]:
-    key = (kind, project, version)
-    with _INFLIGHT_GUARD:
-        lock = _INFLIGHT.setdefault(key, threading.Lock())
-    lock.acquire()
-    try:
-        yield
-    finally:
-        lock.release()
-        with _INFLIGHT_GUARD:
-            if not lock.locked() and _INFLIGHT.get(key) is lock:
-                del _INFLIGHT[key]
-
-
-def cached_accumulated(
-    project: str, version: str, compute: Callable[[], dict],
-    cacheable: Callable[[dict], bool] | None = None,
-) -> dict:
-    """Read-through cache for the accumulated payload.
-
-    Hit -> return the deserialized cached payload. Miss (or kill switch / cache
-    error) -> call *compute*, cache the result best-effort, return it.
-    Concurrent misses on one (project, version) share a single compute.
-
-    *cacheable*, when given, is called with the computed result before it is
-    persisted; returning False serves the result without caching it. This lets
-    the caller withhold payloads it knows are incomplete (e.g. a rescore that
-    covered only part of the dimensions), which would otherwise freeze under a
-    version hash that cannot self-invalidate.
-    """
-    if score_cache_disabled():
-        return compute()
-    try:
-        with open_score_cache() as conn:
-            cached = read_cached_accumulated(conn, project, version)
-        if cached is not None:
-            return cached
-    except sqlite3.Error:
-        return compute()
-    with _single_flight("accumulated", project, version):
-        # Re-check: a caller we waited on may have computed and cached it.
-        try:
-            with open_score_cache() as conn:
-                cached = read_cached_accumulated(conn, project, version)
-            if cached is not None:
-                return cached
-        except sqlite3.Error:
-            pass
-        result = compute()
-        if cacheable is not None and not cacheable(result):
-            return result
-        try:
-            with open_score_cache() as conn:
-                write_cached_accumulated(conn, project, version, result)
-        except sqlite3.Error:
-            pass
-        return result
-
-
-def read_cached_project_summary(
-    conn: sqlite3.Connection, project: str, version: str,
-) -> dict | None:
-    """Return the cached project-card summary for (project, version), or None."""
-    try:
-        row = conn.execute(
-            "SELECT payload FROM project_summary_cache WHERE project=? AND version=?",
-            (project, version),
-        ).fetchone()
-    except sqlite3.Error:
-        return None
-    if row is None:
-        return None
-    try:
-        return json.loads(row[0])
-    except (ValueError, TypeError):
-        return None
-
-
-def write_cached_project_summary(
-    conn: sqlite3.Connection, project: str, version: str, payload: dict,
-) -> None:
-    """Single-slot-per-project write for the project-card summary."""
-    try:
-        blob = json.dumps(payload)
-    except (TypeError, ValueError):
-        return
-    try:
-        conn.execute("DELETE FROM project_summary_cache WHERE project=?", (project,))
-        conn.execute(
-            "INSERT OR REPLACE INTO project_summary_cache (project, version, payload) VALUES (?, ?, ?)",
-            (project, version, blob),
-        )
-        conn.commit()
-    except sqlite3.Error:
-        _logger.warning("project summary cache write failed for %s", project, exc_info=True)
-
-
-def cached_project_summary(
-    project: str, version: str, compute: Callable[[], dict],
-) -> dict:
-    """Read-through cache for the project-card summary (mirrors cached_accumulated)."""
-    if score_cache_disabled():
-        return compute()
-    try:
-        with open_score_cache() as conn:
-            hit = read_cached_project_summary(conn, project, version)
-        if hit is not None:
-            return hit
-    except sqlite3.Error:
-        return compute()
-    with _single_flight("summary", project, version):
-        # Re-check: a caller we waited on may have computed and cached it.
-        try:
-            with open_score_cache() as conn:
-                hit = read_cached_project_summary(conn, project, version)
-            if hit is not None:
-                return hit
-        except sqlite3.Error:
-            pass
-        result = compute()
-        try:
-            with open_score_cache() as conn:
-                write_cached_project_summary(conn, project, version, result)
-        except sqlite3.Error:
-            pass
-        return result
-
-
-def make_cache_backed_fetcher(
-    project: str, version_for: Callable[[str], str],
-    base_fetcher: Callable[[str], list[DimensionResult]],
-    is_cacheable: Callable[[str], bool] | None = None,
-) -> Callable[[str], list[DimensionResult]]:
-    """Wrap *base_fetcher* with the read-through cache, versioned PER RUN.
-
-    *version_for(run_id)* returns that run's scoped version (params + the
-    suppressions touching it). Bulk-loads every cached row for *project* keyed by
-    (run_id, version); a hit requires the row's version to equal the run's
-    current version, so a dismiss/delete only misses the runs it touches. Misses
-    compute via *base_fetcher*, cache scalars at the run's version (only when
-    ``is_cacheable``), and return them. Kill switch -> *base_fetcher* unchanged.
-
-    ``is_cacheable`` gates *persistence* per run: only terminal (complete) runs
-    are safe. An in-progress run's scalar set grows as dimensions finish, and the
-    version hash can't see that, so persisting its partial set would strand a
-    stale row -- so opening History mid-scan would leave the trend showing one
-    dimension forever while run-detail shows all six. Non-cacheable runs
-    compute-through and are served for the current build but never written to
-    disk. Defaults to "always cacheable" for backward compatibility.
-    """
-    if score_cache_disabled():
-        return base_fetcher
-
-    by_run_version: dict[tuple[str, str], list[DimensionResult]] = {}
-    try:
-        with open_score_cache() as conn:
-            for rid, ver, dim, score, grade in conn.execute(
-                "SELECT run_id, version, dimension, overall_score, overall_grade "
-                "FROM run_scalars WHERE project=? ORDER BY run_id, dimension",
-                (project,),
-            ):
-                by_run_version.setdefault((rid, ver), []).append(
-                    DimensionResult(dimension=dim, overall_score=score, overall_grade=grade))
-    except sqlite3.Error:
-        by_run_version = {}
-
-    def fetch(run_id: str) -> list[DimensionResult]:
-        version = version_for(run_id)
-        hit = by_run_version.get((run_id, version))
-        if hit is not None:
-            return hit
-        dims = base_fetcher(run_id)
-        scalars = [DimensionResult(dimension=d.dimension, overall_score=d.overall_score,
-                                   overall_grade=d.overall_grade)
-                   for d in dims if d.dimension]
-        by_run_version[(run_id, version)] = scalars
-        if is_cacheable is None or is_cacheable(run_id):
-            try:
-                with open_score_cache() as conn:
-                    write_cached_rows(conn, project, run_id, version, scalars)
-            except sqlite3.Error:
-                pass
-        return scalars
-
-    return fetch

--- a/src/quodeq/services/scoring_view/_states.py
+++ b/src/quodeq/services/scoring_view/_states.py
@@ -190,7 +190,7 @@ def select_trend_runs(run_infos):
     wait-until-terminal rule.
 
     Used by:
-      - ``dashboard._compute_dashboard_payload`` — history window.
+      - ``_dashboard_history._compute_dashboard_payload`` — history window.
       - ``scoring.get_project_scores`` — the /scores trend.
 
     Args/returns are ``RunInfo``-shaped objects; order is preserved.

--- a/tests/services/test_accumulated_partial_not_persisted.py
+++ b/tests/services/test_accumulated_partial_not_persisted.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import pytest
 
-from quodeq.services import score_cache, scoring
+from quodeq.services import _score_cache_fetch, scoring
 from quodeq.services.dashboard import clear_shared_dimension_cache
 from quodeq.services.dismissed import dismiss_finding
 from quodeq.services.scoring import get_project_scores
@@ -45,13 +45,15 @@ def project(tmp_path):
 @pytest.fixture()
 def persist_spy(monkeypatch):
     calls: list = []
-    real_write = score_cache.write_cached_accumulated
+    real_write = _score_cache_fetch.write_cached_accumulated
 
     def spying_write(conn, project_name, version, payload):
         calls.append(version)
         return real_write(conn, project_name, version, payload)
 
-    monkeypatch.setattr(score_cache, "write_cached_accumulated", spying_write)
+    # Patch where cached_accumulated resolves the write, not the facade:
+    # score_cache only re-exports the name.
+    monkeypatch.setattr(_score_cache_fetch, "write_cached_accumulated", spying_write)
     return calls
 
 

--- a/tests/tools/test_serialization_boundary.py
+++ b/tests/tools/test_serialization_boundary.py
@@ -22,7 +22,7 @@ DECLARED_WIRE_BOUNDARIES: dict[str, str] = {
     "data/fs/report_parser/_eval_parsing.py": "parses stored camelCase findings back out (stored contract)",
     "services/accumulated.py": "payload feeds both routes and the persisted score cache — burn-down: WS5/scoring reader",
     "services/rescore.py": "envelope consumed by routes AND services/scoring — burn-down: WS5/scoring reader",
-    "services/dashboard.py": "run-dim LRU stores wire payloads — burn-down: WS5/scoring reader",
+    "services/_dashboard_response.py": "run-dim LRU stores wire payloads — burn-down: WS5/scoring reader",
     "services/_fs_reports.py": "violation responses cached in wire shape — burn-down: WS5",
     "services/scoring/_response_builders.py": "scoring payloads flow into SSE + caches in wire shape — burn-down: WS5/scoring reader",
 }


### PR DESCRIPTION
score_cache.py (440 lines) becomes a facade owning the version hashes, with the mechanics in _score_cache_db (connection, schema, corrupt-db rebuild), _score_cache_store (per-table reads/writes), _score_cache_fetch (read-through wrappers) and _score_cache_epoch. dashboard.py sheds ~400 lines into _dashboard_cache (run-dim LRU), _dashboard_history and _dashboard_response.

The #1077 single-flight machinery moves with its code: the open lock into _score_cache_db, the per-key in-flight registry into _score_cache_fetch. All five tests from test_score_cache_single_flight.py pass unchanged against the facade.

One test change: the accumulated-persist spy in test_accumulated_partial_not_persisted.py now patches _score_cache_fetch, where cached_accumulated resolves the write. Patching the facade re-export no longer intercepts it.

No behavior change. Full suite: 5928 passed.