### PR TITLE
fix(compare): expansion gets breathing room below the row

### DIFF
--- a/src/quodeq/ui/src/styles/compare.css
+++ b/src/quodeq/ui/src/styles/compare.css
@@ -339,7 +339,9 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 2px 16px 12px 41px; /* aligns under the project column */
+  /* Left edge aligns under the project column; 10px top so the facts line
+     breathes below the row instead of hugging it. */
+  padding: 10px 16px 12px 41px;
 }
 
 /* Header row of the expansion: facts left, actions right on one line so


### PR DESCRIPTION
Follow-up to #1106, which merged minutes before this landed on the branch. One CSS change: the expansion's top padding goes 2px to 10px so the facts line no longer hugs the project row.