### PR TITLE
fix(analysis): send reasoning_effort=none to local providers too

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -310,12 +310,13 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
 
     is_openai = _OPENAI_API_HOST in (config.api_base or "")
     extra_body: dict = {}
-    if is_openai:
-        extra_body["reasoning_effort"] = "none"
-    else:
-        # Disable chat-template thinking on reasoning-mode local models
-        # (Gemma 4, Qwen3); without it they burn 1000s of tokens before the
-        # JSON. Ignored by models that don't support thinking.
+    # Disable reasoning-mode thinking (Gemma 4, Qwen3); without it they burn
+    # 1000s of hidden tokens before the JSON and can loop past the read
+    # timeout. Ollama only honours `reasoning_effort` (it silently ignores
+    # `chat_template_kwargs` and top-level `think` on /v1); llama.cpp/vLLM
+    # style servers take `chat_template_kwargs`, so local providers get both.
+    extra_body["reasoning_effort"] = "none"
+    if not is_openai:
         extra_body["chat_template_kwargs"] = {"enable_thinking": False}
     ctx_size = config.context_size
     if ctx_size <= 0:

--- a/src/quodeq/assistant/adapters/_api.py
+++ b/src/quodeq/assistant/adapters/_api.py
@@ -39,9 +39,10 @@ def _extra_body(config: "ApiTurnConfig") -> dict:
     analysis run and an assistant turn.
     """
     body: dict = {}
-    if _OPENAI_API_HOST in (config.api_base or ""):
-        body["reasoning_effort"] = "none"
-    else:
+    # Ollama only honours `reasoning_effort`; `chat_template_kwargs` is the
+    # llama.cpp/vLLM knob. Local providers get both (see _api_runner).
+    body["reasoning_effort"] = "none"
+    if _OPENAI_API_HOST not in (config.api_base or ""):
         body["chat_template_kwargs"] = {"enable_thinking": False}
     env_ctx = os.environ.get("QUODEQ_CONTEXT_SIZE", "").strip()
     if env_ctx.isdigit() and int(env_ctx) > 0:

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -200,6 +200,32 @@ class TestRunApiAnalysis:
         assert mock_oa.call_args.kwargs["max_retries"] == 0
 
 
+class TestExtraBodyThinkingControls:
+    """Ollama only honours `reasoning_effort`; `chat_template_kwargs` is a
+    llama.cpp/vLLM convention it silently ignores. Both must go out to local
+    providers or Gemma-style thinking loops blow the read timeout."""
+
+    def _create_kwargs(self, cfg):
+        raw_client = _mock_raw_client('{"findings":[]}')
+        with patch("quodeq.analysis._api_runner.openai.OpenAI") as mock_oa:
+            mock_oa.return_value.__enter__.return_value = raw_client
+            _call_api("prompt", cfg)
+        return raw_client.chat.completions.create.call_args.kwargs
+
+    def test_local_sends_both_thinking_knobs(self, api_config):
+        extra = self._create_kwargs(api_config)["extra_body"]
+        assert extra["reasoning_effort"] == "none"
+        assert extra["chat_template_kwargs"] == {"enable_thinking": False}
+
+    def test_openai_sends_only_reasoning_effort(self):
+        cfg = ApiRunnerConfig(
+            model="gpt", api_base="https://api.openai.com/v1", api_key="k",
+        )
+        extra = self._create_kwargs(cfg)["extra_body"]
+        assert extra["reasoning_effort"] == "none"
+        assert "chat_template_kwargs" not in extra
+
+
 class TestParserDropAccounting:
     """Every finding-shaped object the model emits but we can't keep must be
     counted, so a systemic loss is visible in the logs instead of silent."""

--- a/tests/assistant/test_api_adapter.py
+++ b/tests/assistant/test_api_adapter.py
@@ -151,7 +151,9 @@ def test_extra_body_disables_thinking_for_local_and_sets_ctx(monkeypatch):
     body = _extra_body(local)
     assert body["chat_template_kwargs"] == {"enable_thinking": False}
     assert body["num_ctx"] == 32768
-    assert "reasoning_effort" not in body
+    # Ollama ignores chat_template_kwargs; reasoning_effort is the knob it
+    # honours, so local providers must get it too.
+    assert body["reasoning_effort"] == "none"
 
 
 def test_extra_body_openai_uses_reasoning_effort(monkeypatch):


### PR DESCRIPTION
## Problem

Local analyses with gemma4:26b (both mlx and standard builds) kept dying mid-run with `exit_reason: incomplete_dimensions`. Victor suspected Mac sleep or the time limit; both were ruled out with evidence (no system sleep since Aug 25 per pmset, and Unlimited runs correctly carry `time_limit_s: 0`).

The actual chain: Gemma 4 has the `thinking` capability and Ollama enables it by default. The disable knob quodeq sends to local providers, `chat_template_kwargs: {enable_thinking: false}`, is a llama.cpp/vLLM convention that **Ollama silently ignores** (so is top-level `think: false` on `/v1`). Some calls fall into a degenerate reasoning loop, captured live: 28k-55k hidden thinking tokens repeating "Wait, I'll just copy it." with zero visible content. The call blows the 500s read timeout, six consecutive failures trip the failure-streak breaker, and the run is cancelled with the remaining dimensions skipped.

Which build loops is a coin flip per call. In an A/B on the same file the mlx build completed in 79s while the standard build ran away past 40k tokens, so switching models does not fix it.

## Fix

`reasoning_effort: "none"` IS honoured by Ollama's `/v1/chat/completions` (verified live on 0.33.1: 0 reasoning tokens, 8s completion on a prompt that otherwise looped past 7 minutes). Local providers now get it alongside the existing `chat_template_kwargs`; cloud OpenAI behaviour is unchanged. The assistant adapter (`assistant/adapters/_api.py`) mirrors the analysis runner and had the identical gap, so it gets the same fix.

## Testing

- New `TestExtraBodyThinkingControls` in `tests/analysis/test_api_runner.py` (local gets both knobs, cloud gets only `reasoning_effort`), written red first.
- Updated the assistant adapter extra-body test to expect `reasoning_effort` for local providers.
- `tests/analysis` + `tests/assistant`: 1770 passed.