### PR TITLE
fix(ui): nav feedback covers breadcrumb jumps; detail pages paint before heavy lists

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -972,13 +972,20 @@ function MainContent({ activePage, props }) {
  * @param {{ sidebar: JSX.Element, header: JSX.Element|null, content: JSX.Element }} props
  * @returns {JSX.Element}
  */
-function AppShell({ sidebar, header, content, drawer }) {
+function AppShell({ sidebar, header, content, drawer, navPending }) {
   return (
     <div className={`app-shell${header ? ' app-shell--with-topbar' : ''}`}>
       {header && <div className="app-shell__topbar">{header}</div>}
       <div className="app-shell__body">
         {sidebar}
         <div className="app-shell__main-column">
+          {/* Feedback while a navigation's target page renders (useNavStack
+              transition). Must live HERE, outside the scrolling <main>: the
+              .dashboard is position:relative, so an absolutely-positioned bar
+              inside it anchors to the top of the scrollable CONTENT and
+              scrolls out of view — exactly where every detail-page card
+              lives, so the one navigation that needed feedback never got it. */}
+          {navPending && <div className="nav-pending-bar" aria-hidden="true" />}
           <UpdateBanner />
           <main className="dashboard">
             {content}
@@ -1341,6 +1348,7 @@ export default function App() {
             <LlamaCppLogProvider>
               <VerifiedFindingsProvider project={state.selectedProject} source={state.selectedSource}>
               <AppShell
+          navPending={state.navPending}
           drawer={<BottomDrawer uiState={assistantCtx.uiState} projectName={resolvedDisplayName}
             onOpenSettings={() => navTab('settings')} />}
           sidebar={
@@ -1410,12 +1418,6 @@ export default function App() {
               {!state.serverConnected && (
                 <ServerDisconnectedOverlay onReconnect={() => state.setServerConnected(true)} />
               )}
-              {/* Route pushes render the target page in a transition
-                  (useNavStack); this bar is the feedback while that render
-                  runs. Without it a heavy detail page (or a slow webview
-                  engine) leaves the click looking ignored — there is no
-                  yield point where a spinner could otherwise paint. */}
-              {state.navPending && <div className="nav-pending-bar" aria-hidden="true" />}
               {/* One stable mount for the startup loader: it covers every
                   route's not-yet-loaded state and fades out when the projects
                   land, instead of each gate ripping its own copy out of the

--- a/src/quodeq/ui/src/features/explorer/components/DeferredMount.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/DeferredMount.jsx
@@ -1,0 +1,21 @@
+import { useState, useEffect, startTransition } from 'react';
+
+/**
+ * Two-commit mount for heavy, param-fed content (the principle / file detail
+ * card lists). Commit 1 shows `fallback`, so a navigation to the page paints
+ * something immediately; the children then render in a transition, off the
+ * urgent path, and replace it.
+ *
+ * Only worth using where the children are expensive enough to hold the first
+ * paint hostage — pages that fetch already get this shape for free from
+ * their loading state.
+ */
+export default function DeferredMount({ fallback, children }) {
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    // Transition, not a plain set: lets the fallback's frame reach the screen
+    // before React starts the heavy render, and keeps that render time-sliced.
+    startTransition(() => setReady(true));
+  }, []);
+  return ready ? children : fallback;
+}

--- a/src/quodeq/ui/src/features/explorer/components/DeferredMount.test.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/DeferredMount.test.jsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import DeferredMount from './DeferredMount.jsx';
+
+// A param-fed detail page (principle / file) renders its whole card list
+// synchronously — there is no fetch, so nothing ever painted between the
+// click and the finished page and the click looked ignored. DeferredMount
+// splits that into two commits: the cheap page frame with a fallback first
+// (the paint that makes the navigation feel acknowledged), the heavy
+// children right after.
+describe('DeferredMount', () => {
+  it('renders the fallback strictly before the content ever renders', () => {
+    const order = [];
+    function Fallback() {
+      order.push('fallback');
+      return <div>loading</div>;
+    }
+    function Content() {
+      order.push('content');
+      return <div>content</div>;
+    }
+
+    render(<DeferredMount fallback={<Fallback />}><Content /></DeferredMount>);
+
+    expect(order[0]).toBe('fallback');
+    expect(order).toContain('content');
+    expect(order.indexOf('fallback')).toBeLessThan(order.indexOf('content'));
+  });
+
+  it('settles on the content with the fallback unmounted', () => {
+    render(
+      <DeferredMount fallback={<div>loading</div>}>
+        <div>content</div>
+      </DeferredMount>
+    );
+
+    expect(screen.getByText('content')).toBeInTheDocument();
+    expect(screen.queryByText('loading')).toBeNull();
+  });
+});

--- a/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
@@ -12,6 +12,8 @@ import { VerifiedChip } from '../../violations/components/VerifiedChip.jsx';
 import { useRegisterWindowSpec, ReportContent, useSidePane, violationFixPlanSpec } from '../../side-pane/index.js';
 import { isLowConfidence } from '../../violations/components/LowConfidenceGroup.jsx';
 import VirtualList, { useDashboardScrollElement } from './VirtualList.jsx';
+import DeferredMount from './DeferredMount.jsx';
+import LoadingScreen from '../../../components/LoadingScreen.jsx';
 import { t } from '../../../strings/index.js';
 import { severityLabel, scopeGateRuleLabel } from '../../../strings/labels.js';
 
@@ -355,14 +357,19 @@ const FileDetailPage = memo(function FileDetailPage({ file, runId, dateLabel, on
         />
       )}
 
-      <VirtualList
-        key={virtualKey}
-        items={items}
-        scrollElement={scrollElement}
-        estimateSize={estimateItemSize(items)}
-        getItemKey={itemKey(items)}
-        renderItem={renderItem}
-      />
+      {/* Same two-commit split as PrincipleDetailPage: this page is param-fed
+          (no fetch), so the first paint would otherwise wait for the visible
+          cards' pretext layout effects. */}
+      <DeferredMount fallback={<LoadingScreen variant="inline" />}>
+        <VirtualList
+          key={virtualKey}
+          items={items}
+          scrollElement={scrollElement}
+          estimateSize={estimateItemSize(items)}
+          getItemKey={itemKey(items)}
+          renderItem={renderItem}
+        />
+      </DeferredMount>
     </>
   );
 });

--- a/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -9,6 +9,8 @@ import { useRegisterWindowSpec, ReportContent } from '../../side-pane/index.js';
 import { useStandardDescriptions } from '../hooks/useStandardDescriptions.js';
 import { usePrincipleData } from './explorerDataHooks.js';
 import VirtualList, { useDashboardScrollElement } from './VirtualList.jsx';
+import DeferredMount from './DeferredMount.jsx';
+import LoadingScreen from '../../../components/LoadingScreen.jsx';
 import { t } from '../../../strings/index.js';
 
 function filterTitleSuffix(filter) {
@@ -283,14 +285,20 @@ const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, s
           onFilterChange={setActiveSevFilter}
         />
       )}
-      <VirtualList
-        key={virtualKey}
-        items={items}
-        scrollElement={scrollElement}
-        estimateSize={estimateItemSize(items)}
-        getItemKey={itemKey(items)}
-        renderItem={renderItem}
-      />
+      {/* This page gets all its data through nav params — nothing fetches, so
+          without this split the first paint waits for every visible card's
+          pretext layout effect and the click that navigated here looks
+          ignored. Header first, cards one commit later. */}
+      <DeferredMount fallback={<LoadingScreen variant="inline" />}>
+        <VirtualList
+          key={virtualKey}
+          items={items}
+          scrollElement={scrollElement}
+          estimateSize={estimateItemSize(items)}
+          getItemKey={itemKey(items)}
+          renderItem={renderItem}
+        />
+      </DeferredMount>
     </>
   );
 });

--- a/src/quodeq/ui/src/hooks/useNavStack.js
+++ b/src/quodeq/ui/src/hooks/useNavStack.js
@@ -83,16 +83,23 @@ function createNavActions(setNavStack, navStackRef, history, entriesByIndex, sta
     history.back();
   }
 
-  function navReplace(entry) {
-    // Swap the top entry in place (e.g. repositories local/online tab flips):
-    // browser history must NOT grow, or Back has to unwind every flip.
-    // Same purity rule as navPush (#363): state + history as two sequential
-    // statements, never inside the updater.
+  function replaceTop(entry, setStack) {
+    // Swap the top entry in place: browser history must NOT grow, or Back has
+    // to unwind every flip. Same purity rule as navPush (#363): state +
+    // history as two sequential statements, never inside the updater.
     const prev = navStackRef.current;
     const next = [...prev.slice(0, -1), entry];
-    setNavStack(next);
+    setStack(next);
     entriesByIndex.set(next.length - 1, entry);
     history.replaceState({ navIndex: next.length - 1, entry: toHistoryEntry(entry) }, '');
+  }
+
+  function navReplace(entry) {
+    // In-place view-state changes on the SAME screen (repositories tab flips,
+    // typed filters). Plain set, never a transition: this state can be driven
+    // by controlled inputs, and rendering keystrokes at transition priority
+    // makes typing lag.
+    replaceTop(entry, setNavStack);
   }
 
   function navGoTo(index) {
@@ -109,17 +116,28 @@ function createNavActions(setNavStack, navStackRef, history, entriesByIndex, sta
     const prev = navStackRef.current;
     const stepsBack = prev.length - 1 - index;
     if (stepsBack <= 0) {
-      navReplace(entry);
+      // Swapping the top entry (the common breadcrumb case: switching
+      // dimension while ON the dimension page) is a real navigation to a
+      // possibly-heavy page — transition it, unlike navReplace's view-state
+      // flips.
+      replaceTop(entry, (next) => startNavTransition(() => setNavStack(next)));
       return;
     }
-    setNavStack([...prev.slice(0, index), entry]);
+    // Same transition rationale as navPush: sibling swaps land on the same
+    // heavy pages (a big dimension from the breadcrumb's jump bar).
+    startNavTransition(() => {
+      setNavStack([...prev.slice(0, index), entry]);
+    });
     rememberEntry(index, entry);
     history.go(-stepsBack);
   }
 
   function navReset() {
     const stepsBack = navStackRef.current.length - 1;
-    setNavStack([{ page: DEFAULT_PAGE }]);
+    // Overview on a large project renders heavy too; same transition.
+    startNavTransition(() => {
+      setNavStack([{ page: DEFAULT_PAGE }]);
+    });
     rememberEntry(0, { page: DEFAULT_PAGE });
     if (stepsBack > 0) history.go(-stepsBack);
   }

--- a/src/quodeq/ui/src/hooks/useNavStack.test.jsx
+++ b/src/quodeq/ui/src/hooks/useNavStack.test.jsx
@@ -325,6 +325,63 @@ describe('useNavStack navReplace (repositories tab flips must not grow history)'
   });
 });
 
+describe('useNavStack navSwapAt (breadcrumb sibling swaps)', () => {
+  let historyAdapter;
+
+  beforeEach(() => {
+    historyAdapter = {
+      pushState: vi.fn(),
+      replaceState: vi.fn(),
+      back: vi.fn(),
+      go: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // The top-entry swap (switching dimension while ON the dimension page) runs
+  // in a transition since the nav-pending-feedback work — these pin that the
+  // swap still lands, replaces instead of pushing, and stays StrictMode-pure.
+  it('swaps the top entry in place via replaceState, exactly once in StrictMode', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    act(() => { result.current.navPush({ page: 'explorer', dimension: 'security' }); });
+    historyAdapter.pushState.mockClear();
+    historyAdapter.replaceState.mockClear();
+
+    act(() => { result.current.navSwapAt(1, { page: 'explorer', dimension: 'maintainability' }); });
+
+    expect(result.current.navStack).toHaveLength(2);
+    expect(result.current.navStack.at(-1).dimension).toBe('maintainability');
+    expect(historyAdapter.pushState).not.toHaveBeenCalled();
+    expect(historyAdapter.replaceState).toHaveBeenCalledTimes(1);
+    expect(result.current.navPending).toBe(false);
+  });
+
+  it('swaps an ancestor entry, truncates deeper entries, and walks history back', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    act(() => { result.current.navPush({ page: 'explorer', dimension: 'security' }); });
+    act(() => { result.current.navPush({ page: 'evalprinciple' }); });
+    historyAdapter.go.mockClear();
+
+    act(() => { result.current.navSwapAt(1, { page: 'explorer', dimension: 'maintainability' }); });
+
+    expect(result.current.navStack).toHaveLength(2);
+    expect(result.current.navStack.at(-1).dimension).toBe('maintainability');
+    expect(historyAdapter.go).toHaveBeenCalledTimes(1);
+    expect(historyAdapter.go).toHaveBeenCalledWith(-1);
+  });
+});
+
 describe('useNavStack navPending', () => {
   let historyAdapter;
 


### PR DESCRIPTION
Follow-up to #1067. Three gaps in the nav-pending feedback:

- The pending bar lived inside the scrolling <main> (.dashboard is position:relative), so it anchored to the top of the scrollable content and scrolled out of view on exactly the pages that needed it. It now renders in AppShell, above <main>.
- Breadcrumb sibling swaps (navGoToWith on the top entry) and navReset ran as plain sets, so navigating to a heavy page from the breadcrumb showed no feedback. They now run in the nav transition. navReplace stays a plain set: it carries typed filter state, and rendering keystrokes at transition priority makes typing lag.
- FileDetailPage and PrincipleDetailPage mount their card lists through a new DeferredMount: first commit paints a skeleton, the heavy list renders in a transition. Clicking into a large principle previously blocked the first paint entirely.

Tests: 486 node + 1598 vitest, all passing.