### PR TITLE
Remote projects join the Compare fleet

### DIFF
--- a/src/quodeq/api/routes_shared.py
+++ b/src/quodeq/api/routes_shared.py
@@ -22,6 +22,7 @@ from quodeq.api.import_project import import_zip_stream
 from quodeq.api.zip import _build_project_zip
 from quodeq.core.types import to_camel_dict
 from quodeq.services import _fs_projects, _fs_reports
+from quodeq.services.compare import build_compare_summary
 from quodeq.services._runs_unit import build_runs_unit
 from quodeq.services.dismissed import load_dismissed
 from quodeq.services.score_cache import score_cache_path_override
@@ -470,6 +471,23 @@ def register_shared_routes(app: Flask) -> None:
         except Exception:
             _logger.exception("Unexpected error fetching shared scores for project %s", project)
             body, status = error_response("Failed to load scores", HTTPStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR")
+            return jsonify(body), status
+        if result is None:
+            body, status = error_response("Project not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+        return jsonify(result)
+
+    @app.get("/api/shared/projects/<project>/compare-summary")
+    @_with_shared_root
+    def shared_compare_summary(project: str, eval_root: Path, url: str):
+        err = _validate_segment(project)
+        if err:
+            return err
+        try:
+            result = build_compare_summary(eval_root, project)
+        except Exception:
+            _logger.exception("Unexpected error building shared compare summary for project %s", project)
+            body, status = error_response("Failed to load compare summary", HTTPStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR")
             return jsonify(body), status
         if result is None:
             body, status = error_response("Project not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -812,8 +812,10 @@ export const ROUTE_RENDERERS = {
       projects={props.navigation.projects}
       projectsLoaded={props.navigation.projectsLoaded}
       dimension={params.dimension || null}
-      onOpenProject={(id) => {
-        props.navigation.handleProjectChange(id, 'local');
+      onOpenProject={(id, source = 'local') => {
+        // Remote fleet rows open through the shared source; the same
+        // machinery the projects drawer uses for shared selections.
+        props.navigation.handleProjectChange(id, source);
         props.navigation.navTab('overview');
       }}
       // Drill-down is a real nav-stack entry: push from the fleet so the
@@ -1362,8 +1364,13 @@ export default function App() {
                 sharedProjectInfo: state.sharedProjectInfo,
               })}
               // Compare needs two analyzed projects to rank anything; below
-              // that the tab is redundant and stays hidden.
-              showCompareTab={state.projects.filter((p) => (p.runsCount ?? 0) > 0).length >= 2}
+              // that the tab is redundant and stays hidden. Remote projects
+              // from the shared repository count toward the pair: one local
+              // project plus published teammates is a comparable fleet.
+              showCompareTab={(() => {
+                const localWithRuns = state.projects.filter((p) => (p.runsCount ?? 0) > 0).length;
+                return localWithRuns >= 2 || (localWithRuns >= 1 && sharedSignal.hasContent);
+              })()}
               selectedSource={state.selectedSource}
               projectInfo={{
                 displayName: resolvedDisplayName,

--- a/src/quodeq/ui/src/api/shared.js
+++ b/src/quodeq/ui/src/api/shared.js
@@ -157,6 +157,17 @@ export async function sharedGetDashboard(projectId, run = 'latest') {
 }
 
 /**
+ * Slim compare-summary for a shared project — the /compare-summary payload
+ * served from the shared clone's own evaluations root, shape-identical to
+ * the local endpoint so the Compare tab can mix sources row by row.
+ * @param {string} projectId
+ * @returns {Promise<{project: string, summary: Object, dimensions: Array, trend: Array, runsCount: number, lastRun: Object|null}>}
+ */
+export function sharedGetCompareSummary(projectId) {
+  return request(`/shared/projects/${encodeURIComponent(projectId)}/compare-summary`);
+}
+
+/**
  * Get accumulated scores for a shared project.
  * @param {string} projectId
  * @param {string} [asOfRun=null]

--- a/src/quodeq/ui/src/features/compare/compareModel.js
+++ b/src/quodeq/ui/src/features/compare/compareModel.js
@@ -164,6 +164,12 @@ export function buildRow(project, summary, now) {
     .filter((d) => d.key);
   return {
     id,
+    // Remote (shared-repo) rows: `id` is the prefixed fleet-unique key, and
+    // `sourceId` is the raw project id every API call and source-switching
+    // navigation needs. Local rows keep sourceId === id.
+    source: project.source === 'shared' ? 'shared' : 'local',
+    sourceId: project.sourceId || id,
+    remote: project.source === 'shared',
     name: project.displayName || project.name || id,
     lang: topLanguage(project.languageStats),
     totalFiles,
@@ -460,6 +466,9 @@ export function buildDimensionView(dimensionKey, rows, now, summariesById) {
         score: p.score,
         // Everything a click needs to open THIS project's view of THIS
         // principle: the run the number came from and the raw spellings.
+        // Remote rows can't deep-link into local project pages; the click
+        // handler falls back to opening the shared project instead.
+        remote: s.row.remote ?? false,
         principle: p.name,
         runId: s.runId,
         dimName: s.dimName,

--- a/src/quodeq/ui/src/features/compare/components/CompareDimensionView.jsx
+++ b/src/quodeq/ui/src/features/compare/components/CompareDimensionView.jsx
@@ -170,8 +170,9 @@ export default function CompareDimensionView({
                   // In a dimension context, a project opens ITS view of the
                   // same dimension (cross-project explorer entry), not its
                   // overview. Falls back to the overview if the run target
-                  // is unknowable.
-                  onClick={() => (s.runId && onOpenProjectDimension
+                  // is unknowable — and for remote rows, whose detail pages
+                  // live behind the shared source, not local routes.
+                  onClick={() => (s.runId && onOpenProjectDimension && !s.row.remote
                     ? onOpenProjectDimension({ id: s.row.id, runId: s.runId, dimName: s.dimName, dateLabel: s.dateLabel })
                     : onOpenProject(s.row.id))}
                   onMouseEnter={() => setFocusId(s.row.id)}

--- a/src/quodeq/ui/src/features/compare/components/CompareDuelView.jsx
+++ b/src/quodeq/ui/src/features/compare/components/CompareDuelView.jsx
@@ -33,6 +33,7 @@ function VersusSide({ side, row, onOpenProject }) {
         title={t('compare.openProject')}
       >
         {row.name}
+        {row.remote && <span className="compare-row__remote">{t('compare.remoteTag')}</span>}
       </button>
       <div className="compare-versus__scoreRow">
         <span className={`compare-versus__score ${scoreColorClass(row.score)}`}>{score1(row.score)}</span>

--- a/src/quodeq/ui/src/features/compare/components/CompareFleetView.jsx
+++ b/src/quodeq/ui/src/features/compare/components/CompareFleetView.jsx
@@ -81,7 +81,10 @@ function ScopePicker({
                       checked={on}
                       onChange={() => toggleProject(row.id)}
                     />
-                    <span className="compare-picker__name">{row.name}</span>
+                    <span className="compare-picker__name">
+                      {row.name}
+                      {row.remote && <span className="compare-row__remote">{t('compare.remoteTag')}</span>}
+                    </span>
                     <span
                       className={`compare-picker__score ${scoreColorClass(row.score)}`}
                     >
@@ -140,7 +143,10 @@ function DuelTrigger({ row, targets, onPick }) {
               className="compare-dueltrigger__item"
               onClick={() => { setOpen(false); onPick(other.id); }}
             >
-              <span>{other.name}</span>
+              <span>
+                {other.name}
+                {other.remote && <span className="compare-row__remote">{t('compare.remoteTag')}</span>}
+              </span>
               <span className={`compare-dueltrigger__itemScore ${scoreColorClass(other.score)}`}>
                 {score1(other.score)}
               </span>
@@ -236,6 +242,7 @@ function ProjectRow({ row, rank, expanded, onToggle, onOpenProject, openDimensio
         <span className="compare-row__project">
           <span className="compare-row__name">{row.name}</span>
           {row.lang && <span className="compare-row__meta">{row.lang}</span>}
+          {row.remote && <span className="compare-row__remote">{t('compare.remoteTag')}</span>}
         </span>
         {row.hasData ? (
           <>

--- a/src/quodeq/ui/src/features/compare/components/ComparePage.jsx
+++ b/src/quodeq/ui/src/features/compare/components/ComparePage.jsx
@@ -20,7 +20,7 @@ import {
   computeComplianceByPrinciple,
 } from '../../explorer/components/explorerDataHooks.js';
 import { t } from '../../../strings/index.js';
-import { useCompareData } from '../hooks/useCompareData.js';
+import { useCompareData, useSharedCompareProjects } from '../hooks/useCompareData.js';
 import {
   buildRow, buildFleet, buildDimensionsBoard, buildAttention,
   buildDimensionView, buildDuelView, sortRows, consequenceOf, consequenceLevel,
@@ -72,7 +72,15 @@ export default function ComparePage({
     () => (projects || []).filter((p) => p && (p.id || p.name)),
     [projects],
   );
-  const { summariesById, errorsById } = useCompareData(localProjects);
+  // Remote projects from the configured shared repository join the fleet as
+  // ordinary rows (empty list when nothing is configured). A project can
+  // exist both locally and remotely; both rows show, the remote one tagged.
+  const sharedProjects = useSharedCompareProjects();
+  const fleetProjects = useMemo(
+    () => localProjects.concat(sharedProjects),
+    [localProjects, sharedProjects],
+  );
+  const { summariesById, errorsById } = useCompareData(fleetProjects);
 
   const view = dimension || 'fleet';
   // Score is the only table ordering (consequence ranked near-inverse of it
@@ -87,9 +95,17 @@ export default function ComparePage({
   const now = useMemo(() => new Date().toISOString(), []);
 
   const rows = useMemo(
-    () => localProjects.map((p) => buildRow(p, summariesById[p.id || p.name], now)),
-    [localProjects, summariesById, now],
+    () => fleetProjects.map((p) => buildRow(p, summariesById[p.id || p.name], now)),
+    [fleetProjects, summariesById, now],
   );
+
+  // Every "open this project" affordance funnels through here: rows carry
+  // their own source, so a remote row switches the app to the shared
+  // source instead of asking the local registry for a project it lacks.
+  const openProject = useCallback((rowId) => {
+    const row = rows.find((r) => r.id === rowId);
+    onOpenProject?.(row?.sourceId ?? rowId, row?.source ?? 'local');
+  }, [rows, onOpenProject]);
 
   const scopeSet = scopeIds == null ? null : new Set(scopeIds);
   const scopeRows = useMemo(
@@ -143,6 +159,10 @@ export default function ComparePage({
   // not change, so browser back pops straight back to this drill-down.
   const queryClient = useQueryClient();
   const openPrinciple = useCallback(async (target) => {
+    // Remote rows can't deep-link into local project pages; opening the
+    // shared project itself is the honest fallback (same degradation the
+    // standings rows use).
+    if (target?.remote) { openProject(target.id); return; }
     if (!onOpenEvalPrincipal || !target?.runId || !target?.dimName) return;
     try {
       const evalData = await queryClient.fetchQuery({
@@ -162,7 +182,7 @@ export default function ComparePage({
       // Fetch failed (run pruned, server hiccup): stay on Compare rather
       // than landing on an empty principle page.
     }
-  }, [onOpenEvalPrincipal, queryClient]);
+  }, [onOpenEvalPrincipal, queryClient, openProject]);
 
   const openDimension = useCallback((key) => {
     setPickerOpen(false);
@@ -221,7 +241,7 @@ export default function ComparePage({
     // A duel can also start from any row's expansion ("compare with…") —
     // no need to narrow the scope to two first.
     openDuelPair: onOpenDuel ? (idA, idB) => onOpenDuel([idA, idB]) : null,
-    onOpenProject,
+    onOpenProject: openProject,
     now,
   };
 
@@ -231,7 +251,7 @@ export default function ComparePage({
         <CompareDuelView
           duel={duelView}
           onBack={onBack}
-          onOpenProject={onOpenProject}
+          onOpenProject={openProject}
         />
       ) : dimensionView ? (
         <CompareDimensionView
@@ -240,7 +260,7 @@ export default function ComparePage({
           fleet={fleet}
           onBack={onBack}
           onOpenDimension={openDimension}
-          onOpenProject={onOpenProject}
+          onOpenProject={openProject}
           onOpenPrinciple={openPrinciple}
           onOpenProjectDimension={onOpenProjectDimension}
         />

--- a/src/quodeq/ui/src/features/compare/components/ComparePage.test.jsx
+++ b/src/quodeq/ui/src/features/compare/components/ComparePage.test.jsx
@@ -12,9 +12,14 @@ vi.mock('../../../api/index.js', () => ({
 vi.mock('../../../api/standards.js', () => ({
   getStandardsVisibility: vi.fn(),
 }));
+vi.mock('../../../api/shared.js', () => ({
+  sharedListProjects: vi.fn(),
+  sharedGetCompareSummary: vi.fn(),
+}));
 
 import { getCompareSummary, getDimensionEval } from '../../../api/index.js';
 import { getStandardsVisibility } from '../../../api/standards.js';
+import { sharedListProjects, sharedGetCompareSummary } from '../../../api/shared.js';
 
 const iso = (daysAgo) => new Date(Date.now() - daysAgo * 86400000).toISOString();
 
@@ -62,6 +67,9 @@ beforeEach(() => {
   ));
   // Null ids = no filtering (fail-open), so most tests see the raw payload.
   getStandardsVisibility.mockResolvedValue({ visibleStandardIds: null, isDefault: true });
+  // Default: no shared repository configured — the local-only flow.
+  sharedListProjects.mockRejectedValue(Object.assign(new Error('no shared repository configured'), { status: 409 }));
+  sharedGetCompareSummary.mockRejectedValue(new Error('unexpected shared fetch'));
 });
 
 /* Mimics the App wiring: `dimension` is a route param — drilling in pushes,
@@ -113,7 +121,7 @@ describe('ComparePage', () => {
     // of navigating away.
     expect(onOpenProject).not.toHaveBeenCalled();
     await userEvent.click(await screen.findByText(/open project/));
-    await waitFor(() => expect(onOpenProject).toHaveBeenCalledWith('alpha'));
+    await waitFor(() => expect(onOpenProject).toHaveBeenCalledWith('alpha', 'local'));
   });
 
   it('keeps multiple rows expanded independently', async () => {
@@ -285,5 +293,54 @@ describe('ComparePage', () => {
     expect(await screen.findByText('failed to load scores', undefined, { timeout: 4000 })).toBeInTheDocument();
     // The healthy project still renders its data (row + scope card).
     expect((await screen.findAllByText('7.4')).length).toBeGreaterThan(0);
+  });
+});
+
+describe('ComparePage remote projects', () => {
+  const REMOTE = {
+    id: 'gamma', name: 'gamma', displayName: 'gamma', languageStats: { rb: 10 }, totalFiles: 50, analyzedFiles: 50, runsCount: 1, latestDate: iso(3),
+  };
+
+  beforeEach(() => {
+    sharedListProjects.mockResolvedValue({ projects: [REMOTE], lastSynced: null, stale: false });
+    sharedGetCompareSummary.mockResolvedValue(summary(6.5, 6.2));
+  });
+
+  it('remote rows join the fleet through the shared route, tagged', async () => {
+    renderPage();
+    expect(await screen.findByText('gamma')).toBeInTheDocument();
+    expect((await screen.findAllByText('remote')).length).toBeGreaterThan(0);
+    await waitFor(() => expect(sharedGetCompareSummary).toHaveBeenCalledWith('gamma'));
+    // The local endpoint is never asked for the remote project.
+    expect(getCompareSummary).not.toHaveBeenCalledWith('gamma');
+  });
+
+  it('opening a remote row switches to the shared source', async () => {
+    const onOpenProject = vi.fn();
+    renderPage({ onOpenProject });
+    const rowName = (await screen.findAllByText('gamma'))
+      .find((el) => el.classList.contains('compare-row__name'));
+    await userEvent.click(rowName);
+    await userEvent.click(await screen.findByText(/open project/));
+    await waitFor(() => expect(onOpenProject).toHaveBeenCalledWith('gamma', 'shared'));
+  });
+
+  it('duels a local project against a remote one', async () => {
+    renderPage();
+    const rowName = (await screen.findAllByText('alpha'))
+      .find((el) => el.classList.contains('compare-row__name'));
+    await userEvent.click(rowName);
+    const trigger = await screen.findByLabelText(/Compare alpha with/);
+    await userEvent.click(trigger);
+    await userEvent.click(await screen.findByRole('menuitem', { name: /gamma/ }));
+    expect(await screen.findByText(/PRINCIPLE_DIFFS/)).toBeInTheDocument();
+  });
+
+  it('leaves the fleet local-only when no shared repository is configured', async () => {
+    sharedListProjects.mockRejectedValue(Object.assign(new Error('no shared repository configured'), { status: 409 }));
+    renderPage();
+    expect(await screen.findByText('alpha')).toBeInTheDocument();
+    expect(screen.queryByText('gamma')).toBeNull();
+    expect(screen.queryByText('remote')).toBeNull();
   });
 });

--- a/src/quodeq/ui/src/features/compare/hooks/useCompareData.js
+++ b/src/quodeq/ui/src/features/compare/hooks/useCompareData.js
@@ -11,10 +11,11 @@
  * dimension the project has disabled.
  */
 import { useMemo } from 'react';
-import { useQueries } from '@tanstack/react-query';
+import { useQueries, useQuery } from '@tanstack/react-query';
 import { getCompareSummary } from '../../../api/index.js';
+import { sharedListProjects, sharedGetCompareSummary } from '../../../api/shared.js';
 import { getStandardsVisibility } from '../../../api/standards.js';
-import { projectKeys } from '../../../api/queryKeys.js';
+import { projectKeys, sharedKeys } from '../../../api/queryKeys.js';
 import { applyVisibleStandards } from '../compareModel.js';
 
 // A cold project's first summary can take as long as its Overview takes to
@@ -33,16 +34,33 @@ export function useCompareData(projects) {
   const summaryResults = useQueries({
     queries: list.map((p) => {
       const id = p.id || p.name;
+      // Remote (shared-repo) rows fetch from the shared mirror route with
+      // the RAW project id; `id` stays the fleet-unique row key. The key's
+      // source segment keeps a same-named local project's cache separate.
+      const raw = p.sourceId || id;
+      const remote = p.source === 'shared';
       return {
         ...QUERY_DEFAULTS,
-        queryKey: projectKeys.compareSummary(id),
-        queryFn: () => getCompareSummary(id),
+        queryKey: projectKeys.compareSummary(raw, remote ? 'shared' : 'local'),
+        queryFn: () => (remote ? sharedGetCompareSummary(raw) : getCompareSummary(raw)),
       };
     }),
   });
   const visibilityResults = useQueries({
     queries: list.map((p) => {
       const id = p.id || p.name;
+      const raw = p.sourceId || id;
+      if (p.source === 'shared') {
+        // Standards visibility is local per-project configuration; a
+        // remote project has none here, so its summary passes unfiltered
+        // (exactly the 404 fail-open below, without the request).
+        return {
+          ...QUERY_DEFAULTS,
+          queryKey: projectKeys.standardsVisibility(raw, 'shared'),
+          queryFn: async () => ({ visibleStandardIds: null, isDefault: true }),
+          staleTime: Infinity,
+        };
+      }
       return {
         ...QUERY_DEFAULTS,
         queryKey: projectKeys.standardsVisibility(id),
@@ -97,4 +115,33 @@ export function useCompareData(projects) {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [summaryResults, visibilityResults]);
+}
+
+/**
+ * Projects published to the configured shared repository, shaped for the
+ * Compare fleet: each entry keeps its raw id in `sourceId`, takes a
+ * fleet-unique `shared:`-prefixed `id` (a project can exist both locally
+ * and remotely under the same name), and is tagged `source: 'shared'`.
+ *
+ * No shared repository configured (409), not fetched yet (503), or any
+ * other failure all resolve to an empty list: Compare simply shows the
+ * local fleet, exactly as before the feature existed.
+ */
+export function useSharedCompareProjects() {
+  const { data } = useQuery({
+    queryKey: [...sharedKeys.all(), 'compareProjects'],
+    queryFn: () => sharedListProjects().then((r) => r.projects || []).catch(() => []),
+    staleTime: COMPARE_SUMMARY_STALE_MS,
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+  return useMemo(
+    () => (data || [])
+      .filter((p) => p && (p.id || p.name))
+      .map((p) => {
+        const raw = p.id || p.name;
+        return { ...p, id: `shared:${raw}`, sourceId: raw, source: 'shared' };
+      }),
+    [data],
+  );
 }

--- a/src/quodeq/ui/src/features/help/content/en/compare.md
+++ b/src/quodeq/ui/src/features/help/content/en/compare.md
@@ -31,3 +31,7 @@ Any two projects can go head to head: expand a row and pick an opponent under **
 ### Scope
 
 The project picker narrows every number on the screen to a chosen subset; **flagged** selects only the projects currently needing attention. Each project's numbers respect its own enabled standards, exactly as its Overview does, so a dimension nobody enables never appears here.
+
+### Remote projects
+
+When a shared repository is connected, its published projects join the fleet as ordinary rows tagged **remote**. They rank, count toward the scope score, appear in the attention strip, and can duel local projects. A project you both work on locally and publish shows twice, one row per side, so you can compare your working copy against the published state. Opening a remote row switches to its shared, read-only view; deep links into principle pages stay local-only.

--- a/src/quodeq/ui/src/strings/en.json
+++ b/src/quodeq/ui/src/strings/en.json
@@ -240,6 +240,7 @@
   "compare.reasonStale": "graded on stale data",
   "compare.reasonStaleCommits": "{count} commits since last scan",
   "compare.reasonWorstDim": "{dim} at {score}",
+  "compare.remoteTag": "remote",
   "compare.rowExpandHint": "click a row for detail",
   "compare.scopeAll": "all {count} projects",
   "compare.scopeAverage": "scope average",

--- a/src/quodeq/ui/src/styles/compare.css
+++ b/src/quodeq/ui/src/styles/compare.css
@@ -298,6 +298,21 @@
   flex-shrink: 0;
 }
 
+/* Remote (shared-repo) rows carry a small origin chip wherever the project
+   name appears: fleet rows, the scope picker, and the versus header. */
+.compare-row__remote {
+  font-size: 8.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 1px 5px;
+  margin-left: 6px;
+  flex-shrink: 0;
+  vertical-align: middle;
+}
+
 .compare-row__score { display: flex; align-items: baseline; gap: 7px; font-size: 15px; }
 
 .compare-row__tier {

--- a/tests/api/test_routes_shared_read.py
+++ b/tests/api/test_routes_shared_read.py
@@ -381,6 +381,38 @@ def test_shared_scores_uses_isolated_score_cache(client, shared_clone_fixture):
     assert cache_path.exists()
 
 
+# --- GET /api/shared/projects/<project>/compare-summary -----------------------
+
+def test_shared_compare_summary(client, shared_clone_fixture):
+    """The Compare tab's slim payload served from the shared clone's own
+    evaluations root: same shape as the local endpoint, findings stripped."""
+    resp = client.get("/api/shared/projects/proj-a/compare-summary")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["project"] == "proj-a"
+    assert "summary" in body
+    assert "trend" in body
+    assert isinstance(body["dimensions"], list)
+    for dim in body["dimensions"]:
+        assert "violations" not in dim
+        assert "compliance" not in dim
+    # The clone records the publisher's repo path, which does not exist
+    # here — the staleness signal must fail open, not error.
+    assert body["commitsSinceLastRun"] is None or isinstance(body["commitsSinceLastRun"], int)
+
+
+def test_shared_compare_summary_not_found(client, shared_clone_fixture):
+    resp = client.get("/api/shared/projects/does-not-exist/compare-summary")
+    assert resp.status_code == 404
+
+
+def test_shared_compare_summary_unconfigured_409(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("QUODEQ_DIR", str(tmp_path))
+    resp = client.get("/api/shared/projects/proj-a/compare-summary")
+    assert resp.status_code == 409
+    assert resp.get_json()["error"] == "no shared repository configured"
+
+
 # --- GET /api/shared/projects/<project>/scores/<run_id> -----------------------
 
 def test_shared_run_scores(client, shared_clone_fixture):


### PR DESCRIPTION
## What

Answers "why can't remote projects be compared?" by making them comparable. Projects published to the configured shared repository join the Compare fleet as ordinary rows tagged **remote**: they rank, count toward the scope score, surface in the attention strip, and duel local projects. A project that exists both locally and published shows twice — working copy vs published state, duel-able against each other.

**Backend**: `/api/shared/projects/<project>/compare-summary` mirrors the local endpoint through the existing `_with_shared_root` decorator — `build_compare_summary` was already root-parameterized, so the clone's own evaluations root and isolated score cache drop straight in. No request-supplied roots anywhere; the hardened root-resolution contract from routes_common is untouched.

**Frontend**: the fleet merges the shared project list (409/unconfigured resolves to an empty list, so the local-only flow is byte-identical), remote rows fetch through the shared route under their own `['project', id, 'shared', ...]` cache subtree, and every open-project affordance resolves its row's source — remote rows switch to the shared read-only view. Principle deep-links stay local-only; remote targets degrade to opening the shared project. The Compare tab now appears with one analyzed local project plus shared content, not only at two local projects.

## Verified

- 3 new backend tests (real clone-fixture summary, 404, 409-unconfigured); 5937 passing total
- 4 new UI tests (remote row via shared route + tag, source-aware open, cross-source duel, unconfigured fallback); 1602 passing total; string lint clean
- End-to-end against the real configured shared repo: 17-project fleet with 5 remote rows, selectives-android ranked #2, and a local-quodeq (7.0, 22 commits behind) vs published-quodeq (6.3, 42 commits behind) duel rendering gaps, radar, and trend

🤖 Generated with [Claude Code](https://claude.com/claude-code)