### PR TITLE
docs(ui): refresh Compare help for the duel board, expansion rework, and principle page

### DIFF
--- a/src/quodeq/ui/src/features/help/content/en/compare.md
+++ b/src/quodeq/ui/src/features/help/content/en/compare.md
@@ -1,6 +1,6 @@
 ## Compare
 
-The **Compare** tab ranks every local project side by side. It appears in the sidebar once at least two projects have been evaluated; with fewer there is nothing to rank.
+The **Compare** tab ranks every project side by side. It appears in the sidebar once at least two projects have been evaluated; with fewer there is nothing to rank.
 
 ### Reading the fleet
 
@@ -14,19 +14,31 @@ A grade is *stale* when commits landed after the run that produced it, not when 
 
 ### Row expansion
 
-Click a row to expand it in place: severity split, the score trend as a line (oldest to newest, coloured by the latest grade), coverage, the commit count since the scan, one chip per dimension, and the jump to the project's overview. Any number of rows can stay expanded, so two projects' details can sit side by side. Projects that were never evaluated collapse into a single line with a show toggle.
+Click a row to expand it in place. The first line carries the facts on the left, severity split, the score trend as a line (oldest to newest, coloured by the latest grade), coverage, and the commit count since the scan, and the actions on the right: **open project** and the **duel** button. Below it, one chip per dimension. A chip inside an expansion is project-scoped: it opens *that project's own dimension page*, and the browser back button returns here. Remote rows fall back to the scope-wide drill-down instead. Any number of rows can stay expanded, so two projects' details can sit side by side. Projects that were never evaluated collapse into a single line with a show toggle.
 
 ### The dimension drill-down
 
-Click any dimension chip or board row to see that dimension across the scope:
+Click a row on the **DIMENSIONS** board, or an attention card's dimension link, to see that dimension across the scope:
 
 - **Standings** projects ranked on this dimension. Clicking a row opens *that project's own screen of the same dimension*; the browser back button returns here, and your selected project never changes.
 - **Radar** overlays the leader, the trailer, and the scope average across the dimension's principles. Hovering a standings row draws that project's shape on top.
-- **Principle cards** the scope average per principle with the leader and trailer named. The small bars follow the standings order and carry the standings rank, so the same slot is the same project in every card. Clicking a bar, or the leader/trailer entry, opens that project's own principle page.
+- **Principle cards** the scope average per principle with the leader and trailer named. The small bars follow the standings order and carry the standings rank, so the same slot is the same project in every card.
 
-### Head-to-head
+### The principle page
 
-Any two projects can go head to head: expand a row and pick an opponent under **compare with…**. The duel view shows per-dimension gaps, principle differences for shared dimensions, and both trends on one chart; gaps always read left minus right. When the scope holds exactly two projects, a **compare these two** shortcut also appears in the header.
+Principle cards go one level deeper than the drill-down itself: clicking a bar, or the leader/trailer entry, opens *that project's own principle page*, the same screen its explorer shows, violations and passing checks included. The jump is a detour, not a switch: your selected project stays what it was, and the browser back button pops straight back to the drill-down. Actions taken there, like dismissing a violation, belong to the project being viewed, not the one selected in the sidebar.
+
+### The duel
+
+Any two projects can go head to head. Every expanded row carries a **duel** button listing every other scored project; pick the opponent and the duel opens, scope untouched, back returns to Compare. When the scope holds exactly two projects, a **compare these two** shortcut also appears in the header. Remote projects duel like any others.
+
+The board reads left versus right. Each side keeps one identity colour throughout, chosen away from the grade colours so a colour never reads as a judgement; scores themselves stay grade-coloured.
+
+- **The versus header** both names (click one to open that project), each side's vitals, and the gap spelled out in plain words in the middle (*leads by* / *dead even*).
+- **DIMENSIONS** every dimension either project scores, as mirrored bars meeting in the middle, with a gap tinted toward the winner. Gaps always read left minus right; a dimension only one side scores shows a dash instead.
+- **SHAPE** both projects' radar on one grid across the shared dimensions.
+- **SCORE_TREND** both score trends on one chart, one point per day (a day's newest run counts), with the 30-day delta window shaded.
+- **PRINCIPLE_DIFFS** every principle difference, grouped by shared dimension; each group heading repeats the dimension's two scores and the gap, so a group reads without scrolling back up.
 
 ### Scope
 


### PR DESCRIPTION
The Compare help predated the duel versus board and the expansion rework. Content-only change to `help/content/en/compare.md`.

- Row expansion: facts left, open-project and duel actions right, dimension chips on their own line. A chip inside an expansion opens that project's own dimension page; remote rows fall back to the scope drill-down.
- The dimension drill-down entry points corrected: DIMENSIONS board and attention cards, since expansion chips are project-scoped now.
- New "The principle page" section: the cross-project jump from principle cards, back returns to the drill-down, selection never changes, dismissals apply to the viewed project.
- "Head-to-head" becomes "The duel": entry via the duel button on any expanded row, then the board section by section (versus header, mirrored DIMENSIONS over the union of scored dimensions, SHAPE radar, SCORE_TREND with one point per day and the shaded 30-day window, PRINCIPLE_DIFFS with scored group headings).
- Intro drops "local" since remote projects joined the fleet.

Help tests pass (29).