### PR TITLE
feat(ui): hold startup loader through overview data; accurate skeletons on every main surface

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -37,6 +37,12 @@ import { ACTIVE_PROVIDER_KEY, providerKey } from './constants.js';
 import { useAppState, formatDayLabel } from './hooks/useAppState.js';
 import { useNativeNavBridge } from './hooks/useNativeNavBridge.js';
 import { useOneShotGate } from './hooks/useOneShotGate.js';
+import { useLinger } from './hooks/useLinger.js';
+import { warmOverviewChunks } from './bootChunks.js';
+
+// How long the startup loader stays opaque after its data-hold releases,
+// covering the overview's final commit (lazy chart first render).
+const STARTUP_LOADER_LINGER_MS = 250;
 import { readVisibleStandardIds, hydrateVisibleStandardIds } from './utils/visibleStandards.js';
 import { buildProjectRootFile } from './utils/explorerUtils.js';
 import { filterTrendByVisibleStandards, filterAccumulatedByVisibleStandards } from './utils/scoreFiltering.js';
@@ -1029,6 +1035,10 @@ export default function App() {
   const { dismissFinding } = useApi();
   const queryClient = useQueryClient();
   const state = useAppState();
+  // Warm the Overview's lazy chunks (DashboardPage + the recharts chart)
+  // while the startup loader is up — see bootChunks.js for why page-mount
+  // time measured too late.
+  useEffect(() => { warmOverviewChunks(); }, []);
   // Passive shared-repo content signal driving the zero-local-projects flow:
   // wizard auto-open (below), the one-shot landing redirect, and the
   // "browse remote repositories" empty-state actions. Same react-query cache
@@ -1192,7 +1202,7 @@ export default function App() {
   // switch re-enters (Compare's open-project lands on a not-yet-loaded
   // overview); the gate makes sure the fullscreen loader is boot-only —
   // after it drops once, switches get the overview skeleton instead.
-  const showStartupLoader = useOneShotGate(shouldShowStartupLoader({
+  const startupHoldActive = useOneShotGate(shouldShowStartupLoader({
     projectsLoaded: state.projectsLoaded,
     projectsLoadFailed: state.projectsLoadFailed,
     projectsCount: state.projects.length,
@@ -1204,6 +1214,10 @@ export default function App() {
     error: state.error,
     loading: state.loading,
   }));
+  // Linger a beat after the hold drops so the overview's final commit (the
+  // lazy chart's first render, ~200ms) happens under a still-opaque loader;
+  // the fade then reveals a finished page instead of a chart placeholder.
+  const showStartupLoader = useLinger(startupHoldActive, STARTUP_LOADER_LINGER_MS);
   // Initial landing: decided exactly once, the first render after both the
   // local projects list and the shared signal have settled (whatever the
   // outcome). Mid-session changes never re-trigger it.

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -36,6 +36,7 @@ import TopBar from './components/TopBar.jsx';
 import { ACTIVE_PROVIDER_KEY, providerKey } from './constants.js';
 import { useAppState, formatDayLabel } from './hooks/useAppState.js';
 import { useNativeNavBridge } from './hooks/useNativeNavBridge.js';
+import { useOneShotGate } from './hooks/useOneShotGate.js';
 import { readVisibleStandardIds, hydrateVisibleStandardIds } from './utils/visibleStandards.js';
 import { buildProjectRootFile } from './utils/explorerUtils.js';
 import { filterTrendByVisibleStandards, filterAccumulatedByVisibleStandards } from './utils/scoreFiltering.js';
@@ -458,17 +459,21 @@ export function shouldRedirectToRemoteRepositories({ projectsLoaded, projectsCou
 }
 
 /**
- * Startup-loader gate. Dropping the loader at projectsLoaded hands the user
+ * Startup-loader hold. Dropping the loader at projectsLoaded hands the user
  * a skeleton flash (loader > skeleton > data) on every boot, so on the
  * default Overview landing it holds until the Overview's data is actually
  * in. It must drop the moment we know no data is coming: load failure,
- * zero local projects, nothing selected, a query error, or a restored
- * non-overview tab — every one of those renders its own state and an
- * overlay would wall it off forever. Exported for unit tests.
+ * zero local projects, nothing selected, a query error, a restored
+ * non-overview tab, or the queries settling empty (`loading` false covers
+ * a project with no completed evaluations, whose `accumulated` stays null
+ * forever) — every one of those renders its own state and an overlay
+ * would wall it off forever. This describes a STATE, not "booting": the
+ * caller must scope it with useOneShotGate or a mid-session project
+ * switch re-triggers it. Exported for unit tests.
  */
 export function shouldShowStartupLoader({
   projectsLoaded, projectsLoadFailed, projectsCount, selectedProject,
-  selectedSource, activeTab, dashboard, accumulated, error,
+  selectedSource, activeTab, dashboard, accumulated, error, loading,
 }) {
   if (projectsLoadFailed) return false;
   if (!projectsLoaded) return true;
@@ -476,7 +481,8 @@ export function shouldShowStartupLoader({
   if ((projectsCount ?? 0) === 0 && selectedSource !== 'shared') return false;
   if (!selectedProject) return false;
   if (error) return false;
-  return !(dashboard && accumulated);
+  if (dashboard && accumulated) return false;
+  return !!loading;
 }
 
 function renderEvalPrincipleDetail(params, props) {
@@ -1182,7 +1188,11 @@ export default function App() {
     ? localStorage.getItem(providerKey(sidebarProvider, 'model'))
     : null;
   const { activePage, navStack, navPop, navGoTo, navSwapAt, navTab, activeTab } = state;
-  const showStartupLoader = shouldShowStartupLoader({
+  // One-shot: the hold predicate describes a state a mid-session project
+  // switch re-enters (Compare's open-project lands on a not-yet-loaded
+  // overview); the gate makes sure the fullscreen loader is boot-only —
+  // after it drops once, switches get the overview skeleton instead.
+  const showStartupLoader = useOneShotGate(shouldShowStartupLoader({
     projectsLoaded: state.projectsLoaded,
     projectsLoadFailed: state.projectsLoadFailed,
     projectsCount: state.projects.length,
@@ -1192,7 +1202,8 @@ export default function App() {
     dashboard: state.dashboard,
     accumulated: state.accumulated,
     error: state.error,
-  });
+    loading: state.loading,
+  }));
   // Initial landing: decided exactly once, the first render after both the
   // local projects list and the shared signal have settled (whatever the
   // outcome). Mid-session changes never re-trigger it.

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -34,7 +34,6 @@ import LoadingScreen, { FadingLoadingScreen } from './components/LoadingScreen.j
 import Sidebar from './components/Sidebar.jsx';
 import TopBar from './components/TopBar.jsx';
 import { ACTIVE_PROVIDER_KEY, providerKey } from './constants.js';
-import ProjectHeader from './components/ProjectHeader.jsx';
 import { useAppState, formatDayLabel } from './hooks/useAppState.js';
 import { useNativeNavBridge } from './hooks/useNativeNavBridge.js';
 import { readVisibleStandardIds, hydrateVisibleStandardIds } from './utils/visibleStandards.js';
@@ -456,6 +455,28 @@ export function shouldRedirectToRemoteRepositories({ projectsLoaded, projectsCou
   if (selectedSource === 'shared') return false;
   if (!sharedHasContent) return false;
   return activeTab === 'overview';
+}
+
+/**
+ * Startup-loader gate. Dropping the loader at projectsLoaded hands the user
+ * a skeleton flash (loader > skeleton > data) on every boot, so on the
+ * default Overview landing it holds until the Overview's data is actually
+ * in. It must drop the moment we know no data is coming: load failure,
+ * zero local projects, nothing selected, a query error, or a restored
+ * non-overview tab — every one of those renders its own state and an
+ * overlay would wall it off forever. Exported for unit tests.
+ */
+export function shouldShowStartupLoader({
+  projectsLoaded, projectsLoadFailed, projectsCount, selectedProject,
+  selectedSource, activeTab, dashboard, accumulated, error,
+}) {
+  if (projectsLoadFailed) return false;
+  if (!projectsLoaded) return true;
+  if (activeTab !== 'overview') return false;
+  if ((projectsCount ?? 0) === 0 && selectedSource !== 'shared') return false;
+  if (!selectedProject) return false;
+  if (error) return false;
+  return !(dashboard && accumulated);
 }
 
 function renderEvalPrincipleDetail(params, props) {
@@ -1161,6 +1182,17 @@ export default function App() {
     ? localStorage.getItem(providerKey(sidebarProvider, 'model'))
     : null;
   const { activePage, navStack, navPop, navGoTo, navSwapAt, navTab, activeTab } = state;
+  const showStartupLoader = shouldShowStartupLoader({
+    projectsLoaded: state.projectsLoaded,
+    projectsLoadFailed: state.projectsLoadFailed,
+    projectsCount: state.projects.length,
+    selectedProject: state.selectedProject,
+    selectedSource: state.selectedSource,
+    activeTab,
+    dashboard: state.dashboard,
+    accumulated: state.accumulated,
+    error: state.error,
+  });
   // Initial landing: decided exactly once, the first render after both the
   // local projects list and the shared signal have settled (whatever the
   // outcome). Mid-session changes never re-trigger it.
@@ -1409,6 +1441,19 @@ export default function App() {
             />
           }
           content={
+            <>
+              {/* One stable mount for the startup loader, OUTSIDE the
+                  Suspense: inside it, a lazy chunk's suspension unmounts the
+                  loader itself and the plain fallback restarts the fade and
+                  tips from zero (a loader-to-loader flash). Out here it
+                  covers chunk loads AND holds through the Overview's first
+                  data (shouldShowStartupLoader), so boot goes loader ->
+                  content with no skeleton in between. */}
+              <FadingLoadingScreen
+                show={showStartupLoader}
+                tips
+                warmup={state.warmup}
+              />
             <Suspense fallback={<LoadingScreen />}>
               {/* Every route, not just Evaluate. A dead backend is the one
                   failure no page can render around: the Overview's own wall
@@ -1418,16 +1463,6 @@ export default function App() {
               {!state.serverConnected && (
                 <ServerDisconnectedOverlay onReconnect={() => state.setServerConnected(true)} />
               )}
-              {/* One stable mount for the startup loader: it covers every
-                  route's not-yet-loaded state and fades out when the projects
-                  land, instead of each gate ripping its own copy out of the
-                  DOM on the same frame the content appears. */}
-              <FadingLoadingScreen
-                show={!state.projectsLoaded && !state.projectsLoadFailed}
-                tips
-                warmup={state.warmup}
-              />
-
               <div className="tab-fade" key={activeTab}>
                 <MainContent activePage={activePage} props={contentProps} />
               </div>
@@ -1438,6 +1473,7 @@ export default function App() {
                 />
               )}
             </Suspense>
+            </>
           }
             />
               </VerifiedFindingsProvider>

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -6,6 +6,7 @@ import {
   resolveSelectionAfterSharedDisconnect, shouldAutoOpenOnboardingWizard, shouldRedirectToRemoteRepositories, shouldShowProjectTabs,
   buildNavigationBundle, buildDashboardDataBundle, shouldWallEmptyProjects, buildWizardHandlers, buildAssistantSessionPayload,
   buildAssistantActionAppliedHandler, resolveProjectDisplayName, selectSidebarCounts,
+  shouldShowStartupLoader,
 } from './App.jsx';
 import Sidebar from './components/Sidebar.jsx';
 
@@ -1071,5 +1072,62 @@ describe('projects-load failure threading', () => {
       state, navTab: vi.fn(), navStackLength: 1, isEvaluating: false,
       showToast: vi.fn(), setWizardEntry: vi.fn(),
     }).warmup).toBe(warmup);
+  });
+});
+
+// The startup loader must outlive projectsLoaded: dropping it there hands the
+// user a skeleton flash (loader > skeleton > data) on every boot. It holds
+// until the Overview's data is in, and drops immediately on any dead end
+// where no data will ever arrive (failure, zero projects, nothing selected,
+// query error, or the user restored into a different tab).
+describe('shouldShowStartupLoader', () => {
+  const base = {
+    projectsLoaded: true, projectsLoadFailed: false, projectsCount: 2,
+    selectedProject: 'proj-1', selectedSource: 'local', activeTab: 'overview',
+    dashboard: null, accumulated: null, error: null,
+  };
+
+  it('shows before projects load', () => {
+    expect(shouldShowStartupLoader({ ...base, projectsLoaded: false })).toBe(true);
+  });
+
+  it('shows before projects load regardless of the restored tab', () => {
+    expect(shouldShowStartupLoader({ ...base, projectsLoaded: false, activeTab: 'settings' })).toBe(true);
+  });
+
+  it('drops on projects load failure (retry state must be reachable)', () => {
+    expect(shouldShowStartupLoader({ ...base, projectsLoaded: false, projectsLoadFailed: true })).toBe(false);
+  });
+
+  it('holds after projects load while overview data is still loading', () => {
+    expect(shouldShowStartupLoader(base)).toBe(true);
+  });
+
+  it('keeps holding when only the dashboard payload has arrived', () => {
+    expect(shouldShowStartupLoader({ ...base, dashboard: { runs: [] } })).toBe(true);
+  });
+
+  it('drops once dashboard and accumulated are both in', () => {
+    expect(shouldShowStartupLoader({ ...base, dashboard: { runs: [] }, accumulated: { dims: [] } })).toBe(false);
+  });
+
+  it('drops on a dashboard query error (error state must be reachable)', () => {
+    expect(shouldShowStartupLoader({ ...base, error: new Error('boom') })).toBe(false);
+  });
+
+  it('drops with zero local projects (onboarding/empty states take over)', () => {
+    expect(shouldShowStartupLoader({ ...base, projectsCount: 0, selectedProject: null })).toBe(false);
+  });
+
+  it('holds for a shared selection even with zero local projects', () => {
+    expect(shouldShowStartupLoader({ ...base, projectsCount: 0, selectedSource: 'shared' })).toBe(true);
+  });
+
+  it('drops when nothing is selected', () => {
+    expect(shouldShowStartupLoader({ ...base, selectedProject: null })).toBe(false);
+  });
+
+  it('drops when the user restored into a non-overview tab', () => {
+    expect(shouldShowStartupLoader({ ...base, activeTab: 'violations' })).toBe(false);
   });
 });

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -1084,7 +1084,7 @@ describe('shouldShowStartupLoader', () => {
   const base = {
     projectsLoaded: true, projectsLoadFailed: false, projectsCount: 2,
     selectedProject: 'proj-1', selectedSource: 'local', activeTab: 'overview',
-    dashboard: null, accumulated: null, error: null,
+    dashboard: null, accumulated: null, error: null, loading: true,
   };
 
   it('shows before projects load', () => {
@@ -1129,5 +1129,16 @@ describe('shouldShowStartupLoader', () => {
 
   it('drops when the user restored into a non-overview tab', () => {
     expect(shouldShowStartupLoader({ ...base, activeTab: 'violations' })).toBe(false);
+  });
+
+  it('drops when the queries settle with no data coming (project with no completed evaluations)', () => {
+    // accumulated stays null forever for a run-less project; only `loading`
+    // (dashboard + scores queries combined) says nothing more is in flight.
+    // Without this escape the loader would wall off the empty state forever.
+    expect(shouldShowStartupLoader({ ...base, loading: false })).toBe(false);
+  });
+
+  it('keeps holding while either query is still in flight even with partial data', () => {
+    expect(shouldShowStartupLoader({ ...base, dashboard: { runs: [] }, loading: true })).toBe(true);
   });
 });

--- a/src/quodeq/ui/src/bootChunks.js
+++ b/src/quodeq/ui/src/bootChunks.js
@@ -1,0 +1,13 @@
+// Warm the lazy chunks the boot path is guaranteed to need, while the
+// startup loader is still up. Boot lands on the Overview, and its
+// score-history chart (recharts) is the heaviest chunk in the app: warming
+// it only at DashboardPage mount measured too late — the loader could drop
+// on data-ready with the chunk still in flight, showing the chart
+// placeholder through the loader's fade-out. Called from App's mount
+// effect; dynamic import() dedupes, so later lazy() resolutions are hits.
+export function warmOverviewChunks() {
+  return Promise.allSettled([
+    import('./features/dashboard/components/DashboardPage.jsx'),
+    import('./features/dashboard/components/RunHistoryPanel.jsx'),
+  ]);
+}

--- a/src/quodeq/ui/src/bootChunks.test.jsx
+++ b/src/quodeq/ui/src/bootChunks.test.jsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { warmOverviewChunks } from './bootChunks.js';
+
+// Boot lands on the Overview, so its lazy chunks (DashboardPage, and the
+// recharts-heavy RunHistoryPanel) must start fetching at app mount — while
+// the startup loader is still up — not when the page first renders. This
+// pins that the warm list resolves: a moved/renamed chunk path would
+// otherwise silently reintroduce the boot chart-placeholder flash.
+describe('warmOverviewChunks', () => {
+  it('resolves every overview boot chunk', async () => {
+    const results = await warmOverviewChunks();
+    expect(results.length).toBeGreaterThanOrEqual(2);
+    for (const r of results) expect(r.status).toBe('fulfilled');
+  });
+});

--- a/src/quodeq/ui/src/components/LoadingScreen.jsx
+++ b/src/quodeq/ui/src/components/LoadingScreen.jsx
@@ -9,7 +9,7 @@ const TIP_KEYS = [
   'loading.tips.ignore', 'loading.tips.history', 'loading.tips.compliance',
   'loading.tips.shared',
 ];
-const TIPS_DELAY_MS = 1000;
+const TIPS_DELAY_MS = 300;
 const TIPS_ROTATE_MS = 8000;
 const LEAVE_MS = 400;
 

--- a/src/quodeq/ui/src/components/LoadingScreen.jsx
+++ b/src/quodeq/ui/src/components/LoadingScreen.jsx
@@ -9,7 +9,7 @@ const TIP_KEYS = [
   'loading.tips.ignore', 'loading.tips.history', 'loading.tips.compliance',
   'loading.tips.shared',
 ];
-const TIPS_DELAY_MS = 3000;
+const TIPS_DELAY_MS = 1000;
 const TIPS_ROTATE_MS = 8000;
 const LEAVE_MS = 400;
 

--- a/src/quodeq/ui/src/components/LoadingScreen.test.jsx
+++ b/src/quodeq/ui/src/components/LoadingScreen.test.jsx
@@ -10,14 +10,14 @@ describe('LoadingScreen tips', () => {
     expect(container.querySelector('.loading-tip')).toBeNull();
   });
 
-  it('shows a tip only after the 1s delay, then rotates to a different one', async () => {
+  it('shows a tip only after the 300ms delay, then rotates to a different one', async () => {
     vi.useFakeTimers();
     try {
       const { container } = render(<LoadingScreen tips />);
       expect(container.querySelector('.loading-tip')).toBeNull();
-      await act(async () => { await vi.advanceTimersByTimeAsync(900); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(250); });
       expect(container.querySelector('.loading-tip')).toBeNull();
-      await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(50); });
       const first = container.querySelector('.loading-tip');
       expect(first).toBeTruthy();
       const firstText = first.textContent;

--- a/src/quodeq/ui/src/components/LoadingScreen.test.jsx
+++ b/src/quodeq/ui/src/components/LoadingScreen.test.jsx
@@ -10,12 +10,12 @@ describe('LoadingScreen tips', () => {
     expect(container.querySelector('.loading-tip')).toBeNull();
   });
 
-  it('shows a tip only after the 3s delay, then rotates to a different one', async () => {
+  it('shows a tip only after the 1s delay, then rotates to a different one', async () => {
     vi.useFakeTimers();
     try {
       const { container } = render(<LoadingScreen tips />);
       expect(container.querySelector('.loading-tip')).toBeNull();
-      await act(async () => { await vi.advanceTimersByTimeAsync(2900); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(900); });
       expect(container.querySelector('.loading-tip')).toBeNull();
       await act(async () => { await vi.advanceTimersByTimeAsync(100); });
       const first = container.querySelector('.loading-tip');

--- a/src/quodeq/ui/src/features/compare/components/ComparePage.jsx
+++ b/src/quodeq/ui/src/features/compare/components/ComparePage.jsx
@@ -13,6 +13,7 @@
 import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import EmptyState from '../../../components/EmptyState.jsx';
+import CompareSkeleton from './CompareSkeleton.jsx';
 import { getDimensionEval } from '../../../api/index.js';
 import { projectKeys } from '../../../api/queryKeys.js';
 import {
@@ -178,7 +179,7 @@ export default function ComparePage({
   }, [view, duel]);
 
   if (!projectsLoaded) {
-    return <div className="compare-page" ref={rootRef}><div className="compare-loading">{t('compare.loading')}</div></div>;
+    return <div className="compare-page" ref={rootRef}><CompareSkeleton /></div>;
   }
 
   if (!localProjects.length) {

--- a/src/quodeq/ui/src/features/compare/components/ComparePage.test.jsx
+++ b/src/quodeq/ui/src/features/compare/components/ComparePage.test.jsx
@@ -96,6 +96,12 @@ describe('ComparePage', () => {
     expect(screen.getByText('Nothing to compare yet')).toBeInTheDocument();
   });
 
+  it('renders a table skeleton (not a bare text line) before projects load', () => {
+    const { container } = renderPage({ projectsLoaded: false });
+    expect(container.querySelector('.compare-skeleton')).toBeTruthy();
+    expect(container.querySelector('.compare-loading')).toBeNull();
+  });
+
   it('renders a row per project once summaries arrive', async () => {
     renderPage();
     expect(await screen.findByText('alpha')).toBeInTheDocument();

--- a/src/quodeq/ui/src/features/compare/components/CompareSkeleton.jsx
+++ b/src/quodeq/ui/src/features/compare/components/CompareSkeleton.jsx
@@ -1,0 +1,18 @@
+// Pre-projectsLoaded stand-in for the fleet table, replacing the bare
+// "loading comparison…" text line. Once projects load the page renders
+// immediately and rows fill in progressively (per-row pending marks), so
+// this only covers the initial wait. House skeleton idiom: static dimmed
+// blocks, no shimmer, no spinner.
+
+const ROW_COUNT = 5;
+
+export default function CompareSkeleton() {
+  return (
+    <div className="compare-skeleton" aria-busy="true" aria-hidden="true">
+      <span className="compare-skeleton__bar compare-skeleton__bar--header" />
+      {Array.from({ length: ROW_COUNT }, (_, index) => (
+        <span key={index} className="compare-skeleton__bar compare-skeleton__bar--row" />
+      ))}
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/compare/components/CompareSkeleton.test.jsx
+++ b/src/quodeq/ui/src/features/compare/components/CompareSkeleton.test.jsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import CompareSkeleton from './CompareSkeleton.jsx';
+
+// Pre-projectsLoaded stand-in for the fleet table. Once projects load, the
+// page renders immediately and rows fill in progressively (per-row pending
+// marks), so this only covers the initial wait.
+describe('CompareSkeleton', () => {
+  it('renders a header bar and 5 fleet-row bars', () => {
+    const { container } = render(<CompareSkeleton />);
+    expect(container.querySelectorAll('.compare-skeleton__bar--header').length).toBe(1);
+    expect(container.querySelectorAll('.compare-skeleton__bar--row').length).toBe(5);
+  });
+
+  it('is quiet: aria-busy container, aria-hidden, no spinner', () => {
+    const { container } = render(<CompareSkeleton />);
+    const root = container.querySelector('.compare-skeleton');
+    expect(root).toHaveAttribute('aria-busy', 'true');
+    expect(root).toHaveAttribute('aria-hidden', 'true');
+    expect(container.querySelector('.loading-screen')).toBeFalsy();
+  });
+});

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -3,7 +3,17 @@ import TrendBadge from '../../../components/TrendBadge.jsx';
 import DimensionCardsGrid from './DimensionCardsGrid.jsx';
 import { formatRunId, gradeLetter, complianceRatio, extDisplayName } from '../../../utils/formatters.js';
 import { collapseByPeriod, collectPeriodDimensions, bucketKey, extractDimensionPeriodSeries, sliceTrendAtRun } from '../../../utils/dailyGrouping.js';
-const RunHistoryPanel = lazy(() => import('./RunHistoryPanel.jsx'));
+const runHistoryPanelImport = () => import('./RunHistoryPanel.jsx');
+const RunHistoryPanel = lazy(runHistoryPanelImport);
+
+// Warm the chart chunk before the overview first mounts with data (called
+// from DashboardPage while the boot loader / skeleton is still up). The
+// dynamic import caches, so the lazy() above resolves without ever
+// committing its RunHistoryPanelPlaceholder fallback — otherwise a cold
+// boot pays a placeholder beat inside otherwise-real content.
+export function preloadRunHistoryPanel() {
+  runHistoryPanelImport();
+}
 import RunHistoryPanelPlaceholder from './RunHistoryPanelPlaceholder.jsx';
 import DimensionScorePanel from './DimensionScorePanel.jsx';
 import TopOffendingFilesTable from './TopOffendingFilesTable.jsx';

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import DimensionCard from './DimensionCard.jsx';
-import AccumulatedOverviewPanel from './AccumulatedOverviewPanel.jsx';
+import AccumulatedOverviewPanel, { preloadRunHistoryPanel } from './AccumulatedOverviewPanel.jsx';
 import RunOverviewPanel from './RunOverviewPanel.jsx';
 import IncompleteSetupCard from './IncompleteSetupCard.jsx';
 import OverviewSkeleton from './OverviewSkeleton.jsx';
@@ -145,6 +145,11 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   const { selectedProject, selectedSource, selectedRun, projects = [], sharedProjectInfo = null, dashboard, accumulated, loading, isFetching, scoresPending = false, error, availableRuns = [], dailyRuns, overviewRunIndex = 0, granularity = 'day', onGranularityChange, sharedHasContent = false, customFormula = false, warmup = null } = data;
   const projectInfo = selectDashboardProjectInfo({ selectedSource, projects, selectedProject, sharedProjectInfo });
   const { onNavigate, onRunSelect, onProjectsReload } = callbacks;
+  // Warm the score-history chunk while the boot loader / skeleton is still
+  // up: the chart is a separate lazy chunk, and without this the first
+  // data-bearing mount commits its placeholder for a beat inside otherwise
+  // real content — the exact flash the startup hold exists to remove.
+  useEffect(() => { preloadRunHistoryPanel(); }, []);
   // After a successful clone-on-add migration the project's repository_info.json
   // has been rewritten with location: "local". Refetch the projects list so the
   // sidebar/header reflect the new state. Fall back to a full reload if no

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -9,6 +9,10 @@ import WarmupNotice from '../../../components/WarmupNotice.jsx';
 import EmptyState from '../../../components/EmptyState.jsx';
 import { t } from '../../../strings/index.js';
 
+// Matches the .dashboard-appear animation length (dashboard.css) -- the
+// class is held for this long so re-renders can't cut the fade short.
+const DASHBOARD_APPEAR_MS = 400;
+
 function NoCompletedEvalPanel({ availableRuns = [], onNavigate, selectedSource }) {
   const hasRunning = availableRuns.some((r) => r?.status === 'in_progress');
   if (hasRunning) {
@@ -254,16 +258,26 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   useEffect(() => {
     if (!isLoading && !showOverviewSkeleton) dashboardAppearedKeyRef.current = dashboardAppearKey;
   }, [isLoading, showOverviewSkeleton, dashboardAppearKey]);
-  const dashboardAppearClass = dashboardAppearNow ? ' dashboard-appear' : '';
-  // Trade-off: the appear class only lives for the one render where it's computed
-  // above -- it doesn't stay latched until dashboardAppearKey next changes -- so any
-  // *unrelated* re-render inside the animation window (e.g. isFetching flipping a
-  // moment after content first appears) drops it and snaps opacity to 1, cutting
-  // the fade short. Latching it across renders was rejected: it would fail to
-  // re-arm on a run switch without reintroducing a loading gap. (The
-  // grace-fallback -> content-ready flip used to be an example of this too, until
-  // the graceElapsed reset above moved to render-phase specifically to stop that
-  // one from self-inflicting a same-tick drop -- see the comment on graceElapsed.)
+  // Hold the class for the animation's duration, not just the one render
+  // where dashboardAppearNow computes true: an unrelated re-render inside
+  // the window (isFetching flipping a moment after content appeared) used
+  // to drop it and snap opacity to 1, cutting the fade short. The className
+  // never toggles mid-window, so the animation runs uninterrupted; removal
+  // after the window is visually a no-op (the animation has finished).
+  // Latching until the key next changes was rejected instead: a key change
+  // then re-applies the class onto a node that still has it, which does not
+  // restart a CSS animation.
+  const [appearHeld, setAppearHeld] = useState(false);
+  const appearTimerRef = useRef(null);
+  useEffect(() => {
+    if (!dashboardAppearNow) return;
+    setAppearHeld(true);
+    clearTimeout(appearTimerRef.current);
+    appearTimerRef.current = setTimeout(() => setAppearHeld(false), DASHBOARD_APPEAR_MS);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dashboardAppearNow, dashboardAppearKey]);
+  useEffect(() => () => clearTimeout(appearTimerRef.current), []);
+  const dashboardAppearClass = (dashboardAppearNow || appearHeld) ? ' dashboard-appear' : '';
 
   // Sticky "no evaluations yet" latch: once that empty state is showing for
   // this project+source, stay on it through a subsequent load (the post-eval

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.preload.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.preload.test.jsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import DashboardPage from './DashboardPage.jsx';
+import { SidePaneProvider } from '../../side-pane/index.js';
+import { preloadRunHistoryPanel } from './AccumulatedOverviewPanel.jsx';
+
+vi.mock('./AccumulatedOverviewPanel.jsx', async (importOriginal) => {
+  const mod = await importOriginal();
+  return { ...mod, preloadRunHistoryPanel: vi.fn() };
+});
+
+// The score-history chart is a separate lazy chunk: without warming it
+// while the boot loader/skeleton is still up, the freshly mounted overview
+// shows the chart placeholder for a beat — the exact placeholder flash the
+// startup hold exists to remove.
+describe('DashboardPage warms the score-history chunk', () => {
+  it('kicks the preload on mount, while still loading', () => {
+    render(
+      <SidePaneProvider>
+        <DashboardPage
+          data={{
+            projectsLoaded: true,
+            projects: [{ id: 'p1', name: 'p1' }],
+            selectedProject: 'p1',
+            selectedSource: 'local',
+            dashboard: null,
+            accumulated: null,
+            loading: true,
+            isFetching: true,
+            error: null,
+            availableRuns: [],
+          }}
+          callbacks={{}}
+          runMode={false}
+        />
+      </SidePaneProvider>,
+    );
+    expect(preloadRunHistoryPanel).toHaveBeenCalled();
+  });
+});

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -640,38 +640,59 @@ describe('DashboardPage frame stability and fade-once across branch transitions 
     expect(nodeAfter).toBe(nodeBefore);
   });
 
-  it('carries dashboard-appear on first content appearance, not while still loading, and not on a second ready render over the same context', () => {
-    const { container, rerender } = render(
-      <SidePaneProvider>
-        <DashboardPage data={{ ...readyOverview, accumulated: null, loading: true }} callbacks={{}} runMode={false} />
-      </SidePaneProvider>,
-    );
-    let page = container.querySelector('.dashboard-page');
-    // P6: the Overview never dims -- the skeleton is showing here, undimmed --
-    // but it's still "still loading" for the appear latch's purposes.
-    expect(page.className).not.toContain('dashboard-loading');
-    expect(page.className).toContain('dashboard-ready');
-    expect(page.className).not.toContain('dashboard-appear');
-    expect(page.querySelector('.overview-skeleton')).toBeTruthy();
+  it('carries dashboard-appear on first content appearance, holds it through unrelated re-renders for the animation window, then releases', () => {
+    vi.useFakeTimers();
+    try {
+      const { container, rerender } = render(
+        <SidePaneProvider>
+          <DashboardPage data={{ ...readyOverview, accumulated: null, loading: true }} callbacks={{}} runMode={false} />
+        </SidePaneProvider>,
+      );
+      let page = container.querySelector('.dashboard-page');
+      // P6: the Overview never dims -- the skeleton is showing here, undimmed --
+      // but it's still "still loading" for the appear latch's purposes.
+      expect(page.className).not.toContain('dashboard-loading');
+      expect(page.className).toContain('dashboard-ready');
+      expect(page.className).not.toContain('dashboard-appear');
+      expect(page.querySelector('.overview-skeleton')).toBeTruthy();
 
-    rerender(
-      <SidePaneProvider>
-        <DashboardPage data={readyOverview} callbacks={{}} runMode={false} />
-      </SidePaneProvider>,
-    );
-    page = container.querySelector('.dashboard-page');
-    expect(page.className).toContain('dashboard-ready');
-    expect(page.className).toContain('dashboard-appear');
+      rerender(
+        <SidePaneProvider>
+          <DashboardPage data={readyOverview} callbacks={{}} runMode={false} />
+        </SidePaneProvider>,
+      );
+      page = container.querySelector('.dashboard-page');
+      expect(page.className).toContain('dashboard-ready');
+      expect(page.className).toContain('dashboard-appear');
 
-    rerender(
-      <SidePaneProvider>
-        <DashboardPage data={{ ...readyOverview, isFetching: true }} callbacks={{}} runMode={false} />
-      </SidePaneProvider>,
-    );
-    page = container.querySelector('.dashboard-page');
-    expect(page.className).toContain('dashboard-ready');
-    expect(page.className).toContain('dashboard-refreshing');
-    expect(page.className).not.toContain('dashboard-appear');
+      // An unrelated re-render inside the animation window (isFetching
+      // flipping a moment after content appeared) must NOT drop the class:
+      // that snapped opacity to 1 and cut the fade short.
+      rerender(
+        <SidePaneProvider>
+          <DashboardPage data={{ ...readyOverview, isFetching: true }} callbacks={{}} runMode={false} />
+        </SidePaneProvider>,
+      );
+      page = container.querySelector('.dashboard-page');
+      expect(page.className).toContain('dashboard-ready');
+      expect(page.className).toContain('dashboard-refreshing');
+      expect(page.className).toContain('dashboard-appear');
+
+      // Once the animation window has passed, the class releases -- and a
+      // further render over the same context must not re-add it.
+      act(() => { vi.advanceTimersByTime(450); });
+      page = container.querySelector('.dashboard-page');
+      expect(page.className).not.toContain('dashboard-appear');
+      rerender(
+        <SidePaneProvider>
+          <DashboardPage data={readyOverview} callbacks={{}} runMode={false} />
+        </SidePaneProvider>,
+      );
+      page = container.querySelector('.dashboard-page');
+      expect(page.className).not.toContain('dashboard-appear');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   // P6 fix: the appear latch's read AND write are gated on `!showOverviewSkeleton`
@@ -713,7 +734,11 @@ describe('DashboardPage frame stability and fade-once across branch transitions 
           <DashboardPage data={{ ...readyOverview, isFetching: true }} callbacks={{}} runMode={false} />
         </SidePaneProvider>,
       );
-      // Repeat render over the same context: no replay.
+      // Still inside the animation window: the hold keeps the fade running.
+      page = container.querySelector('.dashboard-page');
+      expect(page.className).toContain('dashboard-appear');
+      // After the window: released, and no replay over the same context.
+      act(() => { vi.advanceTimersByTime(450); });
       page = container.querySelector('.dashboard-page');
       expect(page.className).not.toContain('dashboard-appear');
     } finally {
@@ -764,56 +789,68 @@ describe('DashboardPage frame stability and fade-once across branch transitions 
       error: null,
       availableRuns: [],
     };
-    const { container, rerender, getByText, queryByText } = render(
-      <SidePaneProvider>
-        <DashboardPage data={baseNoRuns} callbacks={{}} runMode={false} />
-      </SidePaneProvider>,
-    );
-    expect(getByText('No evaluations yet')).toBeTruthy();
-    let page = container.querySelector('.dashboard-page');
-    expect(page.className).toContain('dashboard-appear');
+    vi.useFakeTimers();
+    try {
+      const { container, rerender, getByText, queryByText } = render(
+        <SidePaneProvider>
+          <DashboardPage data={baseNoRuns} callbacks={{}} runMode={false} />
+        </SidePaneProvider>,
+      );
+      expect(getByText('No evaluations yet')).toBeTruthy();
+      let page = container.querySelector('.dashboard-page');
+      expect(page.className).toContain('dashboard-appear');
+      act(() => { vi.advanceTimersByTime(450); });
 
-    rerender(
-      <SidePaneProvider>
-        <DashboardPage data={{ ...readyOverview, selectedProject: 'p1', selectedSource: 'local' }} callbacks={{}} runMode={false} />
-      </SidePaneProvider>,
-    );
-    expect(queryByText('No evaluations yet')).toBeNull();
-    page = container.querySelector('.dashboard-page');
-    expect(page.className).toContain('dashboard-ready');
-    expect(page.className).not.toContain('dashboard-appear');
+      rerender(
+        <SidePaneProvider>
+          <DashboardPage data={{ ...readyOverview, selectedProject: 'p1', selectedSource: 'local' }} callbacks={{}} runMode={false} />
+        </SidePaneProvider>,
+      );
+      expect(queryByText('No evaluations yet')).toBeNull();
+      page = container.querySelector('.dashboard-page');
+      expect(page.className).toContain('dashboard-ready');
+      expect(page.className).not.toContain('dashboard-appear');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('re-arms dashboard-appear on a project switch (a new context gets its own fade)', () => {
-    const { container, rerender } = render(
-      <SidePaneProvider>
-        <DashboardPage data={readyOverview} callbacks={{}} runMode={false} />
-      </SidePaneProvider>,
-    );
-    let page = container.querySelector('.dashboard-page');
-    expect(page.className).toContain('dashboard-appear');
+    vi.useFakeTimers();
+    try {
+      const { container, rerender } = render(
+        <SidePaneProvider>
+          <DashboardPage data={readyOverview} callbacks={{}} runMode={false} />
+        </SidePaneProvider>,
+      );
+      let page = container.querySelector('.dashboard-page');
+      expect(page.className).toContain('dashboard-appear');
+      act(() => { vi.advanceTimersByTime(450); });
 
-    rerender(
-      <SidePaneProvider>
-        <DashboardPage data={{ ...readyOverview, isFetching: true }} callbacks={{}} runMode={false} />
-      </SidePaneProvider>,
-    );
-    page = container.querySelector('.dashboard-page');
-    expect(page.className).not.toContain('dashboard-appear');
+      rerender(
+        <SidePaneProvider>
+          <DashboardPage data={{ ...readyOverview, isFetching: true }} callbacks={{}} runMode={false} />
+        </SidePaneProvider>,
+      );
+      page = container.querySelector('.dashboard-page');
+      expect(page.className).not.toContain('dashboard-appear');
 
-    const project2 = {
-      ...readyOverview,
-      selectedProject: 'p2',
-      projects: [{ id: 'p2', name: 'p2' }],
-      dashboard: { ...readyOverview.dashboard, selectedRun: { runId: 'r2', dateLabel: '2026-06-01' } },
-    };
-    rerender(
-      <SidePaneProvider>
-        <DashboardPage data={project2} callbacks={{}} runMode={false} />
-      </SidePaneProvider>,
-    );
-    page = container.querySelector('.dashboard-page');
-    expect(page.className).toContain('dashboard-appear');
+      const project2 = {
+        ...readyOverview,
+        selectedProject: 'p2',
+        projects: [{ id: 'p2', name: 'p2' }],
+        dashboard: { ...readyOverview.dashboard, selectedRun: { runId: 'r2', dateLabel: '2026-06-01' } },
+      };
+      rerender(
+        <SidePaneProvider>
+          <DashboardPage data={project2} callbacks={{}} runMode={false} />
+        </SidePaneProvider>,
+      );
+      page = container.querySelector('.dashboard-page');
+      expect(page.className).toContain('dashboard-appear');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('re-arms dashboard-appear on a run switch in run-detail, but not on a repeat render of the same run', () => {
@@ -835,31 +872,37 @@ describe('DashboardPage frame stability and fade-once across branch transitions 
       availableRuns: [{ runId, status: 'complete' }],
     });
 
-    const { container, rerender } = render(
-      <SidePaneProvider>
-        <DashboardPage data={readyRun('r1')} callbacks={{}} runMode={true} />
-      </SidePaneProvider>,
-    );
-    let page = container.querySelector('.dashboard-page');
-    expect(page.className).toContain('dashboard-appear');
+    vi.useFakeTimers();
+    try {
+      const { container, rerender } = render(
+        <SidePaneProvider>
+          <DashboardPage data={readyRun('r1')} callbacks={{}} runMode={true} />
+        </SidePaneProvider>,
+      );
+      let page = container.querySelector('.dashboard-page');
+      expect(page.className).toContain('dashboard-appear');
+      act(() => { vi.advanceTimersByTime(450); });
 
-    // Same run re-rendered (e.g. an unrelated prop changing): must not replay.
-    rerender(
-      <SidePaneProvider>
-        <DashboardPage data={{ ...readyRun('r1'), isFetching: true }} callbacks={{}} runMode={true} />
-      </SidePaneProvider>,
-    );
-    page = container.querySelector('.dashboard-page');
-    expect(page.className).not.toContain('dashboard-appear');
+      // Same run re-rendered (e.g. an unrelated prop changing): must not replay.
+      rerender(
+        <SidePaneProvider>
+          <DashboardPage data={{ ...readyRun('r1'), isFetching: true }} callbacks={{}} runMode={true} />
+        </SidePaneProvider>,
+      );
+      page = container.querySelector('.dashboard-page');
+      expect(page.className).not.toContain('dashboard-appear');
 
-    // Switching to a different run in run-detail is a legitimate new context.
-    rerender(
-      <SidePaneProvider>
-        <DashboardPage data={readyRun('r2')} callbacks={{}} runMode={true} />
-      </SidePaneProvider>,
-    );
-    page = container.querySelector('.dashboard-page');
-    expect(page.className).toContain('dashboard-appear');
+      // Switching to a different run in run-detail is a legitimate new context.
+      rerender(
+        <SidePaneProvider>
+          <DashboardPage data={readyRun('r2')} callbacks={{}} runMode={true} />
+        </SidePaneProvider>,
+      );
+      page = container.querySelector('.dashboard-page');
+      expect(page.className).toContain('dashboard-appear');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/quodeq/ui/src/features/dashboard/components/OverviewSkeleton.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/OverviewSkeleton.jsx
@@ -1,8 +1,10 @@
 import { TermHeader, StatStrip, SectionLabel } from '../../../components/terminal/index.js';
 import { t } from '../../../strings/index.js';
+import RunHistoryPanelPlaceholder from './RunHistoryPanelPlaceholder.jsx';
 
-// Skeleton frame for the Overview's guaranteed content: the stat-strip hero
-// and the quality-dimensions grid. Rides the same classes the real
+// Skeleton frame for the Overview's full footprint: the stat-strip hero,
+// the score-history + dimensions-table row, the quality-dimensions grid,
+// and the offending-files table. Rides the same classes the real
 // AccumulatedHeroSection / AccumulatedDimensionsSection / DimensionGaugeCard
 // render (dashboard.css / terminal.css / dim-gauge-card.css) so the footprint
 // (card sizes, grid gaps, min-heights) matches exactly -- only the label/
@@ -21,10 +23,15 @@ import { t } from '../../../strings/index.js';
 
 const STAT_SLOTS = ['score', 'violations', 'compliance', 'ratio'];
 
-// Representative placeholder count -- the real grid's card count varies per
+// Representative placeholder counts -- the real grid's card count varies per
 // project (server-filtered by visible standards, see readVisibleStandardIds),
-// there is no fixed list to mirror here.
+// there is no fixed list to mirror here. Same idea for the score-history
+// chart (only mounted with >=2 days of trend) and the offending-files table
+// (only rendered when a project has offenders): both are the common case,
+// so the skeleton reserves them rather than let data arrival grow the page.
 const DIMENSION_CARD_COUNT = 6;
+const DIM_SCORE_ROW_COUNT = 6;
+const OFFENDING_FILE_ROW_COUNT = 5;
 
 function SkeletonStat({ slot }) {
   return (
@@ -61,6 +68,18 @@ function SkeletonDimensionCard({ index }) {
   );
 }
 
+function SkeletonDimScoreRow({ index }) {
+  return (
+    <div className="dim-score-row dim-score-row--terminal" data-skeleton-index={index}>
+      <span className="dim-score-label"><span className="overview-skeleton__bar overview-skeleton__bar--dim-label" /></span>
+      <span className="dim-score-spark"><span className="overview-skeleton__bar overview-skeleton__bar--spark" /></span>
+      <span className="dim-score-value"><span className="overview-skeleton__bar overview-skeleton__bar--dim-value" /></span>
+      <span className="dim-score-trend"><span className="overview-skeleton__bar overview-skeleton__bar--dim-trend" /></span>
+      <span className="dim-score-viol"><span className="overview-skeleton__bar overview-skeleton__bar--dim-viol" /></span>
+    </div>
+  );
+}
+
 /**
  * @param {object} props
  * @param {string} [props.projectName] The project being loaded, carried in
@@ -77,6 +96,17 @@ export default function OverviewSkeleton({ projectName }) {
           {STAT_SLOTS.map((slot) => <SkeletonStat key={slot} slot={slot} />)}
         </StatStrip>
       </section>
+      <div className="history-panels-row" aria-hidden="true">
+        <RunHistoryPanelPlaceholder />
+        <section className="dim-score-panel dim-score-panel--terminal panel">
+          <header className="dim-score-panel__header">{t('overview.dimensionsHeader')}</header>
+          <div className="dim-score-rows">
+            {Array.from({ length: DIM_SCORE_ROW_COUNT }, (_, index) => (
+              <SkeletonDimScoreRow key={index} index={index} />
+            ))}
+          </div>
+        </section>
+      </div>
       <section className="quality-dimensions" aria-hidden="true">
         <div className="quality-dimensions__head">
           <SectionLabel>{t('overview.qualityDimensionsLabel')}</SectionLabel>
@@ -88,6 +118,14 @@ export default function OverviewSkeleton({ projectName }) {
             ))}
           </div>
         </div>
+      </section>
+      <section className="qd-cards-panel offending-panel" aria-hidden="true">
+        <div className="qd-cards-panel__head">
+          <SectionLabel>{t('overview.violationsByFileLabel')}</SectionLabel>
+        </div>
+        {Array.from({ length: OFFENDING_FILE_ROW_COUNT }, (_, index) => (
+          <span key={index} className="overview-skeleton__bar overview-skeleton__file-row" />
+        ))}
       </section>
     </div>
   );

--- a/src/quodeq/ui/src/features/dashboard/components/OverviewSkeleton.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/OverviewSkeleton.test.jsx
@@ -62,4 +62,53 @@ describe('OverviewSkeleton', () => {
     const { getByText } = render(<OverviewSkeleton />);
     expect(getByText('loading…')).toBeTruthy();
   });
+
+  // The real overview renders a chart+dimensions row and (usually) an
+  // offending-files table below the gauge grid. The skeleton must reserve
+  // both, or data arrival grows the page under the user.
+  it('renders the history-panels row with both panel shells', () => {
+    const { container } = render(<OverviewSkeleton projectName="acme" />);
+    const row = container.querySelector('.history-panels-row');
+    expect(row).toBeTruthy();
+    expect(row.querySelector('.run-history-panel.run-history-panel--terminal.panel')).toBeTruthy();
+    expect(row.querySelector('.run-history-panel__chart-slot')).toBeTruthy();
+    expect(row.querySelector('.dim-score-panel.dim-score-panel--terminal.panel')).toBeTruthy();
+  });
+
+  it('places the history-panels row between the hero and the dimensions grid', () => {
+    const { container } = render(<OverviewSkeleton projectName="acme" />);
+    const children = Array.from(container.querySelector('.overview-skeleton').children);
+    const heroIdx = children.findIndex((el) => el.classList.contains('acc-eval-panel'));
+    const rowIdx = children.findIndex((el) => el.classList.contains('history-panels-row'));
+    const gridIdx = children.findIndex((el) => el.classList.contains('quality-dimensions'));
+    expect(heroIdx).toBeGreaterThanOrEqual(0);
+    expect(rowIdx).toBeGreaterThan(heroIdx);
+    expect(gridIdx).toBeGreaterThan(rowIdx);
+  });
+
+  it('renders 6 dimension-score placeholder rows carrying every slot the real row has', () => {
+    const { container } = render(<OverviewSkeleton />);
+    const rows = container.querySelectorAll('.dim-score-rows > .dim-score-row');
+    expect(rows.length).toBe(6);
+    ['label', 'spark', 'value', 'trend', 'viol'].forEach((slot) => {
+      expect(rows[0].querySelector(`.dim-score-${slot} .overview-skeleton__bar`)).toBeTruthy();
+    });
+  });
+
+  it('renders an offending-files placeholder section after the dimensions grid', () => {
+    const { container } = render(<OverviewSkeleton />);
+    const panel = container.querySelector('.qd-cards-panel.offending-panel');
+    expect(panel).toBeTruthy();
+    expect(panel).toHaveAttribute('aria-hidden', 'true');
+    expect(panel.querySelectorAll('.overview-skeleton__file-row').length).toBeGreaterThan(2);
+    const children = Array.from(container.querySelector('.overview-skeleton').children);
+    const gridIdx = children.findIndex((el) => el.classList.contains('quality-dimensions'));
+    const offIdx = children.findIndex((el) => el.classList.contains('offending-panel'));
+    expect(offIdx).toBeGreaterThan(gridIdx);
+  });
+
+  it('marks the new sections aria-hidden', () => {
+    const { container } = render(<OverviewSkeleton />);
+    expect(container.querySelector('.history-panels-row')).toHaveAttribute('aria-hidden', 'true');
+  });
 });

--- a/src/quodeq/ui/src/features/explorer/components/CardListSkeleton.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/CardListSkeleton.jsx
@@ -1,0 +1,21 @@
+// Fallback for DeferredMount on the detail pages' card lists. The inline
+// LoadingScreen it replaces is position:absolute and reserves zero height,
+// so the page jumped from shell-only to full list height when the
+// VirtualList mounted (and the spinner overlaid the page from the top of
+// main.dashboard, not the list slot). These bars stand in the list's slot
+// with a card-like footprint instead: one 36px section-header row plus
+// 160px card rows, matching the pages' estimateItemSize. House skeleton
+// idiom: static dimmed blocks, no shimmer, no spinner.
+
+const DEFAULT_ROW_COUNT = 4;
+
+export default function CardListSkeleton({ rows = DEFAULT_ROW_COUNT }) {
+  return (
+    <div className="card-list-skeleton" aria-busy="true" aria-hidden="true">
+      <span className="card-list-skeleton__bar card-list-skeleton__bar--header" />
+      {Array.from({ length: rows }, (_, index) => (
+        <span key={index} className="card-list-skeleton__bar card-list-skeleton__bar--card" />
+      ))}
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/explorer/components/CardListSkeleton.test.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/CardListSkeleton.test.jsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import CardListSkeleton from './CardListSkeleton.jsx';
+
+// DeferredMount's fallback used to be an absolutely-positioned inline
+// spinner that reserved zero height: the page jumped from shell-only to
+// full list height when the VirtualList mounted. This skeleton stands in
+// for the card list itself, so the fallback commit already has a list-like
+// footprint below the header and pills.
+describe('CardListSkeleton', () => {
+  it('renders a section-header bar and 4 card bars by default', () => {
+    const { container } = render(<CardListSkeleton />);
+    expect(container.querySelectorAll('.card-list-skeleton__bar--header').length).toBe(1);
+    expect(container.querySelectorAll('.card-list-skeleton__bar--card').length).toBe(4);
+  });
+
+  it('honors a custom row count', () => {
+    const { container } = render(<CardListSkeleton rows={2} />);
+    expect(container.querySelectorAll('.card-list-skeleton__bar--card').length).toBe(2);
+  });
+
+  it('is quiet: aria-busy container, aria-hidden visuals, no spinner', () => {
+    const { container } = render(<CardListSkeleton />);
+    const root = container.querySelector('.card-list-skeleton');
+    expect(root).toHaveAttribute('aria-busy', 'true');
+    expect(root).toHaveAttribute('aria-hidden', 'true');
+    expect(container.querySelector('.loading-screen')).toBeFalsy();
+  });
+});

--- a/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
@@ -13,7 +13,7 @@ import { useRegisterWindowSpec, ReportContent, useSidePane, violationFixPlanSpec
 import { isLowConfidence } from '../../violations/components/LowConfidenceGroup.jsx';
 import VirtualList, { useDashboardScrollElement } from './VirtualList.jsx';
 import DeferredMount from './DeferredMount.jsx';
-import LoadingScreen from '../../../components/LoadingScreen.jsx';
+import CardListSkeleton from './CardListSkeleton.jsx';
 import { t } from '../../../strings/index.js';
 import { severityLabel, scopeGateRuleLabel } from '../../../strings/labels.js';
 
@@ -360,7 +360,7 @@ const FileDetailPage = memo(function FileDetailPage({ file, runId, dateLabel, on
       {/* Same two-commit split as PrincipleDetailPage: this page is param-fed
           (no fetch), so the first paint would otherwise wait for the visible
           cards' pretext layout effects. */}
-      <DeferredMount fallback={<LoadingScreen variant="inline" />}>
+      <DeferredMount fallback={<CardListSkeleton />}>
         <VirtualList
           key={virtualKey}
           items={items}

--- a/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -10,7 +10,7 @@ import { useStandardDescriptions } from '../hooks/useStandardDescriptions.js';
 import { usePrincipleData } from './explorerDataHooks.js';
 import VirtualList, { useDashboardScrollElement } from './VirtualList.jsx';
 import DeferredMount from './DeferredMount.jsx';
-import LoadingScreen from '../../../components/LoadingScreen.jsx';
+import CardListSkeleton from './CardListSkeleton.jsx';
 import { t } from '../../../strings/index.js';
 
 function filterTitleSuffix(filter) {
@@ -289,7 +289,7 @@ const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, s
           without this split the first paint waits for every visible card's
           pretext layout effect and the click that navigated here looks
           ignored. Header first, cards one commit later. */}
-      <DeferredMount fallback={<LoadingScreen variant="inline" />}>
+      <DeferredMount fallback={<CardListSkeleton />}>
         <VirtualList
           key={virtualKey}
           items={items}

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -16,6 +16,7 @@ import { filterTrendByVisibleStandards } from '../../../utils/scoreFiltering.js'
 import { TermHeader } from '../../../components/terminal/index.js';
 import EmptyState from '../../../components/EmptyState.jsx';
 import LoadingScreen from '../../../components/LoadingScreen.jsx';
+import HistorySkeleton from './HistorySkeleton.jsx';
 import FittedText from '../../../components/FittedText.jsx';
 import SharedReadOnlyBadge from '../../../components/SharedReadOnlyBadge.jsx';
 import { abbrevDim } from '../utils/dimAbbrev.js';
@@ -518,7 +519,7 @@ export default function HistoryPage({ trend: rawTrend, selection, availableRuns,
     if (loading) {
       return (
         <HistoryEmptyShell sub={t('overview.loading')}>
-          <LoadingScreen variant="inline" />
+          <HistorySkeleton />
         </HistoryEmptyShell>
       );
     }
@@ -531,7 +532,7 @@ export default function HistoryPage({ trend: rawTrend, selection, availableRuns,
       if (isFetching) {
         return (
           <HistoryEmptyShell sub={t('overview.loading')}>
-            <LoadingScreen variant="inline" />
+            <HistorySkeleton />
           </HistoryEmptyShell>
         );
       }

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.test.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.test.jsx
@@ -171,14 +171,14 @@ describe('HistoryPage — scenario 9: loader gate, containment, refresh dim', ()
     expect(screen.getByText('No completed evaluation yet')).toBeInTheDocument();
   });
 
-  it('initial load renders exactly one inline loader inside the page frame', () => {
+  it('initial load renders the history skeleton inside the page frame, no spinner', () => {
     renderHistoryPageWithData({ loading: true, isFetching: true });
-    expect(document.querySelectorAll('.loading-screen').length).toBe(1);
-    const loader = document.querySelector('.loading-screen--inline');
-    expect(loader).not.toBeNull();
+    expect(document.querySelector('.loading-screen')).toBeNull();
+    const skeleton = document.querySelector('.history-skeleton');
+    expect(skeleton).not.toBeNull();
     const frame = document.querySelector('.history-page--terminal');
     expect(frame).not.toBeNull();
-    expect(frame.contains(loader)).toBe(true);
+    expect(frame.contains(skeleton)).toBe(true);
   });
 
   it('applies the refresh dim class to the empty state during a background refetch', () => {
@@ -207,13 +207,14 @@ describe('HistoryPage — error state + retry feedback (P4-T2)', () => {
     expect(onRetry).toHaveBeenCalled();
   });
 
-  it('error + isFetching renders the inline loader instead of the error state', () => {
+  it('error + isFetching renders the skeleton instead of the error state', () => {
     renderHistoryPageWithData({
       selectedSource: 'local', selectedProject: 'p1', projects: [{ id: 'p1', name: 'p1' }],
       error: 'Failed to load', isFetching: true,
     });
     expect(screen.queryByText("Couldn't load this project")).toBeNull();
-    expect(document.querySelector('.loading-screen')).toBeTruthy();
+    expect(document.querySelector('.history-skeleton')).toBeTruthy();
+    expect(document.querySelector('.loading-screen')).toBeNull();
   });
 
   it('data present with a stale error still renders the data, not the error screen', () => {

--- a/src/quodeq/ui/src/features/history/components/HistorySkeleton.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistorySkeleton.jsx
@@ -1,0 +1,24 @@
+import HistoryChartPanelPlaceholder from './HistoryChartPanelPlaceholder.jsx';
+
+// Footprint stand-in for the loaded history page while the trend data is
+// loading (and while an error-retry is in flight). Reuses the chart chunk's
+// Suspense placeholder for the chart half — same shell, same reserved
+// height — and adds dense rows for the evaluations table below. The
+// floating inline spinner it replaces reserved no height, so both sections
+// popped in when data landed. House skeleton idiom: static dimmed blocks,
+// no shimmer, no spinner.
+
+const TABLE_ROW_COUNT = 6;
+
+export default function HistorySkeleton() {
+  return (
+    <div className="history-skeleton" aria-busy="true" aria-hidden="true">
+      <HistoryChartPanelPlaceholder />
+      <div className="history-skeleton__table">
+        {Array.from({ length: TABLE_ROW_COUNT }, (_, index) => (
+          <span key={index} className="history-skeleton__row" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/history/components/HistorySkeleton.test.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistorySkeleton.test.jsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import HistorySkeleton from './HistorySkeleton.jsx';
+
+// Footprint stand-in for the loaded history page: the chart panel (reusing
+// the existing HistoryChartPanelPlaceholder shell) plus evaluations-table
+// rows. Replaces the floating inline spinner so the chart and table swap
+// in place instead of popping in below the header.
+describe('HistorySkeleton', () => {
+  it('reserves the chart panel with the real shell classes', () => {
+    const { container } = render(<HistorySkeleton />);
+    expect(container.querySelector('.run-history-panel.run-history-panel--terminal.panel')).toBeTruthy();
+    expect(container.querySelector('[data-testid="history-chart-panel-placeholder"]')).toBeTruthy();
+  });
+
+  it('renders evaluations-table placeholder rows below the chart', () => {
+    const { container } = render(<HistorySkeleton />);
+    expect(container.querySelectorAll('.history-skeleton__row').length).toBe(6);
+  });
+
+  it('is quiet: aria-busy container, aria-hidden, no spinner', () => {
+    const { container } = render(<HistorySkeleton />);
+    const root = container.querySelector('.history-skeleton');
+    expect(root).toHaveAttribute('aria-busy', 'true');
+    expect(root).toHaveAttribute('aria-hidden', 'true');
+    expect(container.querySelector('.loading-screen')).toBeFalsy();
+  });
+});

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -8,6 +8,7 @@ import { TermHeader, SevBadge, FlagPill } from '../../../components/terminal/ind
 import { useDismissedFindings } from './useDismissedFindings.js';
 import EmptyState from '../../../components/EmptyState.jsx';
 import LoadingScreen from '../../../components/LoadingScreen.jsx';
+import ViolationsSkeleton from './ViolationsSkeleton.jsx';
 import SharedReadOnlyBadge from '../../../components/SharedReadOnlyBadge.jsx';
 import { t } from '../../../strings/index.js';
 
@@ -278,7 +279,7 @@ export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 
       return (
         <div className="violations-page violations-page--terminal">
           <TermHeader name={t('violations.termName')} sub={t('overview.loading')} />
-          <LoadingScreen variant="inline" />
+          <ViolationsSkeleton />
         </div>
       );
     }
@@ -292,7 +293,7 @@ export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 
         return (
           <div className="violations-page violations-page--terminal">
             <TermHeader name={t('violations.termName')} sub={t('overview.loading')} />
-            <LoadingScreen variant="inline" />
+            <ViolationsSkeleton />
           </div>
         );
       }

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.test.jsx
@@ -164,14 +164,14 @@ describe('ViolationsPage — scenario 9: loader gate, containment, refresh dim',
     expect(screen.getByText('No completed evaluation yet')).toBeInTheDocument();
   });
 
-  it('initial load renders exactly one inline loader inside the page frame', () => {
+  it('initial load renders the violations skeleton inside the page frame, no spinner', () => {
     const { container } = renderPage(baseData({ loading: true, isFetching: true }));
-    expect(container.querySelectorAll('.loading-screen').length).toBe(1);
-    const loader = container.querySelector('.loading-screen--inline');
-    expect(loader).not.toBeNull();
+    expect(container.querySelector('.loading-screen')).toBeNull();
+    const skeleton = container.querySelector('.violations-skeleton');
+    expect(skeleton).not.toBeNull();
     const frame = container.querySelector('.violations-page--terminal');
     expect(frame).not.toBeNull();
-    expect(frame.contains(loader)).toBe(true);
+    expect(frame.contains(skeleton)).toBe(true);
   });
 
   it('applies the refresh dim class to the empty state during a background refetch', () => {
@@ -200,12 +200,13 @@ describe('ViolationsPage — error state + retry feedback (P4-T2)', () => {
     expect(onRetry).toHaveBeenCalled();
   });
 
-  it('error + isFetching renders the inline loader instead of the error state', () => {
+  it('error + isFetching renders the skeleton instead of the error state', () => {
     const { container } = renderPage(
       baseData({ selectedSource: 'local', selectedProject: 'p1', projects: [{ id: 'p1', name: 'p1' }], error: 'Failed to load', isFetching: true }),
     );
     expect(screen.queryByText("Couldn't load this project")).toBeNull();
-    expect(container.querySelector('.loading-screen')).toBeTruthy();
+    expect(container.querySelector('.violations-skeleton')).toBeTruthy();
+    expect(container.querySelector('.loading-screen')).toBeNull();
   });
 
   it('data present with a stale error still renders the data, not the error screen', () => {

--- a/src/quodeq/ui/src/features/violations/components/ViolationsSkeleton.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsSkeleton.jsx
@@ -1,0 +1,30 @@
+// Footprint stand-in for the loaded violations page, shown while the
+// dimension data is loading (and while an error-retry is in flight). The
+// floating inline spinner it replaces reserved no height, so the sub-tab
+// pills and dimension groups popped in below the header when data landed.
+// Rides the real .violations-flag-row for the pill row's spacing; the
+// groups are representative (3 groups of a header + two card rows) since
+// the real dimension count varies per project. House skeleton idiom:
+// static dimmed blocks, no shimmer, no spinner.
+
+const GROUP_COUNT = 3;
+const PILL_COUNT = 3;
+
+export default function ViolationsSkeleton() {
+  return (
+    <div className="violations-skeleton" aria-busy="true" aria-hidden="true">
+      <div className="violations-flag-row">
+        {Array.from({ length: PILL_COUNT }, (_, index) => (
+          <span key={index} className="violations-skeleton__bar violations-skeleton__pill" />
+        ))}
+      </div>
+      {Array.from({ length: GROUP_COUNT }, (_, index) => (
+        <div key={index} className="violations-skeleton__group">
+          <span className="violations-skeleton__bar violations-skeleton__bar--group-header" />
+          <span className="violations-skeleton__bar violations-skeleton__bar--card" />
+          <span className="violations-skeleton__bar violations-skeleton__bar--card" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/violations/components/ViolationsSkeleton.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsSkeleton.test.jsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import ViolationsSkeleton from './ViolationsSkeleton.jsx';
+
+// Footprint stand-in for the loaded violations page: the flag-pill row and
+// the by-dimension groups. Replaces the floating inline spinner so data
+// arrival swaps content in place instead of growing the page.
+describe('ViolationsSkeleton', () => {
+  it('renders the flag-pill row with 3 pill placeholders', () => {
+    const { container } = render(<ViolationsSkeleton />);
+    const row = container.querySelector('.violations-flag-row');
+    expect(row).toBeTruthy();
+    expect(row.querySelectorAll('.violations-skeleton__pill').length).toBe(3);
+  });
+
+  it('renders dimension group placeholders, each with a header and card bars', () => {
+    const { container } = render(<ViolationsSkeleton />);
+    const groups = container.querySelectorAll('.violations-skeleton__group');
+    expect(groups.length).toBe(3);
+    groups.forEach((group) => {
+      expect(group.querySelector('.violations-skeleton__bar--group-header')).toBeTruthy();
+      expect(group.querySelectorAll('.violations-skeleton__bar--card').length).toBe(2);
+    });
+  });
+
+  it('is quiet: aria-busy container, aria-hidden, no spinner', () => {
+    const { container } = render(<ViolationsSkeleton />);
+    const root = container.querySelector('.violations-skeleton');
+    expect(root).toHaveAttribute('aria-busy', 'true');
+    expect(root).toHaveAttribute('aria-hidden', 'true');
+    expect(container.querySelector('.loading-screen')).toBeFalsy();
+  });
+});

--- a/src/quodeq/ui/src/hooks/useLinger.js
+++ b/src/quodeq/ui/src/hooks/useLinger.js
@@ -1,0 +1,21 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Return true while *value* is true, and keep returning true for *delayMs*
+ * after it drops, then settle false. Used to hold the startup loader
+ * opaque for a beat after its data-hold releases: the overview beneath
+ * needs one more commit (the lazy chart's first render) before the fade
+ * starts, or the fade reveals a placeholder inside otherwise-real content.
+ * One-way by design: a value that flips back to true during the linger is
+ * ignored (the caller gates re-arms separately, see useOneShotGate).
+ */
+export function useLinger(value, delayMs) {
+  const [lingering, setLingering] = useState(value);
+  const startedRef = useRef(value);
+  useEffect(() => {
+    if (!startedRef.current || value) return undefined;
+    const id = setTimeout(() => setLingering(false), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+  return startedRef.current && (value || lingering);
+}

--- a/src/quodeq/ui/src/hooks/useLinger.test.jsx
+++ b/src/quodeq/ui/src/hooks/useLinger.test.jsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useLinger } from './useLinger.js';
+
+// The startup loader fades the instant its hold drops, but the page
+// beneath needs a beat to finish committing (the recharts chart's first
+// render measured ~200ms) — without a linger the fade reveals a chart-slot
+// placeholder inside otherwise-real content. useLinger keeps the loader
+// opaque for a fixed beat after the drop so the fade reveals a finished page.
+describe('useLinger', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('passes true through immediately', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(({ v }) => useLinger(v, 250), { initialProps: { v: true } });
+    expect(result.current).toBe(true);
+  });
+
+  it('keeps returning true for the linger window after the value drops', () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(({ v }) => useLinger(v, 250), { initialProps: { v: true } });
+    rerender({ v: false });
+    expect(result.current).toBe(true);
+    act(() => { vi.advanceTimersByTime(200); });
+    expect(result.current).toBe(true);
+    act(() => { vi.advanceTimersByTime(100); });
+    expect(result.current).toBe(false);
+  });
+
+  it('starting false never lingers', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(({ v }) => useLinger(v, 250), { initialProps: { v: false } });
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/quodeq/ui/src/hooks/useOneShotGate.js
+++ b/src/quodeq/ui/src/hooks/useOneShotGate.js
@@ -1,0 +1,21 @@
+import { useRef } from 'react';
+
+/**
+ * Pass `active` through until the first render where it is false, then
+ * return false forever. Used to scope the startup loader to boot: the hold
+ * predicate describes a *state* ("overview data not in yet"), and a
+ * mid-session project switch re-enters that state — without the gate the
+ * fullscreen loader would flash over the app on every switch (e.g. opening
+ * a project from Compare). Ref-latched during render on purpose: the latch
+ * must be consumed in the same render that drops the value, or a
+ * same-batch re-entry could re-arm it before an effect ran.
+ */
+export function useOneShotGate(active) {
+  const consumedRef = useRef(false);
+  if (consumedRef.current) return false;
+  if (!active) {
+    consumedRef.current = true;
+    return false;
+  }
+  return true;
+}

--- a/src/quodeq/ui/src/hooks/useOneShotGate.test.jsx
+++ b/src/quodeq/ui/src/hooks/useOneShotGate.test.jsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useOneShotGate } from './useOneShotGate.js';
+
+// The startup loader must be a boot-scoped one-shot: once it has dropped,
+// it may never re-arm. Without the gate, a mid-session project switch to a
+// not-yet-loaded overview (opening a project from Compare) re-satisfies
+// the hold predicate and flashes the fullscreen loader over the app.
+describe('useOneShotGate', () => {
+  it('passes the active value through while it has never dropped', () => {
+    const { result, rerender } = renderHook(({ active }) => useOneShotGate(active), {
+      initialProps: { active: true },
+    });
+    expect(result.current).toBe(true);
+    rerender({ active: true });
+    expect(result.current).toBe(true);
+  });
+
+  it('latches off permanently after the first inactive render', () => {
+    const { result, rerender } = renderHook(({ active }) => useOneShotGate(active), {
+      initialProps: { active: true },
+    });
+    rerender({ active: false });
+    expect(result.current).toBe(false);
+    rerender({ active: true });
+    expect(result.current).toBe(false);
+  });
+
+  it('starting inactive consumes the gate immediately', () => {
+    const { result, rerender } = renderHook(({ active }) => useOneShotGate(active), {
+      initialProps: { active: false },
+    });
+    expect(result.current).toBe(false);
+    rerender({ active: true });
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/quodeq/ui/src/strings/en.json
+++ b/src/quodeq/ui/src/strings/en.json
@@ -210,7 +210,6 @@
   "compare.levelSevere": "severe",
   "compare.levelWatch": "watch",
   "compare.loadFailed": "failed to load scores",
-  "compare.loading": "Loading projects…",
   "compare.needTwo": "needs two scored projects",
   "compare.noEvalsCollapsed": "{count} projects without evaluations",
   "compare.noRuns": "no evaluations yet",

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1898,6 +1898,15 @@ textarea:focus {
   animation: loading-fadein 500ms ease;
 }
 
+/* Opaque ground for the fullscreen loader: the startup hold (App.jsx
+   linger) keeps it up while real content commits BENEATH it, so without a
+   background the logo floats over the half-built page it exists to cover.
+   Fullscreen only -- the inline variant overlays already-rendered pages by
+   design and must stay transparent. */
+.loading-screen:not(.loading-screen--inline) {
+  background: var(--color-bg);
+}
+
 /* Contained variant for loaders mounted within an already-rendered page (see
    LoadingScreen.jsx's `variant` prop). Scoped to the nearest positioned
    ancestor -- `main.dashboard` -- instead of the viewport, so it never covers

--- a/src/quodeq/ui/src/styles/compare.css
+++ b/src/quodeq/ui/src/styles/compare.css
@@ -11,11 +11,22 @@
    strip's own bottom margin stacks on top of the gap. */
 .compare-page .term-stat-strip { margin-bottom: 0; }
 
-.compare-loading {
-  padding: 40px 0;
-  color: var(--color-text-muted);
-  font-size: 13px;
+/* Pre-projectsLoaded fleet-table stand-in (CompareSkeleton.jsx). Same
+   idiom as dashboard.css .overview-skeleton: static dimmed blocks. */
+.compare-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: 24px 0;
 }
+.compare-skeleton__bar {
+  display: block;
+  border-radius: 4px;
+  background: var(--color-surface-alt);
+  opacity: 0.6;
+}
+.compare-skeleton__bar--header { width: 35%; height: 20px; }
+.compare-skeleton__bar--row { width: 100%; height: 44px; }
 
 /* ── header ─────────────────────────────────────────────────────────── */
 

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -1962,11 +1962,28 @@
 .overview-skeleton__bar--gauge { width: 100px; height: 100px; border-radius: 50%; }
 .overview-skeleton__bar--meta { width: 50%; height: 8px; }
 .overview-skeleton__bar--sev { width: 40%; height: 12px; }
+/* Dimension-score table row slots. The spans they sit in carry the real
+   flex sizing (dashboard.css .dim-score-*), so the bars only need to fill
+   the text's height: rows stay the real ~28px (6px padding + content). */
+.overview-skeleton__bar--dim-label { width: 70%; height: 10px; }
+.overview-skeleton__bar--spark { width: 100%; height: 14px; }
+.overview-skeleton__bar--dim-value { width: 100%; height: 12px; }
+.overview-skeleton__bar--dim-trend { width: 100%; height: 10px; }
+.overview-skeleton__bar--dim-viol { width: 60%; height: 10px; }
+/* Offending-files placeholder rows: full-width dense-table rows. 25px
+   matches the real GridTable dense row (content + padding + row border). */
+.overview-skeleton__file-row {
+  display: block;
+  width: 100%;
+  height: 25px;
+  margin-top: 4px;
+}
 
-/* The real .dim-gauge-card is cursor:pointer + hover/focus affordances
-   (dim-gauge-card.css) -- this card isn't clickable, so neutralize both
-   rather than let a placeholder look interactive. */
-.overview-skeleton .dim-gauge-card {
+/* The real .dim-gauge-card and .dim-score-row are cursor:pointer + hover
+   affordances (dim-gauge-card.css, dashboard.css) -- the placeholders are
+   not clickable, so neutralize both rather than let them look interactive. */
+.overview-skeleton .dim-gauge-card,
+.overview-skeleton .dim-score-row {
   cursor: default;
   pointer-events: none;
 }

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -3240,3 +3240,21 @@
 }
 .violations-skeleton__bar--group-header { width: 30%; height: 20px; }
 .violations-skeleton__bar--card { width: 100%; height: 72px; }
+
+/* ── History loading skeleton ───────────────────────────
+   Chart shell (HistoryChartPanelPlaceholder) + dense evaluations-table
+   rows while the trend data loads. Same idiom as .overview-skeleton. */
+.history-skeleton__table {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: var(--space-6);
+}
+.history-skeleton__row {
+  display: block;
+  width: 100%;
+  height: 25px;
+  border-radius: 4px;
+  background: var(--color-surface-alt);
+  opacity: 0.6;
+}

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -3218,3 +3218,25 @@
 .incomplete-setup-card p {
   margin: 0 0 8px 0;
 }
+
+/* ── Violations loading skeleton ────────────────────────
+   Stand-in for the loaded violations page (flag pills + by-dimension
+   groups) while dimension data loads. Same idiom as .overview-skeleton:
+   static dimmed blocks, no shimmer. */
+.violations-skeleton__bar {
+  display: inline-block;
+  border-radius: 4px;
+  background: var(--color-surface-alt);
+  opacity: 0.6;
+}
+/* Pill row rides the real .violations-flag-row spacing; pills approximate
+   the FlagPill footprint. */
+.violations-skeleton__pill { width: 110px; height: 24px; border-radius: 12px; }
+.violations-skeleton__group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-top: var(--space-6);
+}
+.violations-skeleton__bar--group-header { width: 30%; height: 20px; }
+.violations-skeleton__bar--card { width: 100%; height: 72px; }

--- a/src/quodeq/ui/src/styles/explorer.css
+++ b/src/quodeq/ui/src/styles/explorer.css
@@ -720,3 +720,25 @@
 .violation-table-row--clickable:hover {
   background: var(--color-surface-alt);
 }
+
+/* ── Detail-page card-list skeleton ─────────────────────
+   DeferredMount fallback for the file/principle detail lists. Static
+   dimmed blocks (house idiom, see dashboard.css .overview-skeleton__bar):
+   36px header row + 160px card rows, mirroring the pages'
+   estimateItemSize so the fallback commit and the mounted VirtualList
+   occupy the same slot at the same scale. */
+.card-list-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+.card-list-skeleton__bar {
+  display: block;
+  width: 100%;
+  border-radius: 4px;
+  background: var(--color-surface-alt);
+  opacity: 0.6;
+}
+.card-list-skeleton__bar--header { height: 36px; width: 40%; }
+.card-list-skeleton__bar--card { height: 160px; }

--- a/src/quodeq/ui/tools/loading_screen_rules.test.mjs
+++ b/src/quodeq/ui/tools/loading_screen_rules.test.mjs
@@ -1,0 +1,31 @@
+// The startup hold (App.jsx linger) keeps the fullscreen loader up while
+// real content commits beneath it. Without an opaque background the logo
+// floats over the half-built page it exists to cover — invisible in the
+// old flow, where the page beneath was empty until the loader dropped.
+// The inline variant overlays already-rendered pages by design and must
+// stay transparent.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const css = readFileSync(new URL('../src/styles/base.css', import.meta.url), 'utf8');
+
+function rulesFor(selectorRe) {
+  return css.match(new RegExp(`${selectorRe}\\s*\\{[^}]*\\}`, 'g')) || [];
+}
+
+test('fullscreen loading screen declares the opaque page background', () => {
+  const rules = rulesFor(String.raw`\.loading-screen:not\(\.loading-screen--inline\)`);
+  assert.ok(
+    rules.some((rule) => /background:\s*var\(--color-bg\)/.test(rule)),
+    'expected a .loading-screen:not(.loading-screen--inline) rule with background: var(--color-bg)',
+  );
+});
+
+test('inline loading screen stays transparent', () => {
+  const rules = rulesFor(String.raw`\.loading-screen--inline`);
+  assert.ok(
+    rules.every((rule) => !/background/.test(rule)),
+    'the inline variant must not gain a background',
+  );
+});


### PR DESCRIPTION
Boot used to play up to four visual states: plain loader > tips loader > overview skeleton (overlapping the fading loader) > real content, and the skeleton grew a chart row, dimensions table, and offending-files table when data landed. Boot is now loader > content.

Startup:
- shouldShowStartupLoader (unit-tested predicate) keeps the app loader up until dashboard and accumulated are both in on the overview landing. It drops immediately on every dead end: load failure, zero projects, no selection, query error, or a non-overview tab (the auto-redirect flows). Long holds are fine, the loader is the screen with warmup progress and tips.
- FadingLoadingScreen moved outside the Suspense boundary. A lazy chunk's suspension used to unmount the loader itself and restart the fade and tips from zero (the loader-to-loader flash).
- The overview skeleton now only appears on mid-session project/source switches.

Accurate skeletons (house idiom, no shimmer, aria-busy):
- Overview: adds the missing history-panels row (chart shell + dimensions-table rows) and an offending-files block. No more page growth on data arrival.
- Violations and History: the floating inline spinner branches become footprint skeletons (pills + dimension groups; chart shell + table rows).
- Compare: the bare loading text line becomes a fleet-table skeleton. Progressive per-row loading is unchanged.
- File/Principle detail: DeferredMount's fallback was a zero-height absolute spinner (page jumped from shell to full list). CardListSkeleton reserves list-shaped height.

Transitions:
- dashboard-appear is held for the animation's 400ms, so an unrelated re-render (isFetching flipping right after content appears) no longer snaps opacity to 1 mid-fade.
- Drops a dead ProjectHeader import and the now-unused compare.loading string.

Tests: TDD throughout, 28 new. Full suites: 486 node + 1626 vitest, lint:strings clean, vite build clean.