### PR TITLE
fix(analysis): honest num_ctx handling on Ollama + default local output cap

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -15,6 +15,7 @@ Requires the ``quodeq[api]`` extra: ``pip install 'quodeq[api]'``
 """
 from __future__ import annotations
 
+import functools
 import json
 import logging
 import os
@@ -50,6 +51,12 @@ _LOCAL_TIMEOUT = httpx.Timeout(connect=10.0, read=500.0, write=30.0, pool=10.0)
 # would otherwise block the analysis worker forever. Read budget matches the
 # SDK's own 600s default; a timeout lands in the existing lossy-file branch.
 _CLOUD_TIMEOUT = httpx.Timeout(connect=10.0, read=600.0, write=30.0, pool=10.0)
+# Default output budget for local calls (QUODEQ_MAX_OUTPUT_TOKENS overrides,
+# 0 disables). Healthy per-batch responses are well under 4k tokens; the cap
+# bounds a runaway generation by output budget instead of only wall clock. A
+# capped response arrives with finish_reason=length and takes the existing
+# lossy path (error marker, re-dispatch next run), so nothing is silently lost.
+_DEFAULT_LOCAL_MAX_TOKENS = 8192
 _SYSTEM_PROMPT = (
     "You are a code quality evaluator. Quote the offending code into "
     "`snippet` VERBATIM from the source, one or a few contiguous lines, "
@@ -142,6 +149,38 @@ class ApiRunnerConfig:
     context_size: int = 0
     n_subagents: int = 1
     """Pool size this call competes with; scales the local read timeout."""
+
+
+@functools.lru_cache(maxsize=8)
+def _warn_ollama_ctx_noop(api_base: str) -> None:
+    """One warning per base URL: Ollama's /v1 endpoint ignores num_ctx
+    (top-level and nested options alike, verified on 0.33.1), so a configured
+    context size never reaches the model there. The server-side setting is
+    the only lever."""
+    _log.warning(
+        "A context size is configured but %s looks like Ollama, whose "
+        "OpenAI-compatible endpoint ignores per-request num_ctx. Set "
+        "OLLAMA_CONTEXT_LENGTH (or the Ollama app's context-length setting) "
+        "instead.",
+        api_base,
+    )
+
+
+def _resolve_max_tokens(config: ApiRunnerConfig, *, is_openai: bool) -> int | None:
+    """Output budget for one completion call.
+
+    Explicit config wins; otherwise local calls get a default cap and cloud
+    calls stay uncapped. QUODEQ_MAX_OUTPUT_TOKENS overrides the local default
+    (0 disables the cap).
+    """
+    if config.max_tokens is not None:
+        return config.max_tokens
+    if is_openai:
+        return None
+    env_val = os.environ.get("QUODEQ_MAX_OUTPUT_TOKENS", "").strip()
+    if env_val.isdigit():
+        return int(env_val) or None
+    return _DEFAULT_LOCAL_MAX_TOKENS
 
 
 def _resolve_timeout(config: ApiRunnerConfig, *, is_openai: bool) -> httpx.Timeout:
@@ -324,7 +363,12 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
         if env_val.isdigit():
             ctx_size = int(env_val)
     if ctx_size > 0:
+        # Kept for proxies (LiteLLM-style) that forward it to Ollama's native
+        # API; direct Ollama ignores it on /v1, hence the warning.
         extra_body["num_ctx"] = ctx_size
+        base = config.api_base or _OLLAMA_DEFAULT_BASE
+        if ":11434" in base:
+            _warn_ollama_ctx_noop(base)
 
     create_kwargs: dict = dict(
         model=config.model,
@@ -339,8 +383,9 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
         create_kwargs["response_format"] = {"type": "json_object"}
     if extra_body:
         create_kwargs["extra_body"] = extra_body
-    if config.max_tokens is not None:
-        create_kwargs["max_tokens"] = config.max_tokens
+    max_tokens = _resolve_max_tokens(config, is_openai=is_openai)
+    if max_tokens is not None:
+        create_kwargs["max_tokens"] = max_tokens
 
     timeout = _resolve_timeout(config, is_openai=is_openai)
     _log.debug("Calling %s model=%s (per-finding parse)", config.api_base, config.model)
@@ -372,7 +417,8 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
                     "Model %s call timed out after %.0fs. Likely causes: "
                     "--n-subagents > 1 with OLLAMA_NUM_PARALLEL=1 (requests "
                     "queue and the second exceeds the timeout), or context "
-                    "too large (try QUODEQ_CONTEXT_SIZE).",
+                    "too large (on Ollama set OLLAMA_CONTEXT_LENGTH; "
+                    "QUODEQ_CONTEXT_SIZE only reaches non-Ollama providers).",
                     config.model, elapsed,
                 )
             else:

--- a/src/quodeq/assistant/adapters/_api.py
+++ b/src/quodeq/assistant/adapters/_api.py
@@ -34,9 +34,9 @@ def _extra_body(config: "ApiTurnConfig") -> dict:
     Local reasoning models (Gemma, Qwen3) otherwise burn thousands of thinking
     tokens before answering — a multi-minute streamed generation that is prone
     to dropped connections ("Connection error"). Disabling chat-template
-    thinking keeps them fast. `num_ctx` is pinned from the same env the
-    analysis path reads, so Ollama doesn't evict/reload the model between an
-    analysis run and an assistant turn.
+    thinking keeps them fast. `num_ctx` mirrors the analysis path but only
+    reaches non-Ollama providers: Ollama's /v1 endpoint ignores per-request
+    num_ctx, so there the model's context comes from the server setting.
     """
     body: dict = {}
     # Ollama only honours `reasoning_effort`; `chat_template_kwargs` is the

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -200,20 +200,21 @@ class TestRunApiAnalysis:
         assert mock_oa.call_args.kwargs["max_retries"] == 0
 
 
+def _create_kwargs(cfg):
+    raw_client = _mock_raw_client('{"findings":[]}')
+    with patch("quodeq.analysis._api_runner.openai.OpenAI") as mock_oa:
+        mock_oa.return_value.__enter__.return_value = raw_client
+        _call_api("prompt", cfg)
+    return raw_client.chat.completions.create.call_args.kwargs
+
+
 class TestExtraBodyThinkingControls:
     """Ollama only honours `reasoning_effort`; `chat_template_kwargs` is a
     llama.cpp/vLLM convention it silently ignores. Both must go out to local
     providers or Gemma-style thinking loops blow the read timeout."""
 
-    def _create_kwargs(self, cfg):
-        raw_client = _mock_raw_client('{"findings":[]}')
-        with patch("quodeq.analysis._api_runner.openai.OpenAI") as mock_oa:
-            mock_oa.return_value.__enter__.return_value = raw_client
-            _call_api("prompt", cfg)
-        return raw_client.chat.completions.create.call_args.kwargs
-
     def test_local_sends_both_thinking_knobs(self, api_config):
-        extra = self._create_kwargs(api_config)["extra_body"]
+        extra = _create_kwargs(api_config)["extra_body"]
         assert extra["reasoning_effort"] == "none"
         assert extra["chat_template_kwargs"] == {"enable_thinking": False}
 
@@ -221,9 +222,76 @@ class TestExtraBodyThinkingControls:
         cfg = ApiRunnerConfig(
             model="gpt", api_base="https://api.openai.com/v1", api_key="k",
         )
-        extra = self._create_kwargs(cfg)["extra_body"]
+        extra = _create_kwargs(cfg)["extra_body"]
         assert extra["reasoning_effort"] == "none"
         assert "chat_template_kwargs" not in extra
+
+
+class TestLocalOutputCap:
+    """Local calls get a default max_tokens so a runaway generation is bounded
+    by output budget, not only by the wall-clock read timeout."""
+
+    def test_local_gets_default_cap(self, api_config):
+        kwargs = _create_kwargs(api_config)
+        assert kwargs["max_tokens"] == 8192
+
+    def test_env_override_and_zero_disables(self, api_config, monkeypatch):
+        monkeypatch.setenv("QUODEQ_MAX_OUTPUT_TOKENS", "4096")
+        assert _create_kwargs(api_config)["max_tokens"] == 4096
+        monkeypatch.setenv("QUODEQ_MAX_OUTPUT_TOKENS", "0")
+        assert "max_tokens" not in _create_kwargs(api_config)
+
+    def test_explicit_config_wins(self):
+        cfg = ApiRunnerConfig(
+            model="m", api_base="http://localhost:8000/v1", api_key="k",
+            max_tokens=123,
+        )
+        assert _create_kwargs(cfg)["max_tokens"] == 123
+
+    def test_openai_uncapped_by_default(self):
+        cfg = ApiRunnerConfig(
+            model="gpt", api_base="https://api.openai.com/v1", api_key="k",
+        )
+        assert "max_tokens" not in _create_kwargs(cfg)
+
+
+class TestOllamaCtxNoopWarning:
+    """Ollama's /v1 endpoint ignores num_ctx (top-level and nested options),
+    so a configured context size silently does nothing there. Users must hear
+    about it once instead of debugging truncated context."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_warn_cache(self):
+        from quodeq.analysis._api_runner import _warn_ollama_ctx_noop
+        _warn_ollama_ctx_noop.cache_clear()
+        yield
+        _warn_ollama_ctx_noop.cache_clear()
+
+    def test_warns_once_for_ollama_base(self, caplog):
+        cfg = ApiRunnerConfig(
+            model="m", api_base="http://localhost:11434/v1", api_key="k",
+            context_size=32768,
+        )
+        with caplog.at_level("WARNING"):
+            _create_kwargs(cfg)
+            _create_kwargs(cfg)
+        hits = [r for r in caplog.records if "OLLAMA_CONTEXT_LENGTH" in r.message]
+        assert len(hits) == 1
+
+    def test_silent_for_non_ollama_base(self, caplog):
+        cfg = ApiRunnerConfig(
+            model="m", api_base="http://localhost:8000/v1", api_key="k",
+            context_size=32768,
+        )
+        with caplog.at_level("WARNING"):
+            extra = _create_kwargs(cfg)["extra_body"]
+        assert extra["num_ctx"] == 32768
+        assert not [r for r in caplog.records if "OLLAMA_CONTEXT_LENGTH" in r.message]
+
+    def test_silent_without_context_size(self, api_config, caplog):
+        with caplog.at_level("WARNING"):
+            _create_kwargs(api_config)
+        assert not [r for r in caplog.records if "OLLAMA_CONTEXT_LENGTH" in r.message]
 
 
 class TestParserDropAccounting:


### PR DESCRIPTION
Follow-up to #1121, same silent-no-op class.

## num_ctx never reaches Ollama

Verified live on Ollama 0.33.1: `num_ctx` in the `/v1/chat/completions` body is ignored (top-level and nested `options` alike), and a native-endpoint warm-up doesn't stick because the next `/v1` call reloads the model at the server default. So `QUODEQ_CONTEXT_SIZE` has never had any effect for the default provider — while the model-timeout warning explicitly recommended it.

- New one-shot warning (per base URL) when a context size is configured against an Ollama base, pointing at `OLLAMA_CONTEXT_LENGTH` / the app's context setting.
- `num_ctx` stays in `extra_body`: LiteLLM-style proxies forward it to Ollama's native API, and it's honored there.
- The timeout warning's advice is corrected.

## Default output cap for local calls

Local calls now get `max_tokens: 8192` by default (`QUODEQ_MAX_OUTPUT_TOKENS` overrides; `0` disables; explicit `config.max_tokens` always wins; cloud stays uncapped). With thinking disabled (#1121) healthy responses are well under 4k tokens, so the cap is belt-and-braces: a runaway generation is now bounded by output budget, not only the 500s wall clock. A capped response arrives with `finish_reason: length` and takes the existing lossy path (error marker, re-dispatch next run) — nothing is silently lost.

## Testing

- New `TestLocalOutputCap` and `TestOllamaCtxNoopWarning` in `tests/analysis/test_api_runner.py` (written red first).
- `tests/analysis` + `tests/assistant`: 1777 passed.
- End-to-end `quodeq evaluate` on the taskflow demo repo with `gemma4:26b`: 5/5 files in ~30s, 13 findings kept, 0 dropped.