### PR TITLE
Trend line follows the bars; stranded restore commit recovered

### DIFF
--- a/src/quodeq/ui/src/features/compare/components/CompareTrendLine.jsx
+++ b/src/quodeq/ui/src/features/compare/components/CompareTrendLine.jsx
@@ -11,13 +11,12 @@ const PAD = 2;
 
 export default function CompareTrendLine({ scores, width = 90 }) {
   if (!scores || scores.length < 2) return null;
-  const min = Math.min(...scores);
-  const max = Math.max(...scores);
-  // A flat series still draws mid-height instead of collapsing onto an edge.
-  const span = Math.max(0.5, max - min);
+  // Absolute 0-10 scale, matching the score-history charts: the spark's
+  // height position means score, not a magnified window. The duel trend
+  // is the one deliberately zoomed view.
   const point = (s, i) => {
     const x = PAD + (i / (scores.length - 1)) * (width - PAD * 2);
-    const y = HEIGHT - PAD - ((s - min) / span) * (HEIGHT - PAD * 2);
+    const y = HEIGHT - PAD - (s / 10) * (HEIGHT - PAD * 2);
     return [x, y];
   };
   const pts = scores.map((s, i) => point(s, i).map((v) => v.toFixed(1)).join(',')).join(' ');

--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -18,7 +18,6 @@ import {
 import {
   cssVar,
   scoreBarColor,
-  scoreDomain,
   refLineValues,
   CHART_MARGIN,
   SELECTED_BAR_OPACITY,
@@ -87,7 +86,6 @@ function ScoreBars({ data, hoveredIndex, selectedRunId }) {
   // they reach the chart-level onClick handler.
   return (
     <Bar
-      yAxisId="abs"
       dataKey="numericAverage"
       radius={[0, 0, 0, 0]}
       maxBarSize={28}
@@ -123,7 +121,6 @@ function ScoreHistoryChart({ data, interaction }) {
     const runId = data[idx]?.runId;
     if (runId) onBarClick?.(runId);
   };
-  const domain = scoreDomain(data.map((d) => d.numericAverage));
   return (
     <ResponsiveContainer width="100%" height="100%" minHeight={CHART_HEIGHT}>
       <ComposedChart
@@ -144,21 +141,20 @@ function ScoreHistoryChart({ data, interaction }) {
             clean edge-to-edge bars with just the accent-coloured trend line
             on top. Labels live in the banner (MIN / MAX / AVG). */}
         <XAxis dataKey="dateLabel" hide />
-        {/* Two hidden Y axes on purpose. Bars keep the absolute 0-10 scale
-            so a 7 always fills 70% of the chart (a zoomed bar reads as a
-            smaller score). The line rides the data-fitted domain so the
-            trend's shape stays visible instead of flattening at the top. */}
-        <YAxis yAxisId="abs" domain={[0, 10]} hide />
-        <YAxis yAxisId="shape" domain={domain} hide />
+        {/* One absolute 0-10 axis for everything: bar height means score
+            (a 7 always fills 70%) and the line sits exactly on the bar
+            tops. A zoomed line was tried twice and rejected both ways: a
+            zoomed BAR reads as a smaller score, and a zoomed LINE visibly
+            detaches from the bars. The shape stays subtle by design; the
+            MIN/MAX/AVG banner carries the numbers. */}
+        <YAxis domain={[0, 10]} hide />
         <Tooltip cursor={false} isAnimationActive={false} offset={20} content={<RunHistoryTooltip />} />
-        {/* Soft horizontal reference lines framing the line's domain —
-            subtle grid anchors even though numeric ticks are hidden. */}
-        {refLineValues(domain).map((y, i) => (
-          <ReferenceLine key={y} yAxisId="shape" y={y} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={i % 2 ? 0.2 : 0.3} />
+        {refLineValues([0, 10]).map((y, i) => (
+          <ReferenceLine key={y} y={y} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={i % 2 ? 0.2 : 0.3} />
         ))}
-        <Area yAxisId="shape" dataKey="numericAverage" type="monotone" fill="url(#scoreAreaGrad)" stroke="none" isAnimationActive={false} />
+        <Area dataKey="numericAverage" type="monotone" fill="url(#scoreAreaGrad)" stroke="none" isAnimationActive={false} />
         <ScoreBars data={data} hoveredIndex={hoveredIndex} selectedRunId={selectedRunId} />
-        <Line yAxisId="shape" isAnimationActive={false} dataKey="numericAverage" type="monotone" stroke={cssVar('--color-accent')} strokeOpacity={0.9} strokeWidth={2} dot={<SelectedDot selectedRunId={selectedRunId} />} activeDot={false} />
+        <Line isAnimationActive={false} dataKey="numericAverage" type="monotone" stroke={cssVar('--color-accent')} strokeOpacity={0.9} strokeWidth={2} dot={<SelectedDot selectedRunId={selectedRunId} />} activeDot={false} />
       </ComposedChart>
     </ResponsiveContainer>
   );

--- a/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
@@ -19,7 +19,6 @@ import { t } from '../../../strings/index.js';
 import {
   cssVar,
   scoreBarColor,
-  scoreDomain,
   refLineValues,
   CHART_MARGIN,
   SELECTED_BAR_OPACITY,
@@ -75,7 +74,6 @@ function DimensionHistoryChart({ data, selectedRunId, hoveredIndex, setHoveredIn
     const point = data[idx];
     if (point?.runId) onBarClick?.(point);
   };
-  const domain = scoreDomain(data.map((d) => d.numericAverage));
   return (
     <ResponsiveContainer width="100%" height="100%" minHeight={CHART_HEIGHT}>
       <ComposedChart
@@ -93,16 +91,13 @@ function DimensionHistoryChart({ data, selectedRunId, hoveredIndex, setHoveredIn
           </linearGradient>
         </defs>
         <XAxis dataKey="dateLabel" hide />
-        {/* Bars stay absolute (0-10: a 7 fills 70%); only the line and its
-            grid ride the data-fitted domain so the shape stays visible. */}
-        <YAxis yAxisId="abs" domain={[0, 10]} hide />
-        <YAxis yAxisId="shape" domain={domain} hide />
+        <YAxis domain={[0, 10]} hide />
         <Tooltip cursor={false} isAnimationActive={false} offset={20} content={<DimensionTooltip />} />
-        {refLineValues(domain).map((y, i) => (
-          <ReferenceLine key={y} yAxisId="shape" y={y} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={i % 2 ? 0.2 : 0.3} />
+        {refLineValues([0, 10]).map((y, i) => (
+          <ReferenceLine key={y} y={y} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={i % 2 ? 0.2 : 0.3} />
         ))}
-        <Area yAxisId="shape" dataKey="numericAverage" type="monotone" fill="url(#dimScoreAreaGrad)" stroke="none" isAnimationActive={false} />
-        <Bar yAxisId="abs" dataKey="numericAverage" radius={[0, 0, 0, 0]} maxBarSize={28} isAnimationActive={false}>
+        <Area dataKey="numericAverage" type="monotone" fill="url(#dimScoreAreaGrad)" stroke="none" isAnimationActive={false} />
+        <Bar dataKey="numericAverage" radius={[0, 0, 0, 0]} maxBarSize={28} isAnimationActive={false}>
           {data.map((entry, i) => (
             <Cell
               key={entry.runId ?? i}
@@ -114,7 +109,6 @@ function DimensionHistoryChart({ data, selectedRunId, hoveredIndex, setHoveredIn
           ))}
         </Bar>
         <Line
-          yAxisId="shape"
           isAnimationActive={false}
           dataKey="numericAverage"
           type="monotone"

--- a/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
@@ -16,7 +16,6 @@ import {
 import {
   cssVar,
   scoreBarColor,
-  scoreDomain,
   refLineValues,
   CHART_MARGIN,
   SELECTED_BAR_OPACITY,
@@ -82,7 +81,6 @@ function ScoreHistoryChart({ data, interaction }) {
     const runId = data[idx]?.runId;
     if (runId) onBarClick?.(runId);
   };
-  const domain = scoreDomain(data.map((d) => d.numericAverage));
   return (
     <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
       <ComposedChart
@@ -94,17 +92,13 @@ function ScoreHistoryChart({ data, interaction }) {
         style={onBarClick ? { cursor: 'pointer' } : undefined}
       >
         <XAxis dataKey="dateLabel" hide />
-        {/* Bars stay absolute (0-10: a 7 fills 70%); only the line and its
-            grid ride the data-fitted domain so the shape stays visible. */}
-        <YAxis yAxisId="abs" domain={[0, 10]} hide />
-        <YAxis yAxisId="shape" domain={domain} hide />
+        <YAxis domain={[0, 10]} hide />
         <Tooltip cursor={false} isAnimationActive={false} offset={20} content={<RunHistoryTooltip />} />
-        {refLineValues(domain).map((y, i) => (
-          <ReferenceLine key={y} yAxisId="shape" y={y} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={i % 2 ? 0.2 : 0.3} />
+        {refLineValues([0, 10]).map((y, i) => (
+          <ReferenceLine key={y} y={y} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={i % 2 ? 0.2 : 0.3} />
         ))}
         <Bar
-          yAxisId="abs"
-          dataKey="numericAverage"
+              dataKey="numericAverage"
           radius={[0, 0, 0, 0]}
           maxBarSize={32}
           isAnimationActive={false}
@@ -120,7 +114,6 @@ function ScoreHistoryChart({ data, interaction }) {
           ))}
         </Bar>
         <Line
-          yAxisId="shape"
           isAnimationActive={false}
           dataKey="numericAverage"
           type="monotone"

--- a/src/quodeq/ui/src/strings/en.json
+++ b/src/quodeq/ui/src/strings/en.json
@@ -167,7 +167,7 @@
   "compare.colRatio": "ratio",
   "compare.colScore": "score",
   "compare.colViolations": "violations",
-  "compare.commitsSince": "{count} commits since last scan",
+  "compare.commitsSince": "{count} commits behind",
   "compare.computing": "computing scores…",
   "compare.crumbDuel": "duel",
   "compare.dimSubtitle": "{principles} principles · {violations} violations · {projects} projects in scope",

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -288,17 +288,14 @@
   --color-accent-soft:  color-mix(in srgb, var(--primitive-crimson-500) 6%, transparent);
 
   /* Duel sides — stable IDENTITY hues for head-to-head views. Grade colors
-     cannot tell two projects apart (both sides are often the same tier), so
-     side A rides the theme accent and side B is a per-family counter-hue.
-     B must stay deltaE >= 20 from the accent AND from every grade-tier
-     color (a B line that matches a tier reads as a judgement), guarded in
-     tools/token_distinctness.mjs. Each family block picks its own B in the
-     hue territory its accent and grade ramp leave free: daruma (crimson +
-     gold/slate grades) -> purple, neo (all green) -> sand, galadriel
-     (green + gold) -> steel, ifrit (orange + gold/slate) -> purple,
-     deckard (magenta + purple grades) -> steel. */
+     cannot tell two projects apart (both sides are often the same tier),
+     so side A rides the theme accent and side B is warm sand, the same in
+     every family: #a1782f in light modes, #d8b36a in dark. Against the
+     original v1.9.1 grade palette sand clears the accent and every grade
+     tier in all 10 contexts (guarded in tools/token_distinctness.mjs), so
+     no per-family counter-hues are needed. */
   --color-duel-a: var(--color-accent);
-  --color-duel-b: #8a5fb0;
+  --color-duel-b: #a1782f;
 
   /* Status */
   --color-danger:  var(--primitive-red-600);
@@ -380,9 +377,9 @@
   --logo-needle-dark:    var(--primitive-crimson-700);
 
   /* Compliance — deep emerald; gold now belongs to the grade ramp */
-  --color-compliance:        #157347;
-  --color-compliance-bg:     color-mix(in srgb, #157347 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, #157347 38%, transparent);
+  --color-compliance:        #b08000;
+  --color-compliance-bg:     color-mix(in srgb, #b08000 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #b08000 38%, transparent);
 
   /* Warning */
   --color-warning:      var(--primitive-amber-700);
@@ -428,7 +425,7 @@
     --color-accent-hover: var(--primitive-flynn-accent-hover);
     --color-accent-soft:  color-mix(in srgb, var(--primitive-flynn-accent) 10%, transparent);
     --color-on-accent:    var(--primitive-flynn-950);
-    --color-duel-b:       #b08ad8;
+    --color-duel-b:       #d8b36a;
 
     --color-danger:  #e05c4b;
     --color-success: #4caf7d;
@@ -463,9 +460,9 @@
     --color-danger-bg:     color-mix(in srgb, var(--primitive-red-300) 15%, transparent);
     --color-danger-border: color-mix(in srgb, var(--primitive-red-300) 30%, transparent);
 
-    --color-compliance:        var(--primitive-compliance);
-    --color-compliance-bg:     color-mix(in srgb, var(--primitive-compliance) 4%, transparent);
-    --color-compliance-border: color-mix(in srgb, var(--primitive-compliance) 38%, transparent);
+    --color-compliance:        var(--primitive-flynn-accent);
+    --color-compliance-bg:     color-mix(in srgb, var(--primitive-flynn-accent) 4%, transparent);
+    --color-compliance-border: color-mix(in srgb, var(--primitive-flynn-accent) 38%, transparent);
 
     --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
     --color-overlay-medium: rgba(0, 0, 0, 0.82);
@@ -559,7 +556,7 @@ html[data-theme="dark"]:root, [data-theme="dark"] {
   --color-accent-hover: var(--primitive-flynn-accent-hover);
   --color-accent-soft:  color-mix(in srgb, var(--primitive-flynn-accent) 10%, transparent);
   --color-on-accent:    var(--primitive-flynn-950);
-  --color-duel-b:       #b08ad8;
+  --color-duel-b:       #d8b36a;
 
   --color-danger:  #e05c4b;
   --color-success: #4caf7d;
@@ -595,9 +592,9 @@ html[data-theme="dark"]:root, [data-theme="dark"] {
   --color-danger-border: color-mix(in srgb, var(--primitive-red-300) 30%, transparent);
 
   /* Compliance — spring green, off the cyan accent */
-  --color-compliance:        var(--primitive-compliance);
-  --color-compliance-bg:     color-mix(in srgb, var(--primitive-compliance) 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, var(--primitive-compliance) 38%, transparent);
+  --color-compliance:        var(--primitive-flynn-accent);
+  --color-compliance-bg:     color-mix(in srgb, var(--primitive-flynn-accent) 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, var(--primitive-flynn-accent) 38%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
@@ -684,9 +681,9 @@ html[data-theme="light"]:root, [data-theme="light"] {
   --color-danger-border: var(--color-sev-critical-border);
 
   /* Compliance — deep emerald; gold now belongs to the grade ramp */
-  --color-compliance:        #157347;
-  --color-compliance-bg:     color-mix(in srgb, #157347 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, #157347 38%, transparent);
+  --color-compliance:        #b08000;
+  --color-compliance-bg:     color-mix(in srgb, #b08000 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #b08000 38%, transparent);
 
   /* Overlays */
   --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
@@ -735,8 +732,7 @@ html[data-theme="ifrit-dark"]:root, [data-theme="ifrit-dark"] {
   --color-accent:       var(--primitive-ifrit-accent-dark);
   --color-accent-hover: #f09040;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-ifrit-accent-dark) 14%, transparent);
-  /* Purple: ifrit's accent is warm and its grade ramp holds the slates. */
-  --color-duel-b:       #b08ad8;
+  --color-duel-b:       #d8b36a;
   --color-on-accent:    var(--primitive-ifrit-950);
 
   --color-danger:  #ff5030;
@@ -774,9 +770,9 @@ html[data-theme="ifrit-dark"]:root, [data-theme="ifrit-dark"] {
   --color-danger-border: color-mix(in srgb, #ff5030 30%, transparent);
 
   /* Compliance — spring green, clear of the orange accent and gold grades */
-  --color-compliance:        var(--primitive-compliance);
-  --color-compliance-bg:     color-mix(in srgb, var(--primitive-compliance) 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, var(--primitive-compliance) 38%, transparent);
+  --color-compliance:        #f0b830;
+  --color-compliance-bg:     color-mix(in srgb, #f0b830 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #f0b830 38%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
@@ -824,7 +820,7 @@ html[data-theme="galadriel-light"]:root, [data-theme="galadriel-light"] {
   --color-text-subtle:  #688968;
 
   --color-accent:       #1b6b3a;
-  --color-duel-b:       #3a6a8a; /* steel: sand collides with the gold top tier */
+  --color-duel-b:       #a1782f;
   --color-accent-hover: #145228;
   --color-accent-soft:  color-mix(in srgb, #1b6b3a 8%, transparent);
   /* Light mode on dark-green accent — explicit white for AA contrast
@@ -867,9 +863,9 @@ html[data-theme="galadriel-light"]:root, [data-theme="galadriel-light"] {
   --color-danger-border: var(--color-sev-critical-border);
 
   /* Compliance — blue-teal, off the forest-green accent */
-  --color-compliance:        #0c7a86;
-  --color-compliance-bg:     color-mix(in srgb, #0c7a86 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, #0c7a86 38%, transparent);
+  --color-compliance:        #1b6b3a;
+  --color-compliance-bg:     color-mix(in srgb, #1b6b3a 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #1b6b3a 38%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
   --color-overlay-medium: rgba(0, 0, 0, 0.5);
@@ -912,7 +908,7 @@ html[data-theme="neo-dark"]:root, [data-theme="neo-dark"] {
   --color-text-muted:   var(--primitive-neo-500);
   --color-text-subtle:  #596f59;
   --color-accent:       var(--primitive-neo-accent);
-  --color-duel-b:       #d8b36a; /* sand vs neo green */
+  --color-duel-b:       #d8b36a;
   --color-accent-hover: #33ff66;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-neo-accent) 14%, transparent);
   --color-on-accent:    var(--primitive-neo-950);
@@ -947,9 +943,9 @@ html[data-theme="neo-dark"]:root, [data-theme="neo-dark"] {
   --color-danger-border: color-mix(in srgb, #ff4040 30%, transparent);
 
   /* Compliance — teal, off the matrix-green accent */
-  --color-compliance:        var(--primitive-teal-400);
-  --color-compliance-bg:     color-mix(in srgb, var(--primitive-teal-400) 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, var(--primitive-teal-400) 38%, transparent);
+  --color-compliance:        #00ff41;
+  --color-compliance-bg:     color-mix(in srgb, #00ff41 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #00ff41 38%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.92);
   --color-overlay-medium: rgba(0, 0, 0, 0.85);
@@ -990,7 +986,7 @@ html[data-theme="neo-light"]:root, [data-theme="neo-light"] {
   --color-text-muted:   #516e51;
   --color-text-subtle:  #6a8b6a;
   --color-accent:       var(--primitive-neo-accent-dark);
-  --color-duel-b:       #a1782f; /* sand vs neo green */
+  --color-duel-b:       #a1782f;
   --color-accent-hover: #006622;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-neo-accent-dark) 8%, transparent);
   --color-on-accent:    #ffffff;
@@ -1025,9 +1021,9 @@ html[data-theme="neo-light"]:root, [data-theme="neo-light"] {
   --color-danger-border: var(--color-sev-critical-border);
 
   /* Compliance — deep teal, off the green accent */
-  --color-compliance:        #0c7a70;
-  --color-compliance-bg:     color-mix(in srgb, #0c7a70 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, #0c7a70 38%, transparent);
+  --color-compliance:        #008833;
+  --color-compliance-bg:     color-mix(in srgb, #008833 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #008833 38%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
   --color-overlay-medium: rgba(0, 0, 0, 0.5);
@@ -1066,7 +1062,7 @@ html[data-theme="galadriel-dark"]:root, [data-theme="galadriel-dark"] {
   --color-text-muted:   #7a9d7a;
   --color-text-subtle:  #548254;
   --color-accent:       var(--primitive-green-400);
-  --color-duel-b:       #7fa8c9; /* steel: sand collides with the gold top tier */
+  --color-duel-b:       #d8b36a;
   --color-accent-hover: #6ee7a0;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-green-400) 14%, transparent);
   --color-on-accent:    var(--primitive-galadriel-950);
@@ -1101,9 +1097,9 @@ html[data-theme="galadriel-dark"]:root, [data-theme="galadriel-dark"] {
   --color-danger-border: color-mix(in srgb, var(--primitive-crimson-200) 30%, transparent);
 
   /* Compliance — bright teal, off the sage-green accent */
-  --color-compliance:        var(--primitive-teal-400);
-  --color-compliance-bg:     color-mix(in srgb, var(--primitive-teal-400) 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, var(--primitive-teal-400) 38%, transparent);
+  --color-compliance:        #4caf7d;
+  --color-compliance-bg:     color-mix(in srgb, #4caf7d 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #4caf7d 38%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
@@ -1148,8 +1144,7 @@ html[data-theme="ifrit-light"]:root, [data-theme="ifrit-light"] {
   --color-accent:       var(--primitive-ifrit-accent-light);
   --color-accent-hover: #a84a08;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-ifrit-accent-light) 8%, transparent);
-  /* Purple: ifrit's accent is warm and its grade ramp holds the slates. */
-  --color-duel-b:       #7a4fa0;
+  --color-duel-b:       #a1782f;
   --color-on-accent:    #ffffff;
 
   --color-danger:  #b82010;
@@ -1187,9 +1182,9 @@ html[data-theme="ifrit-light"]:root, [data-theme="ifrit-light"] {
   --color-danger-border: var(--color-sev-critical-border);
 
   /* Compliance — deep green, clear of the orange accent and gold grades */
-  --color-compliance:        #1a7a42;
-  --color-compliance-bg:     color-mix(in srgb, #1a7a42 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, #1a7a42 38%, transparent);
+  --color-compliance:        #c08000;
+  --color-compliance-bg:     color-mix(in srgb, #c08000 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #c08000 38%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
   --color-overlay-medium: rgba(0, 0, 0, 0.5);
@@ -1234,7 +1229,7 @@ html[data-theme="deckard-dark"]:root, [data-theme="deckard-dark"] {
   --color-text-subtle:  #706687;
 
   --color-accent:       var(--primitive-deckard-accent-dark);
-  --color-duel-b:       #d8b36a; /* sand: deckard's grade ramp owns the blues and purples */
+  --color-duel-b:       #d8b36a;
   --color-accent-hover: #ff60d0;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-deckard-accent-dark) 14%, transparent);
   --color-on-accent:    var(--primitive-deckard-950);
@@ -1325,7 +1320,7 @@ html[data-theme="deckard-light"]:root, [data-theme="deckard-light"] {
   --color-text-subtle:  #857996;
 
   --color-accent:       var(--primitive-deckard-accent-light);
-  --color-duel-b:       #a1782f; /* sand: deckard's grade ramp owns the blues and purples */
+  --color-duel-b:       #a1782f;
   --color-accent-hover: #b01888;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-deckard-accent-light) 8%, transparent);
   --color-on-accent:    #ffffff;

--- a/src/quodeq/ui/tools/token_distinctness.mjs
+++ b/src/quodeq/ui/tools/token_distinctness.mjs
@@ -38,13 +38,12 @@ export const SEV_TOKENS = [
 // Minimum CIE76 delta-E between…
 export const MIN_DUEL_SIDES = 20;        // duel side A (accent) vs side B — identity must survive
 export const MIN_DUEL_VS_GRADE = 20;     // duel side B vs any grade tier — identity is not a judgement
-export const MIN_COMPLIANCE_VS_ACCENT = 20; // compliance and the accent
-
-// There is deliberately NO grade-vs-severity or grade-vs-accent rule. The
-// 2026-08-25 recolor that introduced them (metallic ramp, then a caution
-// descent) was rejected by the user, who chose the original v1.9.1 grade
-// palette: it lives in the red channel severity also uses, and its top
-// tier rides the accent in dark themes. That sharing is the accepted
+// There is deliberately NO grade-vs-severity, grade-vs-accent, or
+// compliance-vs-accent rule. The 2026-08-25 recolor that introduced them
+// (metallic ramp, then a caution descent, plus compliance moved to green)
+// was rejected by the user, who chose the original v1.9.1 palette: grades
+// live in the red channel severity also uses, and grade-top AND
+// compliance ride the accent in dark themes. That sharing is the accepted
 // design; chip vs score context disambiguates.
 
 // The two floors below are grandfathered at the v1.9.1 palette's own
@@ -213,9 +212,6 @@ export function auditDistinctness(cssText) {
   for (const [theme, vars] of Object.entries(themes)) {
     const color = (token) => parseColor(resolveVar(vars, token));
     const grades = GRADE_TOKENS.map((t) => [t, color(t)]).filter(([, c]) => c);
-    const accent = color('--color-accent');
-    const compliance = color('--color-compliance');
-
     for (const [g, gc] of grades) {
       for (const surface of SURFACE_TOKENS) {
         const bg = color(surface);
@@ -226,9 +222,6 @@ export function auditDistinctness(cssText) {
       for (let j = i + 1; j < grades.length; j += 1) {
         push(theme, 'grade-step', grades[i][0], grades[j][0], deltaE(grades[i][1], grades[j][1]), MIN_GRADE_STEP, 'deltaE');
       }
-    }
-    if (accent && compliance) {
-      push(theme, 'compliance-vs-accent', '--color-compliance', '--color-accent', deltaE(compliance, accent), MIN_COMPLIANCE_VS_ACCENT, 'deltaE');
     }
     // Duel identity: the two sides must stay tellable apart, and side B must
     // stay readable on every surface (A rides the accent, already covered).

--- a/src/quodeq/ui/tools/token_distinctness.test.mjs
+++ b/src/quodeq/ui/tools/token_distinctness.test.mjs
@@ -6,9 +6,8 @@
  * and restored the original v1.9.1 grade palette, which shares the red
  * channel with severity and rides the accent at the top tier. What remains
  * guarded: grade steps stay mutually legible and grade text stays readable
- * at the restored palette's own baseline, compliance stays off the accent,
- * and the duel identity colors stay apart from each other and from every
- * grade tier.
+ * at the restored palette's own baseline, and the duel identity colors
+ * stay apart from each other and from every grade tier.
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -47,12 +46,12 @@ test('deltaE matches known reference points', () => {
   assert.equal(deltaE(parseColor('#b00a14'), parseColor('#b00a14')), 0);
 });
 
-test('grade legibility, compliance, and duel identity hold in every theme', () => {
+test('grade legibility and duel identity hold in every theme', () => {
   const { results, failures } = auditDistinctness(css);
-  // 12 contexts x (15 contrast + 10 grade-step + 1 compliance + 1 duel
-  // sides + 3 duel-b contrast + 5 duel-b-vs-grade) = 420 — if this
-  // shrinks, the parser stopped seeing part of the matrix and the guard
-  // is weaker than it looks.
+  // 12 contexts x (15 contrast + 10 grade-step + 1 duel sides + 3 duel-b
+  // contrast + 5 duel-b-vs-grade) = 408 — if this shrinks, the parser
+  // stopped seeing part of the matrix and the guard is weaker than it
+  // looks.
   assert.ok(results.length >= 400, `matrix shrank: only ${results.length} checks ran`);
   const table = failures
     .map((f) => `  ${f.theme}: ${f.rule} ${f.a} vs ${f.b} = ${f.value} (min ${f.min} ${f.kind})`)


### PR DESCRIPTION
## What

Two things, one branch:

**Chart semantics, settled.** One absolute 0-10 axis for the score history charts (Overview, History, Explorer dimension panel): bar height means score, and the line sits exactly on the bar tops. This replaces #1098's dual-axis split after the report that the zoomed line visibly detaches from the bars. The compare row sparkline moves to the same absolute scale; the duel trend stays the one deliberately zoomed view. Staleness copy becomes "{count} commits behind".

**Recovers the stranded half of #1097.** That PR was merged while only its first commit was in: the second commit (c58bbe26) never reached develop, which is why the map still painted healthy files green and the duel side B was still purple. Cherry-picked here: original compliance colors restored in all 12 contexts (cyan in daruma dark, gold in light), duel side B is plain sand everywhere, and the compliance-vs-accent guard rule goes with it.

## Verified

- token_distinctness 408 checks, 0 failures; string lint clean; 1594/1594 UI tests; build clean
- Browser-verified: map Health view shows cyan healthy files (no green), score history line rides the bar tops at the absolute scale

🤖 Generated with [Claude Code](https://claude.com/claude-code)