### PR TITLE
Explain the pre-signing xattr strip in the DMG build scripts

### DIFF
--- a/packaging/macos/build-dashboard-dmg.sh
+++ b/packaging/macos/build-dashboard-dmg.sh
@@ -58,7 +58,11 @@ fi
 
 echo "  Created $APP"
 
-# Step 3: Strip quarantine attribute so users don't need xattr -cr
+# Step 3: Strip extended attributes (build-machine detritus). codesign
+# refuses bundles carrying resource forks or Finder info, so this must run
+# BEFORE signing. It does not weaken end-user Gatekeeper: quarantine is
+# applied by the downloading browser to the DMG, and user trust comes from
+# the notarized signature, not from this build-side cleanup.
 xattr -cr "$APP"
 
 # Step 3b: Sign (no-op unless MACOS_SIGN_IDENTITY is set)

--- a/packaging/macos/build-dmg.sh
+++ b/packaging/macos/build-dmg.sh
@@ -73,7 +73,11 @@ cp "$REPO_ROOT/src/quodeq/data/icons/icon.icns" "$APP/Contents/Resources/icon.ic
 
 echo "  Created $APP"
 
-# Strip quarantine attribute so users don't need xattr -cr
+# Strip extended attributes (build-machine detritus). codesign refuses
+# bundles carrying resource forks or Finder info, so this must run BEFORE
+# signing. It does not weaken end-user Gatekeeper: quarantine is applied by
+# the downloading browser to the DMG, and user trust comes from the
+# notarized signature, not from this build-side cleanup.
 xattr -cr "$APP"
 
 # Sign (no-op unless MACOS_SIGN_IDENTITY is set)


### PR DESCRIPTION
Addresses the two Quodeq-review findings on #1146 ("stripping quarantine attributes"): the xattr -cr is pre-signing cleanup that codesign requires (it refuses bundles carrying resource forks or Finder info) and does not weaken end-user Gatekeeper, whose trust comes from the notarized signature. The finding was written against #1146 but that PR merged before the fix pushed, so this lands the comment on develop.

The same two lines exist on #1148's branch and will pick this up on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)