### PR TITLE
fix(ui): score history bars render black instead of grade colors

### DIFF
--- a/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
@@ -76,7 +76,13 @@ function makeChartClickHandler(data, onBarClick) {
   };
 }
 
-function DimensionBarCells({ data, selectedRunId, hoveredIndex }) {
+// Not a React component: recharts' <Bar> finds its per-bar <Cell> colors by
+// inspecting props.children for elements whose *type* is Cell. That check
+// only looks at Bar's immediate JSX children, so a <Cell> nested inside a
+// custom component (e.g. <DimensionBarCells />) is invisible to it and Bar
+// falls back to its default fill (black). Calling this as a plain function
+// keeps the <Cell> elements themselves as Bar's direct children.
+function renderDimensionBarCells({ data, selectedRunId, hoveredIndex }) {
   return data.map((entry, i) => (
     <Cell
       key={entry.runId ?? i}
@@ -114,7 +120,7 @@ function DimensionHistoryChart({ data, selectedRunId, hoveredIndex, setHoveredIn
         ))}
         <Area dataKey="numericAverage" type="monotone" fill="url(#dimScoreAreaGrad)" stroke="none" isAnimationActive={false} />
         <Bar dataKey="numericAverage" radius={[0, 0, 0, 0]} maxBarSize={28} isAnimationActive={false}>
-          <DimensionBarCells data={data} selectedRunId={selectedRunId} hoveredIndex={hoveredIndex} />
+          {renderDimensionBarCells({ data, selectedRunId, hoveredIndex })}
         </Bar>
         <Line
           isAnimationActive={false}

--- a/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.test.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.test.jsx
@@ -8,6 +8,21 @@ const TREND = [
   { runId: 'r1', dateISO: '2026-04-03T10:00:00', dateLabel: 'Apr 3', dimensionDetails: [{ dimension: 'maintainability', score: 5.2 }] },
 ];
 
+// recharts' <Bar> only recognizes per-bar <Cell> colors when they are its
+// *direct* JSX children; ResponsiveContainer needs a ResizeObserver and a
+// non-zero container size to actually lay the bars out under jsdom.
+function stubChartLayout() {
+  global.ResizeObserver = class {
+    constructor(cb) { this.cb = cb; }
+    observe(el) { this.cb([{ target: el, contentRect: { width: 400, height: 160 } }]); }
+    unobserve() {}
+    disconnect() {}
+  };
+  Element.prototype.getBoundingClientRect = function () {
+    return { width: 400, height: 160, top: 0, left: 0, bottom: 160, right: 400, x: 0, y: 0, toJSON() {} };
+  };
+}
+
 describe('DimensionScoreHistoryPanel', () => {
   it('renders min/max/avg meta from the dimension series', () => {
     render(<DimensionScoreHistoryPanel trend={TREND} dimension="maintainability" />);
@@ -52,5 +67,20 @@ describe('DimensionScoreHistoryPanel', () => {
   it('omits the PeriodSelect when onGranularityChange is absent', () => {
     render(<DimensionScoreHistoryPanel trend={TREND} dimension="maintainability" />);
     expect(screen.queryByLabelText(/Group score history by/i)).toBeNull();
+  });
+
+  it('applies each bar Cell\'s fill/opacity to the rendered bar (not the SVG black default)', () => {
+    stubChartLayout();
+    const { container } = render(<DimensionScoreHistoryPanel trend={TREND} dimension="maintainability" />);
+    const bars = container.querySelectorAll('.recharts-bar-rectangle .recharts-rectangle');
+    expect(bars.length).toBe(3);
+    bars.forEach((bar) => {
+      // The Cell's fill/opacity/stroke props must land on the path. If Cell
+      // is nested inside a wrapper component instead of being Bar's direct
+      // child, recharts never applies these and the attributes are absent
+      // entirely, leaving the browser's SVG default fill (black).
+      expect(bar.getAttribute('fill')).not.toBeNull();
+      expect(bar.getAttribute('opacity')).toBe('0.4');
+    });
   });
 });


### PR DESCRIPTION
## Summary

The score_history bar chart on the standard (dimension) detail screen was rendering every bar solid black instead of the grade-color spectrum.

Root cause: `Bar` finds its per-bar colors by scanning its own direct JSX children for elements typed `Cell`. A same-day refactor (function-cap sweep) moved the `Cell` generation into a wrapper component, `<DimensionBarCells />`, used as `<Bar><DimensionBarCells .../></Bar>`. Recharts only inspects `Bar`'s immediate children, so it never saw a `Cell` there and fell back to `Bar`'s unset `fill`, which the browser renders as SVG's default black.

## Fix

Turn `DimensionBarCells` into a plain function (`renderDimensionBarCells`) called inline inside `<Bar>` instead of used as a JSX component, so the `Cell` elements are `Bar`'s direct children again.

## Test plan

- [x] Added a regression test in `DimensionScoreHistoryPanel.test.jsx` that renders the chart under jsdom (stubbing `ResizeObserver`) and asserts each bar carries its `Cell`'s `fill`/`opacity` attributes.
- [x] Confirmed the new test fails against the pre-fix code and passes after the fix.
- [x] `npx vitest run src/features/explorer/` — 61/61 passing.
- [x] Checked sibling charts using the same `Bar`+`Cell` pattern (`RunHistoryPanel`, `HistoryChartPanel`, `HistoryDimensionPanel`) — unaffected, they already keep `Cell` as a direct child or use a plain-function helper.