### PR TITLE
Delta badges stop outshouting the scores

### DIFF
--- a/src/quodeq/ui/src/styles/compare.css
+++ b/src/quodeq/ui/src/styles/compare.css
@@ -512,6 +512,15 @@
 
 .compare-board__score { font-size: 13px; text-align: right; }
 .compare-board__delta { text-align: right; }
+
+/* The delta annotates the score and must not outshout it: caption-size
+   inside board cells, the same treatment the Overview's gauge cards give
+   their trend badge. */
+.compare-board__delta .trend-badge {
+  font-size: 10.5px;
+  padding: 0;
+  gap: 2px;
+}
 .compare-board__viol { font-size: 11px; color: var(--color-text-muted); text-align: right; }
 .compare-board__chevron { font-size: 12px; color: var(--color-text-subtle); text-align: right; }
 

--- a/src/quodeq/ui/src/styles/compare.css
+++ b/src/quodeq/ui/src/styles/compare.css
@@ -273,6 +273,14 @@
 .compare-row__project { flex: 1 1 200px; min-width: 150px; display: flex; align-items: baseline; gap: 8px; }
 .compare-row__score { width: 96px; flex-shrink: 0; }
 .compare-row__delta { width: 68px; flex-shrink: 0; }
+
+/* The 30D column annotates the score column: its badge sits a clear step
+   below the score's size so the level stays the loudest number in a row. */
+.compare-row__delta .trend-badge {
+  font-size: 11.5px;
+  padding: 0;
+  gap: 3px;
+}
 .compare-row__viol { width: 84px; flex-shrink: 0; font-size: 12.5px; font-variant-numeric: tabular-nums; }
 .compare-row__ratio { width: 52px; flex-shrink: 0; font-size: 12px; font-variant-numeric: tabular-nums; color: var(--color-text-muted); }
 .compare-row__last { width: 92px; flex-shrink: 0; }


### PR DESCRIPTION
Follow-up to Victor's "why are the trends so big" review of the Compare screen, plus a recovery:

- **Recovers the stranded tail of #1105**: the board-cell caption sizing (e4378301) was pushed moments after the merge, so it never reached develop. Cherry-picked here.
- **Projects table 30D column**: same treatment — the delta annotates the score, so its badge sits a clear step below the score's size (11.5px vs 15px) instead of matching it.

24/24 compare tests, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)