### PR TITLE
fix(dashboard): skip npm audit during dev/build npm ci install

### DIFF
--- a/src/quodeq/dashboard/_build_npm.py
+++ b/src/quodeq/dashboard/_build_npm.py
@@ -71,8 +71,11 @@ def run_npm_build(workdir: Path, static_dir: Path) -> None:
     # Use `npm ci` to enforce lockfile-pinned installs (refuses to mutate
     # package-lock.json, errors if it's out of sync). `_SYNC_ITEMS` in
     # `_build_hash.py` copies package-lock.json into the workdir before this
-    # runs, so a lockfile is always present.
-    subprocess.run([npm, "ci"], cwd=str(workdir), check=True, timeout=_NPM_INSTALL_TIMEOUT_S)
+    # runs, so a lockfile is always present. `--no-audit` skips the live,
+    # uncached POST to the npm advisories endpoint, which is purely
+    # informational here (it never fails the install) but can single-handedly
+    # blow past the timeout on slow networks.
+    subprocess.run([npm, "ci", "--no-audit"], cwd=str(workdir), check=True, timeout=_NPM_INSTALL_TIMEOUT_S)
 
     log_info("Building web UI...")
     env = {**os.environ, "QUODEQ_BUILD_OUTDIR": str(static_dir)}


### PR DESCRIPTION
## Summary
- `npm ci` in `run_npm_build()` was making a live, uncached POST to the npm advisories endpoint on every dev build. It's purely informational (never fails the install) but on slow networks it took 70s+ in testing and can blow past the 300s install timeout entirely, breaking `quodeq --dev` startup with `Command '[...npm ci...]' timed out after 300 seconds`.
- Added `--no-audit` to skip that call. `ui/.npmrc`'s `audit-level=high` is untouched, so explicit `npm audit` runs (CI, manual security review) keep their coverage.

## Test plan
- [x] `rm -rf node_modules && npm ci` in `src/quodeq/ui`: ~73s (audit POST alone was 73s)
- [x] `rm -rf node_modules && npm ci --no-audit`: ~10s, same 457 packages installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuoTiZwV5pnogcF8rXGXdp