### PR TITLE
fix(compare): row chips open the project's dimension; two-row expansion layout

### DIFF
--- a/src/quodeq/ui/src/features/compare/components/CompareFleetView.jsx
+++ b/src/quodeq/ui/src/features/compare/components/CompareFleetView.jsx
@@ -200,7 +200,7 @@ function DuelTrigger({ row, targets, onPick }) {
 
 /* Detail-on-demand block under an expanded row: everything the single-line
    row no longer carries. */
-function RowDetail({ row, duelTargets, openDimension, onOpenProject, openDuelPair }) {
+function RowDetail({ row, duelTargets, openDimension, onOpenProject, onOpenProjectDimension, openDuelPair }) {
   return (
     <div className="compare-rowdetail">
       <div className="compare-rowdetail__facts">
@@ -227,18 +227,37 @@ function RowDetail({ row, duelTargets, openDimension, onOpenProject, openDuelPai
         )}
       </div>
       <div className="compare-rowdetail__dims">
-        {row.dims.filter((d) => d.score != null).map((dim) => (
-          <button
-            key={dim.key}
-            type="button"
-            className="compare-dim-chip compare-dim-chip--inline"
-            title={t('compare.openDimension', { dim: dim.label })}
-            onClick={(e) => { e.stopPropagation(); openDimension(dim.key); }}
-          >
-            <span className={scoreColorClass(dim.score)}>{score1(dim.score)}</span>
-            <span className="compare-dim-chip__label">{dim.label}</span>
-          </button>
-        ))}
+        {row.dims.filter((d) => d.score != null).map((dim) => {
+          // A chip inside a project's expansion is project-scoped: it jumps
+          // to THAT project's dimension screen (same cross-project entry as
+          // the standings rows, back pops to Compare). The scope-wide
+          // drill-down belongs to the DIMENSIONS panel below the fleet.
+          // Falls back to the drill-down when the run target is unknowable
+          // — and for remote rows, whose detail pages live behind the
+          // shared source, not local routes.
+          const toProject = !!(dim.fromRunId && onOpenProjectDimension && !row.remote);
+          return (
+            <button
+              key={dim.key}
+              type="button"
+              className="compare-dim-chip compare-dim-chip--inline"
+              title={toProject
+                ? t('compare.openProjectDimension', { name: row.name, dim: dim.label })
+                : t('compare.openDimension', { dim: dim.label })}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (toProject) {
+                  onOpenProjectDimension({ id: row.id, runId: dim.fromRunId, dimName: dim.name, dateLabel: dim.fromDateLabel });
+                } else {
+                  openDimension(dim.key);
+                }
+              }}
+            >
+              <span className={scoreColorClass(dim.score)}>{score1(dim.score)}</span>
+              <span className="compare-dim-chip__label">{dim.label}</span>
+            </button>
+          );
+        })}
       </div>
       <div className="compare-rowdetail__actions">
         <button
@@ -260,7 +279,7 @@ function RowDetail({ row, duelTargets, openDimension, onOpenProject, openDuelPai
   );
 }
 
-function ProjectRow({ row, rank, expanded, onToggle, onOpenProject, openDimension, error, duelTargets, openDuelPair }) {
+function ProjectRow({ row, rank, expanded, onToggle, onOpenProject, onOpenProjectDimension, openDimension, error, duelTargets, openDuelPair }) {
   const level = consequenceLevel(consequenceOf(row));
   return (
     <div
@@ -332,6 +351,7 @@ function ProjectRow({ row, rank, expanded, onToggle, onOpenProject, openDimensio
           duelTargets={duelTargets}
           openDimension={openDimension}
           onOpenProject={onOpenProject}
+          onOpenProjectDimension={onOpenProjectDimension}
           openDuelPair={openDuelPair}
         />
       )}
@@ -343,6 +363,7 @@ export default function CompareFleetView({
   rows, orderedRows, fleet, board, attention, errorsById,
   sortDir, toggleSortDir, pickerOpen, setPickerOpen, scopeIds, scopeCount,
   toggleProject, selectAll, selectFlagged, openDimension, openDuel, openDuelPair, onOpenProject,
+  onOpenProjectDimension,
 }) {
   // Any number of rows can hold their detail open at once — comparing two
   // projects' expansions side by side is the point of this screen.
@@ -525,6 +546,7 @@ export default function CompareFleetView({
               expanded={expandedIds.has(row.id)}
               onToggle={toggleRow}
               onOpenProject={onOpenProject}
+              onOpenProjectDimension={onOpenProjectDimension}
               openDimension={openDimension}
               error={errorsById[row.id]}
               duelTargets={rows.filter((r) => r.hasData && r.id !== row.id)}

--- a/src/quodeq/ui/src/features/compare/components/CompareFleetView.jsx
+++ b/src/quodeq/ui/src/features/compare/components/CompareFleetView.jsx
@@ -203,6 +203,10 @@ function DuelTrigger({ row, targets, onPick }) {
 function RowDetail({ row, duelTargets, openDimension, onOpenProject, onOpenProjectDimension, openDuelPair }) {
   return (
     <div className="compare-rowdetail">
+      {/* One justified header row — facts left, actions right — then the
+          chips as their own wrap line. Three stacked sparse rows left the
+          right half of the expansion dead. */}
+      <div className="compare-rowdetail__head">
       <div className="compare-rowdetail__facts">
         <span className="compare-row__sev">
           <SevBadge level="critical" format="count-abbr" count={row.severity.critical} />
@@ -225,6 +229,23 @@ function RowDetail({ row, duelTargets, openDimension, onOpenProject, onOpenProje
             {t('compare.commitsSince', { count: nf(row.commitsSince) })}
           </span>
         )}
+      </div>
+      <div className="compare-rowdetail__actions">
+        <button
+          type="button"
+          className="compare-rowdetail__open"
+          onClick={(e) => { e.stopPropagation(); onOpenProject(row.id); }}
+        >
+          {t('compare.openProject')} ›
+        </button>
+        {openDuelPair && duelTargets.length > 0 && (
+          <DuelTrigger
+            row={row}
+            targets={duelTargets}
+            onPick={(otherId) => openDuelPair(row.id, otherId)}
+          />
+        )}
+      </div>
       </div>
       <div className="compare-rowdetail__dims">
         {row.dims.filter((d) => d.score != null).map((dim) => {
@@ -258,22 +279,6 @@ function RowDetail({ row, duelTargets, openDimension, onOpenProject, onOpenProje
             </button>
           );
         })}
-      </div>
-      <div className="compare-rowdetail__actions">
-        <button
-          type="button"
-          className="compare-rowdetail__open"
-          onClick={(e) => { e.stopPropagation(); onOpenProject(row.id); }}
-        >
-          {t('compare.openProject')} ›
-        </button>
-        {openDuelPair && duelTargets.length > 0 && (
-          <DuelTrigger
-            row={row}
-            targets={duelTargets}
-            onPick={(otherId) => openDuelPair(row.id, otherId)}
-          />
-        )}
       </div>
     </div>
   );

--- a/src/quodeq/ui/src/features/compare/components/ComparePage.jsx
+++ b/src/quodeq/ui/src/features/compare/components/ComparePage.jsx
@@ -241,6 +241,9 @@ export default function ComparePage({
     selectAll: () => updateScope(null),
     selectFlagged,
     openDimension,
+    // Expanded-row dimension chips jump to that project's own dimension
+    // screen; the compare drill-down stays on the DIMENSIONS panel.
+    onOpenProjectDimension,
     // "compare these two" only makes sense for a scope of exactly two; the
     // fleet header shows the action whenever that holds (whether the pair
     // was picked explicitly or the fleet just has two projects).

--- a/src/quodeq/ui/src/features/compare/components/ComparePage.test.jsx
+++ b/src/quodeq/ui/src/features/compare/components/ComparePage.test.jsx
@@ -161,6 +161,19 @@ describe('ComparePage', () => {
     expect(await screen.findByText('beta')).toBeInTheDocument();
   });
 
+  it('an expanded row dimension chip opens that project’s own dimension page, not the compare drill-down', async () => {
+    const onOpenProjectDimension = vi.fn();
+    renderPage({ onOpenProjectDimension });
+    await screen.findByText('alpha');
+    await userEvent.click(screen.getByText('alpha'));
+    const chip = await screen.findByTitle('open alpha’s security');
+    await userEvent.click(chip);
+    expect(onOpenProjectDimension).toHaveBeenCalledWith({
+      id: 'alpha', runId: 'r2', dimName: 'Security', dateLabel: '25 Aug',
+    });
+    expect(screen.queryByText(/PROJECT_STANDINGS/)).toBeNull();
+  });
+
   it('drills into a dimension and back', async () => {
     renderPage();
     await screen.findByText('alpha');

--- a/src/quodeq/ui/src/features/compare/components/ComparePage.test.jsx
+++ b/src/quodeq/ui/src/features/compare/components/ComparePage.test.jsx
@@ -161,6 +161,24 @@ describe('ComparePage', () => {
     expect(await screen.findByText('beta')).toBeInTheDocument();
   });
 
+  it('expansion lays out facts and actions on one header row, chips below', async () => {
+    const { container } = renderPage();
+    await screen.findByText('alpha');
+    await userEvent.click(screen.getByText('alpha'));
+    const detail = container.querySelector('.compare-rowdetail');
+    const head = detail.querySelector('.compare-rowdetail__head');
+    expect(head).toBeTruthy();
+    // Facts (left) and actions (right) share the header row: no third
+    // sparse row, no dead space to the right of the facts.
+    expect(head.querySelector('.compare-rowdetail__facts')).toBeTruthy();
+    expect(head.querySelector('.compare-rowdetail__actions')).toBeTruthy();
+    // Chips follow as their own wrap line.
+    const children = Array.from(detail.children);
+    expect(children.indexOf(head)).toBeLessThan(
+      children.indexOf(detail.querySelector('.compare-rowdetail__dims')),
+    );
+  });
+
   it('an expanded row dimension chip opens that project’s own dimension page, not the compare drill-down', async () => {
     const onOpenProjectDimension = vi.fn();
     renderPage({ onOpenProjectDimension });

--- a/src/quodeq/ui/src/strings/en.json
+++ b/src/quodeq/ui/src/strings/en.json
@@ -216,6 +216,7 @@
   "compare.noScores": "no scored projects in scope yet",
   "compare.oldDeltaTip": "change at the last evaluation, before the 30-day window",
   "compare.openDimension": "open {dim}",
+  "compare.openProjectDimension": "open {name}’s {dim}",
   "compare.openDimensionIn": "open {dim} in {project}",
   "compare.openPrincipleIn": "open {principle} in {project}",
   "compare.openProject": "open project",

--- a/src/quodeq/ui/src/styles/compare.css
+++ b/src/quodeq/ui/src/styles/compare.css
@@ -338,8 +338,18 @@
 .compare-rowdetail {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 2px 16px 14px 41px; /* aligns under the project column */
+  gap: 8px;
+  padding: 2px 16px 12px 41px; /* aligns under the project column */
+}
+
+/* Header row of the expansion: facts left, actions right on one line so
+   the detail is two rows, not three, and the right half isn't dead space. */
+.compare-rowdetail__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
 }
 
 .compare-rowdetail__facts {


### PR DESCRIPTION
Two changes to the fleet table's expanded rows.

Navigation: a dimension chip inside a project's expansion is project-scoped, so it now opens that project's own dimension screen (the standings rows' cross-project entry, back pops to Compare) instead of the scope-wide drill-down. The drill-down stays on the DIMENSIONS panel and the attention list. Chips fall back to the drill-down when the run target is unknowable and for remote rows, whose detail pages live behind the shared source.

Layout: the expansion was three sparse stacked rows (facts / chips / actions) with the right half dead. Now facts sit left and the open-project / duel actions right on one justified header row, with the chips as their own wrap line below.

Tests: chip target and layout structure pinned in ComparePage.test.jsx; the existing drill-down test keeps the DIMENSIONS panel behavior honest. 488 node + 1643 vitest, lint:strings and build clean. Verified visually via a Playwright screenshot of the expansion.