### PR TITLE
fix(security): hand the webview launch token over stdin, not argv

### DIFF
--- a/src/quodeq/dashboard/_server.py
+++ b/src/quodeq/dashboard/_server.py
@@ -21,6 +21,7 @@ from quodeq.dashboard._webview_token import (
     _ENV_WEBVIEW_TOKEN,
     _get_webview_token,
     _warn_reused_api_token_mismatch,
+    spawn_window_with_token,
 )
 from quodeq.shared.logging import log_success
 from quodeq.shared.utils import IS_WIN32
@@ -244,10 +245,10 @@ def _serve_native(
     api_pid = str(action_api_process.pid) if action_api_process else ""
     webview_stderr = _open_webview_log()
 
-    shell.spawn_window(
-        subprocess_cmd("webview", [action_api_url, str(instance.sock_path), api_pid, _get_webview_token()]),
-        start_new_session=True,
-        stdout=subprocess.DEVNULL,
+    # The launch token goes over stdin inside here, never argv.
+    spawn_window_with_token(
+        shell.spawn_window,
+        subprocess_cmd("webview", [action_api_url, str(instance.sock_path), api_pid]),
         stderr=webview_stderr,
     )
 

--- a/src/quodeq/dashboard/_webview_token.py
+++ b/src/quodeq/dashboard/_webview_token.py
@@ -1,8 +1,12 @@
 """Per-launch shared secret gating the webview's CSP unsafe-eval relaxation."""
 from __future__ import annotations
 
+import contextlib
 import logging
 import secrets
+import subprocess
+import sys
+import typing
 
 # Env var read by quodeq.api.security to gate the webview-only CSP
 # relaxation. Must match quodeq.api.security._ENV_WEBVIEW_TOKEN.
@@ -41,3 +45,64 @@ def _warn_reused_api_token_mismatch(base_url: str) -> None:
         "'unsafe-eval' relaxation will not be granted and its JS bridge may "
         "not work. Stop that API and relaunch to pair them.", base_url,
     )
+
+
+def read_token_from_stdin() -> str | None:
+    """Child side: read this launch's token from stdin, where the parent's
+    spawn_window_with_token wrote it.
+
+    Returns None on anything unexpected (no stdin, empty line, closed pipe).
+    The window then runs a token-less UA and the API serves it the strict
+    CSP -- the JS bridge degrades, the security property holds.
+    """
+    try:
+        if sys.stdin is None:
+            return None
+        return sys.stdin.readline().strip() or None
+    except (OSError, ValueError):
+        return None
+
+
+def _send_token(window_proc: subprocess.Popen | None) -> None:
+    """Write the launch token to the window's stdin, then close it.
+
+    Best-effort by design: on any failure the child reads an empty line, gets
+    no token, and the API serves it the strict CSP. Same fail-closed path as
+    a wrong token, so a broken handover costs the JS bridge, never the
+    security property.
+    """
+    stdin = getattr(window_proc, "stdin", None)
+    if stdin is None:
+        return
+    try:
+        stdin.write(f"{_get_webview_token()}\n".encode())
+        stdin.flush()
+    except (OSError, ValueError):
+        pass
+    finally:
+        # Must close even when the write failed: the child blocks in
+        # readline() until this end is closed.
+        with contextlib.suppress(OSError, ValueError):
+            stdin.close()
+
+
+def spawn_window_with_token(
+    spawn: typing.Callable[..., subprocess.Popen], cmd: list[str], *, stderr: typing.Any,
+) -> subprocess.Popen:
+    """Spawn the webview window and hand it the token over stdin, never argv.
+
+    argv is world-readable: /proc/<pid>/cmdline is mode 0444 and `ps` shows it
+    to every user on the machine, so a token passed there let any local user
+    forge the UA that wins the CSP 'unsafe-eval' relaxation (see
+    quodeq.api.security._is_trusted_webview for what that grants). A pipe is
+    visible only to the two processes holding it.
+    """
+    window_proc = spawn(
+        cmd,
+        start_new_session=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=stderr,
+    )
+    _send_token(window_proc)
+    return window_proc

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -24,6 +24,7 @@ import webview
 
 from quodeq.dashboard._build_npm import _quodeq_dir
 from quodeq.dashboard._instance import InstanceController
+from quodeq.dashboard._webview_token import read_token_from_stdin
 from quodeq.dashboard._webview_window_about import (  # noqa: F401 — re-export
     _set_app_icon,
     _set_macos_app_identity,
@@ -243,7 +244,7 @@ def main() -> None:
     url = sys.argv[1]
     sock_path = Path(sys.argv[2])
     api_pid = int(sys.argv[3]) if len(sys.argv) > 3 and sys.argv[3] else 0
-    webview_token = sys.argv[4] if len(sys.argv) > 4 and sys.argv[4] else None
+    webview_token = read_token_from_stdin()
 
     instance = InstanceController(sock_path)
     api = _WindowApi()

--- a/tests/dashboard/test_native_chrome.py
+++ b/tests/dashboard/test_native_chrome.py
@@ -1,5 +1,6 @@
 """Native-chrome window: creation args, custom UA, and marker drift guard."""
 import inspect
+import io
 import sys
 
 from unittest.mock import MagicMock, patch
@@ -92,13 +93,20 @@ class TestUaMarkerNoDrift:
 
 
 class TestMainThreadsWebviewToken:
-    """main() must read the optional argv[4] token (same absent-arg guard as
-    api_pid at argv[3]) and pass it through to the actual UA sent to
-    webview.start — that UA is what the API's security check inspects."""
+    """main() must read the launch token from STDIN (never argv) and thread it
+    into the UA handed to webview.start — that UA is what the API's security
+    check inspects.
 
-    def _run_main(self, monkeypatch, tmp_path, argv_tail):
+    Rewritten from an argv[4] version: argv is world-readable
+    (/proc/<pid>/cmdline is 0444, and `ps` shows it to every user), so a token
+    there let any local user forge the UA that wins the CSP 'unsafe-eval'
+    relaxation. The old test asserted exactly the mechanism that was the bug.
+    """
+
+    def _run_main(self, monkeypatch, tmp_path, stdin_text, argv_tail=("",)):
         argv = ["webview.py", "http://127.0.0.1:7863", str(tmp_path / "reload.sock"), *argv_tail]
         monkeypatch.setattr(ww.sys, "argv", argv)
+        monkeypatch.setattr(ww.sys, "stdin", io.StringIO(stdin_text))
         mock_instance = MagicMock()
         mock_instance.try_acquire.return_value = False
         with patch.object(ww, "_set_app_icon"), \
@@ -113,18 +121,40 @@ class TestMainThreadsWebviewToken:
             ww.main()
         return mock_webview.start.call_args.kwargs["user_agent"]
 
-    def test_token_present_reaches_user_agent(self, monkeypatch, tmp_path):
+    def test_token_from_stdin_reaches_user_agent(self, monkeypatch, tmp_path):
         from quodeq.dashboard import _webview_window_about
-        ua = self._run_main(monkeypatch, tmp_path, ["", "shared-secret-123"])
+        ua = self._run_main(monkeypatch, tmp_path, "shared-secret-123\n")
         assert f"{_webview_window_about._WEBVIEW_TOKEN_UA_PREFIX}shared-secret-123" in ua
 
-    def test_token_absent_is_backward_compatible(self, monkeypatch, tmp_path):
-        """Same guard as the existing api_pid optional-arg handling: an argv
-        without a 5th element must not crash main(), and the UA carries no
-        token prefix (matching a standalone/older-launcher invocation)."""
+    def test_empty_stdin_is_backward_compatible(self, monkeypatch, tmp_path):
+        """A launcher that sends nothing (or a parent that died before the
+        write) must not crash main(). The UA carries no token prefix, so the
+        API serves the strict CSP -- fail closed, not fail open."""
         from quodeq.dashboard import _webview_window_about
-        ua = self._run_main(monkeypatch, tmp_path, [])
+        ua = self._run_main(monkeypatch, tmp_path, "")
         assert _webview_window_about._WEBVIEW_TOKEN_UA_PREFIX not in ua
+
+    def test_a_token_left_in_argv_is_ignored(self, monkeypatch, tmp_path):
+        """Regression guard for the fix itself.
+
+        If someone reintroduces an argv token (or an old launcher passes one),
+        it must NOT be honoured -- otherwise the world-readable path is live
+        again and the stdin handover is decorative.
+        """
+        from quodeq.dashboard import _webview_window_about
+        ua = self._run_main(
+            monkeypatch, tmp_path, "", argv_tail=("", "token-from-argv"),
+        )
+        assert "token-from-argv" not in ua
+        assert _webview_window_about._WEBVIEW_TOKEN_UA_PREFIX not in ua
+
+    def test_stdin_wins_over_a_stale_argv_token(self, monkeypatch, tmp_path):
+        from quodeq.dashboard import _webview_window_about
+        ua = self._run_main(
+            monkeypatch, tmp_path, "real-token\n", argv_tail=("", "token-from-argv"),
+        )
+        assert f"{_webview_window_about._WEBVIEW_TOKEN_UA_PREFIX}real-token" in ua
+        assert "token-from-argv" not in ua
 
 
 class TestSetTitlebarTheme:

--- a/tests/dashboard/test_server_serve_modes.py
+++ b/tests/dashboard/test_server_serve_modes.py
@@ -104,6 +104,59 @@ class TestServeNative:
 
         mock_popen.assert_called_once()
 
+    def test_token_goes_over_stdin_and_never_into_argv(self):
+        """The launch token must not appear in the child's argv.
+
+        /proc/<pid>/cmdline is world-readable and `ps` shows argv to every
+        user on the machine, so a token there let any local user forge the UA
+        that wins the CSP 'unsafe-eval' relaxation. It is written to the
+        child's stdin instead, which only the two processes can see.
+        """
+        from quodeq.dashboard import _webview_token
+        from quodeq.dashboard._server import _serve_native
+
+        mock_instance = MagicMock()
+        mock_instance.probe_existing.return_value = False
+        mock_instance._sock_path = Path("/tmp/test.sock")
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 1234
+        window_proc = MagicMock()
+        mock_popen = MagicMock(return_value=window_proc)
+
+        shell = self._shell(make_instance=lambda: mock_instance, spawn_window=mock_popen)
+        with patch.object(_webview_token, "_get_webview_token", return_value="s3cret-token"):
+            _serve_native("http://localhost:8000", mock_proc, MagicMock(), shell=shell)
+
+        argv = mock_popen.call_args[0][0]
+        assert "s3cret-token" not in argv
+        assert not any("s3cret-token" in str(part) for part in argv), (
+            "the launch token must never reach the child's command line"
+        )
+
+        window_proc.stdin.write.assert_called_once_with(b"s3cret-token\n")
+        window_proc.stdin.close.assert_called_once()
+
+    def test_stdin_is_closed_even_when_the_write_fails(self):
+        """The child blocks in readline() until this end closes, so a failed
+        write must not leave it hanging at startup."""
+        from quodeq.dashboard import _webview_token
+        from quodeq.dashboard._server import _serve_native
+
+        mock_instance = MagicMock()
+        mock_instance.probe_existing.return_value = False
+        mock_instance._sock_path = Path("/tmp/test.sock")
+
+        window_proc = MagicMock()
+        window_proc.stdin.write.side_effect = OSError("broken pipe")
+        mock_popen = MagicMock(return_value=window_proc)
+
+        shell = self._shell(make_instance=lambda: mock_instance, spawn_window=mock_popen)
+        with patch.object(_webview_token, "_get_webview_token", return_value="s3cret-token"):
+            _serve_native("http://localhost:8000", MagicMock(), MagicMock(), shell=shell)
+
+        window_proc.stdin.close.assert_called_once()
+
     def test_parent_never_owns_the_reload_socket(self):
         """The window process owns the socket, so the parent must not bind it.
 


### PR DESCRIPTION
Closes #1161.

`argv` is world-readable. `/proc/<pid>/cmdline` is mode 0444 and `ps` shows argv to every user on the machine, so passing the per-launch webview token there let any local user read it, forge the webview User-Agent, and win the CSP `'unsafe-eval'` relaxation from the loopback API. That turns a would-be XSS in the dashboard from blocked into executable.

Deferred during security-cycle1 (#1160) because it needs a design change rather than a patch.

## What changed

The token goes over the child's stdin, which only the two processes holding the pipe can see.

- `_server.py` drops the 4th argv element and delegates to `spawn_window_with_token`.
- `_webview_window.py` reads the token from stdin instead of `sys.argv[4]`.
- `_webview_token.py` now owns both ends of the handover: generate, send, read.

Chose stdin over an inherited pipe fd because `pass_fds` is POSIX-only (`subprocess` rejects a non-empty `pass_fds` on Windows) and this app ships a Windows CI matrix. Chose it over a 0600 token file because that leaves a file to clean up after a crash and puts the secret on disk where it wasn't before.

## Scope: argv only

The API subprocess still learns the expected token from the environment. `/proc/<pid>/environ` is 0400 owner-only while `cmdline` is 0444 world-readable, so argv was the cross-user leak; env is same-user, against an attacker who can already read `~/.quodeq`. Closing that half means rewriting how the Flask subprocess is configured, for considerably less benefit. Say so in review if you want both.

## Fail-closed throughout

No token, an empty line, or a broken pipe yields a token-less UA and the strict CSP. A failed handover costs the JS bridge, never the security property. stdin is closed even when the write fails, or the child would block in `readline()` at startup.

## Tests

`TestMainThreadsWebviewToken` asserted the argv mechanism that was the bug, so it was rewritten to drive stdin. Three of the four new tests fail against the old code:

- `test_a_token_left_in_argv_is_ignored`, the important one. Honouring a stale argv token would leave the world-readable path live and make this change decorative.
- `test_stdin_wins_over_a_stale_argv_token`
- `test_token_goes_over_stdin_and_never_into_argv`, asserts the token is absent from the spawn command
- `test_stdin_is_closed_even_when_the_write_fails`

## Verification

- Full backend suite: 6750 passed, 10 skipped, 0 failed
- `tests/dashboard/` plus the size ratchet: 223 passed
- `tools/check_imports.py`: no new violations
- File sizes all under the 300 cap, `tools/size_baseline.txt` untouched. Extracting `spawn_window_with_token` was what kept `_serve_native` under the 50-line function cap.

## Not verified

I have not launched the real dashboard and confirmed a window opens with a working JS bridge. No test drives an actual pywebview process, so CI will not catch a mistake here. `subprocess_cmd` returns `[sys.executable, "--_webview", ...]` in both frozen and source mode, so the pipe is inherited normally, and passing `stdin=subprocess.PIPE` keeps fd 0 valid even under `pythonw`. Worth one manual `quodeq dashboard` before merging.
