### PR TITLE
fix(ui): surface backend error detail when starting an evaluation fails

### DIFF
--- a/src/quodeq/api/_evaluation_helpers.py
+++ b/src/quodeq/api/_evaluation_helpers.py
@@ -118,11 +118,9 @@ def _path_dirs(env: dict[str, str] | None = None) -> list[str]:
     return [os.path.normcase(os.path.realpath(d)) for d in raw.split(os.pathsep) if d]
 
 
-def _validate_ai_cmd_path(
-    ai_cmd: str | None, ai_cmd_path: str | None,
-) -> tuple[Response, int] | None:
-    """Return an error response if *ai_cmd_path* is not an acceptable binary
-    override for provider *ai_cmd*, or None if valid (or absent).
+def ai_cmd_path_error(ai_cmd: str | None, ai_cmd_path: str | None) -> str | None:
+    """Reason *ai_cmd_path* is not an acceptable binary override for
+    provider *ai_cmd*, or None if valid (or absent).
 
     The aiCmd allow-list exists so the local HTTP API can never spawn an
     arbitrary binary. A free-text override would reopen that, so it must
@@ -133,41 +131,51 @@ def _validate_ai_cmd_path(
     the server's PATH. (c) keeps the override an alternate install of the
     allowed CLI, (e) keeps it out of attacker-writable locations like /tmp
     or a downloads folder.
+
+    Pure rules-to-reason form so both the start-evaluation 400 and the
+    Settings eager check (GET /api/ai-clients/<id>/cmd-path-check) apply
+    the same rules from one place.
     """
     if not ai_cmd_path:
         return None
-
-    def _invalid(reason: str) -> tuple[Response, int]:
-        body, status = error_response(
-            f"Invalid AI command override: {reason}",
-            HTTPStatus.BAD_REQUEST,
-            "INVALID_INPUT",
-        )
-        return jsonify(body), status
-
     if not _SAFE_CMD_PATH_RE.fullmatch(ai_cmd_path):
-        return _invalid(
-            "only letters, digits, '.', '_', '-', ':' and path separators are allowed"
-        )
+        return "only letters, digits, '.', '_', '-', ':' and path separators are allowed"
     normalized = ai_cmd_path.replace("\\", "/")
     if ".." in normalized.split("/"):
-        return _invalid("'..' path segments are not allowed")
+        return "'..' path segments are not allowed"
     if "/" in normalized and not os.path.isabs(ai_cmd_path):
-        return _invalid("a path must be absolute; otherwise use a bare command name")
+        return "a path must be absolute; otherwise use a bare command name"
     provider = ai_cmd or _get_ai_cmd()
     basename = os.path.basename(normalized)
     if not basename.startswith(provider):
-        return _invalid(f"binary name must start with '{provider}'")
+        return f"binary name must start with '{provider}'"
     resolved = shutil.which(ai_cmd_path)
     if resolved is None:
-        return _invalid(f"'{ai_cmd_path}' was not found or is not executable")
+        return f"'{ai_cmd_path}' was not found or is not executable"
     resolved_dir = os.path.normcase(os.path.realpath(os.path.dirname(os.path.abspath(resolved))))
     if resolved_dir not in _path_dirs():
-        return _invalid(
+        return (
             f"'{ai_cmd_path}' is not in a directory on PATH; move it to one "
             f"(e.g. ~/.local/bin) or add its directory to PATH"
         )
     return None
+
+
+def _validate_ai_cmd_path(
+    ai_cmd: str | None, ai_cmd_path: str | None,
+) -> tuple[Response, int] | None:
+    """Return a 400 error response if *ai_cmd_path* is not an acceptable
+    binary override for provider *ai_cmd*, or None if valid (or absent).
+    Rules live in ai_cmd_path_error."""
+    reason = ai_cmd_path_error(ai_cmd, ai_cmd_path)
+    if reason is None:
+        return None
+    body, status = error_response(
+        f"Invalid AI command override: {reason}",
+        HTTPStatus.BAD_REQUEST,
+        "INVALID_INPUT",
+    )
+    return jsonify(body), status
 
 
 def _build_evaluation_options(payload: dict) -> "EvaluationOptions":

--- a/src/quodeq/api/routes_discovery.py
+++ b/src/quodeq/api/routes_discovery.py
@@ -5,6 +5,7 @@ from http import HTTPStatus
 
 from flask import Flask, Response, jsonify, request
 
+from quodeq.api._evaluation_helpers import ai_cmd_path_error
 from quodeq.api.helpers import error_response
 from quodeq.shared.serialization import to_camel_dict
 from quodeq.services.base import ActionProvider
@@ -79,6 +80,17 @@ def register_discovery_routes(app: Flask, provider: ActionProvider) -> None:
     @app.get("/api/ai-clients/<client_id>/models")
     def client_models(client_id: str) -> Response:
         return jsonify(provider.get_client_models(client_id))
+
+    @app.get("/api/ai-clients/<client_id>/cmd-path-check")
+    def client_cmd_path_check(client_id: str) -> Response:
+        """Eager check for the Settings command override field.
+
+        Same rules as the aiCmdPath validation on POST /api/evaluations,
+        returned as data so the UI can flag a bad value when it is typed
+        instead of when a start fails.
+        """
+        reason = ai_cmd_path_error(client_id, request.args.get("path"))
+        return jsonify({"ok": reason is None, "error": reason})
 
     @app.get("/api/plugins")
     def plugins() -> Response:

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -302,6 +302,20 @@ export function getClientModels(clientId) {
   return request(`/ai-clients/${encodeURIComponent(clientId)}/models`);
 }
 
+/**
+ * Eager validation for the Settings command override field. Same rules
+ * the server applies to aiCmdPath when an evaluation starts.
+ *
+ * @param {string} clientId
+ * @param {string} path
+ * @returns {Promise<{ok: boolean, error: string | null}>}
+ */
+export function checkCmdPath(clientId, path) {
+  return request(
+    `/ai-clients/${encodeURIComponent(clientId)}/cmd-path-check?path=${encodeURIComponent(path)}`,
+  );
+}
+
 // ── LLM Bridge ─────────────────────────────────────────────────────────
 
 /** @returns {Promise<Object>} Ollama connection status */

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -34,6 +34,7 @@ import {
 } from "../../../constants.js";
 import { resolveProviderSettings } from "../../../utils/effectiveProviderSettings.js";
 import { t } from "../../../strings/index.js";
+import { apiErrorMessage } from "../../../strings/apiErrors.js";
 
 const SSE_ENABLED = import.meta.env?.VITE_USE_SSE_EVENTS === "true";
 const JOB_POLL_MS = 1500;
@@ -240,9 +241,14 @@ export function useEvaluation() {
       queryClient.invalidateQueries({ queryKey: projectKeys.all() });
     },
     onError: (err) => {
-      // Only our own prereq errors carry copy worth showing; anything else
-      // is a transport/server failure whose raw text would be noise.
-      setJobError(err?.userFacing ? err.message : t("evaluate.startFailed"));
+      // Our own prereq errors carry copy written for the user. Server
+      // rejections go through apiErrorMessage: a mapped code wins
+      // (translated), otherwise the backend's specific sentence (e.g. an
+      // invalid aiCmdPath override names the binary it could not find),
+      // and the generic string is only for failures with no text at all.
+      setJobError(
+        err?.userFacing ? err.message : apiErrorMessage(err, "evaluate.startFailed"),
+      );
     },
   });
 

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
@@ -280,6 +280,48 @@ describe("useEvaluation", () => {
     await waitFor(() => expect(result.current.jobError).toMatch(/provider/i));
   });
 
+  it("startEvaluation surfaces the backend's specific message on a 400", async () => {
+    // Regression: a server-side 400 (e.g. an invalid aiCmdPath override)
+    // used to collapse into the generic "Failed to start evaluation.",
+    // hiding the actionable reason the backend already wrote.
+    const err = new Error(
+      "Invalid AI command override: 'claude-v' was not found or is not executable",
+    );
+    err.status = 400;
+    err.code = "INVALID_INPUT";
+    fakeApi.startEvaluation.mockRejectedValue(err);
+    const { result } = renderHook(() => useEvaluation(), { wrapper: makeWrapper() });
+    await expect(
+      result.current.startEvaluation({ repo: "x", dimensions: [] }),
+    ).rejects.toThrow();
+    await waitFor(() => expect(result.current.jobError).toMatch(/claude-v/));
+  });
+
+  it("startEvaluation shows translated copy for a mapped error code", async () => {
+    const err = new Error("Too many evaluation requests");
+    err.status = 429;
+    err.code = "RATE_LIMITED";
+    fakeApi.startEvaluation.mockRejectedValue(err);
+    const { result } = renderHook(() => useEvaluation(), { wrapper: makeWrapper() });
+    await expect(
+      result.current.startEvaluation({ repo: "x", dimensions: [] }),
+    ).rejects.toThrow();
+    await waitFor(() =>
+      expect(result.current.jobError).toBe("Too many requests. Wait a moment and try again."),
+    );
+  });
+
+  it("startEvaluation falls back to the generic message when the failure carries no text", async () => {
+    fakeApi.startEvaluation.mockRejectedValue(new Error(""));
+    const { result } = renderHook(() => useEvaluation(), { wrapper: makeWrapper() });
+    await expect(
+      result.current.startEvaluation({ repo: "x", dimensions: [] }),
+    ).rejects.toThrow();
+    await waitFor(() =>
+      expect(result.current.jobError).toBe("Failed to start evaluation."),
+    );
+  });
+
   it("adopts a running CLI-started external run on mount", async () => {
     const running = {
       jobId: "ext-abc",

--- a/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useApi } from '../../../api/ApiContext.jsx';
 import { MIN_SUBAGENTS, MAX_SUBAGENTS, DEFAULT_SUBAGENTS } from '../../../constants.js';
 import HelpHint from '../../../components/HelpHint.jsx';
 import PowerSelector from '../../evaluation/components/PowerSelector.jsx';
@@ -45,9 +46,28 @@ function ModelTextInput({ label, value, placeholder, onChange, required }) {
 }
 
 export default function CliProviderTab({ providerId, state, update }) {
+  const api = useApi();
   const [power, setPower] = useState(() => {
     return Number(readString(POWER_KEY)) || DEFAULT_POWER_LEVEL;
   });
+  const [cmdPathError, setCmdPathError] = useState(null);
+
+  // Eager check on blur: the same rules the server applies to aiCmdPath at
+  // start time, so a bad override (a shell function, a typo, a binary off
+  // PATH) is flagged here instead of failing the next evaluation. A check
+  // that cannot be reached stays silent — the start-time validation still
+  // guards, and a transport hiccup must not brand a good value invalid.
+  function validateCmdPath() {
+    const value = state['cmd-path'];
+    if (!value || value === providerId) {
+      setCmdPathError(null);
+      return;
+    }
+    api
+      .checkCmdPath(providerId, value)
+      .then((result) => setCmdPathError(result.ok ? null : result.error))
+      .catch(() => setCmdPathError(null));
+  }
 
   function persistPower(level) {
     setPower(level);
@@ -132,18 +152,26 @@ export default function CliProviderTab({ providerId, state, update }) {
               </span>
               <span className="settings-description">{t('settings.cmdOverrideDesc', { provider: providerId })}</span>
             </div>
-            <input
-              type="text"
-              className="settings-model-input"
-              value={state['cmd-path'] || ''}
-              placeholder={providerId}
-              onChange={(e) => update('cmd-path', e.target.value.trim())}
-              aria-label={t('settings.cmdOverride')}
-              autoCapitalize="off"
-              autoCorrect="off"
-              autoComplete="off"
-              spellCheck={false}
-            />
+            <div className="settings-model-field">
+              <input
+                type="text"
+                className="settings-model-input"
+                value={state['cmd-path'] || ''}
+                placeholder={providerId}
+                onChange={(e) => update('cmd-path', e.target.value.trim())}
+                onBlur={validateCmdPath}
+                aria-label={t('settings.cmdOverride')}
+                autoCapitalize="off"
+                autoCorrect="off"
+                autoComplete="off"
+                spellCheck={false}
+              />
+              {cmdPathError && (
+                <span className="settings-model-hint settings-error" role="alert">
+                  {cmdPathError}
+                </span>
+              )}
+            </div>
           </div>
           <AdvancedAnalysisSettings state={state} update={update} />
         </div>

--- a/src/quodeq/ui/src/features/settings/components/CliProviderTab.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/CliProviderTab.test.jsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
 import { ApiProvider } from '../../../api/ApiContext.jsx';
@@ -30,6 +30,77 @@ describe('CliProviderTab', () => {
     const input = container.querySelector('input.settings-model-input[type="text"]');
     expect(input).toBeTruthy();
     expect(input.value).toBe('sonnet');
+  });
+
+  it('flags an invalid command override on blur with the server reason', async () => {
+    fakeApi.checkCmdPath = vi.fn().mockResolvedValue({
+      ok: false,
+      error: "'claude-v' was not found or is not executable",
+    });
+    const Wrapper = makeWrapper();
+    const state = { model: 'sonnet', 'cmd-path': 'claude-v' };
+    render(
+      <Wrapper>
+        <CliProviderTab providerId="claude" state={state} update={() => {}} />
+      </Wrapper>,
+    );
+
+    fireEvent.blur(screen.getByLabelText('Command'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/was not found or is not executable/)).toBeTruthy();
+    });
+    expect(fakeApi.checkCmdPath).toHaveBeenCalledWith('claude', 'claude-v');
+  });
+
+  it('clears the override error once the value validates', async () => {
+    fakeApi.checkCmdPath = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, error: "'claude-x' was not found or is not executable" })
+      .mockResolvedValueOnce({ ok: true, error: null });
+    const Wrapper = makeWrapper();
+    function Host() {
+      const [state, setState] = React.useState({ model: 'sonnet', 'cmd-path': 'claude-x' });
+      return (
+        <CliProviderTab
+          providerId="claude"
+          state={state}
+          update={(k, v) => setState((s) => ({ ...s, [k]: v }))}
+        />
+      );
+    }
+    render(
+      <Wrapper>
+        <Host />
+      </Wrapper>,
+    );
+
+    const input = screen.getByLabelText('Command');
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(screen.getByText(/was not found/)).toBeTruthy();
+    });
+
+    fireEvent.change(input, { target: { value: 'claude-api' } });
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(screen.queryByText(/was not found/)).toBeNull();
+    });
+  });
+
+  it('does not call the check for an empty or provider-default override', () => {
+    fakeApi.checkCmdPath = vi.fn();
+    const Wrapper = makeWrapper();
+    const state = { model: 'sonnet', 'cmd-path': 'claude' };
+    render(
+      <Wrapper>
+        <CliProviderTab providerId="claude" state={state} update={() => {}} />
+      </Wrapper>,
+    );
+
+    fireEvent.blur(screen.getByLabelText('Command'));
+
+    expect(fakeApi.checkCmdPath).not.toHaveBeenCalled();
   });
 
   it('does not suggest gpt-5-mini for Codex', () => {

--- a/tests/api/test_routes_discovery.py
+++ b/tests/api/test_routes_discovery.py
@@ -64,3 +64,62 @@ def test_browse_valid_path_returns_200(client, tmp_path):
     assert resp.status_code == 200
     body = resp.get_json()
     assert body["current"] == str(tmp_path)
+
+
+# ── GET /api/ai-clients/<id>/cmd-path-check ─────────────────────────────
+#
+# Eager validation for the Settings "command override" field: same rules
+# as the aiCmdPath check on POST /api/evaluations, but returned as data
+# ({ok, error}) so the UI can flag a bad value at save time instead of
+# the user discovering it when a start fails.
+
+def _make_executable(directory, name):
+    import os
+    import stat
+    if os.name == "nt":
+        path = directory / f"{name}.bat"
+        path.write_text("@exit /b 0\n")
+        return str(path)
+    path = directory / name
+    path.write_text("#!/bin/sh\nexit 0\n")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return str(path)
+
+
+@pytest.fixture()
+def bin_dir(tmp_path, monkeypatch):
+    import os
+    d = tmp_path / "bin"
+    d.mkdir()
+    monkeypatch.setenv("PATH", f"{d}{os.pathsep}{os.environ.get('PATH', '')}")
+    return d
+
+
+def test_cmd_path_check_valid_bare_name(client, bin_dir):
+    _make_executable(bin_dir, "claude-api")
+    resp = client.get("/api/ai-clients/claude/cmd-path-check?path=claude-api")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ok": True, "error": None}
+
+
+def test_cmd_path_check_missing_binary(client, bin_dir):
+    resp = client.get("/api/ai-clients/claude/cmd-path-check?path=claude-nowhere")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is False
+    assert "not found" in body["error"]
+
+
+def test_cmd_path_check_wrong_prefix(client, bin_dir):
+    _make_executable(bin_dir, "my-claude")
+    resp = client.get("/api/ai-clients/claude/cmd-path-check?path=my-claude")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is False
+    assert "must start with 'claude'" in body["error"]
+
+
+def test_cmd_path_check_empty_path_is_valid(client):
+    resp = client.get("/api/ai-clients/claude/cmd-path-check")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ok": True, "error": None}


### PR DESCRIPTION
A server-side 400 on POST /api/evaluations collapsed into the generic "Failed to start evaluation.", hiding the backend's actionable message. Found while debugging a start failure caused by a stale claude cmd-path override (`claude-v`, a shell function, not a binary): the API returned "Invalid AI command override: 'claude-v' was not found or is not executable" and the UI threw it away.

Two changes:

**Surface start errors.** The start mutation's onError now routes server rejections through the existing `apiErrorMessage` helper: a mapped code (RATE_LIMITED, MODEL_REQUIRED, ...) shows its translated copy, an unmapped code shows the backend's specific sentence, and the generic fallback remains for failures with no text (network drop, timeout). Prereq errors from `preparePayload` keep their own copy.

**Validate the command override eagerly.** The Settings field accepted any text and the mistake only surfaced when the next start failed. The aiCmdPath rules now live in a pure `ai_cmd_path_error` helper, exposed as `GET /api/ai-clients/<id>/cmd-path-check`, and the field checks on blur, showing the server's reason inline. Transport failures stay silent; the start-time validation still guards.

Tests: 3 new cases in `useEvaluation.test.jsx`, 3 in `CliProviderTab.test.jsx`, 4 endpoint tests in `test_routes_discovery.py`. Full suites green: 1698 vitest, 682 node, 775 pytest (tests/api).