### PR TITLE
fix(security): don't leak raw exception text through refresh_shared_clone

### DIFF
--- a/src/quodeq/data/fs/shared_repo.py
+++ b/src/quodeq/data/fs/shared_repo.py
@@ -99,7 +99,15 @@ def run_git(
         )
         return proc.returncode == 0, (proc.stdout or "") + (proc.stderr or "")
     except (OSError, subprocess.TimeoutExpired) as exc:
-        return False, str(exc)
+        # Unlike a failed git command (whose stdout/stderr is safe, expected
+        # user-facing text -- see refresh_shared_clone's docstring), this
+        # branch only fires for process-launch failures (git missing, a
+        # timeout). str(exc) there can include local details (the resolved
+        # command line, filesystem errno text) that callers surface straight
+        # into HTTP error responses, so keep it out of the returned reason
+        # and log it server-side instead.
+        logger.warning("run_git: %s failed to launch/complete: %s", args, exc)
+        return False, "git command failed to run"
 
 
 def _cache_base(env: dict | None = None) -> Path:


### PR DESCRIPTION
## Summary

Addresses CodeQL alert #283 (py/stack-trace-exposure, CWE-209) on `/api/shared/refresh`.

`run_git`'s `except (OSError, subprocess.TimeoutExpired)` branch returned `str(exc)` as the failure reason, and the shared-refresh route forwards that straight into the JSON error response. That text can include the resolved command line or filesystem errno detail. This differs from a failed git command's own stdout/stderr, which is already safe, expected text surfaced deliberately per `refresh_shared_clone`'s docstring (e.g. "could not resolve host").

## Fix

Log the exception server-side and return a generic `"git command failed to run"` reason to the caller instead of `str(exc)`.

## Other CodeQL/Snyk alerts triaged, not code changes

While investigating the Security tab I triaged the other 7 open alerts and found them to be false positives (pending dismissal on GitHub, blocked by a permission gate — flagging here for visibility):

- **4 CodeQL `py/stack-trace-exposure`** (#285, #284, #282, #281): each flags a `ValueError` we raise ourselves with a hand-crafted, safe message that only echoes the caller's own input back (`validate_relative_scope`, `validate_path_segment`) or a hardcoded string (`SharedSourceUnavailable`). No stack trace or internal detail involved.
- **3 Snyk Code `python/XSS`** (#280, #279, #278): same known FP pattern already triaged in PR #908 ("Snyk models Flask `jsonify` returns as HTML rendering") — all three sinks are `jsonify()` JSON responses, not HTML.

## Test plan

- [x] `python -m pytest tests/data/test_shared_repo.py tests/api/test_routes_shared_config.py` — 43/43 passing.