### PR TITLE
fix(history): unlock the History row once a dimension finishes, not just at run end

### DIFF
--- a/src/quodeq/ui/src/features/history/components/EvaluationsTable.jsx
+++ b/src/quodeq/ui/src/features/history/components/EvaluationsTable.jsx
@@ -115,11 +115,18 @@ function HistoryRow({ className = '', onClick, onHover, cells, onDelete, title }
  * from the SSE-fed cache, and renders a partial summary as soon as the
  * first dim has scored. Falls back to the 'performing an evaluation...'
  * placeholder while no dim has scored.
+ *
+ * `notReady` also checks hasScoredDimension (a poll-based, SSE-independent
+ * signal from useHistoryRunLive): entry.hasScoredDims is a static stub
+ * that's always false for an in-progress run, and liveCount only moves
+ * with SSE, which is off by default -- without hasScoredDimension the row
+ * would stay stuck "not ready" for a run's entire duration even after a
+ * dimension actually finished scoring on disk.
  */
 function InProgressHistoryRow({ entry, onClick, onNotReadyClick }) {
-  const { liveDims, plannedDimensions } = useHistoryRunLive(entry.runId);
+  const { liveDims, plannedDimensions, hasScoredDimension } = useHistoryRunLive(entry.runId);
   const liveCount = Object.values(liveDims || {}).filter((d) => d?.dimension).length;
-  const notReady = entry.hasScoredDims === false && liveCount === 0;
+  const notReady = entry.hasScoredDims === false && liveCount === 0 && !hasScoredDimension;
   const { date } = formatDateParts(new Date().toISOString());
   const liveText = liveCount === 0 ? '' : formatLiveDimSummary(liveDims, plannedDimensions);
   const dimsCell = liveCount === 0

--- a/src/quodeq/ui/src/features/history/components/EvaluationsTable.test.jsx
+++ b/src/quodeq/ui/src/features/history/components/EvaluationsTable.test.jsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { EvaluationsTable } from './EvaluationsTable.jsx';
+import { useHistoryRunLive } from '../hooks/useHistoryRunLive.js';
+
+// Regression coverage for the "No standards fully evaluated yet" bug: an
+// in-progress row must become clickable once hasScoredDimension flips true
+// (the poll-based, SSE-independent signal), not just from hasScoredDims
+// (a static stub, always false) or SSE-only liveCount.
+vi.mock('../hooks/useHistoryRunLive.js', () => ({
+  useHistoryRunLive: vi.fn(() => ({ liveDims: {}, plannedDimensions: [], hasScoredDimension: false })),
+}));
+
+const inProgressEntry = { runId: 'run-1', status: 'in_progress', hasScoredDims: false };
+
+function renderTable(props = {}) {
+  return render(
+    <EvaluationsTable
+      visible={[inProgressEntry]}
+      selectedRunId={null}
+      deltas={[]}
+      statusByRunId={new Map()}
+      onRunClick={vi.fn()}
+      onRunHover={vi.fn()}
+      onRunHoverEnd={vi.fn()}
+      onDeleteRun={vi.fn()}
+      onNotReadyClick={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+describe('EvaluationsTable in-progress row readiness', () => {
+  beforeEach(() => {
+    useHistoryRunLive.mockReset();
+  });
+
+  it('is not clickable and fires onNotReadyClick when nothing has scored yet', () => {
+    useHistoryRunLive.mockReturnValue({ liveDims: {}, plannedDimensions: [], hasScoredDimension: false });
+    const onRunClick = vi.fn();
+    const onNotReadyClick = vi.fn();
+    renderTable({ onRunClick, onNotReadyClick });
+
+    const row = screen.getByRole('button'); // header row uses role="row" (no onClick), so this is the one data row
+    fireEvent.click(row);
+
+    expect(onNotReadyClick).toHaveBeenCalledTimes(1);
+    expect(onRunClick).not.toHaveBeenCalled();
+    expect(row.className).toContain('history-row--not-ready');
+  });
+
+  it('becomes clickable once hasScoredDimension is true, even though hasScoredDims and liveCount are both falsy', () => {
+    useHistoryRunLive.mockReturnValue({ liveDims: {}, plannedDimensions: [], hasScoredDimension: true });
+    const onRunClick = vi.fn();
+    const onNotReadyClick = vi.fn();
+    renderTable({ onRunClick, onNotReadyClick });
+
+    const row = screen.getByRole('button');
+    fireEvent.click(row);
+
+    expect(onRunClick).toHaveBeenCalledWith('run-1');
+    expect(onNotReadyClick).not.toHaveBeenCalled();
+    expect(row.className).not.toContain('history-row--not-ready');
+  });
+
+  it('is already clickable from SSE liveCount alone (unchanged behavior)', () => {
+    useHistoryRunLive.mockReturnValue({
+      liveDims: { security: { dimension: 'security', score: 8.1 } },
+      plannedDimensions: ['security'],
+      hasScoredDimension: false,
+    });
+    const onRunClick = vi.fn();
+    renderTable({ onRunClick });
+
+    const row = screen.getByRole('button');
+    fireEvent.click(row);
+
+    expect(onRunClick).toHaveBeenCalledWith('run-1');
+  });
+});

--- a/src/quodeq/ui/src/features/history/hooks/useHistoryRunLive.js
+++ b/src/quodeq/ui/src/features/history/hooks/useHistoryRunLive.js
@@ -4,7 +4,7 @@
  * Mounts a per-row SSE subscription via useRunEventStream and reactively
  * subscribes to the cache slots that subscription writes. Returns
  *
- *   { liveDims, plannedDimensions }
+ *   { liveDims, plannedDimensions, hasScoredDimension }
  *
  * where liveDims is a `{ [dim]: <evaluation/<dim>.json payload> }` map
  * and plannedDimensions is the dim list the run was started against
@@ -14,12 +14,22 @@
  * caller; this hook is just the data adapter.
  *
  * Gating: useRunEventStream itself is gated on VITE_USE_SSE_EVENTS,
- * so when the flag is off this hook simply returns the empty defaults
- * forever. No behavior change for the SSE-off path.
+ * so when the flag is off liveDims/plannedDimensions stay at their empty
+ * defaults forever. hasScoredDimension does NOT depend on that flag: it
+ * polls the same on-disk progress endpoint the running Evaluation page
+ * uses (getEvaluationProgress), so a row's "ready to view" state reflects
+ * real per-dimension completion even when SSE is off (the default) --
+ * see quality-cycle discussion of the "No standards fully evaluated yet"
+ * bug this fixes: hasScoredDims was previously only ever set from SSE
+ * events, which never arrive with SSE off, so it stayed stuck at false
+ * for a run's entire duration regardless of actual progress.
  */
 import { useQuery } from '@tanstack/react-query';
 import { useRunEventStream } from '../../evaluation/hooks/useRunEventStream.js';
+import { getEvaluationProgress } from '../../../api/index.js';
 import { evaluationKeys } from '../../../api/queryKeys.js';
+
+const PROGRESS_POLL_MS = 3000;
 
 // queryFn never runs (enabled: false); the cache is populated only by
 // the SSE writer in useRunEventStream. useQuery is here for its
@@ -49,9 +59,25 @@ export function useHistoryRunLive(runId) {
     staleTime: Infinity,
   });
 
+  // Unconditional (SSE-independent) poll: a pure on-disk read of per-dim
+  // state, same source the running Evaluation page's progress bar uses.
+  const { data: progress } = useQuery({
+    queryKey: runId
+      ? [...evaluationKeys.evaluation(runId), 'historyProgress']
+      : ['evaluation', '_none_', 'historyProgress'],
+    queryFn: () => getEvaluationProgress(runId),
+    enabled: !!runId,
+    staleTime: 0,
+    refetchInterval: PROGRESS_POLL_MS,
+    retry: false,
+  });
+
   const plannedDimensions = Array.isArray(status?.dimensions)
     ? status.dimensions
     : [];
 
-  return { liveDims, plannedDimensions };
+  const hasScoredDimension = Array.isArray(progress?.dimensions)
+    && progress.dimensions.some((d) => d?.state === 'done');
+
+  return { liveDims, plannedDimensions, hasScoredDimension };
 }

--- a/src/quodeq/ui/src/features/history/hooks/useHistoryRunLive.test.jsx
+++ b/src/quodeq/ui/src/features/history/hooks/useHistoryRunLive.test.jsx
@@ -3,12 +3,19 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import { useHistoryRunLive } from './useHistoryRunLive.js';
 import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
 import { MockEventSource } from '../../../test-utils/MockEventSource.js';
+import { getEvaluationProgress } from '../../../api/index.js';
+
+vi.mock('../../../api/index.js', () => ({
+  getEvaluationProgress: vi.fn(() => Promise.resolve({ dimensions: [] })),
+}));
 
 describe('useHistoryRunLive', () => {
   beforeEach(() => {
     global.EventSource = MockEventSource;
     MockEventSource.last = null;
     vi.stubEnv('VITE_USE_SSE_EVENTS', 'true');
+    getEvaluationProgress.mockReset();
+    getEvaluationProgress.mockResolvedValue({ dimensions: [] });
   });
 
   it('returns empty defaults when no events have arrived', () => {
@@ -76,5 +83,40 @@ describe('useHistoryRunLive', () => {
     expect(MockEventSource.last).toBeNull();
     expect(result.current.liveDims).toEqual({});
     expect(result.current.plannedDimensions).toEqual([]);
+  });
+
+  it('hasScoredDimension becomes true from the progress poll even with SSE off', async () => {
+    vi.stubEnv('VITE_USE_SSE_EVENTS', 'false');
+    getEvaluationProgress.mockResolvedValue({
+      dimensions: [
+        { id: 'security', state: 'done' },
+        { id: 'performance', state: 'running' },
+      ],
+    });
+    const wrapper = withQueryClient();
+    const { result } = renderHook(() => useHistoryRunLive('run-polled'), { wrapper });
+    await waitFor(() => {
+      expect(result.current.hasScoredDimension).toBe(true);
+    });
+    expect(getEvaluationProgress).toHaveBeenCalledWith('run-polled');
+  });
+
+  it('hasScoredDimension stays false while no dimension has finished', async () => {
+    getEvaluationProgress.mockResolvedValue({
+      dimensions: [{ id: 'security', state: 'running' }],
+    });
+    const wrapper = withQueryClient();
+    const { result } = renderHook(() => useHistoryRunLive('run-inflight'), { wrapper });
+    await waitFor(() => {
+      expect(getEvaluationProgress).toHaveBeenCalled();
+    });
+    expect(result.current.hasScoredDimension).toBe(false);
+  });
+
+  it('hasScoredDimension is false and no poll fires when runId is empty', () => {
+    const wrapper = withQueryClient();
+    const { result } = renderHook(() => useHistoryRunLive(''), { wrapper });
+    expect(result.current.hasScoredDimension).toBe(false);
+    expect(getEvaluationProgress).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
An in-progress run's row in History stayed stuck on "No standards fully evaluated yet" for the entire run, even after a dimension had actually finished scoring on disk.

## Root cause

The row's "ready to view" gate (`notReady` in `EvaluationsTable.jsx`) depended on two signals:

- `entry.hasScoredDims`: a static stub in `historyRowAssembly.js`, always `false` for an in-progress run, never updated.
- `liveCount`, from `useHistoryRunLive`'s SSE subscription to `dimension-completed` events.

`liveCount` never moves because `VITE_USE_SSE_EVENTS` is off by default, so no SSE events ever arrive. With both signals stuck, the row stayed "not ready" for the whole run regardless of real progress.

## Fix

Added an unconditional poll of `getEvaluationProgress` (the same on-disk progress endpoint the running Evaluation page's progress bar already uses) to `useHistoryRunLive`, independent of the SSE flag. Exposed as `hasScoredDimension`, used as an additional OR condition in the row's readiness check.

## Testing

- New tests in `useHistoryRunLive.test.jsx` covering the poll firing with SSE both on and off.
- New `EvaluationsTable.test.jsx` covering the row's click gating in all three states (nothing scored, `hasScoredDimension` true, SSE `liveCount` alone).
- Full frontend suite: 1850 passed, 268 files.
- `lint:size`: clean.
