### PR TITLE
Release v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.10.1] - 2026-08-28
+
+### Fixes
+- **Local analyses no longer stop mid-run**: on thinking-capable local models (Gemma 4, Qwen 3.x) served by Ollama, hidden reasoning could loop indefinitely, time out call after call, and trip the failure-streak breaker with "incomplete dimensions" partway through a run. Thinking is now genuinely disabled for local providers (the previous knob was silently ignored by Ollama), which also makes every local call dramatically faster, seconds instead of minutes. The assistant on local models gets the same treatment.
+- **Runaway generations are bounded**: local model calls carry a default output budget of 8192 tokens (QUODEQ_MAX_OUTPUT_TOKENS overrides it, 0 disables it), so a degenerate generation ends at the budget instead of burning the whole call timeout. A capped response is retried on the next run, nothing is silently lost.
+- **Honest context-size handling on Ollama**: QUODEQ_CONTEXT_SIZE cannot reach a model behind Ollama's OpenAI-compatible endpoint, which ignores per-request context settings. Quodeq now warns once and points at OLLAMA_CONTEXT_LENGTH, and the model-timeout hint no longer recommends a setting that cannot work there.
+
 ## [1.10.0] - 2026-08-27
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quodeq"
-version = "1.10.0"
+version = "1.10.1"
 description = "Source code quality evaluation platform powered by AI"
 readme = "README.md"
 license = "MIT"

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -15,6 +15,7 @@ Requires the ``quodeq[api]`` extra: ``pip install 'quodeq[api]'``
 """
 from __future__ import annotations
 
+import functools
 import json
 import logging
 import os
@@ -50,6 +51,12 @@ _LOCAL_TIMEOUT = httpx.Timeout(connect=10.0, read=500.0, write=30.0, pool=10.0)
 # would otherwise block the analysis worker forever. Read budget matches the
 # SDK's own 600s default; a timeout lands in the existing lossy-file branch.
 _CLOUD_TIMEOUT = httpx.Timeout(connect=10.0, read=600.0, write=30.0, pool=10.0)
+# Default output budget for local calls (QUODEQ_MAX_OUTPUT_TOKENS overrides,
+# 0 disables). Healthy per-batch responses are well under 4k tokens; the cap
+# bounds a runaway generation by output budget instead of only wall clock. A
+# capped response arrives with finish_reason=length and takes the existing
+# lossy path (error marker, re-dispatch next run), so nothing is silently lost.
+_DEFAULT_LOCAL_MAX_TOKENS = 8192
 _SYSTEM_PROMPT = (
     "You are a code quality evaluator. Quote the offending code into "
     "`snippet` VERBATIM from the source, one or a few contiguous lines, "
@@ -142,6 +149,38 @@ class ApiRunnerConfig:
     context_size: int = 0
     n_subagents: int = 1
     """Pool size this call competes with; scales the local read timeout."""
+
+
+@functools.lru_cache(maxsize=8)
+def _warn_ollama_ctx_noop(api_base: str) -> None:
+    """One warning per base URL: Ollama's /v1 endpoint ignores num_ctx
+    (top-level and nested options alike, verified on 0.33.1), so a configured
+    context size never reaches the model there. The server-side setting is
+    the only lever."""
+    _log.warning(
+        "A context size is configured but %s looks like Ollama, whose "
+        "OpenAI-compatible endpoint ignores per-request num_ctx. Set "
+        "OLLAMA_CONTEXT_LENGTH (or the Ollama app's context-length setting) "
+        "instead.",
+        api_base,
+    )
+
+
+def _resolve_max_tokens(config: ApiRunnerConfig, *, is_openai: bool) -> int | None:
+    """Output budget for one completion call.
+
+    Explicit config wins; otherwise local calls get a default cap and cloud
+    calls stay uncapped. QUODEQ_MAX_OUTPUT_TOKENS overrides the local default
+    (0 disables the cap).
+    """
+    if config.max_tokens is not None:
+        return config.max_tokens
+    if is_openai:
+        return None
+    env_val = os.environ.get("QUODEQ_MAX_OUTPUT_TOKENS", "").strip()
+    if env_val.isdigit():
+        return int(env_val) or None
+    return _DEFAULT_LOCAL_MAX_TOKENS
 
 
 def _resolve_timeout(config: ApiRunnerConfig, *, is_openai: bool) -> httpx.Timeout:
@@ -324,7 +363,12 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
         if env_val.isdigit():
             ctx_size = int(env_val)
     if ctx_size > 0:
+        # Kept for proxies (LiteLLM-style) that forward it to Ollama's native
+        # API; direct Ollama ignores it on /v1, hence the warning.
         extra_body["num_ctx"] = ctx_size
+        base = config.api_base or _OLLAMA_DEFAULT_BASE
+        if ":11434" in base:
+            _warn_ollama_ctx_noop(base)
 
     create_kwargs: dict = dict(
         model=config.model,
@@ -339,8 +383,9 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
         create_kwargs["response_format"] = {"type": "json_object"}
     if extra_body:
         create_kwargs["extra_body"] = extra_body
-    if config.max_tokens is not None:
-        create_kwargs["max_tokens"] = config.max_tokens
+    max_tokens = _resolve_max_tokens(config, is_openai=is_openai)
+    if max_tokens is not None:
+        create_kwargs["max_tokens"] = max_tokens
 
     timeout = _resolve_timeout(config, is_openai=is_openai)
     _log.debug("Calling %s model=%s (per-finding parse)", config.api_base, config.model)
@@ -372,7 +417,8 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
                     "Model %s call timed out after %.0fs. Likely causes: "
                     "--n-subagents > 1 with OLLAMA_NUM_PARALLEL=1 (requests "
                     "queue and the second exceeds the timeout), or context "
-                    "too large (try QUODEQ_CONTEXT_SIZE).",
+                    "too large (on Ollama set OLLAMA_CONTEXT_LENGTH; "
+                    "QUODEQ_CONTEXT_SIZE only reaches non-Ollama providers).",
                     config.model, elapsed,
                 )
             else:

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -310,12 +310,13 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
 
     is_openai = _OPENAI_API_HOST in (config.api_base or "")
     extra_body: dict = {}
-    if is_openai:
-        extra_body["reasoning_effort"] = "none"
-    else:
-        # Disable chat-template thinking on reasoning-mode local models
-        # (Gemma 4, Qwen3); without it they burn 1000s of tokens before the
-        # JSON. Ignored by models that don't support thinking.
+    # Disable reasoning-mode thinking (Gemma 4, Qwen3); without it they burn
+    # 1000s of hidden tokens before the JSON and can loop past the read
+    # timeout. Ollama only honours `reasoning_effort` (it silently ignores
+    # `chat_template_kwargs` and top-level `think` on /v1); llama.cpp/vLLM
+    # style servers take `chat_template_kwargs`, so local providers get both.
+    extra_body["reasoning_effort"] = "none"
+    if not is_openai:
         extra_body["chat_template_kwargs"] = {"enable_thinking": False}
     ctx_size = config.context_size
     if ctx_size <= 0:

--- a/src/quodeq/assistant/adapters/_api.py
+++ b/src/quodeq/assistant/adapters/_api.py
@@ -34,9 +34,9 @@ def _extra_body(config: "ApiTurnConfig") -> dict:
     Local reasoning models (Gemma, Qwen3) otherwise burn thousands of thinking
     tokens before answering — a multi-minute streamed generation that is prone
     to dropped connections ("Connection error"). Disabling chat-template
-    thinking keeps them fast. `num_ctx` is pinned from the same env the
-    analysis path reads, so Ollama doesn't evict/reload the model between an
-    analysis run and an assistant turn.
+    thinking keeps them fast. `num_ctx` mirrors the analysis path but only
+    reaches non-Ollama providers: Ollama's /v1 endpoint ignores per-request
+    num_ctx, so there the model's context comes from the server setting.
     """
     body: dict = {}
     # Ollama only honours `reasoning_effort`; `chat_template_kwargs` is the

--- a/src/quodeq/assistant/adapters/_api.py
+++ b/src/quodeq/assistant/adapters/_api.py
@@ -39,9 +39,10 @@ def _extra_body(config: "ApiTurnConfig") -> dict:
     analysis run and an assistant turn.
     """
     body: dict = {}
-    if _OPENAI_API_HOST in (config.api_base or ""):
-        body["reasoning_effort"] = "none"
-    else:
+    # Ollama only honours `reasoning_effort`; `chat_template_kwargs` is the
+    # llama.cpp/vLLM knob. Local providers get both (see _api_runner).
+    body["reasoning_effort"] = "none"
+    if _OPENAI_API_HOST not in (config.api_base or ""):
         body["chat_template_kwargs"] = {"enable_thinking": False}
     env_ctx = os.environ.get("QUODEQ_CONTEXT_SIZE", "").strip()
     if env_ctx.isdigit() and int(env_ctx) > 0:

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -200,20 +200,21 @@ class TestRunApiAnalysis:
         assert mock_oa.call_args.kwargs["max_retries"] == 0
 
 
+def _create_kwargs(cfg):
+    raw_client = _mock_raw_client('{"findings":[]}')
+    with patch("quodeq.analysis._api_runner.openai.OpenAI") as mock_oa:
+        mock_oa.return_value.__enter__.return_value = raw_client
+        _call_api("prompt", cfg)
+    return raw_client.chat.completions.create.call_args.kwargs
+
+
 class TestExtraBodyThinkingControls:
     """Ollama only honours `reasoning_effort`; `chat_template_kwargs` is a
     llama.cpp/vLLM convention it silently ignores. Both must go out to local
     providers or Gemma-style thinking loops blow the read timeout."""
 
-    def _create_kwargs(self, cfg):
-        raw_client = _mock_raw_client('{"findings":[]}')
-        with patch("quodeq.analysis._api_runner.openai.OpenAI") as mock_oa:
-            mock_oa.return_value.__enter__.return_value = raw_client
-            _call_api("prompt", cfg)
-        return raw_client.chat.completions.create.call_args.kwargs
-
     def test_local_sends_both_thinking_knobs(self, api_config):
-        extra = self._create_kwargs(api_config)["extra_body"]
+        extra = _create_kwargs(api_config)["extra_body"]
         assert extra["reasoning_effort"] == "none"
         assert extra["chat_template_kwargs"] == {"enable_thinking": False}
 
@@ -221,9 +222,76 @@ class TestExtraBodyThinkingControls:
         cfg = ApiRunnerConfig(
             model="gpt", api_base="https://api.openai.com/v1", api_key="k",
         )
-        extra = self._create_kwargs(cfg)["extra_body"]
+        extra = _create_kwargs(cfg)["extra_body"]
         assert extra["reasoning_effort"] == "none"
         assert "chat_template_kwargs" not in extra
+
+
+class TestLocalOutputCap:
+    """Local calls get a default max_tokens so a runaway generation is bounded
+    by output budget, not only by the wall-clock read timeout."""
+
+    def test_local_gets_default_cap(self, api_config):
+        kwargs = _create_kwargs(api_config)
+        assert kwargs["max_tokens"] == 8192
+
+    def test_env_override_and_zero_disables(self, api_config, monkeypatch):
+        monkeypatch.setenv("QUODEQ_MAX_OUTPUT_TOKENS", "4096")
+        assert _create_kwargs(api_config)["max_tokens"] == 4096
+        monkeypatch.setenv("QUODEQ_MAX_OUTPUT_TOKENS", "0")
+        assert "max_tokens" not in _create_kwargs(api_config)
+
+    def test_explicit_config_wins(self):
+        cfg = ApiRunnerConfig(
+            model="m", api_base="http://localhost:8000/v1", api_key="k",
+            max_tokens=123,
+        )
+        assert _create_kwargs(cfg)["max_tokens"] == 123
+
+    def test_openai_uncapped_by_default(self):
+        cfg = ApiRunnerConfig(
+            model="gpt", api_base="https://api.openai.com/v1", api_key="k",
+        )
+        assert "max_tokens" not in _create_kwargs(cfg)
+
+
+class TestOllamaCtxNoopWarning:
+    """Ollama's /v1 endpoint ignores num_ctx (top-level and nested options),
+    so a configured context size silently does nothing there. Users must hear
+    about it once instead of debugging truncated context."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_warn_cache(self):
+        from quodeq.analysis._api_runner import _warn_ollama_ctx_noop
+        _warn_ollama_ctx_noop.cache_clear()
+        yield
+        _warn_ollama_ctx_noop.cache_clear()
+
+    def test_warns_once_for_ollama_base(self, caplog):
+        cfg = ApiRunnerConfig(
+            model="m", api_base="http://localhost:11434/v1", api_key="k",
+            context_size=32768,
+        )
+        with caplog.at_level("WARNING"):
+            _create_kwargs(cfg)
+            _create_kwargs(cfg)
+        hits = [r for r in caplog.records if "OLLAMA_CONTEXT_LENGTH" in r.message]
+        assert len(hits) == 1
+
+    def test_silent_for_non_ollama_base(self, caplog):
+        cfg = ApiRunnerConfig(
+            model="m", api_base="http://localhost:8000/v1", api_key="k",
+            context_size=32768,
+        )
+        with caplog.at_level("WARNING"):
+            extra = _create_kwargs(cfg)["extra_body"]
+        assert extra["num_ctx"] == 32768
+        assert not [r for r in caplog.records if "OLLAMA_CONTEXT_LENGTH" in r.message]
+
+    def test_silent_without_context_size(self, api_config, caplog):
+        with caplog.at_level("WARNING"):
+            _create_kwargs(api_config)
+        assert not [r for r in caplog.records if "OLLAMA_CONTEXT_LENGTH" in r.message]
 
 
 class TestParserDropAccounting:

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -200,6 +200,32 @@ class TestRunApiAnalysis:
         assert mock_oa.call_args.kwargs["max_retries"] == 0
 
 
+class TestExtraBodyThinkingControls:
+    """Ollama only honours `reasoning_effort`; `chat_template_kwargs` is a
+    llama.cpp/vLLM convention it silently ignores. Both must go out to local
+    providers or Gemma-style thinking loops blow the read timeout."""
+
+    def _create_kwargs(self, cfg):
+        raw_client = _mock_raw_client('{"findings":[]}')
+        with patch("quodeq.analysis._api_runner.openai.OpenAI") as mock_oa:
+            mock_oa.return_value.__enter__.return_value = raw_client
+            _call_api("prompt", cfg)
+        return raw_client.chat.completions.create.call_args.kwargs
+
+    def test_local_sends_both_thinking_knobs(self, api_config):
+        extra = self._create_kwargs(api_config)["extra_body"]
+        assert extra["reasoning_effort"] == "none"
+        assert extra["chat_template_kwargs"] == {"enable_thinking": False}
+
+    def test_openai_sends_only_reasoning_effort(self):
+        cfg = ApiRunnerConfig(
+            model="gpt", api_base="https://api.openai.com/v1", api_key="k",
+        )
+        extra = self._create_kwargs(cfg)["extra_body"]
+        assert extra["reasoning_effort"] == "none"
+        assert "chat_template_kwargs" not in extra
+
+
 class TestParserDropAccounting:
     """Every finding-shaped object the model emits but we can't keep must be
     counted, so a systemic loss is visible in the logs instead of silent."""

--- a/tests/assistant/test_api_adapter.py
+++ b/tests/assistant/test_api_adapter.py
@@ -151,7 +151,9 @@ def test_extra_body_disables_thinking_for_local_and_sets_ctx(monkeypatch):
     body = _extra_body(local)
     assert body["chat_template_kwargs"] == {"enable_thinking": False}
     assert body["num_ctx"] == 32768
-    assert "reasoning_effort" not in body
+    # Ollama ignores chat_template_kwargs; reasoning_effort is the knob it
+    # honours, so local providers must get it too.
+    assert body["reasoning_effort"] == "none"
 
 
 def test_extra_body_openai_uses_reasoning_effort(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -871,7 +871,7 @@ wheels = [
 
 [[package]]
 name = "quodeq"
-version = "1.10.0"
+version = "1.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
Cuts v1.10.1, the local-model reliability patch. CHANGELOG entry in this PR has the full notes.

Fixes shipped: #1121 (thinking runaway on Ollama killed runs mid-analysis), #1122 (num_ctx honesty + default local output cap).

Pre-flight: 5946 Python tests passed, 1644 UI tests passed, vite build clean, end-to-end evaluate verified on gemma4:26b.