### PR TITLE
api: stop echoing exception text in HTTP responses

### DIFF
--- a/src/quodeq/api/_evaluation_helpers.py
+++ b/src/quodeq/api/_evaluation_helpers.py
@@ -39,6 +39,20 @@ _MAX_TIME_LIMIT = 3600
 _MAX_CONTEXT_SIZE = 2_000_000
 
 
+def clean_scan_conflict_error(payload: dict) -> str | None:
+    """Return an error message if *payload* sends both the new ``cleanScan``
+    field and the deprecated ``incremental`` field, else None. Message text
+    mirrors :func:`resolve_clean_scan` exactly."""
+    if "cleanScan" in payload and "incremental" in payload:
+        return (
+            "`cleanScan` and `incremental` cannot be combined in a single payload. "
+            "Use `cleanScan` only -- `incremental` is deprecated. "
+            "Send `cleanScan: false` (use cached findings, default) or `cleanScan: true` "
+            "(force full re-analysis)."
+        )
+    return None
+
+
 def resolve_clean_scan(payload: dict) -> bool:
     """Resolve the user's clean_scan intent from new and legacy fields.
 
@@ -50,15 +64,10 @@ def resolve_clean_scan(payload: dict) -> bool:
     Sending both is rejected: we won't guess intent if a client transitions
     mid-deployment and ends up posting conflicting flags.
     """
-    has_new = "cleanScan" in payload
+    err = clean_scan_conflict_error(payload)
+    if err is not None:
+        raise ValueError(err)
     has_legacy = "incremental" in payload
-    if has_new and has_legacy:
-        raise ValueError(
-            "`cleanScan` and `incremental` cannot be combined in a single payload. "
-            "Use `cleanScan` only -- `incremental` is deprecated. "
-            "Send `cleanScan: false` (use cached findings, default) or `cleanScan: true` "
-            "(force full re-analysis)."
-        )
     if has_legacy:
         _logger.warning(
             "Evaluation payload uses deprecated `incremental` field. "

--- a/src/quodeq/api/_grade_formula_routes.py
+++ b/src/quodeq/api/_grade_formula_routes.py
@@ -29,9 +29,13 @@ def _parse_params(data: dict) -> tuple:
     """Returns (params, None) or (None, (response, status)) on validation error."""
     try:
         params = params_from_dict(data or {})
-    except (TypeError, ValueError, KeyError, AttributeError) as exc:
+    except (TypeError, ValueError, KeyError, AttributeError):
+        # A fixed message, not str(exc): echoing exception text back to a
+        # client is the shape of an information-disclosure bug (CodeQL
+        # py/stack-trace-exposure) even though every message reachable here
+        # today is a bare type-conversion failure with no secret content.
         body, status = error_response(
-            f"Malformed params: {exc}", HTTPStatus.BAD_REQUEST, "INVALID_INPUT",
+            "Malformed params", HTTPStatus.BAD_REQUEST, "INVALID_INPUT",
         )
         return None, (jsonify(body), status)
     errors = validate_params(params)

--- a/src/quodeq/api/_grade_formula_routes.py
+++ b/src/quodeq/api/_grade_formula_routes.py
@@ -17,6 +17,7 @@ from quodeq.api.helpers import error_response
 from quodeq.api.routes_common import reports_dir
 from quodeq.core.scoring.params import (
     DEFAULT_PARAMS,
+    params_error,
     params_from_dict,
     params_to_dict,
     validate_params,
@@ -25,25 +26,25 @@ from quodeq.services import grade_formula
 from quodeq.shared.validation import validate_path_segment
 
 
+def _invalid_input(message: str) -> tuple[Response, int]:
+    body, status = error_response(message, HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+    return jsonify(body), status
+
+
 def _parse_params(data: dict) -> tuple:
     """Returns (params, None) or (None, (response, status)) on validation error."""
+    err = params_error(data or {})
+    if err is not None:
+        return None, _invalid_input(err)
     try:
         params = params_from_dict(data or {})
     except (TypeError, ValueError, KeyError, AttributeError):
-        # A fixed message, not str(exc): echoing exception text back to a
-        # client is the shape of an information-disclosure bug (CodeQL
-        # py/stack-trace-exposure) even though every message reachable here
-        # today is a bare type-conversion failure with no secret content.
-        body, status = error_response(
-            "Malformed params", HTTPStatus.BAD_REQUEST, "INVALID_INPUT",
-        )
-        return None, (jsonify(body), status)
+        # Unreachable once params_error passed; kept as a safety net with a
+        # constant message so nothing here can ever echo exception text.
+        return None, _invalid_input("Malformed params")
     errors = validate_params(params)
     if errors:
-        body, status = error_response(
-            "; ".join(errors), HTTPStatus.BAD_REQUEST, "INVALID_INPUT",
-        )
-        return None, (jsonify(body), status)
+        return None, _invalid_input("; ".join(errors))
     return params, None
 
 

--- a/src/quodeq/api/_import_validation.py
+++ b/src/quodeq/api/_import_validation.py
@@ -28,10 +28,16 @@ _MAX_PATH_DEPTH = 64  # limit on path components to bound recursion-style attack
 
 
 class _ImportError(Exception):
-    """Raised when a zip fails validation. Carries an HTTP status + code."""
+    """Raised when a zip fails validation. Carries an HTTP status + code.
+
+    ``public_message`` is the hand-written text the route returns to the
+    client; routes read that attribute rather than ``str(exc)`` so the
+    response never depends on exception formatting.
+    """
 
     def __init__(self, message: str, status: int, code: str) -> None:
         super().__init__(message)
+        self.public_message = message
         self.status = status
         self.code = code
 

--- a/src/quodeq/api/assistant_turn_routes.py
+++ b/src/quodeq/api/assistant_turn_routes.py
@@ -106,6 +106,10 @@ def register_assistant_turn_routes(app: Flask) -> None:
             return jsonify({"error": "text required"}), 400
         if local_provider_busy(session["provider"]):
             return jsonify({"error": "model busy with analysis"}), 409
+        if (session.get("source") or "local") == "shared":
+            shared_error = _assistant_routes._shared_source_error()
+            if shared_error is not None:
+                return shared_error
         state = _turn_state(app)
         cancel = state.claim_turn(sid)
         if cancel is None:
@@ -129,9 +133,13 @@ def register_assistant_turn_routes(app: Flask) -> None:
             )
             tool_ctx = _assistant_routes.build_tool_context(app, session)
             _start_turn_worker(state, sid, turn, repo, tool_ctx, cancel)
-        except SharedSourceUnavailable as exc:
+        except SharedSourceUnavailable:
+            # Race between the pre-check above and this build_tool_context
+            # call. Constant body, not str(exc): the pre-check already
+            # reported the specific reason; this is just the narrow window
+            # where the shared clone changed state in between.
             state.release_turn(sid)
-            return jsonify({"error": str(exc)}), 409
+            return jsonify({"error": "shared repository unavailable", "code": "SHARED_REPO_UNAVAILABLE"}), 409
         except Exception:
             state.release_turn(sid)
             raise

--- a/src/quodeq/api/import_project.py
+++ b/src/quodeq/api/import_project.py
@@ -251,7 +251,7 @@ def import_zip_stream(
             target_uuid = resolution
             _stage_and_commit(zf, members, reports_root, top_dir, target_uuid, identity)
     except _ImportError as exc:
-        return _error_outcome(str(exc), exc.status, exc.code)
+        return _error_outcome(exc.public_message, exc.status, exc.code)
     except zipfile.BadZipFile:
         return _error_outcome(
             "File is not a valid zip archive.",

--- a/src/quodeq/api/llm_bridge_routes.py
+++ b/src/quodeq/api/llm_bridge_routes.py
@@ -20,7 +20,7 @@ from quodeq.llm_bridge import (
     check_cloud_connection,
     resolve_api_key,
 )
-from quodeq.shared.url_validation import validate_url_safe
+from quodeq.shared.url_validation import url_safety_error
 
 
 def _json_body() -> dict | None:
@@ -45,10 +45,10 @@ def _invalid_base_url(base_url: str | None) -> tuple[Response, int] | None:
     """
     if base_url is None:
         return None
-    try:
-        validate_url_safe(base_url, allow_private=True)
-    except ValueError as exc:
-        return jsonify({"error": str(exc), "code": "INVALID_URL"}), 400
+    # Checker, not the raising validator: nothing here can echo exception text.
+    err = url_safety_error(base_url, allow_private=True)
+    if err is not None:
+        return jsonify({"error": err, "code": "INVALID_URL"}), 400
     return None
 
 
@@ -194,10 +194,9 @@ def register_llm_bridge_routes(app: Flask) -> None:
             api_key, api_key_env = resolve_api_key(provider_id, api_base)
 
         if api_base:
-            try:
-                validate_url_safe(api_base, allow_private=True)
-            except ValueError as exc:
-                return jsonify({"error": str(exc), "code": "INVALID_URL"}), 400
+            err = url_safety_error(api_base, allow_private=True)
+            if err is not None:
+                return jsonify({"error": err, "code": "INVALID_URL"}), 400
         if not api_key and api_key_env:
             return jsonify({
                 "success": False,

--- a/src/quodeq/api/llm_bridge_routes.py
+++ b/src/quodeq/api/llm_bridge_routes.py
@@ -45,7 +45,6 @@ def _invalid_base_url(base_url: str | None) -> tuple[Response, int] | None:
     """
     if base_url is None:
         return None
-    # Checker, not the raising validator: nothing here can echo exception text.
     err = url_safety_error(base_url, allow_private=True)
     if err is not None:
         return jsonify({"error": err, "code": "INVALID_URL"}), 400

--- a/src/quodeq/api/routes_evaluations_list.py
+++ b/src/quodeq/api/routes_evaluations_list.py
@@ -15,9 +15,11 @@ from quodeq.api._evaluation_helpers import (
     _validate_ai_cmd,
     _validate_ai_cmd_path,
     _validate_ai_model,
+    clean_scan_conflict_error,
 )
 from quodeq.api.helpers import error_response, scan_target_error, validate_evaluation_payload
 from quodeq.shared.serialization import to_camel_dict
+from quodeq.shared.validation import relative_scope_error
 from quodeq.assistant import get_provider_configs
 from quodeq.api.routes import _reports_dir
 from quodeq.services.active_evaluation import find_active_evaluation
@@ -62,6 +64,24 @@ class _StartRequest:
     options: Any
 
 
+def _pre_build_options_error(payload: dict) -> tuple[Response, int] | None:
+    """Pre-check every ValueError source ``_build_evaluation_options`` can
+    hit today (clean_scan conflict, then scope path -- same order it checks
+    them internally), so the caller's try/except is an unreachable safety
+    net, never a path that has to echo exception text."""
+    conflict_err = clean_scan_conflict_error(payload)
+    if conflict_err is not None:
+        body, status = error_response(conflict_err, HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+        return jsonify(body), status
+    scope_path = payload.get("scopePath") or None
+    if scope_path is not None:
+        err = relative_scope_error(str(scope_path))
+        if err is not None:
+            body, status = error_response(err, HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+            return jsonify(body), status
+    return None
+
+
 def _validated_start_request(
     payload: dict,
 ) -> tuple[_StartRequest | None, Response | tuple[Response, int] | None]:
@@ -74,10 +94,18 @@ def _validated_start_request(
         return None, error
     repo = payload.get("repo")
     _logger.info("start_evaluation: repo=%s, remote_addr=%s", _sanitize_url(repo), request.remote_addr)
+    pre_error = _pre_build_options_error(payload)
+    if pre_error is not None:
+        return None, pre_error
     try:
         options = _build_evaluation_options(payload)
-    except ValueError as exc:
-        body, status = error_response(str(exc), HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+    except ValueError:
+        # Constant message, not str(exc): both known raise sources are
+        # pre-checked above. Keep it unbound so nothing here can ever echo
+        # exception text.
+        body, status = error_response(
+            "Invalid evaluation options", HTTPStatus.BAD_REQUEST, "INVALID_INPUT",
+        )
         return None, (jsonify(body), status)
     # Same allowlist as /api/scan and POST /api/projects: starting an
     # evaluation registers + scans the directory and persists its file

--- a/src/quodeq/api/routes_project_create.py
+++ b/src/quodeq/api/routes_project_create.py
@@ -18,7 +18,7 @@ from flask import Response, jsonify, request
 
 from quodeq.api.helpers import error_response, scan_target_error as _scan_target_error
 from quodeq.services.base import ActionProvider, NewProjectSpec
-from quodeq.shared.validation import contained_path, validate_relative_scope
+from quodeq.shared.validation import contained_path, relative_scope_error
 
 
 def _reports_dir() -> str:
@@ -49,10 +49,9 @@ def _parse_create_project_request(
 
     scope_path = data.get("scopePath") or None
     if scope_path is not None:
-        try:
-            validate_relative_scope(str(scope_path))
-        except ValueError as exc:
-            body, status = error_response(str(exc), HTTPStatus.BAD_REQUEST, "INVALID_SCOPE")
+        err = relative_scope_error(str(scope_path))
+        if err is not None:
+            body, status = error_response(err, HTTPStatus.BAD_REQUEST, "INVALID_SCOPE")
             return None, (jsonify(body), status)
     discipline = data.get("discipline") or None
     clone_dest = data.get("cloneDest") or None

--- a/src/quodeq/api/routes_shared_config.py
+++ b/src/quodeq/api/routes_shared_config.py
@@ -13,7 +13,7 @@ from quodeq.services.shared_connect import connect_shared_repo
 from quodeq.services.shared_publish import get_publish_status
 from quodeq.services.shared_repo import disconnect_shared_repo, last_synced_at, read_state
 from quodeq.services.shared_settings import read_settings
-from quodeq.shared.validation import validate_path_segment
+from quodeq.shared.validation import path_segment_error
 
 from .helpers import error_response
 from .routes_common import reports_dir
@@ -115,10 +115,9 @@ def register_shared_config_routes(app: Flask) -> None:
 
     @app.post("/api/projects/<project>/publish")
     def shared_publish_start(project: str) -> tuple[Response, int]:
-        try:
-            validate_path_segment(project)
-        except ValueError as exc:
-            return jsonify({"error": str(exc)}), 400
+        err = path_segment_error(project)
+        if err is not None:
+            return jsonify({"error": err}), 400
         settings = read_settings()
         if not settings.url:
             return jsonify({"error": "no shared repository configured"}), 400

--- a/src/quodeq/core/scoring/params.py
+++ b/src/quodeq/core/scoring/params.py
@@ -118,6 +118,29 @@ def params_from_dict(data: Mapping[str, Any]) -> ScoringParams:
     )
 
 
+_COERCION_ERRORS = (TypeError, ValueError, KeyError, AttributeError)
+
+
+def params_error(data: object) -> str | None:
+    """Return ``"Malformed params: <key>"`` naming the first known key whose
+    value :func:`params_from_dict` cannot coerce, ``"Malformed params"`` when
+    *data* is not a mapping at all, else ``None``.
+
+    Names only our own key (from the defaults' key set), never the coercion
+    failure text, so the message is safe to return to an HTTP client.
+    """
+    if not isinstance(data, Mapping):
+        return "Malformed params"
+    for key in params_to_dict(DEFAULT_PARAMS):
+        if key not in data:
+            continue
+        try:
+            params_from_dict({key: data[key]})
+        except _COERCION_ERRORS:
+            return f"Malformed params: {key}"
+    return None
+
+
 def validate_params(params: ScoringParams) -> list[str]:
     """Return a list of human-readable validation errors (empty = valid)."""
     errors: list[str] = []

--- a/src/quodeq/core/utils/io.py
+++ b/src/quodeq/core/utils/io.py
@@ -45,14 +45,24 @@ def read_json(path: Path) -> dict[str, Any]:
     return data
 
 
-def validate_path_segment(*segments: str) -> None:
-    """Raise ValueError if any segment contains path traversal or separator characters."""
+def path_segment_error(*segments: str) -> str | None:
+    """Return an error message for the first segment containing path
+    traversal or separator characters, else None. Message text mirrors
+    :func:`validate_path_segment` exactly."""
     for seg in segments:
         if ".." in seg or "/" in seg or "\\" in seg or "\0" in seg:
-            raise ValueError(
+            return (
                 f"Invalid path segment: {seg!r}. "
                 f"Use only alphanumeric characters, hyphens, underscores, and dots."
             )
+    return None
+
+
+def validate_path_segment(*segments: str) -> None:
+    """Raise ValueError if any segment contains path traversal or separator characters."""
+    err = path_segment_error(*segments)
+    if err is not None:
+        raise ValueError(err)
 
 
 def _match_child_entry(entry: os.DirEntry, root: str | Path, name: str) -> str | None:

--- a/src/quodeq/shared/url_validation.py
+++ b/src/quodeq/shared/url_validation.py
@@ -6,6 +6,34 @@ from urllib.parse import urlparse
 from quodeq.shared.ssrf import is_loopback_address, is_private_address
 
 
+def url_safety_error(
+    url: str,
+    *,
+    allow_private: bool = False,
+    allow_loopback: bool = False,
+) -> str | None:
+    """Return an error message if *url* uses a non-HTTP scheme or targets a
+    private address, else None. Message text and branch order mirror
+    :func:`validate_url_safe` exactly."""
+    if not url:
+        return "URL must not be empty"
+
+    parsed = urlparse(url)
+
+    if parsed.scheme not in ("http", "https"):
+        return f"URL scheme {parsed.scheme!r} is not allowed; use http or https"
+
+    hostname = parsed.hostname
+    if not hostname:
+        return "URL must include a hostname"
+
+    if not allow_private and is_private_address(hostname):
+        if allow_loopback and is_loopback_address(hostname):
+            return None  # loopback is explicitly permitted
+        return f"URL targets a private/internal address: {hostname!r}"
+    return None
+
+
 def validate_url_safe(
     url: str,
     *,
@@ -29,19 +57,6 @@ def validate_url_safe(
     (e.g. omlx running on localhost) without opening up the full private range.
     *allow_loopback* is ignored when *allow_private* is ``True``.
     """
-    if not url:
-        raise ValueError("URL must not be empty")
-
-    parsed = urlparse(url)
-
-    if parsed.scheme not in ("http", "https"):
-        raise ValueError(f"URL scheme {parsed.scheme!r} is not allowed; use http or https")
-
-    hostname = parsed.hostname
-    if not hostname:
-        raise ValueError("URL must include a hostname")
-
-    if not allow_private and is_private_address(hostname):
-        if allow_loopback and is_loopback_address(hostname):
-            return  # loopback is explicitly permitted
-        raise ValueError(f"URL targets a private/internal address: {hostname!r}")
+    err = url_safety_error(url, allow_private=allow_private, allow_loopback=allow_loopback)
+    if err is not None:
+        raise ValueError(err)

--- a/src/quodeq/shared/validation.py
+++ b/src/quodeq/shared/validation.py
@@ -6,9 +6,22 @@ from pathlib import Path
 
 from quodeq.core.utils.io import (  # noqa: F401 — moved inward to core
     contained_path,
+    path_segment_error,
     resolve_child_dir,
     validate_path_segment,
 )
+
+
+def relative_scope_error(scope: str) -> str | None:
+    """Return an error message unless *scope* is a plain relative subpath,
+    else None. Message text mirrors :func:`validate_relative_scope` exactly."""
+    if "\0" in scope or "\\" in scope:
+        return f"Invalid scope path: {scope!r}. Use a forward-slash relative path."
+    if scope.startswith("/") or (len(scope) > 1 and scope[1] == ":"):
+        return f"Invalid scope path: {scope!r}. Scope must be relative to the repository root."
+    if any(part == ".." for part in scope.split("/")):
+        return f"Invalid scope path: {scope!r}. Parent-directory segments are not allowed."
+    return None
 
 
 def validate_relative_scope(scope: str) -> None:
@@ -18,12 +31,9 @@ def validate_relative_scope(scope: str) -> None:
     forward slashes to point at a nested folder, but must not be absolute,
     drive-qualified, backslashed, or contain traversal segments.
     """
-    if "\0" in scope or "\\" in scope:
-        raise ValueError(f"Invalid scope path: {scope!r}. Use a forward-slash relative path.")
-    if scope.startswith("/") or (len(scope) > 1 and scope[1] == ":"):
-        raise ValueError(f"Invalid scope path: {scope!r}. Scope must be relative to the repository root.")
-    if any(part == ".." for part in scope.split("/")):
-        raise ValueError(f"Invalid scope path: {scope!r}. Parent-directory segments are not allowed.")
+    err = relative_scope_error(scope)
+    if err is not None:
+        raise ValueError(err)
 
 
 def validate_canonical_absolute(raw: str) -> Path:

--- a/tests/api/test_assistant_routes.py
+++ b/tests/api/test_assistant_routes.py
@@ -872,13 +872,14 @@ def test_message_on_shared_session_without_repo_409s_and_frees_the_slot(client, 
 def test_message_on_shared_session_with_bad_clone_state_409s_and_frees_the_slot(client, app, monkeypatch):
     from quodeq.services.shared_settings import SharedSettings
     # The session was created while the shared clone was in a servable state;
-    # a background refresh has since pulled a foreign/unsupported clone.
-    # build_tool_context must surface this as a 409, and the running-turn
-    # slot must be released so the session is not permanently locked out.
+    # a background refresh has since pulled a foreign/unsupported clone. The
+    # route's pre-check (_shared_source_error, same helper the session-create
+    # route uses) must surface this as a 409 before claiming the turn slot,
+    # so the slot is never held and nothing needs releasing on this path.
     _repo(app).create_session(session_id="s-foreign", provider="ollama", source="shared")
-    monkeypatch.setattr("quodeq.api._assistant_helpers.read_settings",
+    monkeypatch.setattr("quodeq.api.assistant_routes.read_settings",
                         lambda: SharedSettings(url="file:///tmp/fake.git"))
-    monkeypatch.setattr("quodeq.api._assistant_helpers.read_state", lambda url: "foreign")
+    monkeypatch.setattr("quodeq.api.assistant_routes.read_state", lambda url: "foreign")
     first = client.post("/api/assistant/sessions/s-foreign/messages", json={"text": "hi"})
     assert first.status_code == 409
     assert "foreign" in first.get_json()["error"]

--- a/tests/api/test_grade_formula_api.py
+++ b/tests/api/test_grade_formula_api.py
@@ -139,3 +139,14 @@ def test_preview_rejects_invalid_params(client, formula_path):
         "/api/grade-formula/preview", json={"project": "p", "params": payload}, headers=_ORIGIN,
     )
     assert resp.status_code == 400
+
+
+def test_put_names_the_malformed_key_without_echoing_exception_text(client, formula_path):
+    payload = params_to_dict(DEFAULT_PARAMS)
+    payload["baseK"] = "abc"
+    resp = client.put("/api/grade-formula", json=payload, headers=_ORIGIN)
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["code"] == "INVALID_INPUT"
+    assert body["error"] == "Malformed params: baseK"
+    assert not formula_path.exists()

--- a/tests/api/test_no_exception_echo.py
+++ b/tests/api/test_no_exception_echo.py
@@ -2,17 +2,20 @@
 
 CodeQL's ``py/stack-trace-exposure`` fires on any
 ``except X as exc: ... jsonify(...str(exc)...)`` shape: the caught
-exception's text ends up in an HTTP response. This walks every route module
-under ``src/quodeq/api`` and asserts no handler lets the bound exception (or
-its ``repr()``, an f-string interpolation of it, or its ``.args``) reach a
-``jsonify()`` / ``error_response()`` call -- directly, or through a variable
-assigned from one of those forms earlier in the same handler body.
+exception's text ends up in an HTTP response. This walks every module under
+``src/quodeq/api`` and asserts no handler passes the bound exception's text
+(``str()``, ``repr()``, an f-string interpolation, or ``.args``) to any call
+other than a logger -- directly, or through a variable assigned from one of
+those forms earlier in the same handler body. Sink agnostic on purpose:
+``jsonify``/``error_response`` are the direct shapes, but a helper such as
+``_error_outcome(str(exc), ...)`` is the same leak one hop later.
 
 Zero baseline: this must stay empty. A validator that needs to surface a
 message writes a non-raising `<name>_error()` checker (see
 ``shared/validation.py``, ``core/utils/io.py``, ``shared/url_validation.py``)
 and the route returns the checker's string or a fixed constant, never the
-exception object itself.
+exception object itself. A domain exception with a client-facing text keeps
+it in an attribute (``_ImportError.public_message``).
 """
 from __future__ import annotations
 
@@ -21,18 +24,16 @@ from pathlib import Path
 
 _API_ROOT = Path(__file__).resolve().parents[2] / "src" / "quodeq" / "api"
 _REPO_ROOT = _API_ROOT.parents[2]
-_SINK_NAMES = {"jsonify", "error_response"}
+_LOG_METHODS = {"debug", "info", "warning", "warn", "error", "exception", "critical", "log"}
 
 
 def _is_sink_call(node: ast.AST) -> bool:
-    """True if *node* calls ``jsonify()``, ``error_response()``, or
-    ``<anything>.error_response()``."""
+    """True for any call that may carry text toward a response: every call
+    except logger methods (``log.warning(...)``, ``warnings.warn(...)``)."""
     if not isinstance(node, ast.Call):
         return False
     func = node.func
-    if isinstance(func, ast.Name) and func.id in _SINK_NAMES:
-        return True
-    return isinstance(func, ast.Attribute) and func.attr == "error_response"
+    return not (isinstance(func, ast.Attribute) and func.attr in _LOG_METHODS)
 
 
 def _is_flagged_expr(node: ast.AST, name: str) -> bool:

--- a/tests/api/test_no_exception_echo.py
+++ b/tests/api/test_no_exception_echo.py
@@ -1,0 +1,115 @@
+"""Guard against exception text flowing into API response bodies.
+
+CodeQL's ``py/stack-trace-exposure`` fires on any
+``except X as exc: ... jsonify(...str(exc)...)`` shape: the caught
+exception's text ends up in an HTTP response. This walks every route module
+under ``src/quodeq/api`` and asserts no handler lets the bound exception (or
+its ``repr()``, an f-string interpolation of it, or its ``.args``) reach a
+``jsonify()`` / ``error_response()`` call -- directly, or through a variable
+assigned from one of those forms earlier in the same handler body.
+
+Zero baseline: this must stay empty. A validator that needs to surface a
+message writes a non-raising `<name>_error()` checker (see
+``shared/validation.py``, ``core/utils/io.py``, ``shared/url_validation.py``)
+and the route returns the checker's string or a fixed constant, never the
+exception object itself.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_API_ROOT = Path(__file__).resolve().parents[2] / "src" / "quodeq" / "api"
+_REPO_ROOT = _API_ROOT.parents[2]
+_SINK_NAMES = {"jsonify", "error_response"}
+
+
+def _is_sink_call(node: ast.AST) -> bool:
+    """True if *node* calls ``jsonify()``, ``error_response()``, or
+    ``<anything>.error_response()``."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name) and func.id in _SINK_NAMES:
+        return True
+    return isinstance(func, ast.Attribute) and func.attr == "error_response"
+
+
+def _is_flagged_expr(node: ast.AST, name: str) -> bool:
+    """True if *node* echoes the bound exception *name*: ``str(name)``,
+    ``repr(name)``, an f-string ``{name}`` interpolation, or ``name.args``."""
+    if isinstance(node, ast.Call):
+        func = node.func
+        if (
+            isinstance(func, ast.Name)
+            and func.id in ("str", "repr")
+            and len(node.args) == 1
+            and isinstance(node.args[0], ast.Name)
+            and node.args[0].id == name
+        ):
+            return True
+    if isinstance(node, ast.FormattedValue):
+        if isinstance(node.value, ast.Name) and node.value.id == name:
+            return True
+    if isinstance(node, ast.Attribute):
+        if node.attr == "args" and isinstance(node.value, ast.Name) and node.value.id == name:
+            return True
+    return False
+
+
+def _assigned_flagged_names(handler: ast.ExceptHandler, name: str) -> set[str]:
+    """Variables directly assigned a flagged expression earlier in the same
+    handler body, e.g. ``msg = str(exc)`` later used as ``jsonify({"error": msg})``."""
+    names: set[str] = set()
+    for stmt in handler.body:
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and _is_flagged_expr(stmt.value, name)
+        ):
+            names.add(stmt.targets[0].id)
+    return names
+
+
+def _handler_hits(handler: ast.ExceptHandler) -> list[int]:
+    """Line numbers where the exception (or a variable holding its echoed
+    text) reaches a jsonify()/error_response() call within *handler*."""
+    name = handler.name
+    if name is None:
+        return []
+    flagged_vars = _assigned_flagged_names(handler, name)
+    hits: list[int] = []
+    for stmt in handler.body:
+        for node in ast.walk(stmt):
+            if not _is_sink_call(node):
+                continue
+            for sub in ast.walk(node):
+                if sub is node:
+                    continue
+                if _is_flagged_expr(sub, name):
+                    hits.append(getattr(sub, "lineno", node.lineno))
+                elif isinstance(sub, ast.Name) and sub.id in flagged_vars:
+                    hits.append(getattr(sub, "lineno", node.lineno))
+    return hits
+
+
+def _find_hits() -> list[str]:
+    hits: list[str] = []
+    for path in sorted(_API_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        rel = path.relative_to(_REPO_ROOT)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ExceptHandler):
+                for lineno in _handler_hits(node):
+                    hits.append(f"{rel}:{lineno}")
+    return sorted(set(hits))
+
+
+def test_no_exception_text_in_api_responses() -> None:
+    hits = _find_hits()
+    assert hits == [], (
+        "exception text reaches an HTTP response body at:\n"
+        + "\n".join(hits)
+        + "\nreturn a checker's message or a constant; never str(exc) in a response body"
+    )

--- a/tests/core/test_scoring_params.py
+++ b/tests/core/test_scoring_params.py
@@ -10,6 +10,7 @@ from quodeq.core.scoring.params import (
     DEFAULT_PARAMS,
     ScoringParams,
     dimension_weighted_average,
+    params_error,
     params_from_dict,
     params_to_dict,
     validate_params,
@@ -152,3 +153,31 @@ def test_replace_does_not_alias_default_mappings():
     copy = dataclasses.replace(DEFAULT_PARAMS, base_k=0.3)
     assert copy.dimension_weights is not DEFAULT_PARAMS.dimension_weights
     assert copy.severity_weight is not DEFAULT_PARAMS.severity_weight
+
+
+def test_params_error_none_for_valid_payload():
+    assert params_error(params_to_dict(DEFAULT_PARAMS)) is None
+    assert params_error({}) is None
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("baseK", "abc"),
+        ("severityWeight", 5),
+        ("gradeThresholds", [[1.0]]),
+        ("dimensionWeights", {"security": "heavy"}),
+    ],
+)
+def test_params_error_names_the_offending_key_only(key, value):
+    payload = params_to_dict(DEFAULT_PARAMS)
+    payload[key] = value
+    assert params_error(payload) == f"Malformed params: {key}"
+    # The raising path still fails on the same payload; the checker never
+    # echoes its text, only our own key name.
+    with pytest.raises((TypeError, ValueError, KeyError, AttributeError)):
+        params_from_dict(payload)
+
+
+def test_params_error_non_mapping_is_malformed_without_detail():
+    assert params_error(["not", "a", "dict"]) == "Malformed params"

--- a/tests/core/utils/test_io_path_segment.py
+++ b/tests/core/utils/test_io_path_segment.py
@@ -1,0 +1,37 @@
+"""Parity between path_segment_error and validate_path_segment
+(core/utils/io.py): the checker must return exactly the message the raising
+twin raises."""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.core.utils.io import path_segment_error, validate_path_segment
+
+_BAD_SEGMENTS = ["..", "a/b", "a\\b", "a\0b", "../etc/passwd", "a/../b"]
+_GOOD_SEGMENTS = ["abc", "abc-123_v1.0", "run.42", "a_b-c.d"]
+
+
+@pytest.mark.parametrize("bad", _BAD_SEGMENTS)
+def test_matches_raised_message(bad):
+    with pytest.raises(ValueError) as excinfo:
+        validate_path_segment(bad)
+    assert path_segment_error(bad) == str(excinfo.value)
+
+
+@pytest.mark.parametrize("good", _GOOD_SEGMENTS)
+def test_none_for_valid_segment(good):
+    assert path_segment_error(good) is None
+    validate_path_segment(good)  # must not raise
+
+
+def test_reports_first_offending_segment():
+    # Multiple segments: the checker must flag the *first* bad one, matching
+    # the raising twin's for-loop order.
+    with pytest.raises(ValueError) as excinfo:
+        validate_path_segment("ok", "..", "also-bad/slash")
+    assert path_segment_error("ok", "..", "also-bad/slash") == str(excinfo.value)
+
+
+def test_all_valid_segments_return_none():
+    assert path_segment_error(*_GOOD_SEGMENTS) is None
+    validate_path_segment(*_GOOD_SEGMENTS)  # must not raise

--- a/tests/shared/test_url_validation.py
+++ b/tests/shared/test_url_validation.py
@@ -1,0 +1,54 @@
+"""Parity between url_safety_error and validate_url_safe
+(shared/url_validation.py): the checker must return exactly the message
+the raising twin raises. Covers empty URL, bad scheme, missing host, and
+private/loopback addresses (with and without allow_private)."""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.shared.url_validation import url_safety_error, validate_url_safe
+
+
+def test_empty_url():
+    with pytest.raises(ValueError) as excinfo:
+        validate_url_safe("")
+    assert url_safety_error("") == str(excinfo.value)
+
+
+def test_bad_scheme():
+    with pytest.raises(ValueError) as excinfo:
+        validate_url_safe("ftp://example.com")
+    assert url_safety_error("ftp://example.com") == str(excinfo.value)
+
+
+def test_missing_host():
+    with pytest.raises(ValueError) as excinfo:
+        validate_url_safe("http://")
+    assert url_safety_error("http://") == str(excinfo.value)
+
+
+def test_private_address_rejected_by_default():
+    with pytest.raises(ValueError) as excinfo:
+        validate_url_safe("http://10.0.0.5")
+    assert url_safety_error("http://10.0.0.5") == str(excinfo.value)
+
+
+def test_private_address_allowed_with_allow_private():
+    validate_url_safe("http://10.0.0.5", allow_private=True)  # must not raise
+    assert url_safety_error("http://10.0.0.5", allow_private=True) is None
+
+
+def test_loopback_rejected_without_allow_loopback():
+    with pytest.raises(ValueError) as excinfo:
+        validate_url_safe("http://127.0.0.1")
+    assert url_safety_error("http://127.0.0.1") == str(excinfo.value)
+
+
+def test_loopback_allowed_with_allow_loopback():
+    validate_url_safe("http://127.0.0.1", allow_loopback=True)  # must not raise
+    assert url_safety_error("http://127.0.0.1", allow_loopback=True) is None
+
+
+def test_valid_public_url_returns_none():
+    validate_url_safe("https://example.com")  # must not raise
+    assert url_safety_error("https://example.com") is None

--- a/tests/shared/test_validation.py
+++ b/tests/shared/test_validation.py
@@ -1,4 +1,5 @@
-"""Unit tests for validate_canonical_absolute (shared/validation.py)."""
+"""Unit tests for validate_canonical_absolute and relative_scope_error
+(shared/validation.py)."""
 
 from __future__ import annotations
 
@@ -6,7 +7,11 @@ from pathlib import Path
 
 import pytest
 
-from quodeq.shared.validation import validate_canonical_absolute
+from quodeq.shared.validation import (
+    relative_scope_error,
+    validate_canonical_absolute,
+    validate_relative_scope,
+)
 
 
 class TestValidateCanonicalAbsolute:
@@ -31,3 +36,23 @@ class TestValidateCanonicalAbsolute:
     def test_rejects_relative_parent_segment(self):
         with pytest.raises(ValueError, match="parent-directory"):
             validate_canonical_absolute("../escape")
+
+
+class TestRelativeScopeError:
+    """Parity between relative_scope_error and validate_relative_scope: the
+    checker must return exactly the message the raising twin raises."""
+
+    @pytest.mark.parametrize(
+        "bad", ["../x", "a/../../b", "/abs", "C:evil", "a\\b", "a\0b"]
+    )
+    def test_matches_raised_message(self, bad):
+        with pytest.raises(ValueError) as excinfo:
+            validate_relative_scope(bad)
+        assert relative_scope_error(bad) == str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "good", ["src", "src/backend", "a.b/c-d_e", "src/with..dots"]
+    )
+    def test_none_for_valid_scope(self, good):
+        assert relative_scope_error(good) is None
+        validate_relative_scope(good)  # must not raise

--- a/tools/size_baseline.txt
+++ b/tools/size_baseline.txt
@@ -2,11 +2,11 @@
 # lines). Do NOT add entries without justification -- the goal is
 # to burn this list down, not grow it.
 # Regenerate intentionally: python tools/check_sizes.py --update-baseline
-src/quodeq/api/_import_validation.py:88:function
+src/quodeq/api/_import_validation.py:94:function
 src/quodeq/api/_log_stream_routes.py:54:function
 src/quodeq/api/assistant_turn_routes.py:95:function
 src/quodeq/api/assistant_workspace_routes.py:22:function
-src/quodeq/api/llm_bridge_routes.py:86:function
+src/quodeq/api/llm_bridge_routes.py:85:function
 src/quodeq/api/routes_evaluations_item.py:98:function
 src/quodeq/api/routes_findings.py:111:function
 src/quodeq/api/routes_project_data.py:24:function


### PR DESCRIPTION
Fixes the class behind CodeQL `py/stack-trace-exposure` alert 300 and the seven earlier dismissals of the same rule (228, 229, 281, 282, 284, 285, 294): `except X as exc:` followed by `str(exc)` in a response body. The messages were safe, but every refactor that moved one of these lines re-raised the alert at the new location. Alert 300 closes as fixed on merge.

**Pattern.** Validators keep their raising form and gain a non-raising twin that returns the same message or `None`: `relative_scope_error` (`shared/validation.py`), `path_segment_error` (`core/utils/io.py`), `url_safety_error` (`shared/url_validation.py`), `clean_scan_conflict_error` (`api/_evaluation_helpers.py`), `params_error` (`core/scoring/params.py`). Routes call the twin and return its string; no exception object reaches a response. `_ImportError` exposes `public_message` for the same reason. Parity tests pin each twin to the text its raising form raises, so the other call sites are untouched.

**Sites.** `llm_bridge_routes` (two), `routes_project_create`, `routes_shared_config`, `routes_evaluations_list` (both raise sources of `_build_evaluation_options` are pre-checked; the remaining `except ValueError` is an unreachable safety net with a constant message), `assistant_turn_routes` (the existing `_shared_source_error` gate runs before the turn slot is claimed, so nothing needs releasing on that path), `_grade_formula_routes`, `import_project`.

**Guard.** `tests/api/test_no_exception_echo.py` walks `src/quodeq/api` with `ast` and fails if a bound exception's text (`str`, `repr`, an f-string interpolation, `.args`) reaches any call other than a logger method, directly or through a local variable. Zero baseline. It listed seven sites before the change and none after.

**Behaviour changes** (everything else is byte-identical, pinned by the existing route tests):
- `POST /api/assistant/sessions/<sid>/messages` on a shared session whose repo is not configured: 409 body is now `no shared repository configured` with code `NO_SHARED_REPO` (was `shared repository not configured`, no code). Same text as session creation.
- Grade formula `PUT` and `preview` with a field that cannot be coerced: 400 `Malformed params: <key>` naming only our own key (was `Malformed params: <Python exception text>`).

Verification: full suite 6818 passed, 10 skipped; `check_imports`, `check_sizes`, `check_params` OK. `tools/size_baseline.txt` moved two line keys for shifted functions; the count stays at 72.
