### PR TITLE
feat(cache): schema 4 key without language, adopt results across file moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+- **Cached results follow files that move**: when a file's content is unchanged and only its directory changed (same file name, same test/production role), the previous evaluation is adopted instead of re-run. A repo restructure that moves a top-level folder no longer costs a full re-evaluation. The cache log line and the `cache_stats` event report the count as `adopted`.
+- **Content index beside the cache**: a small sqlite index (`~/.quodeq/cache/results/.index.db`) maps file content to cached results. It is rebuilt automatically if missing or corrupt.
+
+### Changes
+- **Cache key schema 4**: the detected project language is no longer part of the evaluation cache key. A language-detection change (for example `build.gradle` replaced by `build.gradle.kts`) reuses all cached results instead of re-evaluating the repo. Existing entries are migrated in place, once, on the first evaluation or dashboard start after upgrading; on very large caches the one-time pass can take a few minutes.
+
 ## [1.10.1] - 2026-08-28
 
 ### Fixes

--- a/src/quodeq/analysis/_pipeline.py
+++ b/src/quodeq/analysis/_pipeline.py
@@ -10,7 +10,7 @@ from quodeq.analysis._analysis_context import load_analysis_context as _load_ctx
 from quodeq.analysis._loop_state import _run_dir_for, _safe_write_dim_state
 from quodeq.analysis._loops import run_incremental_loop, run_per_dimension_loop
 from quodeq.analysis._types import RunConfig, _AnalysisContext
-from quodeq.analysis.cache.gc import maybe_collect_legacy_entries
+from quodeq.analysis.cache.gc import ensure_cache_ready
 from quodeq.analysis.cache.local import LocalFileBackend
 from quodeq.analysis.dimension_runner import DimensionRunner, _log_dimension_result
 from quodeq.analysis.errors import EvaluationError as EvaluationError  # re-export
@@ -133,11 +133,12 @@ def _prepare_run_context(
 
     Cache is constructed here (composition root) rather than left for
     process_dimension_with_cache to default lazily, so every dimension in
-    this run shares one LocalFileBackend. The legacy-entry GC that used to
-    ride along with the lazy default is called explicitly here instead --
-    it's still once-per-(root, schema)-per-process (see
-    maybe_collect_legacy_entries's own memo), just triggered at runner
-    construction instead of on the first cache-is-None dimension call.
+    this run shares one LocalFileBackend. The cache maintenance (schema
+    migration, content-index build, legacy GC) that used to ride along with
+    the lazy default is called explicitly here instead -- it's still
+    once-per-(root, schema)-per-process (see ensure_cache_ready's own memo),
+    just triggered at runner construction instead of on the first
+    cache-is-None dimension call.
     """
     dimensions, ctx = load_analysis_context(config)
     if config._classify_cache is None:
@@ -145,7 +146,7 @@ def _prepare_run_context(
     _persist_dim_estimates(config, dimensions)
 
     cache = LocalFileBackend()
-    maybe_collect_legacy_entries(cache.root)
+    ensure_cache_ready(cache.root)
     runner = DimensionRunner(cache=cache, log=SHARED_LOG)
     return dimensions, ctx, runner
 

--- a/src/quodeq/analysis/cache/__init__.py
+++ b/src/quodeq/analysis/cache/__init__.py
@@ -28,6 +28,7 @@ from quodeq.analysis.cache.dimension_helpers import (
 from quodeq.analysis.cache.entry import CacheEntry
 from quodeq.analysis.cache.gc import (
     collect_legacy_entries,
+    ensure_cache_ready,
     maybe_collect_legacy_entries,
 )
 from quodeq.analysis.cache.key import CacheKey, compute_key
@@ -59,6 +60,7 @@ __all__ = [
     "collect_legacy_entries",
     "compute_key",
     "default_cache_root",
+    "ensure_cache_ready",
     "format_provenance_drift",
     "maybe_collect_legacy_entries",
     "persist_dispatch_results",

--- a/src/quodeq/analysis/cache/__init__.py
+++ b/src/quodeq/analysis/cache/__init__.py
@@ -1,16 +1,22 @@
 """Content-addressed cache for analysis results.
 
 A successful (file, dimension) analysis is keyed by the SHA-256 of its real
-per-unit inputs (file content, path, dimension, language) and stored as one
-atomic, self-describing JSON entry. The next run computes the same key and
-either serves the recorded result or dispatches the work and writes the new
-entry.
+per-unit inputs (file content, path, dimension, non-default params) and
+stored as one atomic, self-describing JSON entry. The next run computes the
+same key and either serves the recorded result or dispatches the work and
+writes the new entry.
 
 The key is permissive (cost-first): volatile inputs (model, prompts,
 standards, sampling) are NOT keyed — switching them reuses prior work. Each
 entry records those in its ``provenance`` block, so reuse across a model /
 prompts / standards boundary is surfaced, not silent; the user refreshes on
 demand with ``--clean-scan``.
+
+Since schema 4 the project ``language`` is provenance too, so a
+language-detection flip reuses prior work. A file moved inside the repo with
+unchanged content is recovered by adoption (``_adoption.py``) through the
+content index kept beside the entries (``data/cache_store/index.py``); the
+cache log line reports the count as ``adopted``.
 
 This is the canonical incremental layer. Half-computed work never gets a
 key, so there is no partial state to recover from.

--- a/src/quodeq/analysis/cache/_adoption.py
+++ b/src/quodeq/analysis/cache/_adoption.py
@@ -1,0 +1,75 @@
+"""Adopt a cached result across a file move.
+
+A classify miss with a real content hash asks the backend's content index
+for entries written with the same (content hash, dimension, params hash).
+If one of them is the same file under another path (same basename, same
+``path_role``), its findings are cloned under the new key with the ``file``
+field rewritten, and the clone is returned as the hit. Provenance records
+``adopted_from`` so the reuse is visible in the cache log line and never
+silent.
+
+Why these guards: the bytes are identical, so path-insensitive judgments
+carry over exactly. Clean-architecture and the test/production downweight do
+read the path, which is why a rename (different basename) or a role change
+re-evaluates instead. Adoption is deliberately cross-project: entries carry
+no project identity and the cache is already cost-first across model and
+standards changes.
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import PurePosixPath
+
+from quodeq.analysis.cache.backend import CacheBackend
+from quodeq.analysis.cache.entry import CacheEntry
+from quodeq.analysis.cache.key import CacheKey
+from quodeq.context.path_role import path_role
+
+
+def _compatible_move(old_path: str, new_path: str) -> bool:
+    if old_path == new_path:
+        return False
+    if PurePosixPath(old_path).name != PurePosixPath(new_path).name:
+        return False
+    return path_role(old_path) == path_role(new_path)
+
+
+def _clone_for(src: CacheEntry, *, new_key: str, new_path: str, language: str) -> CacheEntry:
+    findings = [
+        {**f, "file": new_path} if f.get("file") == src.file_path else dict(f)
+        for f in src.findings
+    ]
+    provenance = {**(src.provenance or {}), "adopted_from": src.file_path}
+    return replace(
+        src, key=new_key, file_path=new_path, findings=findings, language=language,
+        provenance=provenance,
+        created_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    )
+
+
+def try_adopt(
+    cache: CacheBackend, struct: CacheKey, new_key: str, *, language: str,
+) -> CacheEntry | None:
+    """Return an adopted entry for *struct* written under *new_key*, or None.
+
+    None when the backend has no content index, the content hash is blank,
+    or no indexed entry passes the move guards and verification.
+    """
+    finder = getattr(cache, "find_by_content", None)
+    if finder is None or not struct.file_content_hash:
+        return None
+    for row in finder(struct.file_content_hash, struct.dimension, struct.params_hash):
+        if not _compatible_move(row.file_path, struct.file_path):
+            continue
+        src = cache.get(row.key)
+        if (
+            src is None
+            or src.file_content_hash != struct.file_content_hash
+            or src.dimension != struct.dimension
+        ):
+            continue
+        adopted = _clone_for(src, new_key=new_key, new_path=struct.file_path, language=language)
+        cache.put(new_key, adopted)
+        return adopted
+    return None

--- a/src/quodeq/analysis/cache/_key_provenance.py
+++ b/src/quodeq/analysis/cache/_key_provenance.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from quodeq.analysis._types import RunConfig
 from quodeq.analysis.cache.entry import quodeq_version
+from quodeq.analysis.cache.key import SCHEMA_VERSION as _SCHEMA_VERSION
 from quodeq.analysis.cache.key import CacheKey, compute_key
 from quodeq.analysis.fingerprint import (
     _hash_file,
@@ -26,18 +27,9 @@ from quodeq.analysis.fingerprint import (
     dimension_params_state,
 )
 
-# Bumped on any breaking change to key composition or entry format.
-# v1 -> v2: file_done marker contract; entries written without marker
-# filtering are no longer trusted, so old entries naturally invalidate
-# on the next input change.
-# v2 -> v3: permissive key — model/prompts/standards/sampling left the key
-# (now provenance on the entry). The formula change re-keys every entry, so
-# schema-2 entries land in a different namespace that schema-3 lookups never
-# reach; the one-time GC (cache/gc.py) then reclaims them. This is the LAST
-# key change that costs a re-eval: entries are now self-describing
-# (file_content_hash stored), so any future key change is losslessly
-# migratable.
-_SCHEMA_VERSION = 3
+# The schema constant and its history live with the key formula in
+# ``data/cache_store/key.py``; ``_SCHEMA_VERSION`` is re-exported here for the
+# call sites and tests that import it from this module.
 
 
 # Provenance fields compared at classify time, in display order.
@@ -128,28 +120,36 @@ def _model_id_from(config: RunConfig) -> str:
     return opts.subagent_model or opts.ai_model or "unknown"
 
 
-def build_cache_key_for_file(config: RunConfig, file_path: str, dimension: str) -> str:
-    """Compute the cache key for a (file, dimension) pair under ``config``.
+def build_cache_key_struct(config: RunConfig, file_path: str, dimension: str) -> CacheKey:
+    """The ``CacheKey`` for a (file, dimension) pair under ``config``.
 
-    Returns a 64-char hex SHA-256. The key is permissive: it depends only on
-    the real per-unit inputs (file content, path, dimension, language, and
-    non-default threshold params), so a model switch or a quodeq/standards
-    update reuses the cached result. The volatile context is recorded on the
-    entry's provenance at write time.
+    Exposed as a struct (not only the hash) so classify can reuse the
+    content hash and params hash for adoption lookups without hashing the
+    file twice. The key is permissive: it depends only on the real per-unit
+    inputs (file content, path, dimension, non-default threshold params), so
+    a model switch, a language-detection flip or a quodeq/standards update
+    reuses the cached result. The volatile context is recorded on the entry's
+    provenance at write time.
 
-    MUST stay byte-for-byte identical to the key built in
-    ``cache_writer.build_cache_writer`` and ``cache.runner._key_for`` —
+    MUST stay byte-for-byte identical to the keys built in
+    ``cache_writer._write_cache_entry`` and ``cache.runner._key_for`` --
     ``CacheKey`` is the single source of truth and all three populate exactly
     its fields.
     """
     content_hash = _hash_file(config.src / file_path) or ""
     params_hash, _ = dimension_params_state(config.standards_dir, dimension, config.src)
-    key = CacheKey(
+    return CacheKey(
         schema_version=_SCHEMA_VERSION,
         file_content_hash=content_hash,
         file_path=file_path,
         dimension=dimension,
-        language=config.language or "",
         params_hash=params_hash,
     )
-    return compute_key(key)
+
+
+def build_cache_key_for_file(config: RunConfig, file_path: str, dimension: str) -> str:
+    """Compute the cache key for a (file, dimension) pair under ``config``.
+
+    Returns a 64-char hex SHA-256. See ``build_cache_key_struct``.
+    """
+    return compute_key(build_cache_key_struct(config, file_path, dimension))

--- a/src/quodeq/analysis/cache/cache_writer.py
+++ b/src/quodeq/analysis/cache/cache_writer.py
@@ -96,6 +96,7 @@ def _write_cache_entry(
         model_id=model_id,
         file_content_hash=content_hash,
         language=language,
+        params_hash=params_hash,
         provenance=build_provenance(
             model_id=model_id, prompts_hash=prompts_hash,
             standards_hash=standards_hash, version=version,

--- a/src/quodeq/analysis/cache/cache_writer.py
+++ b/src/quodeq/analysis/cache/cache_writer.py
@@ -83,7 +83,6 @@ def _write_cache_entry(
         file_content_hash=content_hash,
         file_path=file_path,
         dimension=dimension,
-        language=language,
         params_hash=params_hash,
     )
     key = compute_key(key_struct)

--- a/src/quodeq/analysis/cache/dimension_helpers.py
+++ b/src/quodeq/analysis/cache/dimension_helpers.py
@@ -203,7 +203,7 @@ def _group_findings_by_file(jsonl_path: Path) -> tuple[dict[str, list[dict]], se
 def _build_cache_entry_for_file(
     config: RunConfig, dimension: str, f: str, key: str, grouped: dict[str, list[dict]],
     *, model_id: str, standards_hash: str, prompts_hash: str, effective_params: dict,
-    version: str,
+    version: str, params_hash: str = "",
 ) -> CacheEntry:
     """Build the CacheEntry for one dispatched file's persisted result."""
     return CacheEntry(
@@ -216,6 +216,7 @@ def _build_cache_entry_for_file(
         model_id=model_id,
         file_content_hash=_hash_file(config.src / f) or "",
         language=config.language or "",
+        params_hash=params_hash,
         provenance=build_provenance(
             model_id=model_id, prompts_hash=prompts_hash,
             standards_hash=standards_hash, version=version,
@@ -255,7 +256,7 @@ def persist_dispatch_results(
         _hash_standards(config.standards_dir, dimension, config.src)
         if config.standards_dir else ""
     ) or ""
-    _, effective_params = dimension_params_state(
+    params_hash, effective_params = dimension_params_state(
         config.standards_dir, dimension, config.src,
     )
     prompts_hash = _hash_prompts_combined(config.prompts_dir)
@@ -270,6 +271,6 @@ def persist_dispatch_results(
         entry = _build_cache_entry_for_file(
             config, dimension, f, key, grouped,
             model_id=model_id, standards_hash=standards_hash, prompts_hash=prompts_hash,
-            effective_params=effective_params, version=version,
+            effective_params=effective_params, version=version, params_hash=params_hash,
         )
         cache.put(key, entry)

--- a/src/quodeq/analysis/cache/dimension_helpers.py
+++ b/src/quodeq/analysis/cache/dimension_helpers.py
@@ -5,14 +5,14 @@ These are pure functions used by the V2 dimension processor (Phase B5):
 
   - ``build_cache_key_for_file``: derive a deterministic cache key from
     the current ``RunConfig`` and a target file. The key composition
-    matches ``CacheKey``: file content, dimension, standards, prompts,
-    model, language. Sampling params are not yet plumbed through
-    ``AnalysisOptions``; once they are, add them to the key.
+    matches ``CacheKey``: file content, path, dimension, non-default
+    params. Model, prompts, standards and language are provenance, not key.
 
   - ``classify_files_via_cache``: split a file list into cache hits
-    (with findings) and misses (need dispatch). The miss-key mapping is
-    returned so the caller can write entries after dispatch without
-    recomputing keys.
+    (with findings) and misses (need dispatch). A miss with a real content
+    hash first tries adoption from an identical file under another path
+    (``_adoption.py``). The miss-key mapping is returned so the caller can
+    write entries after dispatch without recomputing keys.
 
   - ``persist_dispatch_results``: after a dispatch run writes its JSONL,
     group its findings by file and write per-file cache entries for the
@@ -33,17 +33,20 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from quodeq.analysis._types import RunConfig
+from quodeq.analysis.cache._adoption import try_adopt
 from quodeq.analysis.cache._key_provenance import (
     _SCHEMA_VERSION,
     _accumulate_drift,
     _current_provenance,
     _hash_prompts_combined,
     _model_id_from,
-    build_cache_key_for_file,
+    build_cache_key_for_file,  # noqa: F401 -- re-export
+    build_cache_key_struct,
     format_provenance_drift,  # noqa: F401 -- re-export
 )
 from quodeq.analysis.cache.backend import CacheBackend
 from quodeq.analysis.cache.entry import CacheEntry, build_provenance, quodeq_version
+from quodeq.analysis.cache.key import compute_key
 from quodeq.analysis.fingerprint import (
     _hash_file,
     _hash_standards,
@@ -76,20 +79,30 @@ class ClassifyResult:
     # file -> cache key for those same entries, so a run that reaches done
     # can flip them to consolidated.
     unconsolidated_hit_keys: dict[str, str] = field(default_factory=dict)
+    # Hits served by adopting an entry with identical content from another
+    # path (a directory move). Counted so the cache log line and the
+    # cache_stats marker can surface the reuse.
+    adopted: int = 0
 
 
 def _classify_one_file(
     config: RunConfig, dimension: str, f: str, cache: CacheBackend, *, bypass_reads: bool,
     current_prov: dict | None,
-) -> tuple[str, CacheEntry | None, dict | None]:
-    """Classify one file against the cache. Returns (key, hit, current_prov),
-    where hit is None on a miss and current_prov is lazily computed on the
-    first hit (passed through so the caller only pays for it once)."""
-    key = build_cache_key_for_file(config, f, dimension)
+) -> tuple[str, CacheEntry | None, dict | None, bool]:
+    """Classify one file against the cache. Returns (key, hit, current_prov,
+    adopted), where hit is None on a miss, current_prov is lazily computed on
+    the first hit (passed through so the caller only pays for it once), and
+    adopted says the hit came from ``try_adopt`` rather than a direct get."""
+    struct = build_cache_key_struct(config, f, dimension)
+    key = compute_key(struct)
     hit = None if bypass_reads else cache.get(key)
+    adopted = False
+    if hit is None and not bypass_reads:
+        hit = try_adopt(cache, struct, key, language=config.language or "")
+        adopted = hit is not None
     if hit is not None and current_prov is None:
         current_prov = _current_provenance(config, dimension)
-    return key, hit, current_prov
+    return key, hit, current_prov, adopted
 
 
 def _partition_files_by_cache(
@@ -103,15 +116,17 @@ def _partition_files_by_cache(
     provenance_drift: dict = {}
     unconsolidated_findings: list[dict] = []
     unconsolidated_hit_keys: dict[str, str] = {}
+    adopted = 0
     current_prov: dict | None = None  # computed lazily, only if there are hits
     for f in files:
-        key, hit, current_prov = _classify_one_file(
+        key, hit, current_prov, was_adopted = _classify_one_file(
             config, dimension, f, cache, bypass_reads=bypass_reads, current_prov=current_prov,
         )
         if hit is None:
             misses.append(f)
             miss_keys[f] = key
         else:
+            adopted += int(was_adopted)
             if hit.consolidated:
                 cached_findings.extend(hit.findings)
             else:
@@ -126,6 +141,7 @@ def _partition_files_by_cache(
         provenance_drift=provenance_drift,
         unconsolidated_findings=unconsolidated_findings,
         unconsolidated_hit_keys=unconsolidated_hit_keys,
+        adopted=adopted,
     )
 
 

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -111,15 +111,12 @@ def _classify_and_log(
     )
     n_hits = len(files) - len(classify.misses)
     drift_note = format_provenance_drift(classify.provenance_drift, reused=n_hits)
-    adopted_note = (
-        f" - {classify.adopted} adopted from moved files" if classify.adopted else ""
-    )
+    adopted_note = f" - {classify.adopted} adopted from moved files" if classify.adopted else ""
     _logger.info(
         "[%s] cache: %d hits / %d misses (%d total)%s%s%s",
         dim_id, n_hits, len(classify.misses), len(files),
         " - clean-scan invalidated" if bypass_reads else "",
-        f" - reused {drift_note}" if drift_note else "",
-        adopted_note,
+        f" - reused {drift_note}" if drift_note else "", adopted_note,
     )
     emit_marker(
         "cache_stats", dimension=dim_id, hits=n_hits, misses=len(classify.misses),

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -60,7 +60,7 @@ from quodeq.analysis.cache.dimension_helpers import (
     format_provenance_drift,
     persist_dispatch_results,
 )
-from quodeq.analysis.cache.gc import maybe_collect_legacy_entries
+from quodeq.analysis.cache.gc import ensure_cache_ready
 from quodeq.analysis.cache.local import LocalFileBackend
 from quodeq.analysis.subagents._source_files import _list_source_files
 from quodeq.analysis.subagents.runner import (
@@ -262,7 +262,7 @@ def process_dimension_with_cache(
     list to classify (matches V1's no-files fallback)."""
     if cache is None:
         cache = LocalFileBackend()
-        maybe_collect_legacy_entries(cache.root)
+        ensure_cache_ready(cache.root)
     trust_model = resolve_trust_model(config.src) if config.src is not None else None
     files, _ext, _excluded = _list_source_files(config, dim_id)
     if not files:

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -111,15 +111,19 @@ def _classify_and_log(
     )
     n_hits = len(files) - len(classify.misses)
     drift_note = format_provenance_drift(classify.provenance_drift, reused=n_hits)
+    adopted_note = (
+        f" - {classify.adopted} adopted from moved files" if classify.adopted else ""
+    )
     _logger.info(
-        "[%s] cache: %d hits / %d misses (%d total)%s%s",
+        "[%s] cache: %d hits / %d misses (%d total)%s%s%s",
         dim_id, n_hits, len(classify.misses), len(files),
         " - clean-scan invalidated" if bypass_reads else "",
         f" - reused {drift_note}" if drift_note else "",
+        adopted_note,
     )
     emit_marker(
         "cache_stats", dimension=dim_id, hits=n_hits, misses=len(classify.misses),
-        total=len(files),
+        total=len(files), adopted=classify.adopted,
         mode="clean-scan-invalidated" if bypass_reads else "incremental",
     )
     return classify

--- a/src/quodeq/analysis/cache/gc.py
+++ b/src/quodeq/analysis/cache/gc.py
@@ -1,88 +1,36 @@
-"""One-time garbage collection of cache entries from an older schema.
+"""Shim: cache maintenance moved to ``data/cache_store/migrate``.
 
-Changing the cache-key formula (the schema 2 -> 3 permissive-key change)
-re-keys every entry: old entries land at paths current-schema lookups never
-reach, so they can only waste disk. This module reclaims them once, lazily,
-on the first cache open under a new schema.
-
-Best-effort and idempotent: an entry that fails to read is skipped and
-logged, never fatal; a second pass finds nothing left to remove. A per-root
-marker file plus an in-process memo ensure the walk runs at most once per
-schema per process.
+``ensure_cache_ready`` migrates schema-3 entries to schema 4, builds the
+content index and reclaims legacy entries, once per cache root. This
+analysis-side wrapper resolves the default standards directory (needed to
+derive ``params_hash`` for entries written under threshold overrides) so
+call sites in the pipeline stay a one-liner.
 """
 from __future__ import annotations
 
-import json
-import logging
-import shutil
 from pathlib import Path
 
-_logger = logging.getLogger(__name__)
-
-# Mirrors local._ENTRY_FILENAME. Duplicated rather than imported so this
-# module stays a leaf with no intra-package imports at load time (the GC is
-# triggered from dimension_runner, not local).
-_ENTRY_FILENAME = "entry.json"
-
-# (root, schema) pairs already collected in this process.
-_collected: set[tuple[str, int]] = set()
+from quodeq.config.paths import default_paths
+from quodeq.data.cache_store.migrate import (  # noqa: F401 -- re-exports
+    MigrationStats,
+    collect_legacy_entries,
+    migrate_entries,
+)
+from quodeq.data.cache_store.migrate import ensure_cache_ready as _ensure_cache_ready
 
 
-def _current_schema() -> int:
-    from quodeq.data.cache_store.key import SCHEMA_VERSION  # noqa: PLC0415
-    return SCHEMA_VERSION
-
-
-def collect_legacy_entries(root: Path, *, min_schema: int) -> int:
-    """Delete every cached entry whose ``schema_version`` is below *min_schema*.
-
-    Returns the number of entries removed. Never raises: an entry that cannot
-    be read is skipped and logged (we can't prove it's legacy, so we leave
-    it). Safe to call repeatedly — a second pass removes nothing.
-    """
-    if not root.exists():
-        return 0
-    removed = 0
-    for entry_path in root.rglob(_ENTRY_FILENAME):
-        try:
-            data = json.loads(entry_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError, ValueError) as exc:
-            _logger.debug("cache GC: skipping unreadable entry %s: %s", entry_path, exc)
-            continue
-        schema = data.get("schema_version")
-        if isinstance(schema, int) and schema < min_schema:
-            try:
-                shutil.rmtree(entry_path.parent)
-                removed += 1
-            except OSError as exc:
-                _logger.debug("cache GC: failed to remove %s: %s", entry_path.parent, exc)
-    return removed
-
-
-def maybe_collect_legacy_entries(root: Path) -> None:
-    """Run the legacy-entry GC at most once per (root, schema) per process.
-
-    Guarded by an in-process memo and an on-disk marker so the cache is
-    walked at most once after an upgrade. A non-existent root is a cheap
-    no-op — a brand-new cache has no legacy entries to reclaim.
-    """
-    schema = _current_schema()
-    memo_key = (str(root), schema)
-    if memo_key in _collected:
-        return
-    _collected.add(memo_key)
-    if not root.exists():
-        return
-    marker = root / f".gc_schema_{schema}"
+def _default_standards_dir() -> Path | None:
     try:
-        if marker.exists():
-            return
-        removed = collect_legacy_entries(root, min_schema=schema)
-        marker.write_text("", encoding="utf-8")
-        if removed:
-            _logger.info(
-                "cache GC: reclaimed %d entr%s older than schema %d",
-                removed, "y" if removed == 1 else "ies", schema,
-            )
-    except OSError as exc:  # marker write / unexpected IO — never fatal
-        _logger.debug("cache GC: best-effort pass failed for %s: %s", root, exc)
+        std = default_paths().standards_dir
+    except Exception:  # noqa: BLE001 - maintenance must never break a scan
+        return None
+    return std if std is not None and std.exists() else None
+
+
+def ensure_cache_ready(root: Path) -> None:
+    """Migrate, index and GC *root* once per (root, schema). Never raises."""
+    _ensure_cache_ready(root, standards_dir=_default_standards_dir())
+
+
+# Back-compat name from the schema-3 GC era.
+maybe_collect_legacy_entries = ensure_cache_ready

--- a/src/quodeq/analysis/cache/gc.py
+++ b/src/quodeq/analysis/cache/gc.py
@@ -29,11 +29,8 @@ _collected: set[tuple[str, int]] = set()
 
 
 def _current_schema() -> int:
-    # Lazy import: dimension_helpers is a heavier module (pulls RunConfig,
-    # fingerprint, etc.) and imports this package's other cache modules.
-    # Deferring keeps gc import-cheap and the dependency one-directional.
-    from quodeq.analysis.cache.dimension_helpers import _SCHEMA_VERSION  # noqa: PLC0415
-    return _SCHEMA_VERSION
+    from quodeq.data.cache_store.key import SCHEMA_VERSION  # noqa: PLC0415
+    return SCHEMA_VERSION
 
 
 def collect_legacy_entries(root: Path, *, min_schema: int) -> int:

--- a/src/quodeq/analysis/cache/key.py
+++ b/src/quodeq/analysis/cache/key.py
@@ -1,71 +1,9 @@
-"""Cache key — content-addressed identity for a (file, dimension) work unit.
+"""Shim: cache key moved to ``data/cache_store``.
 
-The key is the SHA-256 of a canonical JSON serialization of the inputs that
-define *"this exact code, evaluated for this dimension."* Two runs with
-identical inputs compute the same key and share the cached result.
-
-The key is **permissive** (cost-first): it invalidates ONLY on a real
-per-unit change. Evaluations are expensive, the user already owns the
-explicit refresh path (``--clean-scan``), so cached findings stay resilient
-to everything except an actual file change.
-
-What is intentionally NOT in the key (recorded in ``CacheEntry.provenance``
-instead, so reuse across these boundaries is surfaced rather than silently
-re-evaluated):
-- ``model_id`` — switching models reuses prior work; the user refreshes if
-  they want the new model to re-run.
-- ``prompts_hash`` / ``standards_hash`` — a quodeq update or a standards edit
-  reuses prior work; ``--clean-scan`` refreshes on demand.
-- ``evaluator_hash`` and sampling params (``temperature``, ``max_tokens``).
-- timestamps, run_id, machine, user, git_commit, branch — run metadata, never
-  inputs to the analysis itself.
-
-``language`` stays in the key: it is a stable project property (not a quodeq
-update) and changing it genuinely changes which files exist and how they are
-analyzed.
-
-``params_hash`` joins the key for the same reason: a threshold override
-rewrites the rule text the model enforces, so results computed under a
-different threshold answer a different question. It is "" (and absent from
-the canonical form) when every param equals its default.
+The key formula is needed by the data-layer schema migration, so it lives at
+``quodeq.data.cache_store.key``. This module re-exports the public names so
+every pre-existing ``quodeq.analysis.cache.key`` import path keeps working.
 """
 from __future__ import annotations
 
-import hashlib
-import json
-from dataclasses import asdict, dataclass
-
-
-@dataclass(frozen=True)
-class CacheKey:
-    """The real per-unit inputs that determine the analysis output.
-
-    Only these fields. Volatile inputs (model, prompts, standards, sampling)
-    are deliberately excluded — they live in ``CacheEntry.provenance``. Adding
-    a field here is a cache-wide invalidation, so do it only for a genuine
-    per-unit input.
-    """
-
-    schema_version: int
-    file_content_hash: str
-    file_path: str
-    dimension: str
-    language: str
-    # Per-dimension hash of non-default threshold params ("" when all
-    # defaults). Unlike model/prompts/standards this IS a per-unit input:
-    # it rewrites the rule text the LLM enforces, so a change genuinely
-    # changes the analysis. Empty is omitted from the canonical form so
-    # default-config keys stay byte-identical to pre-params keys.
-    params_hash: str = ""
-
-
-def compute_key(key: CacheKey) -> str:
-    """Return the hex SHA-256 of the canonical serialization of ``key``."""
-    data = asdict(key)
-    # Legacy identity: default params serialize exactly like pre-params
-    # keys, so existing caches survive the upgrade and removing every
-    # override restores the original cached results.
-    if not data["params_hash"]:
-        del data["params_hash"]
-    canonical = json.dumps(data, sort_keys=True, separators=(",", ":"))
-    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+from quodeq.data.cache_store.key import SCHEMA_VERSION, CacheKey, compute_key  # noqa: F401

--- a/src/quodeq/analysis/cache/runner.py
+++ b/src/quodeq/analysis/cache/runner.py
@@ -87,7 +87,6 @@ def _key_for(unit: WorkUnit, schema_version: int) -> str:
         file_content_hash=unit.file_content_hash,
         file_path=unit.file_path,
         dimension=unit.dimension,
-        language=unit.language,
         params_hash=unit.params_hash,
     ))
 

--- a/src/quodeq/analysis/cache/runner.py
+++ b/src/quodeq/analysis/cache/runner.py
@@ -122,6 +122,7 @@ def analyze_unit(
         model_id=unit.model_id,
         file_content_hash=unit.file_content_hash,
         language=unit.language,
+        params_hash=unit.params_hash,
         provenance=build_provenance(
             model_id=unit.model_id, prompts_hash=unit.prompts_hash,
             standards_hash=unit.standards_hash,

--- a/src/quodeq/analysis/dimension_runner.py
+++ b/src/quodeq/analysis/dimension_runner.py
@@ -40,8 +40,8 @@ class DimensionRunner:
 
     ``cache`` is the composition root's shared cache backend for the whole
     run; left ``None``, ``process_dimension_with_cache`` defaults to its own
-    ``LocalFileBackend()`` (and runs the once-per-process legacy-entry GC) --
-    see ``_pipeline.py`` for the production wiring.
+    ``LocalFileBackend()`` (and runs the once-per-process cache maintenance)
+    -- see ``_pipeline.py`` for the production wiring.
 
     ``log`` defaults to the silent :data:`NULL_LOG`; the composition root
     (``_pipeline.py``) injects ``SHARED_LOG`` so production keeps the colored

--- a/src/quodeq/analysis/fingerprint.py
+++ b/src/quodeq/analysis/fingerprint.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from quodeq.core.standards.overrides import (
     OVERRIDES_RELPATH,
     dimension_params,
+    hash_non_default_params,
 )
 from quodeq.data.fs.standards_prefs import load_project_overrides
 
@@ -83,8 +84,7 @@ def _compute_dimension_params(compiled: Path, project_root: Path | None) -> tupl
         return "", {}
     if not non_default:
         return "", effective
-    canonical = json.dumps(non_default, sort_keys=True, separators=(",", ":"))
-    return hashlib.sha256(canonical.encode("utf-8")).hexdigest(), effective
+    return hash_non_default_params(non_default), effective
 
 
 class HashCache:

--- a/src/quodeq/api/app.py
+++ b/src/quodeq/api/app.py
@@ -184,12 +184,16 @@ def main(env: dict[str, str] | None = None) -> None:
     signal.signal(signal.SIGINT, _handle_shutdown)
 
     # Warm the score caches in the background so the first requests after an
-    # upgrade hit warm or warming caches instead of recomputing inline.
+    # upgrade hit warm or warming caches instead of recomputing inline. Also
+    # migrate and index the result cache once, off the request path, so
+    # estimates stop undercounting cached files after an upgrade.
     # main() only: create_app callers (tests, embedding) stay thread-free.
     try:
         from quodeq.api.routes_common import reports_dir  # noqa: PLC0415
         from quodeq.services._warmup import engine as warmup_engine  # noqa: PLC0415
+        from quodeq.services.cache_maintenance import start_cache_maintenance  # noqa: PLC0415
         warmup_engine.start(reports_dir())
+        start_cache_maintenance()
     except Exception:  # pragma: no cover - warm-up must never block serving
         logging.getLogger(__name__).warning("warm-up start failed", exc_info=True)
 

--- a/src/quodeq/api/app.py
+++ b/src/quodeq/api/app.py
@@ -192,8 +192,9 @@ def main(env: dict[str, str] | None = None) -> None:
         from quodeq.api.routes_common import reports_dir  # noqa: PLC0415
         from quodeq.services._warmup import engine as warmup_engine  # noqa: PLC0415
         from quodeq.services.cache_maintenance import start_cache_maintenance  # noqa: PLC0415
+        from quodeq.shared.log_sink import SHARED_LOG  # noqa: PLC0415
         warmup_engine.start(reports_dir())
-        start_cache_maintenance()
+        start_cache_maintenance(log=SHARED_LOG)
     except Exception:  # pragma: no cover - warm-up must never block serving
         logging.getLogger(__name__).warning("warm-up start failed", exc_info=True)
 

--- a/src/quodeq/core/standards/overrides.py
+++ b/src/quodeq/core/standards/overrides.py
@@ -10,6 +10,8 @@ Invalid entries are skipped with a warning; a bad file never fails analysis.
 """
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import re
 from pathlib import Path
@@ -82,6 +84,52 @@ def dimension_params(
             if diff:
                 non_default[req_id] = diff
     return effective, non_default
+
+
+def hash_non_default_params(non_default: dict[str, dict[str, int]]) -> str:
+    """The cache ``params_hash`` for a non-default params subset.
+
+    "" when nothing differs from the declared defaults, else the SHA-256 of
+    the canonical JSON. This is the ONE formula shared by the cache writer
+    (``analysis.fingerprint``) and the cache schema migration
+    (``data.cache_store.migrate``); a drift between the two would silently
+    orphan every entry written under overrides.
+    """
+    if not non_default:
+        return ""
+    canonical = json.dumps(non_default, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def non_default_from_effective(
+    dimension_data: dict, effective: dict[str, dict[str, int]],
+) -> dict[str, dict[str, int]]:
+    """Recover the non-default subset from a stored *effective* params map.
+
+    Inverse of what ``dimension_params`` computes on the way in: a cache
+    entry stores the full effective map in its provenance, and the migration
+    needs the non-default subset to rebuild the entry's ``params_hash``. A
+    requirement or param the compiled standards no longer declare counts as
+    non-default (its default is unknown), which yields a stale hash and one
+    re-evaluation for that project rather than a wrong reuse.
+    """
+    defaults: dict[str, dict[str, object]] = {}
+    for principle in dimension_data.get("principles", []):
+        for req in principle.get("requirements", []):
+            req_id = req.get("id")
+            params = req.get("params")
+            if not req_id or not params:
+                continue
+            defaults[req_id] = {
+                name: (spec or {}).get("default") for name, spec in params.items()
+            }
+    non_default: dict[str, dict[str, int]] = {}
+    for req_id, values in (effective or {}).items():
+        declared = defaults.get(req_id, {})
+        diff = {name: v for name, v in values.items() if v != declared.get(name)}
+        if diff:
+            non_default[req_id] = diff
+    return non_default
 
 
 def validate_overrides(raw: object, declared: dict[str, dict]) -> tuple[dict, list[str]]:

--- a/src/quodeq/data/cache_store/__init__.py
+++ b/src/quodeq/data/cache_store/__init__.py
@@ -1,14 +1,16 @@
 """Result-cache filesystem store — the on-disk V2 content-addressed cache adapter.
 
 Sub-modules:
+  key      -- CacheKey + compute_key + SCHEMA_VERSION: the key formula
   entry    -- CacheEntry: the persisted record for one cache key
   backend  -- CacheBackend protocol + CacheStats
   local    -- LocalFileBackend: sharded filesystem implementation
+  index    -- ContentIndex: sqlite sidecar mapping content hashes to keys
+  migrate  -- one-time schema migration, index build and legacy GC
 
-``quodeq.analysis.cache.{entry,backend,local}`` re-export this package's
-public names as shims, so every pre-existing import path stays live. The
-analysis-internal cache machinery (key derivation, dispatch, tiered/gc
-policy) stays in ``quodeq.analysis.cache`` -- only the storage record and
-its filesystem backend moved here.
+``quodeq.analysis.cache.{key,entry,backend,local,gc}`` re-export this
+package's public names as shims, so every pre-existing import path stays
+live. The analysis-internal cache machinery (per-run key building, classify,
+adoption, dispatch, tiered policy) stays in ``quodeq.analysis.cache``.
 """
 from __future__ import annotations

--- a/src/quodeq/data/cache_store/entry.py
+++ b/src/quodeq/data/cache_store/entry.py
@@ -16,7 +16,10 @@ from datetime import datetime, timezone
 # ``file_content_hash`` it was keyed under plus a ``provenance`` block, so
 # any future key change can be migrated losslessly by recomputing the key
 # from stored fields instead of re-evaluating.
-ENTRY_FORMAT_VERSION = 2
+# v2 -> v3: ``params_hash`` stored explicitly. It was the one key input not
+# recoverable from the entry alone (derivable only via the compiled
+# standards), which the schema-3 -> 4 migration had to work around.
+ENTRY_FORMAT_VERSION = 3
 
 
 def _utc_now() -> str:
@@ -67,17 +70,22 @@ class CacheEntry:
     file_path: str
     dimension: str
     model_id: str
-    # Self-describing fields (format v2). ``file_content_hash`` and
-    # ``language`` are the key fields not otherwise stored (``file_path`` and
-    # ``dimension`` already are); together with them, an entry records EVERY
-    # input its key was computed from, so any future cache-key change is
+    # Self-describing fields (format v2+). ``file_content_hash`` and
+    # ``params_hash`` are the key fields not otherwise stored (``file_path``
+    # and ``dimension`` already are); together with them, an entry records
+    # EVERY input its key was computed from, so any future cache-key change is
     # losslessly migratable (recompute from stored fields, no re-eval).
+    # ``language`` left the key in schema 4 and is kept as information.
     # ``provenance`` records the volatile context the findings were produced
     # under (model, prompts, standards, quodeq version) so reuse across those
-    # boundaries is never silent. All defaulted so format-1 entries still load.
+    # boundaries is never silent. All defaulted so older entries still load.
     file_content_hash: str = ""
     language: str = ""
     provenance: dict = field(default_factory=dict)
+    # The non-default threshold params hash the key was computed under ("" for
+    # default config). Format v3; older entries load as "" and the migration
+    # derives the real value from ``provenance.effective_params``.
+    params_hash: str = ""
     created_at: str = field(default_factory=_utc_now)
     cache_format_version: int = ENTRY_FORMAT_VERSION
     # Whether a COMPLETED run has consolidated these findings into its

--- a/src/quodeq/data/cache_store/index.py
+++ b/src/quodeq/data/cache_store/index.py
@@ -1,0 +1,207 @@
+"""Content index over cache entries.
+
+A sqlite sidecar at ``<results root>/.index.db`` mapping
+``(content_hash, dimension, params_hash)`` to the keys of entries that were
+written with those inputs. It exists so a classify miss can ask "was this
+exact content already evaluated for this dimension under another path?"
+(a directory move) without walking 100k entry files.
+
+The index is derivable from the entries and is never authoritative: callers
+verify a row against the entry it points to. Every method is best-effort. A
+sqlite or IO failure logs at debug and reports nothing, so the cache degrades
+to today's miss behavior rather than breaking a scan. A corrupt file is
+deleted and recreated on the next open; ``ensure_cache_ready`` rebuilds the
+rows.
+
+One connection per instance, guarded by a lock (``check_same_thread=False``
+because the dimension runner's persist watcher writes from its own thread).
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+INDEX_FILENAME = ".index.db"
+_BUSY_TIMEOUT_MS = 5000
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS entries (
+  key          TEXT PRIMARY KEY,
+  content_hash TEXT NOT NULL,
+  dimension    TEXT NOT NULL,
+  params_hash  TEXT NOT NULL DEFAULT '',
+  file_path    TEXT NOT NULL,
+  created_at   TEXT NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_entries_content
+  ON entries(content_hash, dimension, params_hash);
+CREATE TABLE IF NOT EXISTS meta (k TEXT PRIMARY KEY, v TEXT NOT NULL);
+"""
+_BUILT_KEY = "built_for_schema"
+
+
+@dataclass(frozen=True)
+class IndexRow:
+    key: str
+    file_path: str
+    created_at: str
+
+
+class ContentIndex:
+    """Best-effort sqlite index over cache entries. See module docstring."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._path = db_path
+        self._lock = threading.Lock()
+        self._conn: sqlite3.Connection | None = None
+        self._broken = False
+
+    # -- connection -------------------------------------------------------
+
+    def _open(self) -> sqlite3.Connection:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self._path), check_same_thread=False)
+        try:
+            conn.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}")
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.executescript(_SCHEMA_SQL)
+        except sqlite3.Error:
+            conn.close()
+            raise
+        return conn
+
+    def _connect(self) -> sqlite3.Connection | None:
+        """Return the connection, opening it lazily. None when unusable."""
+        if self._conn is not None:
+            return self._conn
+        if self._broken:
+            return None
+        try:
+            self._conn = self._open()
+        except sqlite3.DatabaseError as exc:
+            # "file is not a database" and friends: drop the corrupt file and
+            # try once more. The rows are rebuilt by ensure_cache_ready.
+            _logger.debug("content index corrupt at %s (%s); recreating", self._path, exc)
+            try:
+                self._path.unlink(missing_ok=True)
+                self._conn = self._open()
+            except (sqlite3.Error, OSError) as exc2:
+                _logger.debug("content index unavailable at %s: %s", self._path, exc2)
+                self._broken = True
+                return None
+        except (sqlite3.Error, OSError) as exc:
+            _logger.debug("content index unavailable at %s: %s", self._path, exc)
+            self._broken = True
+            return None
+        return self._conn
+
+    def close(self) -> None:
+        """Close the connection. The next operation reopens it."""
+        with self._lock:
+            if self._conn is not None:
+                try:
+                    self._conn.close()
+                except sqlite3.Error:
+                    pass
+                self._conn = None
+
+    # -- writes -----------------------------------------------------------
+
+    def record(
+        self, key: str, *, content_hash: str, dimension: str, params_hash: str,
+        file_path: str, created_at: str,
+    ) -> None:
+        self.record_many([(key, content_hash, dimension, params_hash, file_path, created_at)])
+
+    def record_many(self, rows: Iterable[tuple[str, str, str, str, str, str]]) -> None:
+        """Insert or replace rows ``(key, content_hash, dimension, params_hash,
+        file_path, created_at)`` in one transaction. Rows with a blank content
+        hash are skipped: nothing can be adopted from them."""
+        payload = [r for r in rows if r[1]]
+        if not payload:
+            return
+        with self._lock:
+            conn = self._connect()
+            if conn is None:
+                return
+            try:
+                with conn:
+                    conn.executemany(
+                        "INSERT OR REPLACE INTO entries"
+                        "(key, content_hash, dimension, params_hash, file_path, created_at)"
+                        " VALUES (?, ?, ?, ?, ?, ?)",
+                        payload,
+                    )
+            except sqlite3.Error as exc:
+                _logger.debug("content index write failed: %s", exc)
+
+    def forget(self, key: str) -> None:
+        with self._lock:
+            conn = self._connect()
+            if conn is None:
+                return
+            try:
+                with conn:
+                    conn.execute("DELETE FROM entries WHERE key = ?", (key,))
+            except sqlite3.Error as exc:
+                _logger.debug("content index delete failed: %s", exc)
+
+    # -- reads ------------------------------------------------------------
+
+    def find(
+        self, content_hash: str, dimension: str, params_hash: str, *, limit: int = 50,
+    ) -> list[IndexRow]:
+        """Rows with these inputs, newest first. Empty on any failure."""
+        if not content_hash:
+            return []
+        with self._lock:
+            conn = self._connect()
+            if conn is None:
+                return []
+            try:
+                cur = conn.execute(
+                    "SELECT key, file_path, created_at FROM entries"
+                    " WHERE content_hash = ? AND dimension = ? AND params_hash = ?"
+                    " ORDER BY created_at DESC LIMIT ?",
+                    (content_hash, dimension, params_hash, limit),
+                )
+                return [IndexRow(key=k, file_path=p, created_at=c) for k, p, c in cur.fetchall()]
+            except sqlite3.Error as exc:
+                _logger.debug("content index read failed: %s", exc)
+                return []
+
+    def built_for_schema(self) -> int | None:
+        """The schema the rows were last built for, or None when unknown."""
+        with self._lock:
+            conn = self._connect()
+            if conn is None:
+                return None
+            try:
+                row = conn.execute("SELECT v FROM meta WHERE k = ?", (_BUILT_KEY,)).fetchone()
+            except sqlite3.Error:
+                return None
+        if row is None:
+            return None
+        try:
+            return int(row[0])
+        except (TypeError, ValueError):
+            return None
+
+    def mark_built(self, schema: int) -> None:
+        with self._lock:
+            conn = self._connect()
+            if conn is None:
+                return
+            try:
+                with conn:
+                    conn.execute(
+                        "INSERT OR REPLACE INTO meta(k, v) VALUES (?, ?)",
+                        (_BUILT_KEY, str(schema)),
+                    )
+            except sqlite3.Error as exc:
+                _logger.debug("content index meta write failed: %s", exc)

--- a/src/quodeq/data/cache_store/index.py
+++ b/src/quodeq/data/cache_store/index.py
@@ -15,12 +15,21 @@ rows.
 
 One connection per instance, guarded by a lock (``check_same_thread=False``
 because the dimension runner's persist watcher writes from its own thread).
+
+Every instance registers itself in ``_live_instances`` (weakly, so this
+never keeps one alive on its own) purely so ``close_all_for_tests`` can
+reclaim connections deterministically. A long-lived process (the CLI run,
+the dashboard) holds one instance for its lifetime and closing on process
+exit is moot; a test suite creates thousands of short-lived instances in a
+single process, and relying on GC to close each one lets open file
+descriptors pile up under coverage instrumentation, which delays that GC.
 """
 from __future__ import annotations
 
 import logging
 import sqlite3
 import threading
+import weakref
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -28,6 +37,7 @@ from pathlib import Path
 _logger = logging.getLogger(__name__)
 
 INDEX_FILENAME = ".index.db"
+_live_instances: "weakref.WeakSet[ContentIndex]" = weakref.WeakSet()
 _BUSY_TIMEOUT_MS = 5000
 _SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS entries (
@@ -60,6 +70,7 @@ class ContentIndex:
         self._lock = threading.Lock()
         self._conn: sqlite3.Connection | None = None
         self._broken = False
+        _live_instances.add(self)
 
     # -- connection -------------------------------------------------------
 
@@ -205,3 +216,14 @@ class ContentIndex:
                     )
             except sqlite3.Error as exc:
                 _logger.debug("content index meta write failed: %s", exc)
+
+
+def close_all_for_tests() -> None:
+    """Close every live ``ContentIndex`` connection. Test teardown only.
+
+    Production processes hold one instance for their own lifetime; a test
+    suite creates one per test (see ``_live_instances``' docstring above)
+    and must reclaim the fd deterministically rather than waiting on GC.
+    """
+    for index in list(_live_instances):
+        index.close()

--- a/src/quodeq/data/cache_store/key.py
+++ b/src/quodeq/data/cache_store/key.py
@@ -1,0 +1,73 @@
+"""Cache key: content-addressed identity for a (file, dimension) work unit.
+
+The key is the SHA-256 of a canonical JSON serialization of the inputs that
+define "this exact code, evaluated for this dimension". Two runs with
+identical inputs compute the same key and share the cached result.
+
+The key is permissive (cost-first): it invalidates ONLY on a real per-unit
+change. Evaluations are expensive and the user owns the explicit refresh
+path (``--clean-scan``), so cached findings stay resilient to everything
+except an actual file change.
+
+Intentionally NOT in the key (recorded in ``CacheEntry.provenance`` instead,
+so reuse across these boundaries is surfaced rather than silently
+re-evaluated): ``model_id``, ``prompts_hash``, ``standards_hash``,
+``evaluator_hash``, sampling params, timestamps, run/machine/user/git
+metadata, and, since schema 4, the project ``language``. Language reached
+the prompt only as a heading word and never filtered files, yet a
+``detect_language()`` flip (e.g. ``build.gradle`` -> ``build.gradle.kts``)
+re-keyed 100% of a repo.
+
+``file_path`` stays: clean-architecture reads layer directories from the
+prompt and ``path_role`` infers test vs production from it. A moved file with
+unchanged content is recovered by adoption (``analysis.cache._adoption``),
+not by loosening the key.
+
+``params_hash`` stays: a threshold override rewrites the rule text the model
+enforces. It is "" (and absent from the canonical form) when every param
+equals its default.
+
+This module lives in the data layer so the schema migration can compute
+keys without importing ``analysis``. ``quodeq.analysis.cache.key`` re-exports
+it.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+
+# Bumped on any breaking change to key composition or entry format.
+# v1 -> v2: file_done marker contract.
+# v2 -> v3: permissive key; model/prompts/standards/sampling moved to
+#           provenance. Entries became self-describing (content hash stored).
+# v3 -> v4: ``language`` left the key. Migrated losslessly by
+#           ``data.cache_store.migrate`` from the stored fields.
+SCHEMA_VERSION = 4
+
+
+@dataclass(frozen=True)
+class CacheKey:
+    """The real per-unit inputs that determine the analysis output.
+
+    Adding a field here is a cache-wide re-key, so do it only for a genuine
+    per-unit input, and add the matching migration step.
+    """
+
+    schema_version: int
+    file_content_hash: str
+    file_path: str
+    dimension: str
+    # Per-dimension hash of non-default threshold params ("" when all
+    # defaults). Empty is omitted from the canonical form so default-config
+    # keys stay byte-identical to pre-params keys.
+    params_hash: str = ""
+
+
+def compute_key(key: CacheKey) -> str:
+    """Return the hex SHA-256 of the canonical serialization of ``key``."""
+    data = asdict(key)
+    if not data["params_hash"]:
+        del data["params_hash"]
+    canonical = json.dumps(data, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/src/quodeq/data/cache_store/local.py
+++ b/src/quodeq/data/cache_store/local.py
@@ -3,6 +3,7 @@
 Layout (git-style two-char sharding to keep each directory bounded):
 
     <root>/<sha[:2]>/<sha[2:]>/entry.json
+    <root>/.index.db          content index sidecar (see ``index.py``)
 
 Writes go via temp file + ``os.rename``, which is atomic on POSIX and on
 NTFS for same-volume renames. A reader either sees the previous contents
@@ -24,6 +25,7 @@ from pathlib import Path
 
 from quodeq.data.cache_store.backend import CacheStats
 from quodeq.data.cache_store.entry import CacheEntry
+from quodeq.data.cache_store.index import INDEX_FILENAME, ContentIndex, IndexRow
 
 _logger = logging.getLogger(__name__)
 
@@ -51,12 +53,26 @@ def default_cache_root() -> Path:
 class LocalFileBackend:
     """Sharded filesystem cache with atomic writes."""
 
-    def __init__(self, root: Path | None = None) -> None:
+    def __init__(
+        self, root: Path | None = None, *,
+        index: ContentIndex | None = None, enable_index: bool = True,
+    ) -> None:
         self._root = root if root is not None else default_cache_root()
+        if index is not None:
+            self._index: ContentIndex | None = index
+        elif enable_index:
+            self._index = ContentIndex(self._root / INDEX_FILENAME)
+        else:
+            self._index = None
 
     @property
     def root(self) -> Path:
         return self._root
+
+    @property
+    def index(self) -> ContentIndex | None:
+        """The content index beside this root, or None when disabled."""
+        return self._index
 
     def _dir_for(self, key: str) -> Path:
         if len(key) < 3:
@@ -88,7 +104,12 @@ class LocalFileBackend:
                 pass
             return None
 
-    def put(self, key: str, entry: CacheEntry) -> None:
+    def put(self, key: str, entry: CacheEntry, *, index: bool = True) -> None:
+        """Write *entry* atomically and record it in the content index.
+
+        ``index=False`` skips the index write; the schema migration uses it to
+        batch rows itself instead of committing one per entry.
+        """
         target_dir = self._dir_for(key)
         target_dir.mkdir(parents=True, exist_ok=True)
         target = target_dir / _ENTRY_FILENAME
@@ -96,6 +117,12 @@ class LocalFileBackend:
         try:
             tmp.write_text(entry.to_json(), encoding="utf-8")
             os.replace(tmp, target)
+            if index and self._index is not None:
+                self._index.record(
+                    key, content_hash=entry.file_content_hash, dimension=entry.dimension,
+                    params_hash=entry.params_hash, file_path=entry.file_path,
+                    created_at=entry.created_at,
+                )
         except OSError as exc:
             _logger.warning("cache write failed for %s: %s", key, exc)
             try:
@@ -114,6 +141,21 @@ class LocalFileBackend:
             shutil.rmtree(target_dir)
         except OSError as exc:
             _logger.warning("cache delete failed for %s: %s", key, exc)
+            return
+        if self._index is not None:
+            self._index.forget(key)
+
+    def find_by_content(
+        self, content_hash: str, dimension: str, params_hash: str,
+    ) -> list[IndexRow]:
+        """Index rows for entries written with these inputs, newest first.
+
+        Empty when the index is disabled, unavailable, or the hash is blank.
+        Rows are hints: callers must verify the entry they point at.
+        """
+        if self._index is None or not content_hash:
+            return []
+        return self._index.find(content_hash, dimension, params_hash)
 
     def stats(self) -> CacheStats:
         if not self._root.exists():

--- a/src/quodeq/data/cache_store/migrate.py
+++ b/src/quodeq/data/cache_store/migrate.py
@@ -38,6 +38,7 @@ from quodeq.core.standards.overrides import (
     non_default_from_effective,
 )
 from quodeq.data.cache_store.entry import ENTRY_FORMAT_VERSION, CacheEntry
+from quodeq.data.cache_store.index import ContentIndex
 from quodeq.data.cache_store.key import SCHEMA_VERSION, CacheKey, compute_key
 from quodeq.data.cache_store.local import LocalFileBackend
 
@@ -235,13 +236,36 @@ def _release_lock(lock: Path) -> None:
         pass
 
 
+def _migrate_locked(
+    root: Path, *, standards_dir: Path | None, backend: LocalFileBackend,
+    index: ContentIndex | None, memo_key: tuple[str, int],
+) -> None:
+    """Run one migration pass under the lock and record the result."""
+    t0 = time.monotonic()
+    stats = migrate_entries(root, standards_dir=standards_dir, backend=backend)
+    if index is not None:
+        index.mark_built(SCHEMA_VERSION)
+    ready_marker(root).write_text("", encoding="utf-8")
+    _ready_memo.add(memo_key)
+    if stats.migrated or stats.removed or stats.indexed:
+        _logger.info(
+            "cache: schema %d ready in %.1fs (migrated %d, deduplicated %d, "
+            "indexed %d, reclaimed %d, skipped %d)",
+            SCHEMA_VERSION, time.monotonic() - t0, stats.migrated,
+            stats.deduplicated, stats.indexed, stats.removed, stats.skipped,
+        )
+
+
 def ensure_cache_ready(
     root: Path, *, standards_dir: Path | None, backend: LocalFileBackend | None = None,
 ) -> None:
     """Bring *root* to the current schema with a built index, once.
 
     Cheap after the first call: an in-process memo, then the on-disk marker
-    plus the index's built flag. Never raises.
+    plus the index's built flag. Never raises. A backend created here (no
+    *backend* argument) is local to this call, so its index connection is
+    closed before returning rather than left to GC (Windows can't delete an
+    open sqlite file out from under a lingering handle).
     """
     memo_key = (str(root), SCHEMA_VERSION)
     if memo_key in _ready_memo:
@@ -249,32 +273,28 @@ def ensure_cache_ready(
     if not root.exists():
         _ready_memo.add(memo_key)
         return
+    owns_backend = backend is None
     try:
         backend = backend or LocalFileBackend(root=root)
         index = backend.index
-        marker = ready_marker(root)
-        if marker.exists() and (index is None or index.built_for_schema() == SCHEMA_VERSION):
-            _ready_memo.add(memo_key)
-            return
-        lock = root / LOCK_FILENAME
-        if not _acquire_lock(lock):
-            _logger.debug("cache maintenance: %s locked by another process; skipping", root)
-            return
         try:
-            t0 = time.monotonic()
-            stats = migrate_entries(root, standards_dir=standards_dir, backend=backend)
-            if index is not None:
-                index.mark_built(SCHEMA_VERSION)
-            marker.write_text("", encoding="utf-8")
-            _ready_memo.add(memo_key)
-            if stats.migrated or stats.removed or stats.indexed:
-                _logger.info(
-                    "cache: schema %d ready in %.1fs (migrated %d, deduplicated %d, "
-                    "indexed %d, reclaimed %d, skipped %d)",
-                    SCHEMA_VERSION, time.monotonic() - t0, stats.migrated,
-                    stats.deduplicated, stats.indexed, stats.removed, stats.skipped,
+            marker = ready_marker(root)
+            if marker.exists() and (index is None or index.built_for_schema() == SCHEMA_VERSION):
+                _ready_memo.add(memo_key)
+                return
+            lock = root / LOCK_FILENAME
+            if not _acquire_lock(lock):
+                _logger.debug("cache maintenance: %s locked by another process; skipping", root)
+                return
+            try:
+                _migrate_locked(
+                    root, standards_dir=standards_dir, backend=backend,
+                    index=index, memo_key=memo_key,
                 )
+            finally:
+                _release_lock(lock)
         finally:
-            _release_lock(lock)
+            if owns_backend and index is not None:
+                index.close()
     except OSError as exc:
         _logger.debug("cache maintenance: best-effort pass failed for %s: %s", root, exc)

--- a/src/quodeq/data/cache_store/migrate.py
+++ b/src/quodeq/data/cache_store/migrate.py
@@ -1,0 +1,280 @@
+"""One-time cache maintenance: schema migration, content-index build, legacy GC.
+
+Entries are self-describing (every key input is stored), so a key-formula
+change is a lossless re-key rather than a re-evaluation. This module walks
+the cache once per (root, schema):
+
+1. schema 3 entries are re-keyed to schema 4 (``language`` left the key),
+   written under the new key, then removed from the old path;
+2. schema 4 entries get a content-index row (the walk doubles as the index
+   build);
+3. anything older than schema 3, or unmigratable, is reclaimed;
+4. the index is marked built and ``<root>/.schema_4_ready`` is written.
+
+Best-effort and resumable: each entry is either at its old path or its new
+path, never both and never neither, because the new file is renamed into
+place before the old directory is removed. An unreadable entry is skipped
+and logged. The walk runs under ``<root>/.migrate.lock``; a live lock means
+another process is on it and this process simply proceeds with the partially
+migrated cache (a few extra misses). A lock older than ``STALE_LOCK_S`` is
+taken over.
+
+Ordering matters: the GC must never run ahead of the migration, or it would
+delete schema-3 entries that were about to be re-keyed. That is why both live
+in one walk here and ``analysis.cache.gc`` is a shim over this module.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import time
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from quodeq.core.standards.overrides import (
+    hash_non_default_params,
+    non_default_from_effective,
+)
+from quodeq.data.cache_store.entry import ENTRY_FORMAT_VERSION, CacheEntry
+from quodeq.data.cache_store.key import SCHEMA_VERSION, CacheKey, compute_key
+from quodeq.data.cache_store.local import LocalFileBackend
+
+_logger = logging.getLogger(__name__)
+
+_ENTRY_FILENAME = "entry.json"  # mirrors local._ENTRY_FILENAME
+LOCK_FILENAME = ".migrate.lock"
+STALE_LOCK_S = 1800.0
+_BATCH = 500
+
+# (root, schema) pairs known ready in this process.
+_ready_memo: set[tuple[str, int]] = set()
+
+
+def ready_marker(root: Path) -> Path:
+    return root / f".schema_{SCHEMA_VERSION}_ready"
+
+
+@dataclass(frozen=True)
+class MigrationStats:
+    migrated: int = 0
+    deduplicated: int = 0
+    indexed: int = 0
+    removed: int = 0
+    skipped: int = 0
+
+
+def derive_params_hash(
+    dimension: str, effective_params: dict, standards_dir: Path | None,
+) -> str:
+    """Rebuild a schema-3 entry's ``params_hash`` from its stored effective params.
+
+    The writer hashed the non-default subset against the compiled defaults
+    (``analysis.fingerprint._compute_dimension_params``). Diff the stored
+    effective map against the current compiled defaults and hash the same way.
+    "" when there is nothing to compare (no params, no standards dir, no or
+    malformed compiled file), which is exactly what such entries were keyed
+    under.
+    """
+    if not effective_params or standards_dir is None:
+        return ""
+    compiled = Path(standards_dir) / "compiled" / f"{dimension}.json"
+    try:
+        data = json.loads(compiled.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001 - same rationale as the writer: never abort
+        return ""
+    try:
+        return hash_non_default_params(non_default_from_effective(data, effective_params))
+    except (AttributeError, TypeError):
+        return ""
+
+
+def _index_row(entry: CacheEntry) -> tuple[str, str, str, str, str, str]:
+    return (
+        entry.key, entry.file_content_hash, entry.dimension, entry.params_hash,
+        entry.file_path, entry.created_at,
+    )
+
+
+def _remove_dir(entry_dir: Path) -> bool:
+    try:
+        shutil.rmtree(entry_dir)
+        return True
+    except OSError as exc:
+        _logger.debug("cache maintenance: failed to remove %s: %s", entry_dir, exc)
+        return False
+
+
+def _read_entry(entry_path: Path) -> CacheEntry | None:
+    try:
+        return CacheEntry.from_json(entry_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError, KeyError, ValueError) as exc:
+        _logger.debug("cache maintenance: skipping unreadable entry %s: %s", entry_path, exc)
+        return None
+
+
+def _migrate_v3(
+    entry: CacheEntry, entry_dir: Path, backend: LocalFileBackend,
+    standards_dir: Path | None, batch: list[tuple],
+) -> tuple[int, int]:
+    """Re-key one schema-3 entry. Returns (migrated, deduplicated) as 0/1."""
+    params_hash = entry.params_hash or derive_params_hash(
+        entry.dimension, (entry.provenance or {}).get("effective_params") or {}, standards_dir,
+    )
+    new_key = compute_key(CacheKey(
+        schema_version=SCHEMA_VERSION, file_content_hash=entry.file_content_hash,
+        file_path=entry.file_path, dimension=entry.dimension, params_hash=params_hash,
+    ))
+    if backend.has(new_key):
+        _remove_dir(entry_dir)
+        return 0, 1
+    new_entry = replace(
+        entry, key=new_key, schema_version=SCHEMA_VERSION, params_hash=params_hash,
+        cache_format_version=ENTRY_FORMAT_VERSION,
+    )
+    backend.put(new_key, new_entry, index=False)
+    if not backend.has(new_key):
+        return 0, 0  # write failed (logged by the backend); keep the old entry
+    batch.append(_index_row(new_entry))
+    _remove_dir(entry_dir)
+    return 1, 0
+
+
+def migrate_entries(
+    root: Path, *, standards_dir: Path | None, backend: LocalFileBackend | None = None,
+) -> MigrationStats:
+    """Walk *root* once: migrate v3, index v4, reclaim older. See module doc."""
+    if not root.exists():
+        return MigrationStats()
+    backend = backend or LocalFileBackend(root=root)
+    index = backend.index
+    migrated = deduplicated = indexed = removed = skipped = 0
+    batch: list[tuple] = []
+
+    def _flush() -> None:
+        if batch and index is not None:
+            index.record_many(batch)
+        batch.clear()
+
+    for entry_path in list(root.rglob(_ENTRY_FILENAME)):
+        entry = _read_entry(entry_path)
+        if entry is None:
+            skipped += 1
+            continue
+        if entry.schema_version == SCHEMA_VERSION:
+            batch.append(_index_row(entry))
+            indexed += 1
+        elif entry.schema_version == SCHEMA_VERSION - 1:
+            m, d = _migrate_v3(entry, entry_path.parent, backend, standards_dir, batch)
+            migrated += m
+            deduplicated += d
+        elif _remove_dir(entry_path.parent):
+            removed += 1
+        if len(batch) >= _BATCH:
+            _flush()
+    _flush()
+    return MigrationStats(
+        migrated=migrated, deduplicated=deduplicated, indexed=indexed,
+        removed=removed, skipped=skipped,
+    )
+
+
+def collect_legacy_entries(root: Path, *, min_schema: int) -> int:
+    """Delete every entry whose ``schema_version`` is below *min_schema*.
+
+    Kept for callers and tests of the schema-3 GC. ``ensure_cache_ready``
+    does this as part of its walk, after migrating what can be migrated.
+    """
+    if not root.exists():
+        return 0
+    removed = 0
+    for entry_path in root.rglob(_ENTRY_FILENAME):
+        try:
+            data = json.loads(entry_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+        schema = data.get("schema_version")
+        if isinstance(schema, int) and schema < min_schema and _remove_dir(entry_path.parent):
+            removed += 1
+    return removed
+
+
+def _acquire_lock(lock: Path) -> bool:
+    """Create *lock* exclusively. A lock older than STALE_LOCK_S is taken over."""
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+    for attempt in (0, 1):
+        try:
+            fd = os.open(lock, flags)
+        except FileExistsError:
+            if attempt:
+                return False
+            try:
+                age = time.time() - lock.stat().st_mtime
+            except OSError:
+                return False
+            if age < STALE_LOCK_S:
+                return False
+            try:
+                lock.unlink()
+            except OSError:
+                return False
+            continue
+        except OSError:
+            return False
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(str(os.getpid()))
+        return True
+    return False
+
+
+def _release_lock(lock: Path) -> None:
+    try:
+        lock.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def ensure_cache_ready(
+    root: Path, *, standards_dir: Path | None, backend: LocalFileBackend | None = None,
+) -> None:
+    """Bring *root* to the current schema with a built index, once.
+
+    Cheap after the first call: an in-process memo, then the on-disk marker
+    plus the index's built flag. Never raises.
+    """
+    memo_key = (str(root), SCHEMA_VERSION)
+    if memo_key in _ready_memo:
+        return
+    if not root.exists():
+        _ready_memo.add(memo_key)
+        return
+    try:
+        backend = backend or LocalFileBackend(root=root)
+        index = backend.index
+        marker = ready_marker(root)
+        if marker.exists() and (index is None or index.built_for_schema() == SCHEMA_VERSION):
+            _ready_memo.add(memo_key)
+            return
+        lock = root / LOCK_FILENAME
+        if not _acquire_lock(lock):
+            _logger.debug("cache maintenance: %s locked by another process; skipping", root)
+            return
+        try:
+            t0 = time.monotonic()
+            stats = migrate_entries(root, standards_dir=standards_dir, backend=backend)
+            if index is not None:
+                index.mark_built(SCHEMA_VERSION)
+            marker.write_text("", encoding="utf-8")
+            _ready_memo.add(memo_key)
+            if stats.migrated or stats.removed or stats.indexed:
+                _logger.info(
+                    "cache: schema %d ready in %.1fs (migrated %d, deduplicated %d, "
+                    "indexed %d, reclaimed %d, skipped %d)",
+                    SCHEMA_VERSION, time.monotonic() - t0, stats.migrated,
+                    stats.deduplicated, stats.indexed, stats.removed, stats.skipped,
+                )
+        finally:
+            _release_lock(lock)
+    except OSError as exc:
+        _logger.debug("cache maintenance: best-effort pass failed for %s: %s", root, exc)

--- a/src/quodeq/services/cache_maintenance.py
+++ b/src/quodeq/services/cache_maintenance.py
@@ -1,0 +1,46 @@
+"""Background result-cache maintenance for the dashboard process.
+
+The CLI pipeline runs ``ensure_cache_ready`` inline at run start. The
+dashboard serves estimates on the request path, where a minutes-long
+migration would time out a request, so it runs the same maintenance once on
+a daemon thread at startup. Estimates requested during that window may
+undercount cached files; that is transient and self-heals on the next
+request.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from pathlib import Path
+
+from quodeq.config.paths import default_paths
+from quodeq.data.cache_store.local import default_cache_root
+from quodeq.data.cache_store.migrate import ensure_cache_ready
+
+_logger = logging.getLogger(__name__)
+
+
+def _default_standards_dir() -> Path | None:
+    try:
+        std = default_paths().standards_dir
+    except Exception:  # noqa: BLE001 - maintenance must never break serving
+        return None
+    return std if std is not None and std.exists() else None
+
+
+def start_cache_maintenance(
+    root: Path | None = None, *, standards_dir: Path | None = None,
+) -> threading.Thread:
+    """Start ``ensure_cache_ready`` on a daemon thread and return it."""
+    target_root = root if root is not None else default_cache_root()
+    std = standards_dir if standards_dir is not None else _default_standards_dir()
+
+    def _run() -> None:
+        try:
+            ensure_cache_ready(target_root, standards_dir=std)
+        except Exception:  # noqa: BLE001 - never propagate out of a daemon thread
+            _logger.warning("cache maintenance failed", exc_info=True)
+
+    thread = threading.Thread(target=_run, name="cache-maintenance", daemon=True)
+    thread.start()
+    return thread

--- a/src/quodeq/services/cache_maintenance.py
+++ b/src/quodeq/services/cache_maintenance.py
@@ -9,15 +9,13 @@ request.
 """
 from __future__ import annotations
 
-import logging
 import threading
 from pathlib import Path
 
 from quodeq.config.paths import default_paths
+from quodeq.core.observability import NULL_LOG, LogSink
 from quodeq.data.cache_store.local import default_cache_root
 from quodeq.data.cache_store.migrate import ensure_cache_ready
-
-_logger = logging.getLogger(__name__)
 
 
 def _default_standards_dir() -> Path | None:
@@ -30,6 +28,7 @@ def _default_standards_dir() -> Path | None:
 
 def start_cache_maintenance(
     root: Path | None = None, *, standards_dir: Path | None = None,
+    log: LogSink = NULL_LOG,
 ) -> threading.Thread:
     """Start ``ensure_cache_ready`` on a daemon thread and return it."""
     target_root = root if root is not None else default_cache_root()
@@ -38,8 +37,8 @@ def start_cache_maintenance(
     def _run() -> None:
         try:
             ensure_cache_ready(target_root, standards_dir=std)
-        except Exception:  # noqa: BLE001 - never propagate out of a daemon thread
-            _logger.warning("cache maintenance failed", exc_info=True)
+        except Exception as exc:  # noqa: BLE001 - never propagate out of a daemon thread
+            log.warning(f"cache maintenance failed: {exc!r}")
 
     thread = threading.Thread(target=_run, name="cache-maintenance", daemon=True)
     thread.start()

--- a/tests/analysis/cache/test_adoption.py
+++ b/tests/analysis/cache/test_adoption.py
@@ -1,0 +1,186 @@
+"""Adoption: a classify miss reuses an entry with the same content hash when
+the file merely moved (same basename, same path role). This is what makes a
+directory restructure (freemium-app-ios moved ios/ to the repo root) cost
+zero re-evaluation for unchanged files."""
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis._types import AnalysisOptions, RunConfig
+from quodeq.analysis.cache import CacheEntry, LocalFileBackend
+from quodeq.analysis.cache._key_provenance import build_cache_key_struct
+from quodeq.analysis.cache.dimension_helpers import (
+    build_cache_key_for_file,
+    classify_files_via_cache,
+)
+from quodeq.analysis.cache.key import compute_key
+
+
+def _config(src: Path, language: str = "swift") -> RunConfig:
+    return RunConfig(
+        src=src, language=language, standards_dir=None, work_dir=src,
+        options=AnalysisOptions(subagent_model="test-model"),
+    )
+
+
+def _seed_old(cache: LocalFileBackend, src: Path, old_path: str, new_path: str,
+              *, dim: str = "security", consolidated: bool = True,
+              findings: list[dict] | None = None) -> str:
+    """Seed an entry for *old_path* whose content equals the file now at *new_path*."""
+    struct = build_cache_key_struct(_config(src), new_path, dim)
+    old_key = compute_key(replace(struct, file_path=old_path))
+    cache.put(old_key, CacheEntry(
+        key=old_key, schema_version=struct.schema_version,
+        findings=findings if findings is not None else [{"file": old_path, "line": 3, "t": "violation"}],
+        files_read=1, file_path=old_path, dimension=dim, model_id="test-model",
+        file_content_hash=struct.file_content_hash, language="typescript",
+        provenance={"model_id": "test-model"}, consolidated=consolidated,
+    ))
+    return old_key
+
+
+@pytest.fixture
+def cache(tmp_path: Path) -> LocalFileBackend:
+    return LocalFileBackend(root=tmp_path / "cache")
+
+
+def _write(src: Path, rel: str, text: str = "class Foo {}") -> None:
+    p = src / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+
+
+def test_directory_move_adopts_and_rewrites_file_field(tmp_path: Path, cache: LocalFileBackend):
+    src = tmp_path / "repo"
+    _write(src, "KubusApp/Foo.swift")
+    _seed_old(cache, src, "ios/KubusApp/Foo.swift", "KubusApp/Foo.swift")
+
+    result = classify_files_via_cache(_config(src), "security", ["KubusApp/Foo.swift"], cache)
+
+    assert result.misses == []
+    assert result.adopted == 1
+    assert result.cached_findings == [{"file": "KubusApp/Foo.swift", "line": 3, "t": "violation"}]
+    new_key = build_cache_key_for_file(_config(src), "KubusApp/Foo.swift", "security")
+    adopted = cache.get(new_key)
+    assert adopted is not None
+    assert adopted.file_path == "KubusApp/Foo.swift"
+    assert adopted.language == "swift"
+    assert adopted.provenance["adopted_from"] == "ios/KubusApp/Foo.swift"
+    assert adopted.provenance["model_id"] == "test-model"
+
+
+def test_second_classify_is_a_plain_hit(tmp_path: Path, cache: LocalFileBackend):
+    src = tmp_path / "repo"
+    _write(src, "A/Foo.swift")
+    _seed_old(cache, src, "old/A/Foo.swift", "A/Foo.swift")
+    classify_files_via_cache(_config(src), "security", ["A/Foo.swift"], cache)
+    again = classify_files_via_cache(_config(src), "security", ["A/Foo.swift"], cache)
+    assert again.adopted == 0 and again.misses == []
+
+
+def test_different_basename_is_not_adopted(tmp_path: Path, cache: LocalFileBackend):
+    src = tmp_path / "repo"
+    _write(src, "A/Bar.swift")
+    _seed_old(cache, src, "A/Foo.swift", "A/Bar.swift")
+    result = classify_files_via_cache(_config(src), "security", ["A/Bar.swift"], cache)
+    assert result.misses == ["A/Bar.swift"] and result.adopted == 0
+
+
+def test_role_change_is_not_adopted(tmp_path: Path, cache: LocalFileBackend):
+    src = tmp_path / "repo"
+    _write(src, "src/Foo.swift")
+    _seed_old(cache, src, "tests/Foo.swift", "src/Foo.swift")
+    result = classify_files_via_cache(_config(src), "security", ["src/Foo.swift"], cache)
+    assert result.misses == ["src/Foo.swift"] and result.adopted == 0
+
+
+def test_other_dimension_is_not_adopted(tmp_path: Path, cache: LocalFileBackend):
+    src = tmp_path / "repo"
+    _write(src, "A/Foo.swift")
+    _seed_old(cache, src, "old/Foo.swift", "A/Foo.swift", dim="reliability")
+    result = classify_files_via_cache(_config(src), "security", ["A/Foo.swift"], cache)
+    assert result.misses == ["A/Foo.swift"] and result.adopted == 0
+
+
+def test_bypass_reads_never_adopts(tmp_path: Path, cache: LocalFileBackend):
+    src = tmp_path / "repo"
+    _write(src, "A/Foo.swift")
+    _seed_old(cache, src, "old/Foo.swift", "A/Foo.swift")
+    result = classify_files_via_cache(
+        _config(src), "security", ["A/Foo.swift"], cache, bypass_reads=True,
+    )
+    assert result.misses == ["A/Foo.swift"] and result.adopted == 0
+
+
+def test_unconsolidated_source_adopts_as_unconsolidated(tmp_path: Path, cache: LocalFileBackend):
+    src = tmp_path / "repo"
+    _write(src, "A/Foo.swift")
+    _seed_old(cache, src, "old/Foo.swift", "A/Foo.swift", consolidated=False)
+    result = classify_files_via_cache(_config(src), "security", ["A/Foo.swift"], cache)
+    new_key = build_cache_key_for_file(_config(src), "A/Foo.swift", "security")
+    assert result.cached_findings == []
+    assert [f["file"] for f in result.unconsolidated_findings] == ["A/Foo.swift"]
+    assert result.unconsolidated_hit_keys == {"A/Foo.swift": new_key}
+    assert cache.get(new_key).consolidated is False
+
+
+def test_backend_without_find_by_content_is_a_plain_miss(tmp_path: Path):
+    class Plain:
+        def __init__(self) -> None:
+            self.store: dict[str, CacheEntry] = {}
+
+        def get(self, key):
+            return self.store.get(key)
+
+        def put(self, key, entry):
+            self.store[key] = entry
+
+        def has(self, key):
+            return key in self.store
+
+        def delete(self, key):
+            self.store.pop(key, None)
+
+        def stats(self):
+            return None
+
+    src = tmp_path / "repo"
+    _write(src, "A/Foo.swift")
+    result = classify_files_via_cache(_config(src), "security", ["A/Foo.swift"], Plain())
+    assert result.misses == ["A/Foo.swift"] and result.adopted == 0
+
+
+def test_stale_index_row_is_verified_and_skipped(tmp_path: Path, cache: LocalFileBackend):
+    src = tmp_path / "repo"
+    _write(src, "A/Foo.swift")
+    old_key = _seed_old(cache, src, "old/Foo.swift", "A/Foo.swift")
+    # Corrupt the pointed-at entry's hash without touching the index row.
+    entry = cache.get(old_key)
+    cache.put(old_key, replace(entry, file_content_hash="ff" * 32), index=False)
+    result = classify_files_via_cache(_config(src), "security", ["A/Foo.swift"], cache)
+    assert result.misses == ["A/Foo.swift"] and result.adopted == 0
+
+
+def test_empty_content_hash_never_adopts(tmp_path: Path, cache: LocalFileBackend):
+    src = tmp_path / "repo"
+    src.mkdir()
+    # File missing on disk: content hash is "", must be a plain miss.
+    result = classify_files_via_cache(_config(src), "security", ["A/Missing.swift"], cache)
+    assert result.misses == ["A/Missing.swift"] and result.adopted == 0
+
+
+def test_adoption_picks_a_surviving_identical_sibling(tmp_path: Path, cache: LocalFileBackend):
+    # Identical files at several paths (empty __init__.py, repeated
+    # Package.swift) are a normal case: a still-present sibling with the same
+    # bytes, basename and role is an equivalent source.
+    src = tmp_path / "repo"
+    _write(src, "Modules/A/Package.swift", "// swift-tools-version:5.9")
+    _write(src, "Modules/B/Package.swift", "// swift-tools-version:5.9")
+    _seed_old(cache, src, "Modules/A/Package.swift", "Modules/B/Package.swift")
+    result = classify_files_via_cache(
+        _config(src), "security", ["Modules/B/Package.swift"], cache,
+    )
+    assert result.misses == [] and result.adopted == 1

--- a/tests/analysis/cache/test_cache_writer.py
+++ b/tests/analysis/cache/test_cache_writer.py
@@ -174,12 +174,12 @@ def test_cache_writer_provenance_folds_project_overrides(tmp_path):
 
 
 def test_entry_is_self_describing_for_future_key_migration(tmp_path):
-    """The schema-3 self-describing guarantee: an entry stores EVERY field its
-    key was computed from (content hash, path, dimension, language), so a
-    future key change can be recomputed losslessly from the entry alone — no
-    re-evaluation. This is what makes the 2->3 change the last one that costs
-    a re-eval. Regressing it (e.g. dropping language from the entry) silently
-    breaks future migratability, so pin it."""
+    """The self-describing guarantee: an entry stores EVERY field its key was
+    computed from (content hash, path, dimension, params hash), so a future
+    key change can be recomputed losslessly from the entry alone — no
+    re-evaluation. This is what let the 3->4 change (language left the key)
+    migrate in place. Regressing it silently breaks future migratability, so
+    pin it."""
     from quodeq.analysis.cache.cache_writer import build_cache_writer
     from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
     from quodeq.analysis.cache.key import CacheKey, compute_key
@@ -209,7 +209,6 @@ def test_entry_is_self_describing_for_future_key_migration(tmp_path):
         file_content_hash=entry.file_content_hash,
         file_path=entry.file_path,
         dimension=entry.dimension,
-        language=entry.language,
     ))
     assert recomputed == key
 

--- a/tests/analysis/cache/test_cache_writer.py
+++ b/tests/analysis/cache/test_cache_writer.py
@@ -209,6 +209,7 @@ def test_entry_is_self_describing_for_future_key_migration(tmp_path):
         file_content_hash=entry.file_content_hash,
         file_path=entry.file_path,
         dimension=entry.dimension,
+        params_hash=entry.params_hash,
     ))
     assert recomputed == key
 
@@ -344,6 +345,12 @@ def test_written_entry_records_effective_params(tmp_path):
     entry = LocalFileBackend(root=cache_root).get(key)
     assert entry is not None
     assert entry.provenance["effective_params"]["M-ANA-2"]["max_lines"] == 60
+    # Format 3: the non-default params hash the key was computed under is
+    # stored on the entry, so a future key change never has to derive it.
+    from quodeq.analysis.cache._key_provenance import build_cache_key_struct
+    expected_params_hash = build_cache_key_struct(config, "auth.py", "maintainability").params_hash
+    assert expected_params_hash != ""
+    assert entry.params_hash == expected_params_hash
 
 
 def test_cache_writer_marks_the_entry_unconsolidated(tmp_path):

--- a/tests/analysis/cache/test_dimension_helpers.py
+++ b/tests/analysis/cache/test_dimension_helpers.py
@@ -109,13 +109,16 @@ class TestKeyComposition:
             == build_cache_key_for_file(c2, "a.py", "security")
         )
 
-    def test_language_change_invalidates(self, tmp_path: Path):
+    def test_language_change_does_not_invalidate(self, tmp_path: Path):
+        # Schema 4: language left the key. It only ever reached the prompt
+        # as a heading word, so a detect_language() flip must not re-key
+        # the whole repo (freemium-app-android, java -> kotlin, Sep 2026).
         _write_files(tmp_path / "src", {"a.py": "x"})
         c1 = _make_config(tmp_path / "src", language="python")
         c2 = _make_config(tmp_path / "src", language="typescript")
         assert (
             build_cache_key_for_file(c1, "a.py", "security")
-            != build_cache_key_for_file(c2, "a.py", "security")
+            == build_cache_key_for_file(c2, "a.py", "security")
         )
 
     def test_standards_change_does_not_invalidate(self, tmp_path: Path):

--- a/tests/analysis/cache/test_dimension_helpers.py
+++ b/tests/analysis/cache/test_dimension_helpers.py
@@ -461,6 +461,9 @@ class TestPersist:
         assert "prompts_hash" in entry.provenance
         assert "standards_hash" in entry.provenance
         assert "quodeq_version" in entry.provenance
+        from quodeq.analysis.cache._key_provenance import build_cache_key_struct
+        assert entry.params_hash == build_cache_key_struct(config, "a.py", "security").params_hash
+        assert entry.cache_format_version == 3
 
     def test_persisted_provenance_folds_project_overrides(
         self, tmp_path: Path, cache: LocalFileBackend,

--- a/tests/analysis/cache/test_dimension_runner_cache_hits.py
+++ b/tests/analysis/cache/test_dimension_runner_cache_hits.py
@@ -13,9 +13,12 @@ import json
 import logging
 from dataclasses import replace
 from pathlib import Path
+from unittest.mock import patch
 
 from quodeq.analysis.cache import CacheEntry, build_cache_key_for_file
+from quodeq.analysis.cache._key_provenance import build_cache_key_struct
 from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+from quodeq.analysis.cache.key import compute_key
 from tests.analysis.cache.conftest import (
     FakeDispatcher,
     _ListHandler,
@@ -262,4 +265,38 @@ class TestNoSourceFiles:
         )
         # Dispatcher was called (even with no files — same as V1 behaviour).
         assert len(dispatcher.calls) == 1
+
+
+class TestAdoptedReporting:
+    def test_cache_line_and_marker_report_adopted_count(self, tmp_path: Path, cache):
+        config, src = _setup(tmp_path, {"new/a.py": "print(1)"})
+        struct = build_cache_key_struct(config, "new/a.py", "security")
+        old_key = compute_key(replace(struct, file_path="old/a.py"))
+        cache.put(old_key, CacheEntry(
+            key=old_key, schema_version=struct.schema_version,
+            findings=[{"file": "old/a.py", "line": 1, "t": "violation", "w": "v"}],
+            files_read=1, file_path="old/a.py", dimension="security", model_id="test-model",
+            file_content_hash=struct.file_content_hash,
+        ))
+        handler = _ListHandler()
+        logger = logging.getLogger("quodeq.analysis.cache.dimension_runner")
+        logger.addHandler(handler)
+        dispatcher = FakeDispatcher(src)
+        try:
+            with patch("quodeq.analysis.cache.dimension_runner.emit_marker") as marker:
+                process_dimension_with_cache(
+                    config, "security", idx=1, ctx=_make_ctx(), callbacks=_make_callbacks(),
+                    cache=cache, dispatcher=dispatcher,
+                )
+        finally:
+            logger.removeHandler(handler)
+
+        assert dispatcher.calls == []  # adopted, nothing dispatched
+        line = next(m for m in handler.messages if "cache:" in m and "hits" in m)
+        assert "1 hits / 0 misses (1 total)" in line
+        assert "1 adopted from moved files" in line
+        stats_call = next(
+            c for c in marker.call_args_list if c.args and c.args[0] == "cache_stats"
+        )
+        assert stats_call.kwargs["adopted"] == 1
 

--- a/tests/analysis/cache/test_entry.py
+++ b/tests/analysis/cache/test_entry.py
@@ -46,12 +46,6 @@ def test_empty_findings_round_trip():
     assert CacheEntry.from_json(entry.to_json()).findings == []
 
 
-def test_format_version_bumped_to_2():
-    # The new self-describing entry (file_content_hash + provenance) is
-    # format 2; the bump marks the shape change for any future migration.
-    assert ENTRY_FORMAT_VERSION == 2
-
-
 def test_file_content_hash_defaults_empty():
     # Self-describing: an entry records the content hash it was keyed under,
     # but the field is defaulted so legacy/partial construction still works.
@@ -158,7 +152,20 @@ def test_consolidated_false_survives_the_json_round_trip():
     assert CacheEntry.from_json(entry.to_json()).consolidated is False
 
 
-def test_entry_format_version_is_unchanged_by_the_consolidated_field():
-    """from_json tolerates missing and unknown keys in both directions, so
-    adding a field needs no format bump and no migration."""
-    assert ENTRY_FORMAT_VERSION == 2
+def test_entry_format_version_is_3():
+    """Format 3 stores ``params_hash`` explicitly. from_json tolerates missing
+    and unknown keys in both directions, so the bump needs no read-side
+    migration; the schema-3 -> 4 key migration fills the field for old entries."""
+    assert ENTRY_FORMAT_VERSION == 3
+
+
+def test_params_hash_round_trips_and_defaults_blank():
+    entry = _make(
+        schema_version=4, file_content_hash="aa" * 32, params_hash="pp" * 32,
+    )
+    restored = CacheEntry.from_json(entry.to_json())
+    assert restored.params_hash == "pp" * 32
+    assert restored.cache_format_version == 3
+    legacy = json.loads(entry.to_json())
+    del legacy["params_hash"]
+    assert CacheEntry.from_json(json.dumps(legacy)).params_hash == ""

--- a/tests/analysis/cache/test_gc.py
+++ b/tests/analysis/cache/test_gc.py
@@ -1,10 +1,11 @@
-"""One-time GC of cache entries from an older schema.
+"""Cache maintenance shim: legacy GC plus the schema-4 migration entry point.
 
-The permissive-key change (schema 2 -> 3) re-keys every entry, orphaning the
-old ones at paths current lookups never reach. The GC reclaims that dead disk
-once, lazily, on first cache open under the new schema. It must be
-best-effort and idempotent: never fatal on a bad entry, a no-op on a second
-pass, and it must never touch current-schema entries.
+A key-formula change re-keys every entry, orphaning the old ones at paths
+current lookups never reach. Entries older than the previous schema are dead
+disk and are reclaimed; entries at the previous schema are self-describing
+and are MIGRATED, never deleted. All of it runs once, lazily, on first cache
+open, and must be best-effort: never fatal on a bad entry, a no-op on a
+second pass, never touching current-schema entries.
 """
 from __future__ import annotations
 
@@ -13,6 +14,7 @@ from pathlib import Path
 
 from quodeq.analysis.cache.gc import (
     collect_legacy_entries,
+    ensure_cache_ready,
     maybe_collect_legacy_entries,
 )
 
@@ -24,7 +26,7 @@ def _write_entry(root: Path, key: str, *, schema: int) -> Path:
     (entry_dir / "entry.json").write_text(json.dumps({
         "key": key, "schema_version": schema, "findings": [],
         "files_read": 1, "file_path": "a.py", "dimension": "security",
-        "model_id": "m",
+        "model_id": "m", "file_content_hash": "aa" * 32,
     }))
     return entry_dir
 
@@ -32,9 +34,9 @@ def _write_entry(root: Path, key: str, *, schema: int) -> Path:
 def test_collect_deletes_entries_below_min_schema(tmp_path: Path):
     root = tmp_path / "cache"
     old = _write_entry(root, "aa" + "0" * 62, schema=2)
-    new = _write_entry(root, "bb" + "1" * 62, schema=3)
+    new = _write_entry(root, "bb" + "1" * 62, schema=4)
 
-    removed = collect_legacy_entries(root, min_schema=3)
+    removed = collect_legacy_entries(root, min_schema=4)
 
     assert removed == 1
     assert not (old / "entry.json").exists()
@@ -43,12 +45,12 @@ def test_collect_deletes_entries_below_min_schema(tmp_path: Path):
 
 def test_collect_is_idempotent(tmp_path: Path):
     root = tmp_path / "cache"
-    new = _write_entry(root, "bb" + "1" * 62, schema=3)
+    new = _write_entry(root, "bb" + "1" * 62, schema=4)
     _write_entry(root, "aa" + "0" * 62, schema=2)
 
-    assert collect_legacy_entries(root, min_schema=3) == 1
+    assert collect_legacy_entries(root, min_schema=4) == 1
     # Second pass finds nothing left to remove.
-    assert collect_legacy_entries(root, min_schema=3) == 0
+    assert collect_legacy_entries(root, min_schema=4) == 0
     assert (new / "entry.json").exists()
 
 
@@ -57,11 +59,11 @@ def test_collect_skips_unreadable_entry(tmp_path: Path):
     corrupt_dir = root / "cc" / ("2" * 62)
     corrupt_dir.mkdir(parents=True)
     (corrupt_dir / "entry.json").write_text("{ not valid json")
-    new = _write_entry(root, "bb" + "1" * 62, schema=3)
+    new = _write_entry(root, "bb" + "1" * 62, schema=4)
 
     # Must not raise; the corrupt entry is left in place (we can't read its
     # schema to know it's legacy), and current entries are untouched.
-    removed = collect_legacy_entries(root, min_schema=3)
+    removed = collect_legacy_entries(root, min_schema=4)
 
     assert removed == 0
     assert (corrupt_dir / "entry.json").exists()
@@ -69,18 +71,25 @@ def test_collect_skips_unreadable_entry(tmp_path: Path):
 
 
 def test_collect_handles_missing_root(tmp_path: Path):
-    assert collect_legacy_entries(tmp_path / "does-not-exist", min_schema=3) == 0
+    assert collect_legacy_entries(tmp_path / "does-not-exist", min_schema=4) == 0
 
 
-def test_maybe_collect_runs_once_per_process(tmp_path: Path):
+def test_ensure_cache_ready_migrates_v3_instead_of_deleting(tmp_path: Path):
+    from quodeq.data.cache_store import migrate as mig
+    mig._ready_memo.clear()
     root = tmp_path / "cache"
-    _write_entry(root, "aa" + "0" * 62, schema=2)
+    _write_entry(root, "aa" + "0" * 62, schema=2)   # legacy: reclaimed
+    _write_entry(root, "bb" + "1" * 62, schema=3)   # migrate, never delete
 
-    maybe_collect_legacy_entries(root)
-    assert not (root / "aa" / ("0" * 62) / "entry.json").exists()  # collected
-    assert (root / ".gc_schema_4").exists()  # marker written
+    ensure_cache_ready(root)
+
+    assert not (root / "aa" / ("0" * 62) / "entry.json").exists()
+    assert not (root / "bb" / ("1" * 62) / "entry.json").exists()  # moved, not lost
+    assert len(list(root.rglob("entry.json"))) == 1
+    assert (root / ".schema_4_ready").exists()
+    assert maybe_collect_legacy_entries is ensure_cache_ready
 
     # A legacy entry seeded after the one-time pass is NOT collected again.
     _write_entry(root, "dd" + "3" * 62, schema=2)
-    maybe_collect_legacy_entries(root)
+    ensure_cache_ready(root)
     assert (root / "dd" / ("3" * 62) / "entry.json").exists()

--- a/tests/analysis/cache/test_gc.py
+++ b/tests/analysis/cache/test_gc.py
@@ -78,7 +78,7 @@ def test_maybe_collect_runs_once_per_process(tmp_path: Path):
 
     maybe_collect_legacy_entries(root)
     assert not (root / "aa" / ("0" * 62) / "entry.json").exists()  # collected
-    assert (root / ".gc_schema_3").exists()  # marker written
+    assert (root / ".gc_schema_4").exists()  # marker written
 
     # A legacy entry seeded after the one-time pass is NOT collected again.
     _write_entry(root, "dd" + "3" * 62, schema=2)

--- a/tests/analysis/cache/test_key.py
+++ b/tests/analysis/cache/test_key.py
@@ -1,10 +1,11 @@
 """Cache key — stability, sensitivity, and the permissive field set.
 
 The V2 cache key is permissive (cost-first): it invalidates ONLY on real
-per-unit changes — file content, file path, dimension, language. Volatile
-inputs (model, prompts, standards, sampling params) are deliberately NOT in
-the key; they are recorded in ``CacheEntry.provenance`` so reuse across those
-boundaries is surfaced, not silently re-evaluated.
+per-unit changes — file content, file path, dimension, non-default params.
+Volatile inputs (model, prompts, standards, sampling params) and, since
+schema 4, the project language are deliberately NOT in the key; they are
+recorded in ``CacheEntry.provenance`` so reuse across those boundaries is
+surfaced, not silently re-evaluated.
 """
 from __future__ import annotations
 
@@ -17,11 +18,10 @@ from quodeq.analysis.cache.key import CacheKey, compute_key
 
 def _base_key(**overrides) -> CacheKey:
     defaults = dict(
-        schema_version=3,
+        schema_version=4,
         file_content_hash="aa" * 32,
         file_path="src/auth.py",
         dimension="security",
-        language="python",
     )
     defaults.update(overrides)
     return CacheKey(**defaults)
@@ -30,17 +30,22 @@ def _base_key(**overrides) -> CacheKey:
 class TestPermissiveFieldSet:
     def test_key_holds_only_file_change_fields(self):
         # Structural guard: this is the contract. If a volatile field
-        # (model_id, prompts_hash, standards_hash, temperature, ...) is ever
-        # re-added to the key, this fails loudly — that is a cache-wide
-        # re-eval the user did not ask for.
+        # (model_id, prompts_hash, standards_hash, language, temperature, ...)
+        # is ever re-added to the key, this fails loudly — that is a
+        # cache-wide re-eval the user did not ask for.
         assert {f.name for f in dataclasses.fields(CacheKey)} == {
             "schema_version",
             "file_content_hash",
             "file_path",
             "dimension",
-            "language",
             "params_hash",
         }
+
+    def test_schema_version_is_4_and_exported_from_data_layer(self):
+        from quodeq.data.cache_store.key import SCHEMA_VERSION
+        from quodeq.data.cache_store.key import CacheKey as DataCacheKey
+        assert SCHEMA_VERSION == 4
+        assert DataCacheKey is CacheKey
 
 
 class TestStability:
@@ -55,8 +60,7 @@ class TestStability:
             file_content_hash="aa" * 32,
             file_path="src/auth.py",
             dimension="security",
-            language="python",
-            schema_version=3,
+            schema_version=4,
         )
         assert compute_key(k1) == compute_key(k2)
 
@@ -72,16 +76,8 @@ class TestSensitivity:
         b = compute_key(_base_key(dimension="documentation"))
         assert a != b
 
-    def test_language_change_invalidates(self):
-        # Language stays in the key: it is a stable project property, and
-        # changing it genuinely changes which files exist and how they are
-        # analyzed.
-        a = compute_key(_base_key(language="python"))
-        b = compute_key(_base_key(language="kotlin"))
-        assert a != b
-
     def test_schema_version_change_invalidates(self):
-        assert compute_key(_base_key(schema_version=2)) != compute_key(_base_key(schema_version=3))
+        assert compute_key(_base_key(schema_version=3)) != compute_key(_base_key(schema_version=4))
 
     def test_path_change_invalidates(self):
         # Path-sensitive rules (e.g. src/ vs tests/) must produce distinct keys.
@@ -96,23 +92,22 @@ class TestKeyShape:
 
 
 class TestParamsHash:
-    def test_empty_params_hash_is_byte_identical_to_legacy_key(self):
-        # The legacy canonical form has NO params_hash member at all. An
-        # empty params_hash must serialize identically, so pre-existing
-        # cache entries stay reachable after upgrade.
+    def test_empty_params_hash_is_omitted_from_canonical_form(self):
+        # An empty params_hash serializes identically to a key with no
+        # params_hash member at all, so default-config keys never shift when
+        # the params feature is a no-op for a project.
         key = _base_key()
-        legacy_canonical = json.dumps(
+        canonical = json.dumps(
             {
                 "dimension": "security",
                 "file_content_hash": "aa" * 32,
                 "file_path": "src/auth.py",
-                "language": "python",
-                "schema_version": 3,
+                "schema_version": 4,
             },
             sort_keys=True, separators=(",", ":"),
         )
-        legacy = hashlib.sha256(legacy_canonical.encode("utf-8")).hexdigest()
-        assert compute_key(key) == legacy
+        expected = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        assert compute_key(key) == expected
 
     def test_non_empty_params_hash_changes_key(self):
         assert compute_key(_base_key(params_hash="ff" * 32)) != compute_key(_base_key())

--- a/tests/analysis/cache/test_local_backend.py
+++ b/tests/analysis/cache/test_local_backend.py
@@ -138,3 +138,46 @@ class TestCacheRoot:
         monkeypatch.setenv("QUODEQ_CACHE_ROOT", "   ")
         root = default_cache_root()
         assert ".quodeq" in root.parts
+
+
+class TestContentIndexWiring:
+    def _entry(self, key: str, *, path: str, hash_: str = "aa" * 32) -> CacheEntry:
+        return CacheEntry(
+            key=key, schema_version=4, findings=[], files_read=1, file_path=path,
+            dimension="security", model_id="m", file_content_hash=hash_,
+            created_at="2026-01-01T00:00:00+00:00",
+        )
+
+    def test_put_records_and_find_by_content_returns_row(self, backend: LocalFileBackend):
+        backend.put("k1" * 32, self._entry("k1" * 32, path="ios/A.swift"))
+        rows = backend.find_by_content("aa" * 32, "security", "")
+        assert [(r.key, r.file_path) for r in rows] == [("k1" * 32, "ios/A.swift")]
+
+    def test_delete_forgets(self, backend: LocalFileBackend):
+        backend.put("k1" * 32, self._entry("k1" * 32, path="A.swift"))
+        backend.delete("k1" * 32)
+        assert backend.find_by_content("aa" * 32, "security", "") == []
+
+    def test_put_with_index_false_skips_indexing(self, backend: LocalFileBackend):
+        backend.put("k1" * 32, self._entry("k1" * 32, path="A.swift"), index=False)
+        assert backend.get("k1" * 32) is not None
+        assert backend.find_by_content("aa" * 32, "security", "") == []
+
+    def test_index_file_lives_inside_root(self, backend: LocalFileBackend):
+        from quodeq.data.cache_store.index import INDEX_FILENAME
+        backend.put("k1" * 32, self._entry("k1" * 32, path="A.swift"))
+        assert (backend.root / INDEX_FILENAME).exists()
+
+    def test_index_can_be_disabled(self, tmp_path: Path):
+        b = LocalFileBackend(root=tmp_path / "c", enable_index=False)
+        b.put("k1" * 32, self._entry("k1" * 32, path="A.swift"))
+        assert b.index is None
+        assert b.find_by_content("aa" * 32, "security", "") == []
+
+    def test_blank_hash_never_indexed(self, backend: LocalFileBackend):
+        backend.put("k1" * 32, self._entry("k1" * 32, path="A.swift", hash_=""))
+        assert backend.find_by_content("", "security", "") == []
+
+    def test_stats_ignore_the_index_file(self, backend: LocalFileBackend):
+        backend.put("k1" * 32, self._entry("k1" * 32, path="A.swift"))
+        assert backend.stats().entries == 1

--- a/tests/analysis/cache/test_runner.py
+++ b/tests/analysis/cache/test_runner.py
@@ -130,7 +130,6 @@ class TestInvalidation:
         {"file_content_hash": "00" * 32},
         {"file_path": "src/other.py"},
         {"dimension": "documentation"},
-        {"language": "typescript"},
     ])
     def test_each_real_change_misses(self, cache: LocalFileBackend, override: dict):
         dispatcher = _RecordingDispatcher()
@@ -146,6 +145,7 @@ class TestInvalidation:
         {"model_id": "claude-sonnet-4-6"},
         {"temperature": 0.7},
         {"max_tokens": 4096},
+        {"language": "typescript"},  # schema 4: language is provenance, not key
     ])
     def test_volatile_change_reuses(self, cache: LocalFileBackend, override: dict):
         # Permissive key: changing model / prompts / standards / sampling

--- a/tests/analysis/cache/test_runner.py
+++ b/tests/analysis/cache/test_runner.py
@@ -281,3 +281,10 @@ def test_analyze_unit_preserves_consolidated_on_a_hit(cache: LocalFileBackend):
     second = analyze_unit(unit, cache=cache, dispatcher=dispatcher)
     assert second.cache_hit is True
     assert second.entry.consolidated is True
+
+
+def test_analyze_unit_stores_params_hash(cache: LocalFileBackend):
+    unit = _unit(params_hash="ee" * 32)
+    result = analyze_unit(unit, cache=cache, dispatcher=_RecordingDispatcher())
+    assert result.entry.params_hash == "ee" * 32
+    assert cache.get(result.entry.key).params_hash == "ee" * 32

--- a/tests/analysis/mcp/test_findings_server_cache.py
+++ b/tests/analysis/mcp/test_findings_server_cache.py
@@ -339,12 +339,13 @@ def test_cli_path_and_api_path_agree_with_standards_dir_and_override(tmp_path):
     assert entry.provenance["effective_params"]["M-ANA-2"]["max_lines"] == 60
 
 
-def test_cli_path_key_diverges_when_language_missing(tmp_path):
-    """Counter-test: when ServerArgs.language is None, the CLI-path's cache
-    writer falls back to "" -- which MUST diverge from the API-path key for
-    a project where RunConfig.language is set. This pins that the regression
-    fixed here cannot silently come back by anyone re-introducing the
-    getattr(ctx, "language", None) pattern.
+def test_cli_path_key_matches_api_path_when_language_missing(tmp_path):
+    """Schema 4: language is provenance, not key. When ServerArgs.language is
+    None the CLI-path writer records "" on the entry, and that MUST still
+    land on the same key the API path computes for a project whose
+    RunConfig.language is set. The old regression (a language mismatch
+    between the two paths silently missing every entry) is structurally
+    impossible now, and this pins that it stays so.
     """
     from quodeq.analysis._types import AnalysisOptions, RunConfig
     from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
@@ -387,9 +388,10 @@ def test_cli_path_key_diverges_when_language_missing(tmp_path):
     router.mark_file_done(file="Foo.kt", status="ok")
 
     cache = LocalFileBackend(root=cache_root)
-    # Parent key MUST miss when CLI side didn't get the language flag.
-    assert cache.get(parent_key) is None, (
-        "Expected divergence: when CLI side has no --language, its key must "
-        "NOT collide with the API-path key. If this fails, language is no "
-        "longer load-bearing in the key composition."
+    # Parent key MUST hit even though the CLI side had no language flag.
+    entry = cache.get(parent_key)
+    assert entry is not None, (
+        "Expected convergence: with language out of the key (schema 4), the "
+        "CLI-path key must equal the API-path key regardless of --language."
     )
+    assert entry.language == ""  # recorded as information, not keyed

--- a/tests/analysis/test_dim_estimates.py
+++ b/tests/analysis/test_dim_estimates.py
@@ -100,6 +100,32 @@ class TestComputeDimEstimates:
             result = compute_dim_estimates(config, ["security"])
         assert result["security"] == {"count": 2, "reason": "first-run", "total": 2, "cached": 0, "excluded": 0}
 
+    def test_estimate_counts_adopted_files_as_cached(self, tmp_path: Path):
+        # The estimate shares classify_files_via_cache with the run, so a
+        # file that moved directory with unchanged content shows as cached
+        # in the dashboard preview rather than "from scratch".
+        from dataclasses import replace
+        from quodeq.analysis.cache._key_provenance import build_cache_key_struct
+        from quodeq.analysis.cache.key import compute_key
+        src = tmp_path / "src"
+        (src / "new").mkdir(parents=True)
+        _write_files(src, ["new/a.py"])
+        config = _make_config(src, ["new/a.py"], incremental=True)
+        cache = LocalFileBackend(root=tmp_path / "fresh-cache")
+        struct = build_cache_key_struct(config, "new/a.py", "security")
+        old_key = compute_key(replace(struct, file_path="old/a.py"))
+        cache.put(old_key, CacheEntry(
+            key=old_key, schema_version=struct.schema_version, findings=[], files_read=1,
+            file_path="old/a.py", dimension="security", model_id="test-model",
+            file_content_hash=struct.file_content_hash,
+        ))
+
+        with patch("quodeq.analysis._dim_estimates.LocalFileBackend", return_value=cache):
+            result = compute_dim_estimates(config, ["security"])
+        assert result["security"] == {
+            "count": 0, "reason": "incremental", "total": 1, "cached": 1, "excluded": 0,
+        }
+
     def test_incremental_partial_cache_marks_incremental(self, tmp_path: Path):
         src = tmp_path / "src"
         _write_files(src, ["a.py", "b.py", "c.py"])

--- a/tests/analysis/test_fingerprint_dimension_params.py
+++ b/tests/analysis/test_fingerprint_dimension_params.py
@@ -159,3 +159,60 @@ def test_deeply_nested_compiled_file_hashes_empty(standards_dir, project_root, d
         deeply_nested_json, encoding="utf-8")
 
     assert dimension_params_state(standards_dir, DIM, project_root) == ("", {})
+
+
+# ---------------------------------------------------------------------------
+# Shared params-hash formula (writer + schema migration must agree)
+# ---------------------------------------------------------------------------
+
+import hashlib  # noqa: E402
+
+from quodeq.core.standards.overrides import (  # noqa: E402
+    dimension_params,
+    hash_non_default_params,
+    non_default_from_effective,
+)
+
+_PARAMS_DIM = {
+    "principles": [{
+        "requirements": [
+            {"id": "M-1", "params": {"max_lines": {"default": 50, "min": 10, "max": 500}}},
+            {"id": "M-2", "params": {"depth": {"default": 3}}},
+        ],
+    }],
+}
+
+
+def test_hash_non_default_params_empty_is_blank():
+    assert hash_non_default_params({}) == ""
+
+
+def test_hash_non_default_params_matches_canonical_sha256():
+    nd = {"M-1": {"max_lines": 60}}
+    expected = hashlib.sha256(
+        json.dumps(nd, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    assert hash_non_default_params(nd) == expected
+
+
+def test_non_default_from_effective_diffs_against_declared_defaults():
+    effective = {"M-1": {"max_lines": 60}, "M-2": {"depth": 3}}
+    assert non_default_from_effective(_PARAMS_DIM, effective) == {"M-1": {"max_lines": 60}}
+
+
+def test_non_default_from_effective_all_defaults_is_empty():
+    effective, _ = dimension_params(_PARAMS_DIM, {})
+    assert non_default_from_effective(_PARAMS_DIM, effective) == {}
+
+
+def test_non_default_from_effective_agrees_with_dimension_params():
+    overrides = {"M-2": {"depth": 5}}
+    effective, non_default = dimension_params(_PARAMS_DIM, overrides)
+    assert non_default_from_effective(_PARAMS_DIM, effective) == non_default
+
+
+def test_non_default_from_effective_treats_undeclared_requirement_as_non_default():
+    # A requirement the compiled standards no longer declare has no known
+    # default, so its stored values count as non-default (stale hash, one
+    # re-eval) rather than silently matching a default-config key.
+    assert non_default_from_effective(_PARAMS_DIM, {"GONE": {"x": 1}}) == {"GONE": {"x": 1}}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import json
 
 import pytest
 
+from quodeq.data.cache_store.index import close_all_for_tests
 from quodeq.data.fs._index_cache import clear_index_cache
 
 # Deep enough to exhaust the C JSON decoder's call stack on a default 8MB
@@ -94,6 +95,23 @@ def _fresh_index_cache() -> None:
     """
     clear_index_cache()
     yield
+
+
+@pytest.fixture(autouse=True)
+def _close_content_indexes() -> None:
+    """Close every ``ContentIndex`` sqlite connection opened during the test.
+
+    ``QUODEQ_CACHE_ROOT`` points at a fresh tmp dir per test (see
+    ``_isolate_quodeq_home``), so most tests that touch cache code open a
+    distinct ``.index.db`` connection that nothing explicitly closes --
+    production code relies on the process exiting to release it. In one
+    long single-process test run those connections pile up faster than GC
+    reclaims them (worse under coverage instrumentation), and file
+    descriptor numbers climb past 1024, which breaks unrelated
+    ``select()``-based PTY tests. Close them all after each test instead.
+    """
+    yield
+    close_all_for_tests()
 
 
 class DummyProcess:

--- a/tests/data/cache_store/test_index.py
+++ b/tests/data/cache_store/test_index.py
@@ -1,0 +1,105 @@
+"""Content index: sqlite sidecar mapping (content hash, dimension, params) to keys.
+
+Never authoritative and never fatal: a corrupt or missing db reports nothing
+and is rebuilt by ensure_cache_ready. Lookups are verified against the entry
+they point at before use (see analysis.cache._adoption).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from quodeq.data.cache_store.index import INDEX_FILENAME, ContentIndex, IndexRow
+
+
+@pytest.fixture
+def index(tmp_path: Path) -> ContentIndex:
+    return ContentIndex(tmp_path / INDEX_FILENAME)
+
+
+def _rec(index: ContentIndex, key: str, *, path: str, created: str, hash_: str = "aa" * 32,
+         dim: str = "security", params: str = "") -> None:
+    index.record(key, content_hash=hash_, dimension=dim, params_hash=params,
+                 file_path=path, created_at=created)
+
+
+def test_record_then_find_newest_first(index: ContentIndex):
+    _rec(index, "k1" * 32, path="ios/A.swift", created="2026-01-01T00:00:00+00:00")
+    _rec(index, "k2" * 32, path="old/A.swift", created="2026-02-01T00:00:00+00:00")
+    rows = index.find("aa" * 32, "security", "")
+    assert rows == [
+        IndexRow(key="k2" * 32, file_path="old/A.swift", created_at="2026-02-01T00:00:00+00:00"),
+        IndexRow(key="k1" * 32, file_path="ios/A.swift", created_at="2026-01-01T00:00:00+00:00"),
+    ]
+
+
+def test_find_filters_on_dimension_and_params(index: ContentIndex):
+    _rec(index, "k1" * 32, path="A.swift", created="t", dim="security", params="")
+    _rec(index, "k2" * 32, path="A.swift", created="t", dim="reliability", params="")
+    _rec(index, "k3" * 32, path="A.swift", created="t", dim="security", params="pp")
+    assert [r.key for r in index.find("aa" * 32, "security", "")] == ["k1" * 32]
+    assert [r.key for r in index.find("aa" * 32, "security", "pp")] == ["k3" * 32]
+
+
+def test_find_respects_limit(index: ContentIndex):
+    for i in range(5):
+        _rec(index, f"k{i}" * 32, path=f"{i}/A.swift", created=f"2026-01-0{i + 1}")
+    assert len(index.find("aa" * 32, "security", "", limit=2)) == 2
+
+
+def test_forget_removes_row(index: ContentIndex):
+    _rec(index, "k1" * 32, path="A.swift", created="t")
+    index.forget("k1" * 32)
+    assert index.find("aa" * 32, "security", "") == []
+
+
+def test_record_replaces_existing_key(index: ContentIndex):
+    _rec(index, "k1" * 32, path="A.swift", created="t1")
+    _rec(index, "k1" * 32, path="B.swift", created="t2")
+    rows = index.find("aa" * 32, "security", "")
+    assert [(r.file_path, r.created_at) for r in rows] == [("B.swift", "t2")]
+
+
+def test_empty_content_hash_is_never_recorded(index: ContentIndex):
+    _rec(index, "k1" * 32, path="A.swift", created="t", hash_="")
+    assert index.find("", "security", "") == []
+
+
+def test_record_many_batches(index: ContentIndex):
+    index.record_many([
+        ("k1" * 32, "aa" * 32, "security", "", "A.swift", "t1"),
+        ("k2" * 32, "aa" * 32, "security", "", "B.swift", "t2"),
+        ("k3" * 32, "", "security", "", "C.swift", "t3"),  # blank hash skipped
+    ])
+    assert {r.key for r in index.find("aa" * 32, "security", "")} == {"k1" * 32, "k2" * 32}
+
+
+def test_built_marker_round_trip(index: ContentIndex):
+    assert index.built_for_schema() is None
+    index.mark_built(4)
+    assert index.built_for_schema() == 4
+
+
+def test_corrupt_db_is_replaced_not_fatal(tmp_path: Path):
+    db = tmp_path / INDEX_FILENAME
+    db.write_text("this is not sqlite")
+    index = ContentIndex(db)
+    assert index.find("aa" * 32, "security", "") == []  # no raise
+    _rec(index, "k1" * 32, path="A.swift", created="t")
+    assert [r.key for r in index.find("aa" * 32, "security", "")] == ["k1" * 32]
+
+
+def test_unwritable_location_degrades_silently(tmp_path: Path):
+    blocker = tmp_path / "file"
+    blocker.write_text("x")
+    index = ContentIndex(blocker / INDEX_FILENAME)  # parent is a file: cannot create
+    _rec(index, "k1" * 32, path="A.swift", created="t")
+    assert index.find("aa" * 32, "security", "") == []
+    assert index.built_for_schema() is None
+
+
+def test_close_then_reuse_reopens(index: ContentIndex):
+    _rec(index, "k1" * 32, path="A.swift", created="t")
+    index.close()
+    assert [r.key for r in index.find("aa" * 32, "security", "")] == ["k1" * 32]

--- a/tests/data/cache_store/test_migrate.py
+++ b/tests/data/cache_store/test_migrate.py
@@ -1,0 +1,265 @@
+"""Schema 3 -> 4 migration, index build and legacy GC. One-time, lazy, lossless.
+
+Entries store every key input, so a v3 entry (with language in its key) is
+re-keyed to v4 (without language) from its own fields. The walk doubles as
+the content-index build. Legacy (< 3) and unmigratable entries are reclaimed.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+
+from quodeq.data.cache_store import migrate as mig
+from quodeq.data.cache_store.entry import CacheEntry
+from quodeq.data.cache_store.key import SCHEMA_VERSION, CacheKey, compute_key
+from quodeq.data.cache_store.local import LocalFileBackend
+from quodeq.data.cache_store.migrate import (
+    MigrationStats,
+    collect_legacy_entries,
+    derive_params_hash,
+    ensure_cache_ready,
+    migrate_entries,
+    ready_marker,
+)
+
+HASH = "aa" * 32
+
+
+def _v3_key(path: str, dim: str, language: str, params_hash: str = "") -> str:
+    """Reproduce the schema-3 formula (language in the canonical form)."""
+    data = {
+        "schema_version": 3, "file_content_hash": HASH, "file_path": path,
+        "dimension": dim, "language": language,
+    }
+    if params_hash:
+        data["params_hash"] = params_hash
+    canonical = json.dumps(data, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _write_raw(root: Path, key: str, payload: dict) -> Path:
+    d = root / key[:2] / key[2:]
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "entry.json").write_text(json.dumps(payload))
+    return d
+
+
+def _write_v3(root: Path, *, path: str, dim: str = "security", language: str = "typescript",
+              effective: dict | None = None, consolidated: bool = True) -> str:
+    key = _v3_key(path, dim, language)
+    _write_raw(root, key, {
+        "key": key, "schema_version": 3, "findings": [{"file": path, "line": 1}],
+        "files_read": 1, "file_path": path, "dimension": dim, "model_id": "m",
+        "file_content_hash": HASH, "language": language,
+        "provenance": {"model_id": "m", "effective_params": effective or {}},
+        "created_at": "2026-08-01T00:00:00+00:00", "cache_format_version": 2,
+        "consolidated": consolidated,
+    })
+    return key
+
+
+def _v4_key(path: str, dim: str = "security", params_hash: str = "") -> str:
+    return compute_key(CacheKey(
+        schema_version=SCHEMA_VERSION, file_content_hash=HASH, file_path=path,
+        dimension=dim, params_hash=params_hash,
+    ))
+
+
+def _write_compiled(standards_dir: Path, dim: str, payload: dict) -> None:
+    (standards_dir / "compiled").mkdir(parents=True, exist_ok=True)
+    (standards_dir / "compiled" / f"{dim}.json").write_text(json.dumps(payload))
+
+
+class TestDeriveParamsHash:
+    _DIM = {"principles": [{"requirements": [
+        {"id": "M-1", "params": {"max_lines": {"default": 50}}},
+    ]}]}
+
+    def test_blank_when_no_effective_params(self, tmp_path: Path):
+        assert derive_params_hash("security", {}, tmp_path) == ""
+
+    def test_blank_when_no_standards_dir(self):
+        assert derive_params_hash("security", {"M-1": {"max_lines": 60}}, None) == ""
+
+    def test_blank_when_compiled_missing(self, tmp_path: Path):
+        assert derive_params_hash("security", {"M-1": {"max_lines": 60}}, tmp_path) == ""
+
+    def test_blank_when_all_defaults(self, tmp_path: Path):
+        _write_compiled(tmp_path, "security", self._DIM)
+        assert derive_params_hash("security", {"M-1": {"max_lines": 50}}, tmp_path) == ""
+
+    def test_matches_writer_formula_for_override(self, tmp_path: Path):
+        from quodeq.core.standards.overrides import hash_non_default_params
+        _write_compiled(tmp_path, "security", self._DIM)
+        got = derive_params_hash("security", {"M-1": {"max_lines": 60}}, tmp_path)
+        assert got == hash_non_default_params({"M-1": {"max_lines": 60}})
+
+    def test_malformed_compiled_is_blank(self, tmp_path: Path):
+        (tmp_path / "compiled").mkdir()
+        (tmp_path / "compiled" / "security.json").write_text("{ nope")
+        assert derive_params_hash("security", {"M-1": {"max_lines": 60}}, tmp_path) == ""
+
+
+class TestMigrateEntries:
+    def test_v3_entry_becomes_reachable_at_v4_key(self, tmp_path: Path):
+        root = tmp_path / "cache"
+        old_key = _write_v3(root, path="ios/A.swift")
+        stats = migrate_entries(root, standards_dir=None)
+        backend = LocalFileBackend(root=root)
+        new = backend.get(_v4_key("ios/A.swift"))
+        assert stats == MigrationStats(migrated=1, deduplicated=0, indexed=0, removed=0, skipped=0)
+        assert new is not None
+        assert new.schema_version == SCHEMA_VERSION
+        assert new.key == _v4_key("ios/A.swift")
+        assert new.language == "typescript"  # informational, kept
+        assert new.params_hash == ""
+        assert new.cache_format_version == 3
+        assert new.consolidated is True
+        assert new.findings == [{"file": "ios/A.swift", "line": 1}]
+        assert not (root / old_key[:2] / old_key[2:]).exists()
+
+    def test_entries_differing_only_in_language_collapse(self, tmp_path: Path):
+        root = tmp_path / "cache"
+        _write_v3(root, path="A.kt", language="java")
+        _write_v3(root, path="A.kt", language="kotlin")
+        stats = migrate_entries(root, standards_dir=None)
+        assert stats.migrated == 1 and stats.deduplicated == 1
+        assert LocalFileBackend(root=root).get(_v4_key("A.kt")) is not None
+        assert len(list(root.rglob("entry.json"))) == 1
+
+    def test_migrated_entries_are_indexed(self, tmp_path: Path):
+        root = tmp_path / "cache"
+        _write_v3(root, path="ios/A.swift")
+        migrate_entries(root, standards_dir=None)
+        rows = LocalFileBackend(root=root).find_by_content(HASH, "security", "")
+        assert [r.file_path for r in rows] == ["ios/A.swift"]
+
+    def test_existing_v4_entries_get_index_rows(self, tmp_path: Path):
+        root = tmp_path / "cache"
+        backend = LocalFileBackend(root=root)
+        key = _v4_key("B.swift")
+        backend.put(key, CacheEntry(
+            key=key, schema_version=SCHEMA_VERSION, findings=[], files_read=1,
+            file_path="B.swift", dimension="security", model_id="m", file_content_hash=HASH,
+        ), index=False)
+        stats = migrate_entries(root, standards_dir=None, backend=backend)
+        assert stats.indexed == 1
+        assert [r.key for r in backend.find_by_content(HASH, "security", "")] == [key]
+
+    def test_params_hash_derived_from_effective_params(self, tmp_path: Path):
+        from quodeq.core.standards.overrides import hash_non_default_params
+        root = tmp_path / "cache"
+        std = tmp_path / "standards"
+        _write_compiled(std, "security", {"principles": [{"requirements": [
+            {"id": "M-1", "params": {"max_lines": {"default": 50}}},
+        ]}]})
+        _write_v3(root, path="A.py", effective={"M-1": {"max_lines": 60}})
+        migrate_entries(root, standards_dir=std)
+        ph = hash_non_default_params({"M-1": {"max_lines": 60}})
+        new = LocalFileBackend(root=root).get(_v4_key("A.py", params_hash=ph))
+        assert new is not None and new.params_hash == ph
+
+    def test_legacy_schema_2_entry_removed(self, tmp_path: Path):
+        root = tmp_path / "cache"
+        d = _write_raw(root, "cc" + "0" * 62, {
+            "key": "cc" + "0" * 62, "schema_version": 2, "findings": [], "files_read": 1,
+            "file_path": "a.py", "dimension": "security", "model_id": "m",
+        })
+        stats = migrate_entries(root, standards_dir=None)
+        assert stats.removed == 1
+        assert not d.exists()
+
+    def test_unreadable_entry_left_in_place(self, tmp_path: Path):
+        root = tmp_path / "cache"
+        d = root / "dd" / ("1" * 62)
+        d.mkdir(parents=True)
+        (d / "entry.json").write_text("{ not json")
+        stats = migrate_entries(root, standards_dir=None)
+        assert stats.skipped == 1
+        assert (d / "entry.json").exists()
+
+    def test_second_pass_is_a_no_op(self, tmp_path: Path):
+        root = tmp_path / "cache"
+        _write_v3(root, path="A.swift")
+        migrate_entries(root, standards_dir=None)
+        stats = migrate_entries(root, standards_dir=None)
+        assert stats.migrated == 0 and stats.removed == 0
+        assert stats.indexed == 1  # re-walk re-records the v4 row, harmless
+
+    def test_missing_root_is_empty_stats(self, tmp_path: Path):
+        assert migrate_entries(tmp_path / "nope", standards_dir=None) == MigrationStats()
+
+
+class TestEnsureCacheReady:
+    def setup_method(self):
+        mig._ready_memo.clear()
+
+    def test_migrates_marks_and_indexes(self, tmp_path: Path):
+        root = tmp_path / "cache"
+        _write_v3(root, path="ios/A.swift")
+        ensure_cache_ready(root, standards_dir=None)
+        backend = LocalFileBackend(root=root)
+        assert backend.get(_v4_key("ios/A.swift")) is not None
+        assert ready_marker(root).exists()
+        assert backend.index.built_for_schema() == SCHEMA_VERSION
+        assert not (root / mig.LOCK_FILENAME).exists()
+
+    def test_marker_short_circuits(self, tmp_path: Path):
+        root = tmp_path / "cache"
+        _write_v3(root, path="first/A.swift")
+        ensure_cache_ready(root, standards_dir=None)
+        mig._ready_memo.clear()
+        _write_v3(root, path="late/A.swift")  # seeded after the pass
+        ensure_cache_ready(root, standards_dir=None)
+        assert LocalFileBackend(root=root).get(_v4_key("late/A.swift")) is None
+
+    def test_missing_index_is_rebuilt_even_with_marker(self, tmp_path: Path):
+        from quodeq.data.cache_store.index import INDEX_FILENAME
+        root = tmp_path / "cache"
+        _write_v3(root, path="A.swift")
+        ensure_cache_ready(root, standards_dir=None)
+        for suffix in ("", "-wal", "-shm"):
+            (root / (INDEX_FILENAME + suffix)).unlink(missing_ok=True)
+        mig._ready_memo.clear()
+        ensure_cache_ready(root, standards_dir=None)
+        backend = LocalFileBackend(root=root)
+        assert backend.index.built_for_schema() == SCHEMA_VERSION
+        assert [r.file_path for r in backend.find_by_content(HASH, "security", "")] == ["A.swift"]
+
+    def test_live_lock_skips_and_does_not_memo(self, tmp_path: Path):
+        root = tmp_path / "cache"
+        _write_v3(root, path="A.swift")
+        (root / mig.LOCK_FILENAME).write_text("12345")
+        ensure_cache_ready(root, standards_dir=None)
+        assert LocalFileBackend(root=root).get(_v4_key("A.swift")) is None
+        assert not ready_marker(root).exists()
+        # Lock released elsewhere: the next call (no memo) does the work.
+        (root / mig.LOCK_FILENAME).unlink()
+        ensure_cache_ready(root, standards_dir=None)
+        assert LocalFileBackend(root=root).get(_v4_key("A.swift")) is not None
+
+    def test_stale_lock_is_taken_over(self, tmp_path: Path):
+        root = tmp_path / "cache"
+        _write_v3(root, path="A.swift")
+        lock = root / mig.LOCK_FILENAME
+        lock.write_text("1")
+        old = time.time() - mig.STALE_LOCK_S - 5
+        os.utime(lock, (old, old))
+        ensure_cache_ready(root, standards_dir=None)
+        assert LocalFileBackend(root=root).get(_v4_key("A.swift")) is not None
+        assert not lock.exists()
+
+    def test_missing_root_is_a_no_op(self, tmp_path: Path):
+        ensure_cache_ready(tmp_path / "nope", standards_dir=None)
+        assert not (tmp_path / "nope").exists()
+
+
+def test_collect_legacy_entries_still_available(tmp_path: Path):
+    root = tmp_path / "cache"
+    _write_raw(root, "aa" + "0" * 62, {"key": "aa" + "0" * 62, "schema_version": 2})
+    _write_raw(root, "bb" + "1" * 62, {"key": "bb" + "1" * 62, "schema_version": 4})
+    assert collect_legacy_entries(root, min_schema=4) == 1
+    assert (root / "bb" / ("1" * 62) / "entry.json").exists()

--- a/tests/services/test_cache_maintenance.py
+++ b/tests/services/test_cache_maintenance.py
@@ -1,0 +1,40 @@
+"""The dashboard migrates and indexes the result cache off the request path."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.data.cache_store import migrate as mig
+from quodeq.services.cache_maintenance import start_cache_maintenance
+
+
+def _write_v3_entry(root: Path) -> None:
+    key = "ab" * 32
+    d = root / key[:2] / key[2:]
+    d.mkdir(parents=True)
+    (d / "entry.json").write_text(json.dumps({
+        "key": key, "schema_version": 3, "findings": [], "files_read": 1,
+        "file_path": "a.py", "dimension": "security", "model_id": "m",
+        "file_content_hash": "aa" * 32, "language": "python",
+    }))
+
+
+def test_start_cache_maintenance_runs_ensure_cache_ready_in_a_daemon_thread(tmp_path: Path):
+    mig._ready_memo.clear()
+    root = tmp_path / "results"
+    _write_v3_entry(root)
+    thread = start_cache_maintenance(root, standards_dir=None)
+    assert thread.daemon is True
+    thread.join(timeout=10)
+    assert not thread.is_alive()
+    assert mig.ready_marker(root).exists()
+    assert len(list(root.rglob("entry.json"))) == 1
+
+
+def test_start_cache_maintenance_survives_failures(tmp_path: Path, monkeypatch):
+    def boom(*_a, **_k):
+        raise RuntimeError("nope")
+    monkeypatch.setattr("quodeq.services.cache_maintenance.ensure_cache_ready", boom)
+    thread = start_cache_maintenance(tmp_path / "results", standards_dir=None)
+    thread.join(timeout=10)
+    assert not thread.is_alive()  # swallowed and logged, never propagated

--- a/tests/tools/test_logging_boundary.py
+++ b/tests/tools/test_logging_boundary.py
@@ -46,7 +46,6 @@ DECLARED_LOGGING_SITES: dict[str, str] = {
     'analysis/cache/consolidation.py': "Consolidation state - flip a completed run's cache entries - out of scope for this sweep (not a flagged per-site conversion)",
     'analysis/cache/dimension_helpers.py': 'Dimension-level cache helpers bridging RunConfig and the filesystem - out of scope for this sweep (not a flagged per-site conversion)',
     'analysis/cache/dimension_runner.py': 'V2 cache-aware dimension processor composing the B4 cache helpers - out of scope for this sweep (not a flagged per-site conversion)',
-    'analysis/cache/gc.py': 'One-time garbage collection of cache entries from an older schema - out of scope for this sweep (not a flagged per-site conversion)',
     'analysis/cache/tiered.py': 'Tiered cache - local-first with optional remote fallback - out of scope for this sweep (not a flagged per-site conversion)',
     'analysis/checks/runner.py': "Run a dimension's deterministic checkers and fold the results into its evidence - out of scope for this sweep (not a flagged per-site conversion)",
     'analysis/manifest_build.py': 'Manifest building - walk a repository and produce a SourceManifest - out of scope for this sweep (not a flagged per-site conversion)',


### PR DESCRIPTION
## Why

Three full cache invalidations in six weeks, none caused by file content:

- freemium-app-android, 2026-09-01: root `build.gradle` replaced by `build.gradle.kts`, detected language flipped java to kotlin. 14,182 entries unreachable.
- freemium-app-ios, 2026-09-02: `ios/` moved to the repo root (4,269 renames). 10,332 entries unreachable.
- freemium-app-android, 2026-07-30: same pattern, fixed by hand with a script.

`language` reaches the prompts only as the `{{DISCIPLINE}}` heading word in the CLI templates. The API prompt never sees it and it does not filter files. It re-keyed 100% of a repo while changing roughly 0% of the per-file judgment.

## What

- Cache key schema 4: `language` leaves `CacheKey`. The formula and `SCHEMA_VERSION` move to `data/cache_store/key.py`; `analysis/cache/key.py` is a shim. `file_path` stays in the key because clean-architecture and `path_role` read it.
- Entry format 3 stores `params_hash`, so every key input is on the entry.
- Content index (`data/cache_store/index.py`): sqlite sidecar at `results/.index.db` mapping (content hash, dimension, params hash) to keys, kept in sync by `LocalFileBackend.put/delete`. Best-effort, never authoritative, rebuilt if missing or corrupt.
- Adoption (`analysis/cache/_adoption.py`): on a classify miss with a real content hash, an indexed entry with the same content, dimension and params is cloned under the new key when basename and `path_role` match. Finding `file` fields are rewritten and `provenance.adopted_from` records the source. The cache log line and the `cache_stats` marker report `adopted=N`. Estimates share the same classify, so the dashboard preview stops saying "from scratch".
- Migration (`data/cache_store/migrate.py`): one-time, lock and marker guarded walk that re-keys schema-3 entries from their stored fields, builds the index and reclaims older entries. Triggered inline at CLI run start and on a daemon thread at dashboard start (`services/cache_maintenance.py`), never on the estimates request path. `analysis/cache/gc.py` is a shim over it, so the GC can no longer run ahead of the migration.
- `params_hash` derivation for schema-3 entries reuses the writer's formula, now shared in `core/standards/overrides.hash_non_default_params`.

## Verification

- Full suite: 6518 passed, 0 failed. `tools/check_imports.py` clean.
- Migration smoke on 945 real schema-3 entries (two shards copied out of `~/.quodeq/cache/results`): all 945 reachable through the v4 key in 0.7 s, second pass a no-op. About 90 s for the 119k-entry live cache.

## Notes

- Adoption is cross-project by default. Entries carry no project identity and the cache is already cost-first across model and standards changes.
- Entries written under threshold overrides whose defaults changed since then derive a stale params hash and re-evaluate once.
- Policy tests adapted, no behavior change: logging-boundary declarations, the 300-line cap on `cache/dimension_runner.py`, and a findings-server test whose premise was language in the key.

Spec and plan: `docs/superpowers/specs/2026-09-06-cache-key-v4-adoption-design.md`, `docs/superpowers/plans/2026-09-06-cache-key-v4-adoption.md` (local, docs/ is ignored).
