### PR TITLE
Quality cycle 3: performance, security, flexibility quick wins

### DIFF
--- a/src/quodeq/analysis/cache/_persist_watcher.py
+++ b/src/quodeq/analysis/cache/_persist_watcher.py
@@ -16,13 +16,36 @@ from __future__ import annotations
 import threading
 from collections.abc import Callable
 
-from quodeq.analysis._types import AnalysisOptions
+from quodeq.analysis._types import AnalysisOptions, RunConfig
+from quodeq.analysis.cache._key_provenance import _hash_prompts_combined
+from quodeq.analysis.fingerprint import _hash_standards, dimension_params_state
 
 # How often the watcher thread persists in-flight cache entries during
 # dispatch. Smaller = less work lost on cancel; larger = less I/O during
 # normal runs. 30s is a pragmatic default -- at typical model dispatch
 # speeds (~10-30s per file), each tick covers a handful of completed files.
 _PERSIST_INTERVAL_S = 30.0
+
+
+def _compute_persist_hash_inputs(config: RunConfig, dimension: str) -> dict:
+    """Provenance hash inputs for persist_dispatch_results, as kwargs.
+
+    standards_dir/prompts_dir/dimension are constant for a whole dispatch,
+    so the caller computes these once (at watcher start) instead of
+    persist_dispatch_results recomputing them on every tick.
+    """
+    standards_hash = (
+        _hash_standards(config.standards_dir, dimension, config.src)
+        if config.standards_dir else ""
+    ) or ""
+    params_hash, effective_params = dimension_params_state(
+        config.standards_dir, dimension, config.src,
+    )
+    return {
+        "standards_hash": standards_hash, "params_hash": params_hash,
+        "effective_params": effective_params,
+        "prompts_hash": _hash_prompts_combined(config.prompts_dir),
+    }
 
 
 def _resolve_failure_streak_threshold(

--- a/src/quodeq/analysis/cache/dimension_helpers.py
+++ b/src/quodeq/analysis/cache/dimension_helpers.py
@@ -38,7 +38,7 @@ from quodeq.analysis.cache._key_provenance import (
     _SCHEMA_VERSION,
     _accumulate_drift,
     _current_provenance,
-    _hash_prompts_combined,
+    _hash_prompts_combined,  # noqa: F401 -- re-export
     _model_id_from,
     build_cache_key_for_file,  # noqa: F401 -- re-export
     build_cache_key_struct,
@@ -47,11 +47,7 @@ from quodeq.analysis.cache._key_provenance import (
 from quodeq.analysis.cache.backend import CacheBackend
 from quodeq.analysis.cache.entry import CacheEntry, build_provenance, quodeq_version
 from quodeq.analysis.cache.key import compute_key
-from quodeq.analysis.fingerprint import (
-    _hash_file,
-    _hash_standards,
-    dimension_params_state,
-)
+from quodeq.analysis.fingerprint import _hash_file
 
 _logger = logging.getLogger(__name__)
 
@@ -256,26 +252,25 @@ def _build_cache_entry_for_file(
 def persist_dispatch_results(
     config: RunConfig, dimension: str, *, miss_files: list[str],
     jsonl_path: Path, miss_keys: dict[str, str], cache: CacheBackend,
+    standards_hash: str, params_hash: str, effective_params: dict,
+    prompts_hash: str,
 ) -> None:
     """Write per-file cache entries for files with a file_done='ok' marker.
 
     Files in *miss_files* that lack an ok marker (worker crashed, token-out,
     abandoned) are NOT cached, so the next run re-dispatches them.
+
+    *standards_hash*/*params_hash*/*effective_params*/*prompts_hash* are
+    provenance context that's constant for the whole dispatch (same
+    standards_dir/prompts_dir/dimension throughout). Callers compute them
+    once and pass them in, rather than this function recomputing them on
+    every call — this is invoked on a fixed interval by the periodic-persist
+    watcher for the life of one dispatch.
     """
     if not jsonl_path.is_file():
         return
     grouped, ok_files = _group_findings_by_file(jsonl_path)
     model_id = _model_id_from(config)
-    # Provenance context — run-constant, computed once. These left the cache
-    # key in schema 3; recording them keeps each entry self-describing.
-    standards_hash = (
-        _hash_standards(config.standards_dir, dimension, config.src)
-        if config.standards_dir else ""
-    ) or ""
-    params_hash, effective_params = dimension_params_state(
-        config.standards_dir, dimension, config.src,
-    )
-    prompts_hash = _hash_prompts_combined(config.prompts_dir)
     version = quodeq_version()
     for f in miss_files:
         if f not in ok_files:

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -1,27 +1,24 @@
 """V2 cache-aware dimension processor — composes B4 helpers with the
 existing dispatcher boundary.
 
-Flow: list source files -> classify via cache (hits return findings
-directly, misses go to the dispatcher) -> all-hits short-circuits
-straight to JSONL + Evidence -> otherwise dispatch misses via
-process_dimension_with_subagents (file filter restricted to misses) ->
-persist new findings per-file -> if there were also hits, append cached
-findings to the JSONL and re-parse for the final Evidence.
+Flow: list source files -> classify via cache (hits return findings directly, misses go to
+the dispatcher) -> all-hits short-circuits straight to JSONL + Evidence -> otherwise
+dispatch misses via process_dimension_with_subagents (file filter restricted to misses) ->
+persist new findings per-file -> if there were also hits, append cached findings to the
+JSONL and re-parse for the final Evidence.
 
-This sits *above* the existing dispatcher — V1's machinery (carry-
-forward, fingerprint, queue salvage) still runs for dispatched files.
-The cache supersedes V1's incrementality decisions but keeps the proven
-dispatch path intact.
+This sits *above* the existing dispatcher — V1's machinery (carry-forward, fingerprint,
+queue salvage) still runs for dispatched files. The cache supersedes V1's incrementality
+decisions but keeps the proven dispatch path intact.
 
-Known limitation: V1 carry-forward can duplicate findings V2 has
-already cached, when migrating a long-lived V1 install to V2; B6
-cleanup removes V1's carry-forward once the V1 path is deleted.
+Known limitation: V1 carry-forward can duplicate findings V2 has already
+cached, when migrating a long-lived V1 install to V2; B6 cleanup removes
+V1's carry-forward once the V1 path is deleted.
 
-Cache-replay lives in ``_replay.py``; the persist-watcher body lives in
-``_persist_watcher.py``. ``emit_marker`` and the
-``threading.Thread``/``threading.Event()`` constructions stay in helpers
-defined here, since a ``mock.patch`` target resolves where a name is
-used, not where it is implemented.
+Cache-replay lives in ``_replay.py``; the persist-watcher body and its
+hoisted provenance-hash computation live in ``_persist_watcher.py``.
+``emit_marker``/``threading.Thread``/``threading.Event()`` stay in
+helpers defined here, since ``mock.patch`` resolves where a name is used.
 """
 from __future__ import annotations
 
@@ -41,6 +38,7 @@ from quodeq.analysis.cache._failure_streak import (
 )
 from quodeq.analysis.cache._persist_watcher import (
     _PERSIST_INTERVAL_S,
+    _compute_persist_hash_inputs,
     _periodic_persist,
     _resolve_failure_streak_threshold,
 )
@@ -178,10 +176,12 @@ def _start_watchers(
     already persists synchronously) and the failure-streak breaker.
     Creates the evidence JSONL up front, when absent, so the breaker's
     first poll doesn't warn about a missing file."""
+    hash_inputs = _compute_persist_hash_inputs(config, dim_id)
+
     def _persist_now() -> None:
         persist_dispatch_results(
-            config, dim_id, miss_files=classify.misses,
-            jsonl_path=jsonl, miss_keys=classify.miss_keys, cache=cache,
+            config, dim_id, miss_files=classify.misses, cache=cache,
+            jsonl_path=jsonl, miss_keys=classify.miss_keys, **hash_inputs,
         )
 
     stop_event = threading.Event()

--- a/src/quodeq/analysis/subagents/_queue_state.py
+++ b/src/quodeq/analysis/subagents/_queue_state.py
@@ -1,11 +1,6 @@
 """Queue state persistence: atomic JSON read/write with file locking.
 
 Internal module — use ``FileQueue`` from ``file_queue.py`` instead.
-
-The filesystem implementation below satisfies ``QueueStateProtocol``.
-To swap in a different backend (e.g. Redis, database), implement that
-protocol and pass your instance where ``read_state``/``write_state`` are
-called.
 """
 from __future__ import annotations
 
@@ -15,24 +10,11 @@ import os
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Protocol, runtime_checkable
 
 import time as _time
 
 from quodeq.analysis.subagents._file_lock import lock_file, unlock_file
 
-
-@runtime_checkable
-class QueueStateProtocol(Protocol):
-    """Abstraction for queue state storage.
-
-    The default implementation uses the filesystem (``read_state`` /
-    ``write_state`` module functions).  Implement this protocol to back
-    the queue with a different storage layer.
-    """
-
-    def read(self, path: Path) -> dict: ...
-    def write(self, state: dict, path: Path) -> None: ...
 
 _QUEUE_VERSION = 1
 

--- a/src/quodeq/api/_evaluation_helpers.py
+++ b/src/quodeq/api/_evaluation_helpers.py
@@ -19,10 +19,27 @@ from quodeq.shared.validation import validate_relative_scope
 
 _logger = logging.getLogger(__name__)
 
-# Userinfo cannot contain an unencoded "/", so excluding it keeps matches
-# identical while a failing scan stays linear (no polynomial backtracking
-# on inputs like repeated "http://" runs).
-_CREDENTIALS_RE = re.compile(r"(https?://)([^/@]+)@")
+# Mirrors _SCHEME_RE / _looks_like_authority in
+# quodeq.services._registration_url. Not imported from there: the api layer
+# must not depend on services internals for this, so the logic is
+# duplicated here rather than layered across.
+_SCHEME_RE = re.compile(r"^(https?://)")
+
+
+def _looks_like_authority(candidate: str) -> bool:
+    """Return True if *candidate* is a plausible ``host[:port]`` authority.
+
+    Deliberately strict: a bare single-label name is rejected so that an
+    ambiguous URL falls to the credential-stripping branch rather than the
+    leaking one.
+    """
+    host, sep, port = candidate.partition(":")
+    if sep and not port.isdigit():
+        return False
+    if not all(c.isalnum() or c in "-._~[]" for c in host):
+        return False
+    return "." in host or host.startswith("[") or host == "localhost"
+
 
 # Bounds for user-supplied evaluation parameters
 _MIN_SUBAGENTS = 1
@@ -73,8 +90,28 @@ def _coerce_int(value: object, default: int) -> int:
 
 
 def _sanitize_url(url: str) -> str:
-    """Remove embedded credentials from a URL for safe logging/error messages."""
-    return _CREDENTIALS_RE.sub(r"\1***@", url)
+    """Remove embedded credentials from a URL for safe logging/error messages.
+
+    Userinfo ends at the LAST "@" of the authority (RFC 3986), so the search
+    runs from the right. A "/" before that "@" usually means the authority
+    already ended and the "@" belongs to a path segment -- but only when the
+    text before that "/" is itself a plausible host. Real credentials
+    (base64-derived tokens, JWTs, CI PATs) often contain a literal "/", and
+    bounding the search by the first "/" would then hide the real "@" and
+    let the whole credential through unmasked.
+    """
+    match = _SCHEME_RE.match(url)
+    if not match:
+        return url
+    scheme = match.group(1)
+    rest = url[len(scheme):]
+    at_pos = rest.rfind("@")
+    if at_pos == -1:
+        return url
+    slash_pos = rest.find("/")
+    if -1 < slash_pos < at_pos and _looks_like_authority(rest[:slash_pos]):
+        return url
+    return f"{scheme}***@{rest[at_pos + 1:]}"
 
 
 def _validate_ai_cmd(ai_cmd: str | None, env: dict[str, str] | None = None) -> tuple[Response, int] | None:

--- a/src/quodeq/api/_evaluation_helpers.py
+++ b/src/quodeq/api/_evaluation_helpers.py
@@ -14,31 +14,20 @@ from flask import Response, jsonify, request
 from quodeq.api.helpers import error_response
 from quodeq.services.tooling_mixin import get_allowed_client_ids as _get_allowed_ai_cmds
 from quodeq.services.base import DEFAULT_MAX_SUBAGENTS, DEFAULT_TIME_LIMIT
+from quodeq.shared._repo import _looks_like_authority
 from quodeq.shared.utils import get_ai_cmd as _get_ai_cmd
 from quodeq.shared.validation import validate_relative_scope
 
 _logger = logging.getLogger(__name__)
 
-# Mirrors _SCHEME_RE / _looks_like_authority in
-# quodeq.services._registration_url. Not imported from there: the api layer
-# must not depend on services internals for this, so the logic is
-# duplicated here rather than layered across.
+# Mirrors _SCHEME_RE in quodeq.services._registration_url. Not imported from
+# there: the api layer must not depend on services internals for this, so
+# this scheme-match pattern is duplicated here rather than layered across.
+# _looks_like_authority is imported from shared/_repo.py instead of
+# duplicated: it's a pure predicate with no shape coupling to this module,
+# and this codebase already imports private helpers from shared._repo
+# elsewhere (e.g. data/git_cli.py, shared/utils.py).
 _SCHEME_RE = re.compile(r"^(https?://)")
-
-
-def _looks_like_authority(candidate: str) -> bool:
-    """Return True if *candidate* is a plausible ``host[:port]`` authority.
-
-    Deliberately strict: a bare single-label name is rejected so that an
-    ambiguous URL falls to the credential-stripping branch rather than the
-    leaking one.
-    """
-    host, sep, port = candidate.partition(":")
-    if sep and not port.isdigit():
-        return False
-    if not all(c.isalnum() or c in "-._~[]" for c in host):
-        return False
-    return "." in host or host.startswith("[") or host == "localhost"
 
 
 # Bounds for user-supplied evaluation parameters

--- a/src/quodeq/api/llm_bridge_routes.py
+++ b/src/quodeq/api/llm_bridge_routes.py
@@ -51,6 +51,16 @@ def _invalid_base_url(base_url: str | None) -> tuple[Response, int] | None:
     return None
 
 
+def _invalid_model_name(model: str) -> tuple[Response, int] | None:
+    """Return a 400 response when *model* contains invalid characters, else None.
+
+    Prevents path traversal and null-byte injection.
+    """
+    if "\\" in model or ".." in model or "\0" in model:
+        return jsonify({"error": "Invalid model name", "code": "INVALID_PARAM"}), 400
+    return None
+
+
 def register_llm_bridge_routes(app: Flask) -> None:
     """Register all llm_bridge API routes."""
 
@@ -70,8 +80,9 @@ def register_llm_bridge_routes(app: Flask) -> None:
         model = data.get("model", "")
         if not model or not isinstance(model, str):
             return jsonify({"error": "model is required", "code": "MISSING_PARAM"}), 400
-        if "\\" in model or ".." in model or "\0" in model:
-            return jsonify({"error": "Invalid model name", "code": "INVALID_PARAM"}), 400
+        err = _invalid_model_name(model)
+        if err is not None:
+            return err
         result = run_concurrency_test(model)
         return jsonify(result)
 
@@ -104,8 +115,9 @@ def register_llm_bridge_routes(app: Flask) -> None:
         model = data.get("model", "")
         if not isinstance(model, str):
             return jsonify({"error": "model must be a string", "code": "INVALID_PARAM"}), 400
-        if "\\" in model or ".." in model or "\0" in model:
-            return jsonify({"error": "Invalid model name", "code": "INVALID_PARAM"}), 400
+        err = _invalid_model_name(model)
+        if err is not None:
+            return err
         result = run_llamacpp_concurrency_test(model)
         return jsonify(result)
 
@@ -136,8 +148,9 @@ def register_llm_bridge_routes(app: Flask) -> None:
         model = data.get("model", "")
         if not isinstance(model, str):
             return jsonify({"error": "model must be a string", "code": "INVALID_PARAM"}), 400
-        if "\\" in model or ".." in model or "\0" in model:
-            return jsonify({"error": "Invalid model name", "code": "INVALID_PARAM"}), 400
+        err = _invalid_model_name(model)
+        if err is not None:
+            return err
         base_url = data.get("base_url") or ""
         api_key = data.get("api_key") or ""
         if not isinstance(base_url, str) or not isinstance(api_key, str):

--- a/src/quodeq/data/cache_store/migrate.py
+++ b/src/quodeq/data/cache_store/migrate.py
@@ -68,6 +68,7 @@ class MigrationStats:
 
 def derive_params_hash(
     dimension: str, effective_params: dict, standards_dir: Path | None,
+    _cache: dict[tuple[str, str], dict] | None = None,
 ) -> str:
     """Rebuild a schema-3 entry's ``params_hash`` from its stored effective params.
 
@@ -80,23 +81,25 @@ def derive_params_hash(
     """
     if not effective_params or standards_dir is None:
         return ""
-    compiled = Path(standards_dir) / "compiled" / f"{dimension}.json"
+    if _cache is None:
+        _cache = {}
+    k = (str(standards_dir), dimension)
+    if k not in _cache:
+        c = Path(standards_dir) / "compiled" / f"{dimension}.json"
+        try:
+            _cache[k] = json.loads(c.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001 - same rationale as the writer: never abort
+            return ""
     try:
-        data = json.loads(compiled.read_text(encoding="utf-8"))
-    except Exception:  # noqa: BLE001 - same rationale as the writer: never abort
-        return ""
-    try:
-        return hash_non_default_params(non_default_from_effective(data, effective_params))
+        return hash_non_default_params(non_default_from_effective(_cache[k], effective_params))
     except (AttributeError, TypeError):
         return ""
-
 
 def _index_row(entry: CacheEntry) -> tuple[str, str, str, str, str, str]:
     return (
         entry.key, entry.file_content_hash, entry.dimension, entry.params_hash,
         entry.file_path, entry.created_at,
     )
-
 
 def _remove_dir(entry_dir: Path) -> bool:
     try:
@@ -106,7 +109,6 @@ def _remove_dir(entry_dir: Path) -> bool:
         _logger.debug("cache maintenance: failed to remove %s: %s", entry_dir, exc)
         return False
 
-
 def _read_entry(entry_path: Path) -> CacheEntry | None:
     try:
         return CacheEntry.from_json(entry_path.read_text(encoding="utf-8"))
@@ -114,14 +116,15 @@ def _read_entry(entry_path: Path) -> CacheEntry | None:
         _logger.debug("cache maintenance: skipping unreadable entry %s: %s", entry_path, exc)
         return None
 
-
 def _migrate_v3(
     entry: CacheEntry, entry_dir: Path, backend: LocalFileBackend,
     standards_dir: Path | None, batch: list[tuple],
+    _cache: dict[tuple[str, str], dict] | None = None,
 ) -> tuple[int, int]:
     """Re-key one schema-3 entry. Returns (migrated, deduplicated) as 0/1."""
     params_hash = entry.params_hash or derive_params_hash(
         entry.dimension, (entry.provenance or {}).get("effective_params") or {}, standards_dir,
+        _cache=_cache,
     )
     new_key = compute_key(CacheKey(
         schema_version=SCHEMA_VERSION, file_content_hash=entry.file_content_hash,
@@ -141,7 +144,6 @@ def _migrate_v3(
     _remove_dir(entry_dir)
     return 1, 0
 
-
 def migrate_entries(
     root: Path, *, standards_dir: Path | None, backend: LocalFileBackend | None = None,
 ) -> MigrationStats:
@@ -152,6 +154,7 @@ def migrate_entries(
     index = backend.index
     migrated = deduplicated = indexed = removed = skipped = 0
     batch: list[tuple] = []
+    cache: dict[tuple[str, str], dict] = {}
 
     def _flush() -> None:
         if batch and index is not None:
@@ -167,7 +170,7 @@ def migrate_entries(
             batch.append(_index_row(entry))
             indexed += 1
         elif entry.schema_version == SCHEMA_VERSION - 1:
-            m, d = _migrate_v3(entry, entry_path.parent, backend, standards_dir, batch)
+            m, d = _migrate_v3(entry, entry_path.parent, backend, standards_dir, batch, _cache=cache)
             migrated += m
             deduplicated += d
         elif _remove_dir(entry_path.parent):
@@ -179,7 +182,6 @@ def migrate_entries(
         migrated=migrated, deduplicated=deduplicated, indexed=indexed,
         removed=removed, skipped=skipped,
     )
-
 
 def collect_legacy_entries(root: Path, *, min_schema: int) -> int:
     """Delete every entry whose ``schema_version`` is below *min_schema*.
@@ -199,7 +201,6 @@ def collect_legacy_entries(root: Path, *, min_schema: int) -> int:
         if isinstance(schema, int) and schema < min_schema and _remove_dir(entry_path.parent):
             removed += 1
     return removed
-
 
 def _acquire_lock(lock: Path) -> bool:
     """Create *lock* exclusively. A lock older than STALE_LOCK_S is taken over."""
@@ -227,7 +228,6 @@ def _acquire_lock(lock: Path) -> bool:
             fh.write(str(os.getpid()))
         return True
     return False
-
 
 def _release_lock(lock: Path) -> None:
     try:

--- a/src/quodeq/data/fs/suppression_rules.py
+++ b/src/quodeq/data/fs/suppression_rules.py
@@ -39,7 +39,14 @@ def load_suppression_rules(project_dir: Path) -> tuple[SuppressionRule, ...]:
         _logger.warning(
             "Ignoring unreadable or malformed suppression rules %s: %s", path, exc)
         return ()
-    raw_rules = data.get("rules") if isinstance(data, dict) else None
+    if not isinstance(data, dict):
+        return ()
+    version = data.get("version", 1)
+    if version != 1:
+        _logger.warning(
+            "Ignoring suppression rules with unsupported version %s in %s", version, path)
+        return ()
+    raw_rules = data.get("rules")
     if not isinstance(raw_rules, list):
         return ()
     rules: list[SuppressionRule] = []

--- a/src/quodeq/services/_fs_project_helpers.py
+++ b/src/quodeq/services/_fs_project_helpers.py
@@ -35,7 +35,7 @@ _logger = logging.getLogger(__name__)
 
 
 def _backfill_onboarding_field(
-    project_dir: Path, *, heal_completed_at: str | None = None,
+    project_dir: Path, *, pre_read_data: dict | None = None, heal_completed_at: str | None = None,
 ) -> dict | None:
     """Normalize ``onboardingCompletedAt`` in ``repository_info.json``.
 
@@ -44,12 +44,13 @@ def _backfill_onboarding_field(
     happens. Treats absence of the field as already-onboarded — backfills to
     the project's existing ``createdAt`` timestamp, falling back to "now".
 
+    *pre_read_data*: when provided, uses this dict instead of reading from disk.
     *heal_completed_at*: when set and the field is present but null, stamp it
     with this value. Callers pass a timestamp only for projects that have
     evaluation runs — running an evaluation IS completing setup, so a null
     left behind by a pre-stamp wizard must not show 'Resume setup' forever.
     """
-    data = read_repository_info(project_dir)
+    data = pre_read_data if pre_read_data is not None else read_repository_info(project_dir)
     if data is None:
         return None
     if "onboardingCompletedAt" in data:
@@ -77,6 +78,7 @@ def _derive_latest_done_run_id(runs: list[RunInfo]) -> str | None:
 
 def _backfill_and_read_meta(
     reports_root: Path, entry_name: str, runs: list[RunInfo], *, backfill: bool,
+    pre_read_info: dict | None = None,
 ) -> tuple[dict, dict]:
     """Lazy-backfill the project record, then extract its display metadata.
 
@@ -91,17 +93,23 @@ def _backfill_and_read_meta(
     *backfill* mirrors ``build_project_list``'s parameter of the same name:
     when False, the record is read read-only and never rewritten (used by
     the shared-repo route so listing a clone never dirties its worktree).
+    *pre_read_info*: when provided, uses this dict instead of reading from disk.
     """
     project_dir = reports_root / entry_name
     heal_at = (runs[-1].date_iso or datetime.now(timezone.utc).isoformat()) if runs else None
-    backfilled = _backfill_onboarding_field(project_dir, heal_completed_at=heal_at) if backfill else None
-    info = backfilled if backfilled is not None else _read_repo_info(reports_root, entry_name)
+    backfilled = _backfill_onboarding_field(
+        project_dir, pre_read_data=pre_read_info, heal_completed_at=heal_at,
+    ) if backfill else None
+    info = backfilled if backfilled is not None else (
+        pre_read_info if pre_read_info is not None else _read_repo_info(reports_root, entry_name)
+    )
     return info, _extract_project_metadata(info, entry_name)
 
 
 def _build_project_entry(
     reports_root: Path, entry_name: str, runs: list[RunInfo], *,
     backfill: bool = True, inline_summaries: bool = False,
+    pre_read_info: dict | None = None,
 ) -> ProjectEntry:
     """Build a frozen ProjectEntry from its directory and run list.
 
@@ -110,8 +118,11 @@ def _build_project_entry(
     the shared-repo route has no warm-up engine, so it keeps computing a
     missing summary inline instead of reporting it pending. See
     ``_backfill_and_read_meta`` for the *backfill* rationale.
+    *pre_read_info*: when provided, uses this dict instead of reading from disk.
     """
-    info, meta = _backfill_and_read_meta(reports_root, entry_name, runs, backfill=backfill)
+    info, meta = _backfill_and_read_meta(
+        reports_root, entry_name, runs, backfill=backfill, pre_read_info=pre_read_info,
+    )
     latest_grade, latest_score, files_count, summary_pending = _read_accumulated_summary(
         reports_root, entry_name, runs, compute_on_miss=inline_summaries,
     )

--- a/src/quodeq/services/_fs_project_helpers.py
+++ b/src/quodeq/services/_fs_project_helpers.py
@@ -29,6 +29,7 @@ from quodeq.services._fs_project_parents import (  # noqa: F401 — re-export
     _max_projects_listed,
 )
 from quodeq.data.fs.report_parser.runs import RunInfo
+from quodeq.services._registration_url import _strip_credentials
 from quodeq.services._repo_index import _load_repo_index, _repo_index_key, _save_repo_index
 
 _logger = logging.getLogger(__name__)
@@ -200,7 +201,7 @@ def find_existing_project(reports_root: str, repo: str, scope_path: str | None) 
     try:
         is_url = is_repo_url(repo)
     except ValueError as exc:
-        _logger.warning("Rejecting malformed repo identifier %r in duplicate check: %s", repo, exc)
+        _logger.warning("Rejecting malformed repo identifier %r in duplicate check: %s", _strip_credentials(repo), exc)
         return None
     repo_resolved = repo if is_url else str(Path(repo).resolve())
     expected_name = project_name_from_repo(repo)

--- a/src/quodeq/services/_fs_project_index.py
+++ b/src/quodeq/services/_fs_project_index.py
@@ -53,7 +53,7 @@ def _build_lightweight_entry(entry_name: str, info: dict) -> ProjectEntry:
 
 
 def _collect_lightweight_entries(reports_root: Path, dir_names: list[str]) -> list[ProjectEntry]:
-    parent_ids, subproject_ids = _build_parent_child_sets(reports_root, dir_names)
+    parent_ids, subproject_ids, _ = _build_parent_child_sets(reports_root, dir_names)
     registered_ids = {n for n in dir_names if repository_info_exists(reports_root / n)}
     included = [n for n in dir_names if n in registered_ids or n in parent_ids or n in subproject_ids]
     return [

--- a/src/quodeq/services/_fs_projects.py
+++ b/src/quodeq/services/_fs_projects.py
@@ -61,19 +61,21 @@ def _is_evaluable(repo_path: str | None) -> bool:
     return Path(repo_path).is_dir()
 
 
-def _build_parent_child_sets(reports_root: Path, dir_names: list[str]) -> tuple[set[str], set[str]]:
-    """Single pass: return (parent_ids, subproject_ids) from repo info files."""
+def _build_parent_child_sets(reports_root: Path, dir_names: list[str]) -> tuple[set[str], set[str], dict[str, dict]]:
+    """Single pass: return (parent_ids, subproject_ids, info_by_name) from repo info files."""
     parent_ids: set[str] = set()
     subproject_ids: set[str] = set()
+    info_by_name: dict[str, dict] = {}
     for name in dir_names:
         info = read_repository_info(reports_root / name)
         if info is None:
             continue
+        info_by_name[name] = info
         parent = info.get("parent")
         if parent:
             parent_ids.add(parent)
             subproject_ids.add(name)
-    return parent_ids, subproject_ids
+    return parent_ids, subproject_ids, info_by_name
 
 
 def _collect_candidate_dirs(reports_root: Path, max_listed: int) -> list[str]:
@@ -92,6 +94,7 @@ def _build_project_entries_threaded(
     reports_root: Path, dir_names: list[str],
     registered_ids: set[str], parent_ids: set[str], subproject_ids: set[str],
     *, backfill: bool, inline_summaries: bool,
+    info_by_name: dict[str, dict] | None = None,
 ) -> list[ProjectEntry]:
     """Build a ProjectEntry per candidate dir in parallel, dropping stray dirs.
 
@@ -100,12 +103,16 @@ def _build_project_entries_threaded(
     exists and the UI shows an empty state for them. Only dirs with neither
     runs nor a project record (stray non-project dirs) are dropped.
     """
+    if info_by_name is None:
+        info_by_name = {}
+
     def _build_one(name: str) -> ProjectEntry | None:
         runs = list_runs(reports_root, name)
         if not runs and name not in registered_ids and name not in parent_ids and name not in subproject_ids:
             return None
         return _build_project_entry(
             reports_root, name, runs, backfill=backfill, inline_summaries=inline_summaries,
+            pre_read_info=info_by_name.get(name),
         )
 
     # contextvars do NOT propagate into ThreadPoolExecutor worker threads --
@@ -145,23 +152,18 @@ def build_project_list(
     """
     dir_names = _collect_candidate_dirs(reports_root, _max_projects_listed())
 
-    # Lazy backfill: ensure legacy project records have an
-    # ``onboardingCompletedAt`` field. Run before the parent/child sweep so
-    # any subsequent reads see the updated file. Idempotent — no-op for
-    # records that already have the field. Failures are silently ignored.
+    parent_ids, subproject_ids, info_by_name = _build_parent_child_sets(reports_root, dir_names)
     if backfill:
         for name in dir_names:
-            _backfill_onboarding_field(reports_root / name)
-
-    parent_ids, subproject_ids = _build_parent_child_sets(reports_root, dir_names)
+            _backfill_onboarding_field(reports_root / name, pre_read_data=info_by_name.get(name))
     registered_ids = {
         name for name in dir_names
         if repository_info_exists(reports_root / name)
     }
-
     projects = _build_project_entries_threaded(
         reports_root, dir_names, registered_ids, parent_ids, subproject_ids,
         backfill=backfill, inline_summaries=inline_summaries,
+        info_by_name=info_by_name,
     )
     projects.sort(key=lambda p: p.name)
     return _auto_detect_parents(projects)

--- a/src/quodeq/services/_registration_url.py
+++ b/src/quodeq/services/_registration_url.py
@@ -11,13 +11,26 @@ from pathlib import Path
 
 from quodeq.services._wiring import remote_origin_url_raw
 
-# Mirrors _CREDENTIALS_RE in quodeq.api._evaluation_helpers. Not imported from
-# there: services must not depend on the api layer (no other services module
-# does), so the pattern is duplicated here rather than layered across.
-# Userinfo cannot contain an unencoded "/", so excluding it keeps matches
-# identical while a failing scan stays linear (no polynomial backtracking
-# on inputs like repeated "http://" runs).
-_CREDENTIALS_RE = re.compile(r"(https?://)([^/@]+)@")
+# Mirrors _SCHEME_RE / _looks_like_authority in quodeq.api._evaluation_helpers.
+# Not imported from there: services must not depend on the api layer (no
+# other services module does), so the logic is duplicated here rather than
+# layered across.
+_SCHEME_RE = re.compile(r"^(https?://)")
+
+
+def _looks_like_authority(candidate: str) -> bool:
+    """Return True if *candidate* is a plausible ``host[:port]`` authority.
+
+    Deliberately strict: a bare single-label name is rejected so that an
+    ambiguous URL falls to the credential-stripping branch rather than the
+    leaking one.
+    """
+    host, sep, port = candidate.partition(":")
+    if sep and not port.isdigit():
+        return False
+    if not all(c.isalnum() or c in "-._~[]" for c in host):
+        return False
+    return "." in host or host.startswith("[") or host == "localhost"
 
 
 def _strip_credentials(url: str) -> str:
@@ -26,8 +39,27 @@ def _strip_credentials(url: str) -> str:
     Only applies to scheme'd URLs (``https://user@host/...``). scp-style
     remotes (``git@github.com:org/repo.git``) are left untouched, since the
     leading ``git@`` there is a username convention, not a credential.
+
+    Userinfo ends at the LAST "@" of the authority (RFC 3986), so the search
+    runs from the right. A "/" before that "@" usually means the authority
+    already ended and the "@" belongs to a path segment -- but only when the
+    text before that "/" is itself a plausible host. Real credentials
+    (base64-derived tokens, JWTs, CI PATs) often contain a literal "/", and
+    bounding the search by the first "/" would then hide the real "@" and
+    let the whole credential through unstripped.
     """
-    return _CREDENTIALS_RE.sub(r"\1", url)
+    match = _SCHEME_RE.match(url)
+    if not match:
+        return url
+    scheme = match.group(1)
+    rest = url[len(scheme):]
+    at_pos = rest.rfind("@")
+    if at_pos == -1:
+        return url
+    slash_pos = rest.find("/")
+    if -1 < slash_pos < at_pos and _looks_like_authority(rest[:slash_pos]):
+        return url
+    return scheme + rest[at_pos + 1:]
 
 
 def _read_origin_remote(repo_dir: Path) -> str | None:

--- a/src/quodeq/services/_registration_url.py
+++ b/src/quodeq/services/_registration_url.py
@@ -10,27 +10,16 @@ import re
 from pathlib import Path
 
 from quodeq.services._wiring import remote_origin_url_raw
+from quodeq.shared._repo import _looks_like_authority
 
-# Mirrors _SCHEME_RE / _looks_like_authority in quodeq.api._evaluation_helpers.
-# Not imported from there: services must not depend on the api layer (no
-# other services module does), so the logic is duplicated here rather than
-# layered across.
+# Mirrors _SCHEME_RE in quodeq.api._evaluation_helpers. Not imported from
+# there: services must not depend on the api layer (no other services module
+# does), so this scheme-match pattern is duplicated here rather than layered
+# across. _looks_like_authority is imported from shared/_repo.py instead of
+# duplicated: it's a pure predicate with no shape coupling to this module,
+# and this codebase already imports private helpers from shared._repo
+# elsewhere (e.g. data/git_cli.py, shared/utils.py).
 _SCHEME_RE = re.compile(r"^(https?://)")
-
-
-def _looks_like_authority(candidate: str) -> bool:
-    """Return True if *candidate* is a plausible ``host[:port]`` authority.
-
-    Deliberately strict: a bare single-label name is rejected so that an
-    ambiguous URL falls to the credential-stripping branch rather than the
-    leaking one.
-    """
-    host, sep, port = candidate.partition(":")
-    if sep and not port.isdigit():
-        return False
-    if not all(c.isalnum() or c in "-._~[]" for c in host):
-        return False
-    return "." in host or host.startswith("[") or host == "localhost"
 
 
 def _strip_credentials(url: str) -> str:

--- a/src/quodeq/services/project_registration.py
+++ b/src/quodeq/services/project_registration.py
@@ -252,7 +252,7 @@ def register_project_with_rollback(
         # handler would have logged; record it before converting to a
         # generic, no-detail result (the exception text can carry filesystem
         # paths or backend internals that must not reach the remote caller).
-        log.error(f"Registration failed for repo={spec.repo!r}: {exc}")
+        log.error(f"Registration failed for repo={_strip_credentials(spec.repo)!r}: {exc}")
         return _rollback_and_report(reports_dir, before, "internal_error")
 
     # scan.json is now always present after register_project succeeds.

--- a/src/quodeq/ui/src/features/assistant/WorkspaceDiffPanel.jsx
+++ b/src/quodeq/ui/src/features/assistant/WorkspaceDiffPanel.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { t } from '../../strings/index.js';
 import { confirmDialog } from '../../utils/confirmDialog.js';
 import { useWorkspaceDiff } from './hooks/useWorkspaceDiff.js';
@@ -26,6 +26,16 @@ function WorkspaceDiffOutcome({ outcome }) {
 }
 
 function WorkspaceDiffBody({ diff, truncated, error, empty }) {
+  const diffLines = useMemo(() => {
+    if (diff === null) {
+      return [];
+    }
+    return diff.split('\n').map((line, i) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <span key={i} className={classifyDiffLine(line)}>{line}{'\n'}</span>
+    ));
+  }, [diff]);
+
   return (
     <>
       {truncated && (
@@ -38,10 +48,7 @@ function WorkspaceDiffBody({ diff, truncated, error, empty }) {
       {empty && <p className="workspace-diff-empty">{t('assistant.noChanges')}</p>}
       {diff !== null && !empty && (
         <pre className="workspace-diff-body">
-          {diff.split('\n').map((line, i) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <span key={i} className={classifyDiffLine(line)}>{line}{'\n'}</span>
-          ))}
+          {diffLines}
         </pre>
       )}
     </>

--- a/src/quodeq/ui/src/main.jsx
+++ b/src/quodeq/ui/src/main.jsx
@@ -35,6 +35,12 @@ const LEGACY_FAMILY_MAP = {
   cyber: THEME_FAMILIES.DECKARD,
 };
 
+function isMacPlatform() {
+  const ua = navigator.userAgent || '';
+  const platform = navigator.platform || '';
+  return /Mac|iPhone|iPad|iPod/.test(platform) || /Mac OS X/.test(ua);
+}
+
 function applyInitialTheme(storage = localStorage, mediaQuery = window.matchMedia) {
   const oldTheme = storage.getItem(LS_THEME);
   if (oldTheme !== null) {
@@ -63,10 +69,7 @@ applyInitialTheme();
 // every platform, so nothing in-page reserves space for window controls;
 // these classes remain for platform/shell-conditional styling.
 try {
-  const ua = navigator.userAgent || '';
-  const platform = navigator.platform || '';
-  const isMac = /Mac|iPhone|iPad|iPod/.test(platform) || /Mac OS X/.test(ua);
-  if (isMac) document.documentElement.classList.add('platform-mac');
+  if (isMacPlatform()) document.documentElement.classList.add('platform-mac');
 } catch {
   // ignore — platform detection is a progressive enhancement
 }
@@ -85,8 +88,7 @@ window.addEventListener('pywebviewready', markWebview);
 // Only inside the native shell — in a browser these are already native.
 document.addEventListener('keydown', (e) => {
   if (!window.pywebview) return;
-  const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
-  const mod = isMac ? e.metaKey : e.ctrlKey;
+  const mod = isMacPlatform() ? e.metaKey : e.ctrlKey;
   if (mod && e.key === '[') { e.preventDefault(); history.back(); }
   if (mod && e.key === ']') { e.preventDefault(); history.forward(); }
 });

--- a/tests/analysis/cache/test_dimension_helpers.py
+++ b/tests/analysis/cache/test_dimension_helpers.py
@@ -63,6 +63,26 @@ def _write_project_overrides(src: Path, payload: str) -> None:
     path.write_text(payload)
 
 
+def _hash_inputs(config: RunConfig, dimension: str) -> dict:
+    """Compute the provenance hash inputs persist_dispatch_results now
+    expects the caller to hoist and pass in."""
+    from quodeq.analysis.cache._key_provenance import _hash_prompts_combined
+    from quodeq.analysis.fingerprint import _hash_standards, dimension_params_state
+
+    standards_hash = (
+        _hash_standards(config.standards_dir, dimension, config.src)
+        if config.standards_dir else ""
+    ) or ""
+    params_hash, effective_params = dimension_params_state(
+        config.standards_dir, dimension, config.src,
+    )
+    prompts_hash = _hash_prompts_combined(config.prompts_dir)
+    return {
+        "standards_hash": standards_hash, "params_hash": params_hash,
+        "effective_params": effective_params, "prompts_hash": prompts_hash,
+    }
+
+
 @pytest.fixture
 def cache(tmp_path: Path) -> LocalFileBackend:
     return LocalFileBackend(root=tmp_path / "cache")
@@ -377,6 +397,7 @@ class TestPersist:
         persist_dispatch_results(
             config, "security", miss_files=files,
             jsonl_path=jsonl, miss_keys=miss_keys, cache=cache,
+            **_hash_inputs(config, "security"),
         )
 
         a_entry = cache.get(miss_keys["a.py"])
@@ -404,6 +425,7 @@ class TestPersist:
         persist_dispatch_results(
             config, "security", miss_files=files,
             jsonl_path=jsonl, miss_keys=miss_keys, cache=cache,
+            **_hash_inputs(config, "security"),
         )
 
         entry = cache.get(miss_keys["clean.py"])
@@ -429,6 +451,7 @@ class TestPersist:
         persist_dispatch_results(
             config, "security", miss_files=["a.py"],
             jsonl_path=jsonl, miss_keys=miss_keys, cache=cache,
+            **_hash_inputs(config, "security"),
         )
 
         # Only a.py's key is in the cache; carried.py was never dispatched here.
@@ -452,6 +475,7 @@ class TestPersist:
         persist_dispatch_results(
             config, "security", miss_files=files,
             jsonl_path=jsonl, miss_keys=miss_keys, cache=cache,
+            **_hash_inputs(config, "security"),
         )
 
         entry = cache.get(miss_keys["a.py"])
@@ -491,6 +515,7 @@ class TestPersist:
         persist_dispatch_results(
             config, "security", miss_files=files,
             jsonl_path=jsonl, miss_keys=miss_keys, cache=cache,
+            **_hash_inputs(config, "security"),
         )
 
         entry = cache.get(miss_keys["a.py"])
@@ -511,6 +536,7 @@ class TestPersist:
             config, "security", miss_files=["a.py"],
             jsonl_path=tmp_path / "work" / "missing.jsonl",
             miss_keys=miss_keys, cache=cache,
+            **_hash_inputs(config, "security"),
         )
 
         # No entry written — we don't fabricate "no findings" when we
@@ -547,6 +573,7 @@ class TestRoundTrip:
         persist_dispatch_results(
             config, "security", miss_files=first.misses,
             jsonl_path=jsonl, miss_keys=first.miss_keys, cache=cache,
+            **_hash_inputs(config, "security"),
         )
 
         # Second call: cache should be fully populated → all hits. The
@@ -586,6 +613,7 @@ def test_persist_dispatch_results_marks_entries_unconsolidated(tmp_path):
     persist_dispatch_results(
         config, "security", miss_files=["a.py"],
         jsonl_path=jsonl, miss_keys={"a.py": key}, cache=cache,
+        **_hash_inputs(config, "security"),
     )
 
     assert cache.get(key).consolidated is False
@@ -736,6 +764,7 @@ class TestPromptsDirProvenance:
         persist_dispatch_results(
             config, "security", miss_files=files,
             jsonl_path=jsonl, miss_keys=miss_keys, cache=cache,
+            **_hash_inputs(config, "security"),
         )
 
         entry = cache.get(miss_keys["a.py"])

--- a/tests/analysis/cache/test_periodic_persist.py
+++ b/tests/analysis/cache/test_periodic_persist.py
@@ -18,8 +18,9 @@ from __future__ import annotations
 
 import threading
 import time
+from dataclasses import replace
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -116,6 +117,62 @@ class TestWatcherStartsAndStops:
         entry = cache.get(key)
         assert entry is not None
         assert any(f.get("w") == "found" for f in entry.findings)
+
+
+class TestHashInputsHoistedOncePerDispatch:
+    def test_hash_functions_called_once_not_per_tick(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        """standards_hash/params_hash/prompts_hash are dispatch-constant and
+        must be computed once at watcher start, not recomputed on every
+        persist tick — regression test for the redundant per-tick hashing
+        hoisted out of persist_dispatch_results."""
+        config = _setup(tmp_path, {"a.py": "x"})
+        config = replace(config, standards_dir=tmp_path / "standards")
+        from quodeq.core.evidence.model import Evidence
+
+        def slow_dispatcher(cfg, dim_id, idx, ctx, callbacks, **_):
+            jsonl = cfg.work_dir / f"{dim_id}_evidence.jsonl"
+            jsonl.parent.mkdir(parents=True, exist_ok=True)
+            jsonl.write_text(
+                '{"file": "a.py", "line": 1, "t": "violation", "w": "found"}\n'
+                + '{"_marker": "file_done", "file": "a.py", "status": "ok"}\n'
+            )
+            time.sleep(0.3)  # several persist ticks at the tiny interval below
+            return Evidence(
+                repository="", language="python", date="2026-01-01",
+                source_file_count=1, files_read=1, coverage_pct=100.0,
+                principles={},
+            )
+
+        mock_hash_standards = MagicMock(return_value="std-hash")
+        mock_params_state = MagicMock(return_value=("params-hash", {}))
+        mock_hash_prompts = MagicMock(return_value="prompts-hash")
+
+        with (
+            patch(
+                "quodeq.analysis.cache._persist_watcher._hash_standards",
+                mock_hash_standards,
+            ),
+            patch(
+                "quodeq.analysis.cache._persist_watcher.dimension_params_state",
+                mock_params_state,
+            ),
+            patch(
+                "quodeq.analysis.cache._persist_watcher._hash_prompts_combined",
+                mock_hash_prompts,
+            ),
+        ):
+            process_dimension_with_cache(
+                config, "security", 1, _make_ctx(), _make_callbacks(),
+                cache=cache, dispatcher=slow_dispatcher, persist_interval_s=0.05,
+            )
+
+        # Multiple ticks (~0.3s / 0.05s interval) plus the final persist all
+        # reuse the same precomputed values — one call each for the dispatch.
+        assert mock_hash_standards.call_count == 1
+        assert mock_params_state.call_count == 1
+        assert mock_hash_prompts.call_count == 1
 
 
 class TestWatcherSurvivesDispatchException:

--- a/tests/analysis/cache/test_persist_dispatch_results_markers.py
+++ b/tests/analysis/cache/test_persist_dispatch_results_markers.py
@@ -21,6 +21,26 @@ def _write_jsonl(path: Path, lines: list[dict]) -> None:
     path.write_text("".join(json.dumps(l) + "\n" for l in lines))
 
 
+def _hash_inputs(config: RunConfig, dimension: str) -> dict:
+    """Compute the provenance hash inputs persist_dispatch_results now
+    expects the caller to hoist and pass in."""
+    from quodeq.analysis.cache._key_provenance import _hash_prompts_combined
+    from quodeq.analysis.fingerprint import _hash_standards, dimension_params_state
+
+    standards_hash = (
+        _hash_standards(config.standards_dir, dimension, config.src)
+        if config.standards_dir else ""
+    ) or ""
+    params_hash, effective_params = dimension_params_state(
+        config.standards_dir, dimension, config.src,
+    )
+    prompts_hash = _hash_prompts_combined(config.prompts_dir)
+    return {
+        "standards_hash": standards_hash, "params_hash": params_hash,
+        "effective_params": effective_params, "prompts_hash": prompts_hash,
+    }
+
+
 @pytest.fixture
 def cache(tmp_path: Path) -> LocalFileBackend:
     return LocalFileBackend(root=tmp_path / "cache")
@@ -44,6 +64,7 @@ class TestPersistFiltersByOkMarker:
         persist_dispatch_results(
             config, "security", miss_files=["a.py", "b.py", "c.py"],
             jsonl_path=jsonl, miss_keys=miss_keys, cache=cache,
+            **_hash_inputs(config, "security"),
         )
         assert cache.get("key-a-py") is not None
         assert cache.get("key-b-py") is None
@@ -62,6 +83,7 @@ class TestPersistFiltersByOkMarker:
         persist_dispatch_results(
             config, "security", miss_files=["clean.py"],
             jsonl_path=jsonl, miss_keys={"clean.py": "key-clean"}, cache=cache,
+            **_hash_inputs(config, "security"),
         )
         entry = cache.get("key-clean")
         assert entry is not None
@@ -81,6 +103,7 @@ class TestPersistFiltersByOkMarker:
         persist_dispatch_results(
             config, "security", miss_files=["x.py"],
             jsonl_path=jsonl, miss_keys={"x.py": "key-x"}, cache=cache,
+            **_hash_inputs(config, "security"),
         )
         assert cache.get("key-x") is None
 
@@ -93,5 +116,6 @@ class TestPersistFiltersByOkMarker:
             config, "security", miss_files=["a.py"],
             jsonl_path=tmp_path / "missing.jsonl",
             miss_keys={"a.py": "key-a"}, cache=cache,
+            **_hash_inputs(config, "security"),
         )
         assert cache.get("key-a") is None

--- a/tests/api/test_evaluation_helpers_sanitize.py
+++ b/tests/api/test_evaluation_helpers_sanitize.py
@@ -1,0 +1,47 @@
+"""Tests for _sanitize_url in _evaluation_helpers.py.
+
+Mirrors the adversarial cases in tests/shared/test_repo_remote_url.py's
+test_normalize_strips_userinfo_containing_a_slash (the same algorithm,
+ported here with _sanitize_url's own return shape: scheme + "***@" +
+host/path, credentials masked rather than dropped).
+"""
+from __future__ import annotations
+
+from quodeq.api._evaluation_helpers import _sanitize_url
+
+
+def test_sanitize_url_simple_user_pass():
+    assert _sanitize_url("https://user:token@host/repo.git") == "https://***@host/repo.git"
+
+
+def test_sanitize_url_token_only():
+    assert _sanitize_url("https://ghp_supersecrettoken@github.com/org/repo.git") == (
+        "https://***@github.com/org/repo.git"
+    )
+
+
+def test_sanitize_url_no_credentials_present():
+    assert _sanitize_url("https://github.com/org/repo.git") == "https://github.com/org/repo.git"
+
+
+def test_sanitize_url_leaves_a_legitimate_path_at_sign_alone():
+    """An @ after the authority (a path segment) must not be masked."""
+    url = "https://git.example.com/~user@host/repo.git"
+    assert _sanitize_url(url) == url
+
+
+def test_sanitize_url_masks_userinfo_containing_a_slash():
+    """A "/" inside the credential must not truncate the userinfo search
+    window: real tokens (base64/JWT-derived) commonly contain "/", and
+    bounding the search by the first "/" hides the real "@" and lets the
+    whole unredacted credential pass through unmasked."""
+    cases = {
+        "https://user:pa/ss@github.com/org/repo.git": "https://***@github.com/org/repo.git",
+        "https://x-access-token:gh_p/xyz@github.com/foo/bar.git": "https://***@github.com/foo/bar.git",
+        "https://token/with/slashes@github.com/org/repo.git": "https://***@github.com/org/repo.git",
+    }
+    for leaky, expected in cases.items():
+        sanitized = _sanitize_url(leaky)
+        assert sanitized == expected
+        assert "pa/ss" not in sanitized and "gh_p/xyz" not in sanitized
+        assert "token/with/slashes" not in sanitized

--- a/tests/data/cache_store/test_migrate.py
+++ b/tests/data/cache_store/test_migrate.py
@@ -192,6 +192,31 @@ class TestMigrateEntries:
     def test_missing_root_is_empty_stats(self, tmp_path: Path):
         assert migrate_entries(tmp_path / "nope", standards_dir=None) == MigrationStats()
 
+    def test_compiled_standards_cached_per_dimension(self, tmp_path: Path):
+        from unittest.mock import patch
+        root = tmp_path / "cache"
+        std = tmp_path / "standards"
+        dim_data = {"principles": [{"requirements": [
+            {"id": "M-1", "params": {"max_lines": {"default": 50}}},
+        ]}]}
+        _write_compiled(std, "security", dim_data)
+        _write_v3(root, path="A.py", dim="security", effective={"M-1": {"max_lines": 60}})
+        _write_v3(root, path="B.py", dim="security", effective={"M-1": {"max_lines": 70}})
+        _write_v3(root, path="C.py", dim="security", effective={"M-1": {"max_lines": 80}})
+
+        original_read_text = Path.read_text
+        security_json_reads = [0]
+
+        def tracking_read(path_self, *args, **kwargs):
+            if "security.json" in str(path_self):
+                security_json_reads[0] += 1
+            return original_read_text(path_self, *args, **kwargs)
+
+        with patch.object(Path, "read_text", tracking_read):
+            migrate_entries(root, standards_dir=std)
+
+        assert security_json_reads[0] == 1
+
 
 class TestEnsureCacheReady:
     def setup_method(self):

--- a/tests/services/test_evaluation_mixin_register_origin.py
+++ b/tests/services/test_evaluation_mixin_register_origin.py
@@ -8,7 +8,9 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
+from quodeq.services.base import NewProjectSpec
 from quodeq.services.project_registration import register_project as _register_project
+from quodeq.services.project_registration import register_project_with_rollback
 
 
 def _read_info(reports_root: Path, uuid: str) -> dict:
@@ -130,3 +132,30 @@ def test_register_local_repo_without_remote_omits_origin_url(tmp_path):
     uuid = _register_project(str(repo), None, str(reports))
 
     assert "originUrl" not in _read_info(reports, uuid)
+
+
+def test_register_project_with_rollback_strips_credentials_from_error_log(tmp_path, recording_log):
+    """The generic-exception fallback in register_project_with_rollback logs
+    the raw repo string; a credentialed repo (including one with a "/"
+    inside the credential) must never reach that log line unstripped."""
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    clone_dest = tmp_path / "code"
+    clone_dest.mkdir()
+    repo = "https://user:pa/ss@github.com/org/repo.git"
+    spec = NewProjectSpec(
+        repo=repo, discipline=None, scope_path=None, clone_dest=str(clone_dest), ephemeral=False,
+    )
+
+    with (
+        patch("quodeq.services.project_registration.validate_remote_url", return_value=None),
+        patch("quodeq.services.project_registration.run_git_clone", side_effect=RuntimeError("boom")),
+    ):
+        result = register_project_with_rollback(str(reports), spec, log=recording_log)
+
+    assert result.status == "internal_error"
+    assert len(recording_log.error_messages) == 1
+    logged = recording_log.error_messages[0]
+    assert "pa/ss" not in logged
+    assert "user:" not in logged
+    assert "https://github.com/org/repo.git" in logged

--- a/tests/services/test_fs_project_helpers_onboarding.py
+++ b/tests/services/test_fs_project_helpers_onboarding.py
@@ -305,3 +305,36 @@ def test_find_existing_project_logs_malformed_repo_identifier(caplog, tmp_path):
         result = find_existing_project(str(tmp_path), "not a valid repo!!", None)
     assert result is None
     assert any("not a valid repo!!" in r.message for r in caplog.records)
+
+
+def test_find_existing_project_strips_credentials_from_malformed_repo_log(caplog, tmp_path):
+    """A malformed repo identifier can still carry embedded credentials
+    (e.g. a rejected cleartext http:// URL with user:pass@); the duplicate
+    check's warning log must never leak them."""
+    with patch(
+        "quodeq.shared.utils.is_repo_url",
+        side_effect=ValueError("cannot classify repo identifier"),
+    ), caplog.at_level(logging.WARNING):
+        result = find_existing_project(
+            str(tmp_path), "https://user:token@host/repo.git", None,
+        )
+    assert result is None
+    logged = caplog.records[-1].message
+    assert "user:token" not in logged
+    assert "https://host/repo.git" in logged
+
+
+def test_find_existing_project_strips_slash_credential_from_malformed_repo_log(caplog, tmp_path):
+    """Same as above, but for the slash-in-credential bypass case: bounding
+    the credential search by the first "/" must not let the token through."""
+    with patch(
+        "quodeq.shared.utils.is_repo_url",
+        side_effect=ValueError("cannot classify repo identifier"),
+    ), caplog.at_level(logging.WARNING):
+        result = find_existing_project(
+            str(tmp_path), "https://user:pa/ss@github.com/org/repo.git", None,
+        )
+    assert result is None
+    logged = caplog.records[-1].message
+    assert "pa/ss" not in logged
+    assert "https://github.com/org/repo.git" in logged

--- a/tests/services/test_fs_projects.py
+++ b/tests/services/test_fs_projects.py
@@ -75,21 +75,26 @@ class TestBuildParentChildSets:
         (tmp_path / "standalone" / "repository_info.json").write_text(
             json.dumps({"name": "standalone"})
         )
-        parents, subs = _build_parent_child_sets(tmp_path, ["child1", "standalone"])
+        parents, subs, info_by_name = _build_parent_child_sets(tmp_path, ["child1", "standalone"])
         assert parents == {"parent-uuid"}
         assert subs == {"child1"}
+        assert "child1" in info_by_name
+        assert "standalone" in info_by_name
+        assert info_by_name["child1"]["parent"] == "parent-uuid"
 
     def test_empty_dirs(self, tmp_path: Path):
-        parents, subs = _build_parent_child_sets(tmp_path, [])
+        parents, subs, info_by_name = _build_parent_child_sets(tmp_path, [])
         assert parents == set()
         assert subs == set()
+        assert info_by_name == {}
 
     def test_corrupt_json_skipped(self, tmp_path: Path):
         (tmp_path / "bad").mkdir()
         (tmp_path / "bad" / "repository_info.json").write_text("{{{")
-        parents, subs = _build_parent_child_sets(tmp_path, ["bad"])
+        parents, subs, info_by_name = _build_parent_child_sets(tmp_path, ["bad"])
         assert parents == set()
         assert subs == set()
+        assert "bad" not in info_by_name
 
 
 # ---------------------------------------------------------------------------
@@ -120,6 +125,51 @@ class TestBuildProjectList:
     def test_excludes_dir_without_repo_info_or_runs(self, tmp_path: Path):
         (tmp_path / "junk-dir").mkdir()
         assert build_project_list(tmp_path) == []
+
+    def test_reads_repository_info_once_per_directory(self, tmp_path: Path):
+        # Regression test: ensure build_project_list() reads repository_info.json
+        # at most once per directory, not multiple times (deduplication).
+        proj1 = tmp_path / "proj1-uuid"
+        proj1.mkdir()
+        (proj1 / "repository_info.json").write_text(json.dumps({
+            "name": "proj1",
+            "path": str(tmp_path),
+            "location": "local",
+        }))
+        proj2 = tmp_path / "proj2-uuid"
+        proj2.mkdir()
+        (proj2 / "repository_info.json").write_text(json.dumps({
+            "name": "proj2",
+            "path": str(tmp_path),
+            "location": "local",
+            "parent": "parent-uuid",
+        }))
+
+        call_count: dict[str, int] = {}
+
+        def counting_read_repository_info(path):
+            dir_name = path.name
+            call_count[dir_name] = call_count.get(dir_name, 0) + 1
+            # Call the original function
+            return original_read_repository_info(path)
+
+        original_read_repository_info = None
+        with patch("quodeq.services._fs_projects.read_repository_info") as mock_read:
+            with patch("quodeq.services._fs_project_helpers.read_repository_info") as mock_read_helpers:
+                def side_effect(path):
+                    dir_name = path.name
+                    call_count[dir_name] = call_count.get(dir_name, 0) + 1
+                    if path.is_dir() and (path / "repository_info.json").exists():
+                        return json.loads((path / "repository_info.json").read_text())
+                    return None
+
+                mock_read.side_effect = side_effect
+                mock_read_helpers.side_effect = side_effect
+                build_project_list(tmp_path)
+
+        # Each directory should be read at most once
+        assert call_count.get("proj1-uuid", 0) <= 1, f"proj1-uuid read {call_count.get('proj1-uuid', 0)} times"
+        assert call_count.get("proj2-uuid", 0) <= 1, f"proj2-uuid read {call_count.get('proj2-uuid', 0)} times"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_fs_projects.py
+++ b/tests/services/test_fs_projects.py
@@ -147,13 +147,6 @@ class TestBuildProjectList:
 
         call_count: dict[str, int] = {}
 
-        def counting_read_repository_info(path):
-            dir_name = path.name
-            call_count[dir_name] = call_count.get(dir_name, 0) + 1
-            # Call the original function
-            return original_read_repository_info(path)
-
-        original_read_repository_info = None
         with patch("quodeq.services._fs_projects.read_repository_info") as mock_read:
             with patch("quodeq.services._fs_project_helpers.read_repository_info") as mock_read_helpers:
                 def side_effect(path):

--- a/tests/services/test_registration_url.py
+++ b/tests/services/test_registration_url.py
@@ -1,0 +1,54 @@
+"""Tests for the pure credential-stripping helper in _registration_url.py.
+
+Mirrors the adversarial cases in tests/shared/test_repo_remote_url.py's
+test_normalize_strips_userinfo_containing_a_slash (the same algorithm,
+ported here with _strip_credentials's own return shape: full URL with
+scheme, credentials removed).
+"""
+from __future__ import annotations
+
+from quodeq.services._registration_url import _strip_credentials
+
+
+def test_strip_credentials_simple_user_pass():
+    assert _strip_credentials("https://user:token@host/repo.git") == "https://host/repo.git"
+
+
+def test_strip_credentials_token_only():
+    assert _strip_credentials("https://ghp_supersecrettoken@github.com/org/repo.git") == (
+        "https://github.com/org/repo.git"
+    )
+
+
+def test_strip_credentials_no_credentials_present():
+    assert _strip_credentials("https://github.com/org/repo.git") == "https://github.com/org/repo.git"
+
+
+def test_strip_credentials_scp_style_left_untouched():
+    """git@host:org/repo.git has no scheme -- the leading git@ is a username
+    convention, not a credential, and must survive unchanged."""
+    assert _strip_credentials("git@github.com:example/myrepo.git") == "git@github.com:example/myrepo.git"
+
+
+def test_strip_credentials_leaves_a_legitimate_path_at_sign_alone():
+    """An @ after the authority (a path segment) must not be stripped."""
+    url = "https://git.example.com/~user@host/repo.git"
+    assert _strip_credentials(url) == url
+
+
+def test_strip_credentials_removes_userinfo_containing_a_slash():
+    """A "/" inside the credential must not truncate the userinfo search
+    window: real tokens (base64/JWT-derived) commonly contain "/", and
+    bounding the search by the first "/" hides the real "@" and lets the
+    whole unredacted credential pass through."""
+    cases = {
+        "https://user:pa/ss@github.com/org/repo.git": "https://github.com/org/repo.git",
+        "https://x-access-token:gh_p/xyz@github.com/foo/bar.git": "https://github.com/foo/bar.git",
+        "https://token/with/slashes@github.com/org/repo.git": "https://github.com/org/repo.git",
+    }
+    for leaky, expected in cases.items():
+        stripped = _strip_credentials(leaky)
+        assert stripped == expected
+        assert "@" not in stripped
+        assert "pa" not in stripped and "gh_p" not in stripped
+        assert "token" not in stripped and "slashes" not in stripped

--- a/tests/services/test_suppression_rules.py
+++ b/tests/services/test_suppression_rules.py
@@ -136,6 +136,30 @@ class TestLoadSuppressionRules:
 
         assert load_suppression_rules(tmp_path) == ()
 
+    def test_unsupported_version_yields_no_rules(self, tmp_path):
+        """A future incompatible schema version is rejected like malformed data."""
+        from quodeq.data.fs.suppression_rules import load_suppression_rules
+
+        (tmp_path / "suppression_rules.json").write_text(json.dumps({
+            "version": 2,
+            "rules": [{"req": "CLEA-DEP-01", "file": "src/quodeq/services/*", "reason": "WS1"}],
+        }), encoding="utf-8")
+
+        assert load_suppression_rules(tmp_path) == ()
+
+    def test_missing_version_defaults_to_1(self, tmp_path):
+        """Files written before the version guard existed have no version key."""
+        from quodeq.data.fs.suppression_rules import load_suppression_rules
+
+        (tmp_path / "suppression_rules.json").write_text(json.dumps({
+            "rules": [{"req": "CLEA-DEP-01", "file": "src/quodeq/services/*", "reason": "WS1"}],
+        }), encoding="utf-8")
+
+        rules = load_suppression_rules(tmp_path)
+
+        assert len(rules) == 1
+        assert rules[0].req == "CLEA-DEP-01"
+
 
 def test_suppression_rule_is_frozen():
     rule = SuppressionRule(req="X", file="a.py", reason="r")

--- a/tools/size_baseline.txt
+++ b/tools/size_baseline.txt
@@ -7,7 +7,7 @@ src/quodeq/api/_log_stream_routes.py:54:function
 src/quodeq/api/assistant_session_routes.py:58:function
 src/quodeq/api/assistant_turn_routes.py:95:function
 src/quodeq/api/assistant_workspace_routes.py:22:function
-src/quodeq/api/llm_bridge_routes.py:54:function
+src/quodeq/api/llm_bridge_routes.py:64:function
 src/quodeq/api/routes_evaluations_item.py:98:function
 src/quodeq/api/routes_evaluations_list.py:55:function
 src/quodeq/api/routes_findings.py:92:function


### PR DESCRIPTION
## What does this PR do?

Closes 9 self-eval quick-win findings across performance (4), security (1, expanded mid-cycle), and flexibility (4), following #1151 and #1154's pattern. Baseline self-eval (run `c921f1af`, 2026-09-07, post-#1155): performance 8.8/10 (11 major, regressed 0.2 from the cache-key-v4-adoption PR), security 9.3/10 (8 major, unchanged), flexibility 8.2/10 (18 major, regressed 0.1).

## Why?

Continuation of the ongoing self-eval grade-lift work. Five of this cycle's findings trace directly to files touched by the just-merged cache-key-v4-adoption PR (#1155) — this cycle reverses that regression plus tackles pre-existing findings triaged as genuine quick wins.

### Performance (4 tasks)
- Dedupe `repository_info.json` reads in project listing (3 reads per directory → 1)
- Memoize `WorkspaceDiffPanel.jsx` diff parsing so it doesn't re-run on unrelated keystrokes
- Cache the compiled-standards read per dimension during cache migration (my own regression from #1155)
- Hoist standards/prompts/params hashing out of the per-tick persist path into a one-time computation at watcher start

### Security (1 task, scope expanded mid-cycle)
Strip credentials before logging repo URLs/identifiers. The original plan assumed an existing helper was already hardened by a recent fix (#b3e5da96) — investigation found that commit never touched this helper, which still had the identical vulnerable pattern (bounded the credential search by the first `/`, so a credential containing a literal `/` passed through unstripped). Fixed the helper itself (and an independent duplicate in a second file) by porting the proven-correct algorithm from the already-fixed function, then wired it into both log sites. Hand-traced against adversarial inputs by an independent reviewer; no bypass found.

### Flexibility (4 tasks)
- Shared `isMacPlatform()` helper (previously two independent, disagreeable Mac-detection computations)
- Shared model-name validation helper across the ollama/llamacpp/omlx provider routes
- Suppression-rules schema version guard (fail-closed on an unrecognized future version)
- Deleted a dead `QueueStateProtocol` whose docstring promised an extension point nothing implements

### Deferred / not in this cycle
- 3 bigger performance items (async project creation off the request thread, incremental persist-tick JSONL, `HashCache` eviction policy) — real fixes, each needs its own design pass, explicitly deferred by the user's call.
- Folding omlx into the generic provider-credential adapter — investigation found the literal fix (templating omlx's `api_base`) would misclassify its Settings tab as `cloud-api` in the UI, since `classifyProvider()` substring-matches the raw `api_base`. Real fix needs the classification logic made id-based across 3 files; out of scope for a quick win.
- Most of the flexibility "Scalability" findings (9 of 10) — every one flags quodeq's in-process singletons as unsafe for horizontal scaling, but quodeq is a single-process local dev tool by design (several sites already document this with an injection escape hatch). Building distributed infra here would be the premature abstraction this repo's CLAUDE.md warns against.
- Security's other 7 findings (cleartext API key storage, rate-limit race, forgeable CSP marker, etc.) — each already documented as an accepted tradeoff, or the correct fix is a genuine new feature (platform keychain integration) disproportionate to a quick-win cycle.

### An unplanned finding: subagent implementers defaulting to an attribution trailer this session's instructions explicitly excluded
Five of eleven commits picked up a `Co-Authored-By`/session-link trailer despite every task brief explicitly saying not to (a subagent instruction-following gap, not caught by 3 of those tasks' own reviewers). Found via one task's reviewer, then audited the whole branch. Fixed as a commit-message-only rewrite, verified every commit's tree hash identical before/after (zero content change) before trusting it.

### Whole-branch review
Final review (most capable model, full diff) found 0 Critical, 1 Important (a sibling code path Task 1's dedupe didn't reach, correctly out of that task's brief scope, non-regressive — left as a follow-up), and 9 Minor findings (mostly optional git-history tidying and a couple of cheap doc/type-safety improvements for a future pass). None block merge per the reviewer's own assessment.

## How to test

```
uv run pytest tests/ -q --tb=short -m "not integration"   # 6537 passed, 10 skipped
cd src/quodeq/ui && npm run test:all                       # 261 files / 1802 tests, all passed
uv run python tools/check_imports.py                       # OK, no new violations
uv run pytest tests/tools/test_size_limits.py -q            # both tests pass
```

## Checklist

- [x] Tests pass (`uv run pytest`)
- [x] PR targets `develop`, not `main`
