### PR TITLE
Sign and notarize macOS DMGs when Developer ID secrets are configured

### DIFF
--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -3,12 +3,19 @@ name: Build Desktop Apps
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build-menubar-dmg:
     runs-on: macos-latest
     permissions:
       contents: write
+    env:
+      MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+      MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+      NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+      NOTARY_ISSUER_ID: ${{ secrets.NOTARY_ISSUER_ID }}
+      NOTARY_KEY_P8_BASE64: ${{ secrets.NOTARY_KEY_P8_BASE64 }}
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -21,10 +28,34 @@ jobs:
       - name: Install create-dmg
         run: brew install create-dmg
 
+      - name: Set up signing keychain
+        if: env.MACOS_CERT_P12_BASE64 != ''
+        run: |
+          KEYCHAIN="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          echo "$MACOS_CERT_P12_BASE64" | base64 -d > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -P "$MACOS_CERT_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN"
+          rm -f "$RUNNER_TEMP/cert.p12"
+          security set-key-partition-list -S "apple-tool:,apple:" \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain-db
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" \
+            | awk -F'"' '/Developer ID Application/ {print $2; exit}')
+          if [ -z "$IDENTITY" ]; then
+            echo "ERROR: no Developer ID Application identity found in imported cert"
+            exit 1
+          fi
+          echo "MACOS_SIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
+
       - name: Build DMG
         run: bash packaging/macos/build-dmg.sh
 
       - name: Upload DMG to release
+        if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -37,10 +68,27 @@ jobs:
             exit 1
           fi
 
+      - name: Upload DMG as workflow artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: quodeqbar-dmg
+          path: dist/*.dmg
+
+      - name: Clean up signing keychain
+        if: always() && env.MACOS_CERT_P12_BASE64 != ''
+        run: security delete-keychain "$RUNNER_TEMP/signing.keychain-db" || true
+
   build-dashboard-dmg:
     runs-on: macos-latest
     permissions:
       contents: write
+    env:
+      MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+      MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+      NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+      NOTARY_ISSUER_ID: ${{ secrets.NOTARY_ISSUER_ID }}
+      NOTARY_KEY_P8_BASE64: ${{ secrets.NOTARY_KEY_P8_BASE64 }}
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -58,10 +106,34 @@ jobs:
       - name: Install create-dmg
         run: brew install create-dmg
 
+      - name: Set up signing keychain
+        if: env.MACOS_CERT_P12_BASE64 != ''
+        run: |
+          KEYCHAIN="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          echo "$MACOS_CERT_P12_BASE64" | base64 -d > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -P "$MACOS_CERT_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN"
+          rm -f "$RUNNER_TEMP/cert.p12"
+          security set-key-partition-list -S "apple-tool:,apple:" \
+            -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain-db
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" \
+            | awk -F'"' '/Developer ID Application/ {print $2; exit}')
+          if [ -z "$IDENTITY" ]; then
+            echo "ERROR: no Developer ID Application identity found in imported cert"
+            exit 1
+          fi
+          echo "MACOS_SIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
+
       - name: Build DMG
         run: bash packaging/macos/build-dashboard-dmg.sh
 
       - name: Upload DMG to release
+        if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -73,6 +145,17 @@ jobs:
             echo "DMG not found at $DMG"
             exit 1
           fi
+
+      - name: Upload DMG as workflow artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: quodeq-dashboard-dmg
+          path: dist/*.dmg
+
+      - name: Clean up signing keychain
+        if: always() && env.MACOS_CERT_P12_BASE64 != ''
+        run: security delete-keychain "$RUNNER_TEMP/signing.keychain-db" || true
 
   build-windows-exe:
     runs-on: windows-latest
@@ -128,6 +211,7 @@ jobs:
           }
 
       - name: Upload zip to release
+        if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -140,3 +224,10 @@ jobs:
             echo "Zip not found at $ZIP"
             exit 1
           fi
+
+      - name: Upload zip as workflow artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: quodeq-windows-zip
+          path: dist/*.zip

--- a/packaging/macos/build-dashboard-dmg.sh
+++ b/packaging/macos/build-dashboard-dmg.sh
@@ -61,6 +61,9 @@ echo "  Created $APP"
 # Step 3: Strip quarantine attribute so users don't need xattr -cr
 xattr -cr "$APP"
 
+# Step 3b: Sign (no-op unless MACOS_SIGN_IDENTITY is set)
+bash "$SCRIPT_DIR/sign-and-notarize.sh" sign-app "$APP"
+
 # Step 4: Create DMG
 echo "==> Creating DMG..."
 DMG_PATH="$DMG_DIR/Quodeq-${VERSION}-macOS.dmg"
@@ -89,6 +92,8 @@ else
 fi
 
 if [ -f "$DMG_PATH" ]; then
+    # Notarize + staple (no-op unless notary credentials are set)
+    bash "$SCRIPT_DIR/sign-and-notarize.sh" notarize-dmg "$DMG_PATH"
     SIZE=$(du -h "$DMG_PATH" | cut -f1)
     echo ""
     echo "==> Done: $DMG_PATH ($SIZE)"

--- a/packaging/macos/build-dmg.sh
+++ b/packaging/macos/build-dmg.sh
@@ -76,6 +76,9 @@ echo "  Created $APP"
 # Strip quarantine attribute so users don't need xattr -cr
 xattr -cr "$APP"
 
+# Sign (no-op unless MACOS_SIGN_IDENTITY is set)
+bash "$SCRIPT_DIR/sign-and-notarize.sh" sign-app "$APP"
+
 # Step 2: Create DMG
 echo "==> Creating DMG..."
 DMG_PATH="$DMG_DIR/QuodeqBar-${VERSION}-macOS.dmg"
@@ -104,6 +107,8 @@ else
 fi
 
 if [ -f "$DMG_PATH" ]; then
+    # Notarize + staple (no-op unless notary credentials are set)
+    bash "$SCRIPT_DIR/sign-and-notarize.sh" notarize-dmg "$DMG_PATH"
     SIZE=$(du -h "$DMG_PATH" | cut -f1)
     echo ""
     echo "==> Done: $DMG_PATH ($SIZE)"

--- a/packaging/macos/entitlements.plist
+++ b/packaging/macos/entitlements.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Required for PyInstaller-bundled Python under the hardened runtime:
+         ctypes/cffi allocate executable memory, and the bundle loads
+         extension modules built by third parties. -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/packaging/macos/sign-and-notarize.sh
+++ b/packaging/macos/sign-and-notarize.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+set -euo pipefail
+
+# Sign and notarize Quodeq macOS artifacts.
+#
+# Usage:
+#   sign-and-notarize.sh sign-app <path/to/App.app>
+#   sign-and-notarize.sh notarize-dmg <path/to/File.dmg>
+#
+# sign-app is skipped (exit 0) unless MACOS_SIGN_IDENTITY is set.
+# notarize-dmg is skipped unless NOTARY_KEY_ID, NOTARY_ISSUER_ID and
+# NOTARY_KEY_P8_BASE64 are all set.
+# Once the env vars are present, any failure is fatal: an opted-in build
+# must never ship a half-signed artifact.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENTITLEMENTS="$SCRIPT_DIR/entitlements.plist"
+
+sign_app() {
+    local app="$1"
+    if [ -z "${MACOS_SIGN_IDENTITY:-}" ]; then
+        echo "==> Signing skipped (MACOS_SIGN_IDENTITY not set)"
+        return 0
+    fi
+    echo "==> Signing $app as '$MACOS_SIGN_IDENTITY'"
+
+    # Nested code first: shared libraries and extension modules anywhere in
+    # the bundle, then framework bundles, then the .app itself (which covers
+    # the main executable) with entitlements.
+    find "$app/Contents" -type f \( -name '*.dylib' -o -name '*.so' \) -print0 |
+        while IFS= read -r -d '' bin; do
+            codesign --force --options runtime --timestamp \
+                --sign "$MACOS_SIGN_IDENTITY" "$bin"
+        done
+
+    if [ -d "$app/Contents/Frameworks" ]; then
+        find "$app/Contents/Frameworks" -maxdepth 1 -name '*.framework' -print0 |
+            while IFS= read -r -d '' fw; do
+                codesign --force --options runtime --timestamp \
+                    --sign "$MACOS_SIGN_IDENTITY" "$fw"
+            done
+    fi
+
+    codesign --force --options runtime --timestamp \
+        --entitlements "$ENTITLEMENTS" \
+        --sign "$MACOS_SIGN_IDENTITY" "$app"
+
+    echo "==> Verifying signature"
+    codesign --verify --strict --deep --verbose=2 "$app"
+}
+
+notarize_dmg() {
+    local dmg="$1"
+    if [ -z "${NOTARY_KEY_ID:-}" ] || [ -z "${NOTARY_ISSUER_ID:-}" ] \
+        || [ -z "${NOTARY_KEY_P8_BASE64:-}" ]; then
+        echo "==> Notarization skipped (notary credentials not set)"
+        return 0
+    fi
+
+    if [ -n "${MACOS_SIGN_IDENTITY:-}" ]; then
+        echo "==> Signing DMG"
+        codesign --force --timestamp --sign "$MACOS_SIGN_IDENTITY" "$dmg"
+    fi
+
+    local keyfile
+    keyfile="$(mktemp -t notary-key.XXXXXX).p8"
+    # shellcheck disable=SC2064  # expand keyfile now, not at trap time
+    trap "rm -f '$keyfile'" EXIT
+    printf '%s' "$NOTARY_KEY_P8_BASE64" | base64 -d > "$keyfile"
+
+    echo "==> Submitting $dmg for notarization (this can take a few minutes)"
+    local out submission_id status
+    out=$(xcrun notarytool submit "$dmg" \
+        --key "$keyfile" --key-id "$NOTARY_KEY_ID" --issuer "$NOTARY_ISSUER_ID" \
+        --wait 2>&1) || true
+    echo "$out"
+    submission_id=$(echo "$out" | awk '/^[[:space:]]*id: / {print $2; exit}')
+    status=$(echo "$out" | awk '/^[[:space:]]*status: / {print $2; exit}')
+
+    if [ "$status" != "Accepted" ]; then
+        echo "ERROR: notarization did not succeed (status: ${status:-unknown})"
+        if [ -n "$submission_id" ]; then
+            echo "==> notarytool log:"
+            xcrun notarytool log "$submission_id" \
+                --key "$keyfile" --key-id "$NOTARY_KEY_ID" \
+                --issuer "$NOTARY_ISSUER_ID" || true
+        fi
+        exit 1
+    fi
+
+    echo "==> Stapling ticket"
+    xcrun stapler staple "$dmg"
+    echo "==> Gatekeeper check"
+    spctl -a -t open --context context:primary-signature -vv "$dmg"
+    echo "==> Notarization complete: $dmg"
+}
+
+case "${1:-}" in
+    sign-app)     sign_app "$2" ;;
+    notarize-dmg) notarize_dmg "$2" ;;
+    *)
+        echo "Usage: $0 {sign-app <App.app>|notarize-dmg <File.dmg>}" >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
## Summary

Adds Developer ID code signing + notarization to both macOS DMG builds, fully gated on repo secrets:

- Without the secrets (today): builds behave exactly as before, unsigned, with a log line saying signing was skipped. Verified locally end to end.
- With the secrets: the .app is signed with hardened runtime + entitlements, the DMG is signed, notarized (`notarytool submit --wait`) and stapled. Any signing or notarization failure fails the build loudly, including the full `notarytool log` on rejection. No half-signed artifacts.

New files: `packaging/macos/entitlements.plist` (the two entitlements PyInstaller apps need under the hardened runtime), `packaging/macos/sign-and-notarize.sh` (shared by both builds). The workflow gains a conditional keychain-import step that derives the signing identity from the imported cert, an always-run keychain cleanup, and a `workflow_dispatch` trigger that uploads DMGs as workflow artifacts, so the signing pipeline can be tested without cutting a release.

## One-time setup (Victor)

1. Enroll as an individual in the Apple Developer Program at developer.apple.com ($99/year, approval usually 24-48h).
2. Certificates, Identifiers & Profiles: create a **Developer ID Application** certificate. Install it in Keychain, then export it as a .p12 with a password.
3. App Store Connect > Users and Access > Integrations > App Store Connect API: create a key with the **Developer** role. Download the .p8 (one-time download); note the Key ID and Issuer ID.
4. Add these repo secrets (Settings > Secrets and variables > Actions):

| Secret | Value |
|---|---|
| `MACOS_CERT_P12_BASE64` | `base64 -i cert.p12 \| pbcopy` |
| `MACOS_CERT_PASSWORD` | the .p12 export password |
| `NOTARY_KEY_ID` | Key ID from App Store Connect |
| `NOTARY_ISSUER_ID` | Issuer ID from App Store Connect |
| `NOTARY_KEY_P8_BASE64` | `base64 -i AuthKey_XXXX.p8 \| pbcopy` |

No Team ID secret is needed; the API key already scopes the team.

## Acceptance (after secrets exist)

1. Actions > Build Desktop Apps > Run workflow (on develop or main).
2. Download the `quodeq-dashboard-dmg` artifact and verify:

```
spctl -a -t open --context context:primary-signature -vv Quodeq-*.dmg
# expect: accepted, source=Notarized Developer ID

codesign -dv --verbose=2 /Volumes/Quodeq/Quodeq.app   # after mounting the DMG
# expect: Developer ID Application: Victor Purcallas Marchesi, flags=...(runtime)
```

Until then, releases keep shipping unsigned DMGs exactly as today.

## Out of scope

Windows Authenticode signing (deferred: needs a separate certificate purchase and a cloud HSM), Mac App Store (rejected: sandbox is incompatible with git clones, subprocesses and the embedded terminal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
